### PR TITLE
Update system-requirements.mdx

### DIFF
--- a/content/docs/nodes/system-requirements.mdx
+++ b/content/docs/nodes/system-requirements.mdx
@@ -10,7 +10,7 @@ Avalanche is an incredibly lightweight protocol, so nodes can run on commodity h
 - **CPU**: Equivalent of 8 AWS vCPU
 - **RAM**: 8 GiB (16 GiB recommended)
 - **Storage**: 1 TiB SSD
-- **OS**: Ubuntu 20.04 or MacOS >= 12
+- **OS**: Ubuntu 22.04 or MacOS >= 12
 
 <Callout title="Warning" type="warn">
 Nodes which choose to use a HDD may get poor and random read/write latencies, therefore reducing performance and reliability. An SSD is strongly suggested.


### PR DESCRIPTION
Because Ubuntu 20.04 is reaching the end of its support window, the binaries after v1.13.0 release do not support Ubuntu 20.04 (Focal).