### PR TITLE
docs: format smart-contracts/verify-smart-contracts-with-sourcify-truffle.md

### DIFF
--- a/build/tutorials/smart-contracts/verify-smart-contracts-with-sourcify-truffle.md
+++ b/build/tutorials/smart-contracts/verify-smart-contracts-with-sourcify-truffle.md
@@ -122,6 +122,7 @@ truffle migrate --network fuji
 ```
 
 You should see the txn activity in your terminal
+
 ![Step1](https://user-images.githubusercontent.com/73849597/128948790-654fc0dc-25d5-4713-9058-dfc4101a8366.png)
 <br>
 ![Step2](https://user-images.githubusercontent.com/73849597/128949004-c63d366f-3c0e-42e0-92f5-cb86da62bcba.png)


### PR DESCRIPTION
Removed `<br>` from the doc and adjusted headers. See current file at https://docs.avax.network/build/tutorials/smart-contracts/verify-smart-contracts-with-sourcify-truffle
<img width="753" alt="Screen Shot 2021-10-12 at 4 31 18 PM" src="https://user-images.githubusercontent.com/12171681/137037695-f042c53a-7869-44f2-af3f-4cb5d6f563c4.png">
