### PR TITLE
Remove CrossChainTransfer from Academy

### DIFF
--- a/content/academy/l1-validator-management/02-l1-creation/02-transfer-pchain.mdx
+++ b/content/academy/l1-validator-management/02-l1-creation/02-transfer-pchain.mdx
@@ -12,8 +12,6 @@ import CrossChainTransfer from "../../../../toolbox/src/components/CrossChainTra
 Next, we need to transfer the AVAX you've just claimed from the Faucet on the C-Chain to the
 P-Chain. You will need AVAX on the P-Chain to pay for transactions creating your L1.
 
-<ToolboxMdxWrapper walletMode="C-chain">
+Click on the arrow icon to transfer balance from C-Chain to P-Chain, or click "Get tokens" to airdrop 2 AVAX to your P-Chain wallet.
 
-<CrossChainTransfer />
-
-</ToolboxMdxWrapper>
+<ToolboxMdxWrapper walletMode="c-chain" />

--- a/toolbox/src/components/ConnectWallet/ConnectWallet.tsx
+++ b/toolbox/src/components/ConnectWallet/ConnectWallet.tsx
@@ -373,7 +373,7 @@ export const ConnectWallet = ({
                                             }`}
                                         title="Open faucet"
                                     >
-                                        Free tokens
+                                        Get tokens
                                     </button>
                                 )}
                                 <ExplorerButton
@@ -420,7 +420,7 @@ export const ConnectWallet = ({
                                     >
                                         <RefreshCw className={`w-4 h-4 text-zinc-600 dark:text-zinc-300 ${isPChainBalanceLoading ? 'animate-spin' : ''}`} />
                                     </button>
-                                    {pChainAddress && (
+                                    {pChainAddress && isTestnet && (
                                         <button
                                             onClick={async () => {
                                                 if (!isRequestingPTokens) {


### PR DESCRIPTION
- Remove CrossChainTransfer component for using built in transfer module in ConnectWallet
- nit: "Free Tokens" -> "Get tokens"
- hide faucet button on mainnet