### PR TITLE
add: Deploy Your First Smart Contract page

### DIFF
--- a/content/academy/blockchain/blockchain-fundamentals/06-smart-contracts/02-deploy-your-first-contract.mdx
+++ b/content/academy/blockchain/blockchain-fundamentals/06-smart-contracts/02-deploy-your-first-contract.mdx
@@ -73,14 +73,14 @@ Once deployed, a unique contract address will be generated on the blockchain —
 </Step>
 <Step>
 
-### check on SnowTrace
+### Check on SnowTrace
 
 Open [SnowTrace Fuji Explorer](https://testnet.snowtrace.io/), paste your **contract address**, and check `message()` under **Read Contract** to see your robot’s greeting.
 
 </Step>
 <Step>
 
-### What this contract does?
+### What does this contract do?
 
 By deploying this simple contract, a little robot comes to life on the Avalanche Fuji testnet chain. When you call the `message()` function, the robot introduces itself with a friendly greeting.
 


### PR DESCRIPTION
Added a new academy tutorial page: "Deploy your first contract".

This page introduces how to deploy your first smart contract on the Avalanche Fuji Testnet using Remix.

- Step-by-step beginner friendly guide
- Includes verification on SnowTrace

I wanted to make the page where users can mint a NFT ( POAP) using their successful transaction as verification. However, I wasn’t able to make it.

In the future, I would love to add this feature on Fuji chain.

Thank you!
