### PR TITLE
Federiconardelli7/truncate toast messages

### DIFF
--- a/components/ui/custom-error-toast.tsx
+++ b/components/ui/custom-error-toast.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import React, { useState, useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+import { X, AlertCircle } from 'lucide-react';
+
+interface CustomErrorToastProps {
+    message: string;
+    toastId: string | number;
+    maxLength?: number;
+}
+
+export const CustomErrorToast: React.FC<CustomErrorToastProps> = ({message, toastId, maxLength = 220}) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const wasExpandedRef = useRef(false);
+    const shouldTruncate = message.length > maxLength;
+    const displayMessage = isExpanded || !shouldTruncate
+        ? message
+        : message.substring(0, maxLength) + '...';
+
+    const handleExpand = () => {
+        if (!isExpanded) {
+            wasExpandedRef.current = true;
+        }
+        setIsExpanded(!isExpanded);
+    };
+
+    useEffect(() => {
+        if (isExpanded && wasExpandedRef.current) {
+            toast.custom(
+                (t) => (
+                    <CustomErrorToast
+                        message={message}
+                        toastId={t}
+                        maxLength={maxLength}
+                    />
+                ),
+                {
+                    id: toastId,
+                    duration: Infinity,
+                }
+            );
+            wasExpandedRef.current = false;
+        }
+    }, [isExpanded, message, toastId, maxLength]);
+
+    return (
+        <div
+          className="pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-4 pr-8 shadow-lg transition-all bg-red-100 dark:bg-red-850 border-red-200 dark:border-red-800"
+          style={{ wordBreak: "break-word", maxWidth: "420px" }}
+        >
+          <div className="flex items-start gap-3 flex-1">
+            <AlertCircle className="h-5 w-5 text-red-600 dark:text-red-600 flex-shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <div className="text-sm font-semibold text-red-800 dark:text-red-800 mb-1">Error</div>
+              <div className="text-sm text-red-700 dark:text-red-700">{displayMessage}</div>
+              {shouldTruncate && (
+                <button
+                  onClick={handleExpand}
+                  className="text-xs text-red-600 dark:text-red-600 hover:underline mt-2 font-medium"
+                >
+                  {isExpanded ? "Show less" : "Read more"}
+                </button>
+              )}
+            </div>
+          </div>
+          <button
+            onClick={() => toast.dismiss(toastId)}
+            className="absolute right-2 top-2 rounded-md p-1 text-red-700 dark:text-red-700 opacity-70 transition-all hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-red-400 border border-transparent hover:bg-red-300/40 hover:border-red-700 dark:hover:bg-red-300/40 dark:hover:border-red-700"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      );
+};
+
+export const showCustomErrorToast = (message: string, maxLength: number = 220) => {
+    const toastId = toast.custom(
+        (t) => (
+            <CustomErrorToast
+                message={message}
+                toastId={t}
+                maxLength={maxLength}
+            />
+        ),
+        {
+            duration: 4000,
+        }
+    );
+
+    return toastId;
+};

--- a/hooks/useEVMNotifications.ts
+++ b/hooks/useEVMNotifications.ts
@@ -3,6 +3,7 @@ import { toast } from 'sonner';
 import { useConsoleLog } from './use-console-log';
 import { Chain, createPublicClient, http } from 'viem';
 import { usePathname } from 'next/navigation';
+import { showCustomErrorToast } from '@/components/ui/custom-error-toast';
 
 const getEVMExplorerUrl = (txHash: string, viemChain: Chain) => {
     if (viemChain.blockExplorers?.default?.url) {
@@ -142,12 +143,10 @@ const useEVMNotifications = () => {
             })
             .catch((error) => {
                 const errorMessage = messages.error + error.message;
-                const maxLength = 220;
-                const displayMessage = errorMessage.length > maxLength
-                    ? errorMessage.substring(0, maxLength) + '...'
-                    : errorMessage;
 
-                toast.error(displayMessage, { id: toastId });
+                toast.dismiss(toastId);
+                showCustomErrorToast(errorMessage);
+
                 addLog({
                     status: 'error',
                     actionPath,

--- a/hooks/usePChainNotifications.ts
+++ b/hooks/usePChainNotifications.ts
@@ -4,6 +4,7 @@ import { useConsoleLog } from './use-console-log';
 import { PChainClient, createPChainClient } from '@avalanche-sdk/client';
 import { avalanche, avalancheFuji } from '@avalanche-sdk/client/chains';
 import { usePathname } from 'next/navigation';
+import { showCustomErrorToast } from '@/components/ui/custom-error-toast';
 
 const getPChainTxExplorerURL = (txID: string, isTestnet: boolean) => {
     return `https://${isTestnet ? "subnets-test" : "subnets"}.avax.network/p-chain/tx/${txID}`;
@@ -126,12 +127,10 @@ const usePChainNotifications = () => {
                     });
                 } catch (error) {
                     const errorMessage = config.errorMessagePrefix + (error as Error).message;
-                    const maxLength = 220;
-                    const displayMessage = errorMessage.length > maxLength
-                        ? errorMessage.substring(0, maxLength) + '...'
-                        : errorMessage;
 
-                    toast.error(displayMessage, { id: toastId });
+                    toast.dismiss(toastId);
+                    showCustomErrorToast(errorMessage);
+
                     addLog({
                         status: 'error',
                         actionPath,
@@ -141,12 +140,10 @@ const usePChainNotifications = () => {
             })
             .catch((error) => {
                 const errorMessage = config.errorMessagePrefix + error.message;
-                const maxLength = 220;
-                const displayMessage = errorMessage.length > maxLength
-                    ? errorMessage.substring(0, maxLength) + '...'
-                    : errorMessage;
 
-                toast.error(displayMessage, { id: toastId });
+                toast.dismiss(toastId);
+                showCustomErrorToast(errorMessage);
+
                 addLog({
                     status: 'error',
                     actionPath,


### PR DESCRIPTION
Sonner has some limitations for displaying and adding the read more functionality on the toast message after truncating. It can only be displayed on the right and which is not good looking and limits a lot the text window. 

So the first commit it's simply to truncate the toast message:
<img width="716" height="322" alt="image_2025-10-10_17-19-07" src="https://github.com/user-attachments/assets/70aa97bb-c47d-4767-910d-426ed236a5a1" />

I was not satisfied, and in some case it might be useful to read the error entirely without going to the console history. So in the second commit, I tried to create a new UI component to show the error messages that can be more customizable than simply Sonner's toast. 
It opens the toast and goes away after X seconds (4 rn), but if the user clicks Read More it opens in a bigger Toast with full log and stays active and can be closed after reading it. 
<img width="768" height="509" alt="image" src="https://github.com/user-attachments/assets/a719732c-2e82-401b-a95a-a9b62ae63fd6" />
<img width="707" height="455" alt="image" src="https://github.com/user-attachments/assets/abab0c71-4552-403e-a81e-4d5c420250fc" />
<img width="702" height="1148" alt="image" src="https://github.com/user-attachments/assets/714f97b2-cafd-4b05-98d8-3579780b29ed" />
<img width="700" height="1143" alt="image" src="https://github.com/user-attachments/assets/b2fe8c75-4086-4d99-a5bd-bb0d4101e1a3" />

