### PR TITLE
Academy error handling

### DIFF
--- a/components/toolbox/academy/wrapper/ErrorFallback.tsx
+++ b/components/toolbox/academy/wrapper/ErrorFallback.tsx
@@ -1,18 +1,21 @@
 import { Button } from "../../components/Button";
 
 export const ErrorFallback = ({ error, resetErrorBoundary }: { error: Error, resetErrorBoundary: () => void }) => {
+
+    const errorString = (typeof error.message === 'string' ? error.message : error.name || "Unknown error")
+    const isTestnetError = errorString?.includes("The error is mostly returned when the client requests");
+
     return (
-        <div className="space-y-2">
-            <div className="text-red-500 text-sm">
-                {error.message}
+        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+            <div className="text-red-500 text-sm mb-4">
+                {errorString}
             </div>
-            {
-                error.message.includes("The error is mostly returned when the client requests") && (
-                    <div className="text-sm text-red-500">
-                        ^ This usually indicates that the core wallet is not in testnet mode. Open settings &gt; Advanced &gt; Testnet mode.
-                    </div>
-                )
-            }
+            {isTestnetError && (
+                <div className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                    This usually indicates that the Core wallet is not in testnet mode.
+                    Open Settings → Advanced → Enable Testnet mode.
+                </div>
+            )}
             <Button onClick={resetErrorBoundary}>
                 Try Again
             </Button>


### PR DESCRIPTION
closes #2903 
<img width="1028" height="430" alt="Screenshot 2025-09-16 at 15 27 36" src="https://github.com/user-attachments/assets/e38ba6db-6744-4c2f-95ee-11e75b3e09be" />
