### PR TITLE
fix broken spacing between words in banner at the top of the page (#2316)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,14 @@
-import './global.css';
-import 'katex/dist/katex.css';
-import { PHProvider } from './providers'
-import type { Viewport } from 'next';
-import { GeistSans } from 'geist/font/sans';
-import { GeistMono } from 'geist/font/mono';
-import type { ReactNode } from 'react';
-import { baseUrl, createMetadata } from '@/utils/metadata';
-import Chatbot from "@/components/ui/chatbot"
-import { PrivacyPolicyBox } from "@/components/privacy-policy"
-import { SearchRootProvider } from './searchRootProvider';
+import "./global.css";
+import "katex/dist/katex.css";
+import { PHProvider } from "./providers";
+import type { Viewport } from "next";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
+import type { ReactNode } from "react";
+import { baseUrl, createMetadata } from "@/utils/metadata";
+import Chatbot from "@/components/ui/chatbot";
+import { PrivacyPolicyBox } from "@/components/privacy-policy";
+import { SearchRootProvider } from "./searchRootProvider";
 import { Banner } from "fumadocs-ui/components/banner";
 import "./global.css";
 import "katex/dist/katex.css";
@@ -38,11 +38,25 @@ export default function Layout({ children }: { children: ReactNode }) {
       suppressHydrationWarning
     >
       <PHProvider>
-        <Banner id="banner" className="border-b border-border"><span className="bg-red-100 text-red-600 px-2 py-0.5 rounded-full text-xs">NEW</span> Register for the <a href="https://lu.ma/avalanchesummitlondonhackathon?utm_source=builder_hub" target="_blank" rel="noopener noreferrer" className="underline hover:text-red-600 transition-colors">London Hackathon</a>!</Banner>
+        <Banner id="banner" className="border-b border-border">
+          <span>
+            <span className="bg-red-100 text-red-600 px-2 py-0.5 rounded-full text-xs">
+              NEW
+            </span>{" "}
+            Register for the{" "}
+            <a
+              href="https://lu.ma/avalanchesummitlondonhackathon?utm_source=builder_hub"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-red-600 transition-colors"
+            >
+              London Hackathon
+            </a>
+            !
+          </span>
+        </Banner>
         <body className="flex min-h-screen flex-col">
-          <SearchRootProvider>
-            {children}
-          </SearchRootProvider>
+          <SearchRootProvider>{children}</SearchRootProvider>
           <Chatbot />
           <div id="privacy-banner-root" className="relative">
             <PrivacyPolicyBox />


### PR DESCRIPTION
Resolves #2316 

Wrapped the children of <Banner> in a <span> to prevent them from rendering as direct children of the flex container.