### PR TITLE
update icm-contracts tag (v2.1)

### DIFF
--- a/toolbox/contracts/icm-contracts/compile.sh
+++ b/toolbox/contracts/icm-contracts/compile.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(dirname "$0")
 # Convert to absolute path
 SCRIPT_DIR=$(cd "$SCRIPT_DIR" && pwd)
 
-ICM_COMMIT="b24f373149745632b96f0c0a4edff140c811396e"
+ICM_COMMIT="4d5ab0b6dbc653770cfe9709878c9406eb28b71c"
 SUBNET_EVM_VERSION="v0.7.3"
 
 # Get current user and group IDs


### PR DESCRIPTION
bump release to https://github.com/ava-labs/icm-contracts/releases/tag/validator-manager-v2.1.0

(no contract changes since last build)