### PR TITLE
fix(academy): remove console sidebar from embedded tools

### DIFF
--- a/components/toolbox/academy/wrapper/ToolboxMdxWrapper.tsx
+++ b/components/toolbox/academy/wrapper/ToolboxMdxWrapper.tsx
@@ -4,9 +4,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import { ErrorFallback } from "./ErrorFallback";
 import { SessionProvider } from "next-auth/react";
 
-import { AcademySidebar } from "@/components/toolbox/components/console-header/academy-sidebar";
-import { AcademyHeader } from "@/components/toolbox/components/console-header/academy-header";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { EmbeddedConsoleHeader } from "@/components/toolbox/components/console-header/embedded-console-header";
 import { WalletProvider } from "@/components/toolbox/providers/WalletProvider";
 
 export default function ToolboxMdxWrapper({ children }: { children: React.ReactNode, walletMode?: "l1" | "c-chain", enforceChainId?: number }) {
@@ -22,25 +20,14 @@ export default function ToolboxMdxWrapper({ children }: { children: React.ReactN
     >
         <SessionProvider>
             <WalletProvider>
-                <div className="h-screen overflow-hidden m-2 rounded-xl border border-gray-200 dark:border-gray-700 relative">
-                    <SidebarProvider
-                        defaultOpen={false}
-                        className="h-full overflow-hidden relative"
-                        style={
-                            {
-                                "--sidebar-width": "100%",
-                                "--header-height": "calc(var(--spacing) * 12)",
-                            } as React.CSSProperties
-                        }
-                    >
-                        <AcademySidebar />
-                        <SidebarInset className="h-full bg-white dark:bg-gray-800">
-                            <AcademyHeader />
-                            <div className="flex flex-1 flex-col gap-4 p-6 overflow-y-auto h-[calc(100vh-var(--header-height)-1rem)]">
-                                {children}
-                            </div>
-                        </SidebarInset>
-                    </SidebarProvider>
+                <div
+                    className="h-screen overflow-hidden m-2 rounded-xl border border-gray-200 dark:border-gray-700 flex flex-col"
+                    style={{ "--header-height": "calc(var(--spacing) * 12)" } as React.CSSProperties}
+                >
+                    <EmbeddedConsoleHeader />
+                    <div className="flex flex-1 flex-col gap-4 p-6 overflow-y-auto bg-white dark:bg-gray-800">
+                        {children}
+                    </div>
                 </div>
             </WalletProvider>
         </SessionProvider>

--- a/components/toolbox/components/console-header/embedded-console-header.tsx
+++ b/components/toolbox/components/console-header/embedded-console-header.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { TestnetMainnetSwitch } from "./testnet-mainnet-switch";
+import EvmNetworkWallet from "./evm-network-wallet";
+import { WalletPChain } from "./pchain-wallet";
+
+export function EmbeddedConsoleHeader() {
+  return (
+    <header className="flex h-(--header-height) shrink-0 items-center gap-2 border-b backdrop-blur transition-[width,height] ease-linear rounded-t-xl">
+      <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
+        <span className="text-sm text-muted-foreground">Builder Console</span>
+        <div className="ml-auto flex items-center gap-2">
+          <TestnetMainnetSwitch />
+          <EvmNetworkWallet />
+          <WalletPChain />
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- Fix console sidebar overlaying academy sidebar when console tools are embedded in academy course pages
- Remove `AcademySidebar` and `SidebarProvider` from `ToolboxMdxWrapper` entirely
- Create simplified `EmbeddedConsoleHeader` without sidebar trigger
- Keep wallet connectors and network switch for tool functionality

## Problem
When console tools (Faucet, CrossChainTransfer, etc.) were embedded in academy MDX pages via `ToolboxMdxWrapper`, the console's `AcademySidebar` used `fixed` positioning which caused it to overlay on top of the academy's fumadocs sidebar, creating a confusing UI.

## Solution
Instead of trying to contain the fixed-positioned sidebar, we remove it entirely since embedded tools don't need their own navigation - users already have the academy sidebar for navigation context.

## Test plan
- [x] Run `yarn dev`
- [x] Navigate to `/academy/avalanche-l1/avalanche-fundamentals/04-creating-an-l1/02a-claim-testnet-tokens`
- [x] Verify embedded console tools show only header with wallet controls (no sidebar or toggle)
- [x] Verify academy sidebar remains functional and not obscured