### PR TITLE
Fix broken link to Avalanche VM precompiles documentation

### DIFF
--- a/toolbox/src/toolbox/ToolboxApp.tsx
+++ b/toolbox/src/toolbox/ToolboxApp.tsx
@@ -310,7 +310,7 @@ const componentGroups: Record<string, ComponentGroupType> = {
   "Precompiles": {
     academy: {
       text: "Learn about Subnet-EVM precompiled contracts",
-      link: "https://build.avax.network/docs/virtual-machines/default-precompiles"
+      link: "https://build.avax.network/docs/virtual-machines/default-precompiles/rewardmanager"
     },
     components: [
       {


### PR DESCRIPTION
This PR fixes a broken link in toolbox/src/toolbox/ToolboxApp.tsx pointing to Avalanche virtual machines precompiles documentation.

- Fixed: Changed the URL from https://build.avax.network/docs/virtual-machines/default-precompiles (404) 
- To: https://build.avax.network/docs/virtual-machines/default-precompiles/rewardmanager (200)
