### PR TITLE
fixed the incorrect commands in "Verify Teleporter Is Successfully Set Up"

### DIFF
--- a/content/docs/tooling/cross-chain/teleporter-local-network.mdx
+++ b/content/docs/tooling/cross-chain/teleporter-local-network.mdx
@@ -174,7 +174,7 @@ Waiting for message to be received at destination subnet subnet "chain1"
 Message successfully Teleported!
 ```
 
-To verify that Teleporter is successfully, let's send a couple of cross messages (from chain2 to chain1): 
+To verify that Teleporter is successfully deployed, let's send a couple of cross-chain messages (from chain2 to chain1): 
 ```bash
 avalanche teleporter sendMsg chain2 chain1 "Hello World" --local
 ```

--- a/content/docs/tooling/cross-chain/teleporter-local-network.mdx
+++ b/content/docs/tooling/cross-chain/teleporter-local-network.mdx
@@ -161,19 +161,26 @@ Currency Symbol:  TOKEN2
 Verify Teleporter Is Successfully Set Up[​](#verify-teleporter-is-successfully-set-up "Direct link to heading")
 ---------------------------------------------------------------------------------------------------------------
 
-To verify that Teleporter is successfully, let's send a couple of cross messages:
+To verify that Teleporter is successfully, let's send a couple of cross messages (from C-Chain to chain1): 
 
 ```bash
-avalanche teleporter msg C-Chain chain1 "Hello World" --local
+avalanche teleporter sendMsg C-Chain chain1 "Hello World" --local
+```
 
+Results:
+```bash
 Delivering message "this is a message" to source subnet "C-Chain"
 Waiting for message to be received at destination subnet subnet "chain1"
 Message successfully Teleported!
 ```
 
+To verify that Teleporter is successfully, let's send a couple of cross messages (from chain2 to chain1): 
 ```bash
-avalanche teleporter msg chain2 chain1 "Hello World" --local
+avalanche teleporter sendMsg chain2 chain1 "Hello World" --local
+```
 
+Results:
+```bash
 Delivering message "this is a message" to source subnet "chain2"
 Waiting for message to be received at destination subnet subnet "chain1"
 Message successfully Teleported!


### PR DESCRIPTION
The old commands were incorrect.
old command:
"avalanche teleporter msg C-Chain chain1 "Hello World" --local"
new command:
"avalanche teleporter sendMsg C-Chain chain1 "Hello World" --local"
This update replaced "msg" to "sendMsg".
