### PR TITLE
fix(integrations): correct YAML array syntax in octane.mdx frontmatter

### DIFF
--- a/content/integrations/octane.mdx
+++ b/content/integrations/octane.mdx
@@ -1,7 +1,7 @@
 ---
 title: Octane
 category: Security Tooling
-available: ["C-Chain"] ["All Avalanche L1s"]
+available: ["C-Chain", "All Avalanche L1s"]
 description: Octane's AI-powered security platform provides continuous vulnerability detection and deep codebase analysis integrated directly into developer workflows.
 logo: /images/octane.jpg
 developer: Octane


### PR DESCRIPTION
## Summary
- Fixes the Vercel build error: `YAMLException: bad indentation of a mapping entry`
- Corrects invalid YAML syntax where two arrays were placed side by side: `["C-Chain"] ["All Avalanche L1s"]`
- Merges into a single valid array: `["C-Chain", "All Avalanche L1s"]`

## Test plan
- [x] Verified YAML parses correctly with `js-yaml`
- [x] Vercel preview build should pass