### PR TITLE
add redirect for staking tutorial link that appeared on notify.avax

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -947,6 +947,11 @@ const config = {
         destination: "/docs",
         permanent: true,
       },
+      {
+        source: "/docs/build/tutorials/nodes-and-staking/staking-avax-by-validating-or-delegating-with-the-avalanche-wallet",
+        destination: "/docs/primary-network/validate/node-validator",
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
the here link on notify.avax.network sent people to https://build.avax.network/docs/build/tutorials/nodes-and-staking/staking-avax-by-validating-or-delegating-with-the-avalanche-wallet. I believe https://build.avax.network/docs/primary-network/validate/node-validator follows on the idea of "learning more about running a validator"

<img width="1725" height="943" alt="Screenshot 2025-12-04 at 1 41 03 AM" src="https://github.com/user-attachments/assets/1cc07892-30a1-4fac-bf4f-d53752f232bf" />
