### PR TITLE
Modified the header section for stats pages

### DIFF
--- a/app/(home)/stats/l1/[[...slug]]/page.tsx
+++ b/app/(home)/stats/l1/[[...slug]]/page.tsx
@@ -62,6 +62,7 @@ export default async function L1Metrics({
       chainName={currentChain.chainName}
       description={`Real-time insights into ${currentChain.chainName} L1 activity and network usage`}
       themeColor={currentChain.color || "#E57373"}
+      chainLogoURI={currentChain.chainLogoURI}
     />
   );
 }

--- a/components/stats/ChainMetricsPage.tsx
+++ b/components/stats/ChainMetricsPage.tsx
@@ -57,6 +57,7 @@ interface ChainMetricsPageProps {
   chainName?: string;
   description?: string;
   themeColor?: string;
+  chainLogoURI?: string;
 }
 
 export default function ChainMetricsPage({
@@ -64,6 +65,7 @@ export default function ChainMetricsPage({
   chainName = "Avalanche C-Chain",
   description = "Real-time metrics and analytics for the Avalanche C-Chain",
   themeColor = "#E57373",
+  chainLogoURI,
 }: ChainMetricsPageProps) {
   const [metrics, setMetrics] = useState<CChainMetrics | null>(null);
   const [loading, setLoading] = useState(true);
@@ -426,23 +428,71 @@ export default function ChainMetricsPage({
     <div className="min-h-screen bg-gradient-to-br from-background to-muted/20 pt-8">
       <div className="container mx-auto mt-4 p-4 sm:p-6 pb-24 space-y-8 sm:space-y-12">
         {/* Header */}
-        <div className="space-y-3">
-          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4">
-            <div className="min-w-0 flex-1">
-              <h1 className="text-xl sm:text-2xl md:text-5xl break-words mb-2">
-                {chainName.includes("C-Chain")
-                  ? "Avalanche C-Chain Metrics"
-                  : `${chainName} L1 Metrics`}
-              </h1>
-              <p className="text-zinc-400 text-sm sm:text-md text-left">
-                {description}
-              </p>
-            </div>
+        <div className="relative overflow-hidden rounded-2xl p-8 sm:p-12">
+          {/* Multi-layer gradient background */}
+          <div className="absolute inset-0 bg-black" />
+          <div
+            className="absolute inset-0 opacity-60"
+            style={{
+              background: `linear-gradient(140deg, ${themeColor}88 0%, transparent 70%)`
+            }}
+          />
+          <div
+            className="absolute inset-0 opacity-40"
+            style={{
+              background: `linear-gradient(to top left, ${themeColor}66 0%, transparent 50%)`
+            }}
+          />
+          <div
+            className="absolute inset-0 opacity-30"
+            style={{
+              background: `radial-gradient(circle at 50% 50%, ${themeColor}44 0%, transparent 70%)`
+            }}
+          />
+
+          {/* Content */}
+          <div className="relative z-10">
+            {/* Top row with ExplorerDropdown */}
             {!chainName.includes("C-Chain") && currentChain?.explorers && (
-              <div className="shrink-0 mt-1">
-                <ExplorerDropdown explorers={currentChain.explorers} />
+              <div className="flex justify-end mb-4">
+                <div className="[&_button]:border-neutral-300 dark:[&_button]:border-white/30 [&_button]:text-neutral-800 dark:[&_button]:text-white [&_button]:hover:bg-neutral-100 dark:[&_button]:hover:bg-white/10 [&_button]:hover:border-neutral-400 dark:[&_button]:hover:border-white/50">
+                  <ExplorerDropdown
+                    explorers={currentChain.explorers}
+                    variant="outline"
+                    size="sm"
+                  />
+                </div>
               </div>
             )}
+
+            {/* Main content row */}
+            <div className="flex flex-col sm:flex-row items-start gap-6">
+              {/* Logo */}
+              {chainLogoURI && (
+                <div className="shrink-0">
+                  <img
+                    src={chainLogoURI}
+                    alt={`${chainName} logo`}
+                    className="w-20 h-20 sm:w-24 sm:h-24 rounded-xl object-contain bg-white/10 p-2"
+                    onError={(e) => {
+                      (e.target as HTMLImageElement).style.display = 'none';
+                    }}
+                  />
+                </div>
+              )}
+
+              {/* Title and description */}
+              <div className="flex-1 min-w-0">
+                <h1 className="text-2xl sm:text-3xl md:text-4xl font-semibold text-white mb-3 break-words">
+                  {chainName.includes("C-Chain")
+                    ? "Avalanche C-Chain Metrics"
+                    : `${chainName} L1 Metrics`}
+                </h1>
+                <p className="text-white/80 text-sm sm:text-base max-w-3xl">
+                  {description}
+                </p>
+              </div>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
Header with: 
- a shade of color based on the color in the json.
- logo 
- checked for light/dark theme

<img width="2374" height="477" alt="image" src="https://github.com/user-attachments/assets/1d4311ff-3265-437e-a047-958e00a0826d" />
<img width="2347" height="493" alt="image" src="https://github.com/user-attachments/assets/6ddc4276-2e33-4526-b683-bcec5da9446d" />

on mobile:

<img width="1078" height="966" alt="image" src="https://github.com/user-attachments/assets/31bc9e4f-5cc6-4244-b91a-40be9a24d0e5" />
<img width="891" height="883" alt="image" src="https://github.com/user-attachments/assets/723e29b9-dfdc-43b3-8b41-57da3689b741" />

