### PR TITLE
Update Node.js setup action to v4

### DIFF
--- a/.github/workflows/checklinks.yml
+++ b/.github/workflows/checklinks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Install dependencies


### PR DESCRIPTION
Why this matters:
The v4 release includes important updates, better compatibility, and support for newer Node.js versions. GitHub has deprecated older Node runtimes, and continuing with v3 may cause build warnings or failures in future.

Reference:
https://github.com/actions/setup-node/releases/tag/v4.0.0

Let me know if you’d prefer staying on v3, or I’ll be happy to update to the latest patch of v4.