### PR TITLE
[docs]: fix link to from-source article

### DIFF
--- a/content/docs/nodes/validate/node-validator.mdx
+++ b/content/docs/nodes/validate/node-validator.mdx
@@ -26,7 +26,7 @@ our [Discord](https://chat.avalabs.org/) to ask questions.
 
 ## Requirements
 
-You've completed [Run an Avalanche Node](/docs/nodes/run-a-node/manually) and are familiar with
+You've completed [Run an Avalanche Node](/docs/nodes/run-a-node/from-source) and are familiar with
 [Avalanche's architecture](/docs/quick-start/primary-network). In this
 tutorial, we use [AvalancheJS](/docs/tooling/avalanche-js) and
 [Avalanche's Postman collection](/docs/tooling/avalanchego-postman-collection/setup) 


### PR DESCRIPTION
https://build.avax.network/docs/nodes/validate/node-validator#requirements here is this link. 
![Zrzut ekranu 2025-06-22 141245](https://github.com/user-attachments/assets/5cb673b9-e557-4d73-8130-2f7d51f2bca0)
