### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/checklinks.yml
+++ b/.github/workflows/checklinks.yml
@@ -10,7 +10,7 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: '20'


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected