### PR TITLE
fix paths with new academy learning tree

### DIFF
--- a/content/academy/blockchain/x402-payment-infrastructure/03-technical-architecture/05-facilitator-role.mdx
+++ b/content/academy/blockchain/x402-payment-infrastructure/03-technical-architecture/05-facilitator-role.mdx
@@ -299,4 +299,4 @@ Facilitators are essential infrastructure in the x402 ecosystem, handling paymen
 
 Facilitators charge minimal fees (~0.1-0.5% + gas) compared to traditional payment processors (2.9% + $0.30), making micropayments economically viable for the first time.
 
-**Next**: Learn about [Blockchain Settlement](./06-blockchain-settlement) to understand how payments are finalized on-chain, or explore [available facilitators on Avalanche](/academy/x402-payment-infrastructure/04-x402-on-avalanche/03-facilitators) for implementation options.
+**Next**: Learn about [Blockchain Settlement](./06-blockchain-settlement) to understand how payments are finalized on-chain, or explore [available facilitators on Avalanche](/academy/blockchain/x402-payment-infrastructure/04-x402-on-avalanche/03-facilitators) for implementation options.

--- a/content/academy/blockchain/x402-payment-infrastructure/index.mdx
+++ b/content/academy/blockchain/x402-payment-infrastructure/index.mdx
@@ -14,9 +14,9 @@ Traditional payment systems are slow, expensive, and require accounts, KYC, and 
 
 ## Course Content
 
-- [Introduction to x402](/academy/x402-payment-infrastructure/02-introduction/01-what-is-x402)
-- [Technical Architecture](/academy/x402-payment-infrastructure/03-technical-architecture/01-payment-flow)
-- [x402 on Avalanche](/academy/x402-payment-infrastructure/04-x402-on-avalanche/01-why-avalanche)
+- [Introduction to x402](/academy/blockchain/x402-payment-infrastructure/02-introduction/01-what-is-x402)
+- [Technical Architecture](/academy/blockchain/x402-payment-infrastructure/03-technical-architecture/01-payment-flow)
+- [x402 on Avalanche](/academy/blockchain/x402-payment-infrastructure/04-x402-on-avalanche/01-why-avalanche)
 
 ## Prerequisites
 


### PR DESCRIPTION
added the /blockchain/ path to the missing links 