### PR TITLE
fixed the code display in the defining test cases md file

### DIFF
--- a/content/docs/virtual-machines/custom-precompiles/defining-test-cases.mdx
+++ b/content/docs/virtual-machines/custom-precompiles/defining-test-cases.mdx
@@ -186,7 +186,8 @@ contract ExampleHelloWorldTest is AllowListTest {
     example.setGreeting(greeting);
     assertEq(example.sayHello(), greeting);
   }
-}```
+}
+```
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
The tab display is broken on this page at the bottom: https://build.avax.network/docs/virtual-machines/custom-precompiles/defining-test-cases