### PR TITLE
Fix 404 redirects for builderkit, API docs, and restructured content

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1463,6 +1463,7 @@ const config = {
       {
         source: "/docs/apis/avalanchego/apis/p-chain",
         destination: "/docs/rpcs/p-chain",
+        permanent: true,
       },
       // SDK client methods redirect
       {
@@ -1514,6 +1515,7 @@ const config = {
       {
         source: "/docs/virtual-machines/evm-customization/executing-test-cases",
         destination: "/docs/avalanche-l1s/custom-precompiles/executing-test-cases",
+        permanent: true,
       },
       // Node config flags redirect
       {


### PR DESCRIPTION
## Summary

- Add 12 new redirects to fix broken URLs reported from analytics
- Handle BuilderKit removal (redirects to Avalanche SDK)
- Fix old API documentation paths (`/docs/apis/avalanchego/apis/*` → `/docs/rpcs/*`)
- Fix double-docs typos (`/docs/docs/*` → `/docs/*`)
- Update academy course paths for restructured content

## Broken URLs Fixed

| Broken URL | Redirects To | Reason |
|------------|--------------|--------|
| `/builderkit` | `/docs/tooling/avalanche-sdk` | BuilderKit was removed Dec 5, 2025 |
| `/academy/.../03-avalanche-starter-kit/06-networks` | `.../interchain-messaging/.../04-networks` | Academy content restructured |
| `/docs/apis/avalanchego/apis/c-chain` | `/docs/rpcs/c-chain` | API docs moved to /rpcs/ structure |
| `/docs/apis/avalanchego/apis/subnet-evm` | `/docs/rpcs/subnet-evm` | API docs moved to /rpcs/ structure |
| `/docs/build/dapp/smart-contracts/staking` | `/docs/primary-network/validate/how-to-stake` | Staking docs moved to primary-network |
| `/docs/docs/avalanche-l1s/evm-configuration/customize-avalanche-l1` | `/docs/avalanche-l1s/...` | Double `/docs/docs` typo in external links |
| `/docs/docs/avalanche-l1s/upgrade/precompile-upgrades` | `/docs/avalanche-l1s/...` | Double `/docs/docs` typo in external links |
| `/docs/nodes/build/launch-an-avalanche-validator-on-aws-with-one-click` | `/docs/nodes/run-a-node/on-third-party-services/aws-marketplace` | Node docs restructured |
| `/docs/nodes/chain-configs/c-chain#internal-debug` | Already redirected (line 1376) | Existing redirect handles this |
| `/docs/overview` | `/docs` | Overview page removed |
| `/docs/virtual-machines/evm-customization/executing-test-cases` | `/docs/avalanche-l1s/custom-precompiles/executing-test-cases` | EVM docs moved to avalanche-l1s |

## Test plan

- [ ] Verify redirects work locally with `yarn dev`
- [ ] Test each broken URL redirects to the correct destination
- [ ] Confirm destination pages exist and load properly