### PR TITLE
Fix broken link to Chainlink VRF v2.5 supported networks

### DIFF
--- a/content/integrations/chainlink-vrf.mdx
+++ b/content/integrations/chainlink-vrf.mdx
@@ -143,7 +143,7 @@ contract VRFv2MultiplePaths is VRFConsumerBaseV2Plus {
 
     // The gas lane to use, which specifies the maximum gas price to bump to.
     // For a list of available gas lanes on each network,
-    // see https://docs.chain.link/docs/vrf/v2-5/supported-networks
+    // see https://docs.chain.link/vrf/v2-5/supported-networks
     bytes32 keyHash =
         0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae;
 


### PR DESCRIPTION
Updates the outdated or broken URL pointing to the list of supported networks for Chainlink VRF v2.5. The new link ensures accurate and accessible documentation reference.







