### PR TITLE
Fix MCP command syntax in documentation

### DIFF
--- a/content/docs/tooling/ai-llm/index.mdx
+++ b/content/docs/tooling/ai-llm/index.mdx
@@ -65,7 +65,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) server enables AI
 Add the MCP server to your project:
 
 ```bash
-claude mcp add avalanche-docs --transport http --url https://build.avax.network/api/mcp
+claude mcp add avalanche-docs --transport http https://build.avax.network/api/mcp
 ```
 
 Or add to your `.claude/settings.json`:


### PR DESCRIPTION
Remove invalid --url flag. URL should be passed as a positional argument after the server name, not with a --url flag.