### PR TITLE
Add error border styling to validator items when invalid

### DIFF
--- a/components/toolbox/components/ValidatorListInput/ValidatorItem.tsx
+++ b/components/toolbox/components/ValidatorListInput/ValidatorItem.tsx
@@ -106,8 +106,7 @@ export function ValidatorItem({
                   "shadow-sm focus:ring focus:ring-primary/30 focus:ring-opacity-50",
                 )}
               />
-              {l1TotalInitializedWeight && l1TotalInitializedWeight > 0n && validator.validatorWeight > 0n &&
-               (validator.validatorWeight * 100n / l1TotalInitializedWeight) >= 20n && (
+              {hasWeightError && (
                 <p className="text-xs mt-1 text-red-500 dark:text-red-400">
                   Warning: This validator's weight is 20% or more of the current L1 total stake ({ Number(validator.validatorWeight * 10000n / l1TotalInitializedWeight / 100n).toFixed(2) }%). Recommended to be less than 20%.
                 </p>


### PR DESCRIPTION
Add visual error indication to collapsible validator items in the Add Validator flow. The validator item container now displays a red border and subtle red background tint when validation errors exist (weight ≥20% of L1 stake or insufficient balance). This provides immediate visual feedback to users that the validator configuration needs attention.

I can't link the PR to the draft created by @0xstt Add error border on collapsible node items when invalid
