### PR TITLE
fix broken link deploy-with-multisig-auth.mdx

### DIFF
--- a/content/docs/tooling/create-deploy-avalanche-l1s/deploy-with-multisig-auth.mdx
+++ b/content/docs/tooling/create-deploy-avalanche-l1s/deploy-with-multisig-auth.mdx
@@ -350,7 +350,7 @@ If setting up a multisig, don't select your validator start time to be in one mi
 ```bash
 Next, we need the NodeID of the validator you want to whitelist.
 
-Check https://build.avax.network/docs/apis/avalanchego/apis/info#infogetnodeid for instructions about how to query the NodeID from your node
+Check https://build.avax.network/docs/api-reference/info-api#info-getnodeid for instructions about how to query the NodeID from your node
 (Edit host IP address and port to match your deployment, if needed).
 What is the NodeID of the validator you'd like to whitelist?: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
 ✔ Default (20)


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL

https://build.avax.network/docs/apis/avalanchego/apis/info#infogetnodeid - old link
https://build.avax.network/docs/api-reference/info-api#info-getnodeid  - new link