### PR TITLE
docs: Fix Typos

### DIFF
--- a/content/academy/solidity-foundry/06-contract-standarization/04-abstract.mdx
+++ b/content/academy/solidity-foundry/06-contract-standarization/04-abstract.mdx
@@ -167,4 +167,4 @@ By leveraging **abstract contracts**, developers can:
 ✅ Improve security through **standardized implementations**  
 ✅ Design flexible and scalable smart contract architectures  
 
-In the next section, we will explore one of the most common contract standars used for **Fungible Tokens**, diving deeper into this standard, and how it extends and interact with one another efficiently in **EVM-based smart contract development**.
+In the next section, we will explore one of the most common contract standard used for **Fungible Tokens**, diving deeper into this standard, and how it extends and interact with one another efficiently in **EVM-based smart contract development**.

--- a/content/academy/solidity-foundry/08-erc721-smart-contracts/01-erc721-intro.mdx
+++ b/content/academy/solidity-foundry/08-erc721-smart-contracts/01-erc721-intro.mdx
@@ -6,7 +6,7 @@ authors: [Andrea Vargas, Ash, martineckardt]
 icon: Book
 ---
 Previously, we explored the ERC-20 interface, a contract standard which allowed for the implementation of a token contract which the majority of smart contract users are able to easily call. As a result of the ERC-20 standard, many protocols were able flourish without having to worry about incompatible token interfaces. However, there is one thing that the ERC-20 standard did not fix...
-To understand the biggest shortcoming of the ERC-20 standard, we have discussed the concept of fungibility. Its design enables crucial fucntionality. However, this also implies that for a use case that requires for 1 unit of some ERC-20 A to be different in value than 1 unit of the same ERC-20 token A, the ERC-20 token standard is not sufficient for such a use case.
+To understand the biggest shortcoming of the ERC-20 standard, we have discussed the concept of fungibility. Its design enables crucial functionality. However, this also implies that for a use case that requires for 1 unit of some ERC-20 A to be different in value than 1 unit of the same ERC-20 token A, the ERC-20 token standard is not sufficient for such a use case.
 
 ## ERC-721
 


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `standars` → `standard`
  - `fucntionality` → `functionality`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.