### PR TITLE
Fallback when dig myip.opendns.com fails in avalanchego-installer.sh

### DIFF
--- a/scripts/avalanchego-installer.sh
+++ b/scripts/avalanchego-installer.sh
@@ -252,6 +252,8 @@ else
   exit 1
 fi
 foundIP="$(dig +short myip.opendns.com @resolver1.opendns.com)"
+[ -z "$foundIP" ] && \
+  foundIP=$(curl -4 icanhazip.com)
 foundArch="$(uname -m)"                         #get system architecture
 if [ "$foundArch" = "aarch64" ]; then
   getArch="arm64"                               #we're running on arm arch (probably RasPi)


### PR DESCRIPTION
`dig +short myip.opendns.com @resolver1.opendns.com` (at line 254) often fails. In fact, I have installed a dozen or so avalanche nodes on remote servers, and it nearly always failed. Added a test and a command calling icanhazip.com – being owned by Cloudflare now, the service's life expectancy seems reasonable.