### PR TITLE
fix: add redirects for 404 URLs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1350,6 +1350,72 @@ const config = {
         destination: "/academy/avalanche-l1/avalanche-fundamentals/04-creating-an-l1",
         permanent: true,
       },
+      // 404 fixes - December 2025
+      {
+        source: "/docs/build",
+        destination: "/docs",
+        permanent: true,
+      },
+      {
+        source: "/docs/build/:path*",
+        destination: "/docs",
+        permanent: true,
+      },
+      {
+        source: "/docs/nodes/chain-configs",
+        destination: "/docs/nodes/chain-configs/primary-network/c-chain",
+        permanent: true,
+      },
+      {
+        source: "/docs/nodes/chain-configs/c-chain",
+        destination: "/docs/nodes/chain-configs/primary-network/c-chain",
+        permanent: true,
+      },
+      {
+        source: "/docs/nodes/chain-configs/x-chain",
+        destination: "/docs/nodes/chain-configs/primary-network/x-chain",
+        permanent: true,
+      },
+      {
+        source: "/docs/nodes/on-third-party-services/latitude",
+        destination: "/docs/nodes/run-a-node/on-third-party-services/latitude",
+        permanent: true,
+      },
+      {
+        source: "/docs/reference/avalanchego/keystore-api",
+        destination: "/docs/rpcs/other",
+        permanent: true,
+      },
+      {
+        source: "/docs/specs/coreth-arc20s",
+        destination: "/docs/primary-network",
+        permanent: true,
+      },
+      {
+        source: "/docs/tooling/guides/import-avalanche-l1",
+        destination: "/docs/tooling/avalanche-cli/guides/import-avalanche-l1",
+        permanent: true,
+      },
+      {
+        source: "/docs/tooling/maintain/view-avalanche-l1s",
+        destination: "/docs/tooling/avalanche-cli/maintain/view-avalanche-l1s",
+        permanent: true,
+      },
+      {
+        source: "/docs/virtual-machines/evm-l1-customization",
+        destination: "/docs/avalanche-l1s/evm-configuration/evm-l1-customization",
+        permanent: true,
+      },
+      {
+        source: "/academy/avalanche-l1/l1-native-tokenomics/01-tokens-fundamentals/08-transfer-an-erc-20-token",
+        destination: "/academy/avalanche-l1/l1-native-tokenomics/01-tokens-fundamentals/05-erc20",
+        permanent: true,
+      },
+      {
+        source: "/docs/avalanche-l1s/evm-configuration/transaction-fees",
+        destination: "/docs/avalanche-l1s/precompiles/fee-manager",
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
 | Source | Destination | Reason |
   |--------|-------------|--------|
   | `/docs/build` | `/docs` | Legacy path migration |
   | `/docs/build/:path*` | `/docs` | Catches all legacy /build/ subpaths |
   | `/docs/nodes/chain-configs` | `/docs/nodes/chain-configs/primary-network/c-chain` | Missing index page |
   | `/docs/nodes/chain-configs/c-chain` | `/docs/nodes/chain-configs/primary-network/c-chain` | Path restructured |
   | `/docs/nodes/chain-configs/x-chain` | `/docs/nodes/chain-configs/primary-network/x-chain` | Path restructured |
   | `/docs/nodes/on-third-party-services/latitude` | `/docs/nodes/run-a-node/on-third-party-services/latitude` | Path restructured |
   | `/docs/reference/avalanchego/keystore-api` | `/docs/rpcs/other` | Deprecated API |
   | `/docs/specs/coreth-arc20s` | `/docs/primary-network` | Legacy spec doc |
   | `/docs/tooling/guides/import-avalanche-l1` | `/docs/tooling/avalanche-cli/guides/import-avalanche-l1` | CLI reorganization |
   | `/docs/tooling/maintain/view-avalanche-l1s` | `/docs/tooling/avalanche-cli/maintain/view-avalanche-l1s` | CLI reorganization |
   | `/docs/virtual-machines/evm-l1-customization` | `/docs/avalanche-l1s/evm-configuration/evm-l1-customization` | Path restructured |
   | `/academy/.../08-transfer-an-erc-20-token` | `/academy/.../05-erc20` | Course reorganization |
   | `/docs/avalanche-l1s/evm-configuration/transaction-fees` | `/docs/avalanche-l1s/precompiles/fee-manager` | Content moved to precompiles |