### PR TITLE
[docs]: fix links to bootstrapping and rpc sections

### DIFF
--- a/content/docs/nodes/run-a-node/avalanche-l1-nodes.mdx
+++ b/content/docs/nodes/run-a-node/avalanche-l1-nodes.mdx
@@ -80,7 +80,7 @@ You should now see terminal filled with logs and information to suggest the node
 
 ## Bootstrapping and RPC Details
 
-It may take a few hours for the node to fully [bootstrap](/docs/nodes/run-a-node/manually#bootstrapping) to the Avalanche Primary Network and tracked Avalanche L1s.
+It may take a few hours for the node to fully [bootstrap](/docs/nodes/run-a-node/from-source#bootstrapping) to the Avalanche Primary Network and tracked Avalanche L1s.
 
 When finished bootstrapping, the endpoint will be:
 
@@ -98,4 +98,4 @@ if run on a cloud provider. The “X”s should be replaced with the public IP o
 
 For more information on the requests available at these endpoints, please see the [Subnet-EVM API Reference](/docs/api-reference/subnet-evm-api) documentation.
 
-Because each node is also tracking the Primary Network, those [RPC endpoints](/docs/nodes/run-a-node/manually#rpc) are available as well.
+Because each node is also tracking the Primary Network, those [RPC endpoints](/docs/nodes/run-a-node/from-source#rpc) are available as well.


### PR DESCRIPTION
dead links are here https://build.avax.network/docs/nodes/run-a-node/avalanche-l1-nodes