### PR TITLE
fix dead reference remote-github-content-guide.md

### DIFF
--- a/editing-guides/remote-github-content-guide.md
+++ b/editing-guides/remote-github-content-guide.md
@@ -1,7 +1,7 @@
 # Docs Imported Directly from GitHub Repos
 
 Some pages, such as
-[Teleporter Overview](https://build.avax.network/docs/build/cross-chain/teleporter/overview),
+[Teleporter Overview](https://build.avax.network/docs/cross-chain/teleporter/overview),
 are maintained as MarkDown files directly in their respective GitHub repo, and imported into the docs.
 This is accomplished using a community-owned docusaurus plugin called [docusaurus-plugin-remote-content](https://github.com/rdilweb/docusaurus-plugin-remote-content?tab=readme-ov-file#docusaurus-plugin-remote-content). This guide goes into detail about how this is accomplished and how to maintain it.
 


### PR DESCRIPTION
Hi, I fixed dead reference in the documentation and replaced them with working ones.

https://build.avax.network/docs/build/cross-chain/teleporter/overview - old link
https://build.avax.network/docs/cross-chain/teleporter/overview - new link