### PR TITLE
Fix Edit on GitHub button 404 for index.mdx files

### DIFF
--- a/app/academy/[...slug]/page.tsx
+++ b/app/academy/[...slug]/page.tsx
@@ -83,7 +83,10 @@ export default async function Page(props: {
 
   if (!page) notFound();
 
-  const path = `content/academy${page.url.replace('/academy/', '/')}.mdx`;
+  // Use page.path which contains the actual file path relative to collection root
+  // (e.g., "avalanche-l1/course/module/index.mdx" for an index file)
+  // This correctly handles both regular .mdx files and index.mdx files
+  const path = `content/academy/${page.path}`;
   const editUrl = `https://github.com/ava-labs/builders-hub/edit/master/${path}`;
   const MDX = page.data.body;
   // Check both official courses and entrepreneur courses

--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -37,7 +37,10 @@ export default async function Page(props: {
   if (!page) notFound();
 
   const MDX = page.data.body;
-  const path = `content/blog${page.url.replace('/blog/', '/')}.mdx`;
+  // Use page.path which contains the actual file path relative to collection root
+  // (e.g., "post-name/index.mdx" for an index file)
+  // This correctly handles both regular .mdx files and index.mdx files
+  const path = `content/blog/${page.path}`;
 
   return (
     <>

--- a/app/docs/[...slug]/page.tsx
+++ b/app/docs/[...slug]/page.tsx
@@ -42,7 +42,10 @@ export default async function Page(props: {
   if (!page) notFound();
 
   const { body: MDX, toc } = await page.data.load();
-  const path = `content/docs${page.url.replace('/docs/', '/')}.mdx`;
+  // Use page.path which contains the actual file path relative to collection root
+  // (e.g., "tooling/avalanche-sdk/index.mdx" for an index file)
+  // This correctly handles both regular .mdx files and index.mdx files
+  const path = `content/docs/${page.path}`;
 
   // Use custom edit URL if provided in frontmatter, otherwise use default path
   const editUrl =

--- a/app/integrations/[...slug]/page.tsx
+++ b/app/integrations/[...slug]/page.tsx
@@ -22,7 +22,10 @@ export default async function Page(props: {
     : "Update Integration Information";
 
   const { body: MDX } = await page.data.load();
-  const path = `content/integrations${page.url.replace('/integrations/', '/')}.mdx`;
+  // Use page.path which contains the actual file path relative to collection root
+  // (e.g., "integration-name/index.mdx" for an index file)
+  // This correctly handles both regular .mdx files and index.mdx files
+  const path = `content/integrations/${page.path}`;
 
   return (
     <div className="integration-detail-page">


### PR DESCRIPTION
The Edit on GitHub button was generating incorrect URLs for pages served from index.mdx files. The old code used page.url to reconstruct the file path by appending .mdx, but this doesn't work for index files.

Changed to use page.path which contains the actual file path relative to the collection root, correctly handling both regular .mdx files and index.mdx files.

Example fix for /docs/tooling/avalanche-sdk:
- Before: .../content/docs/tooling/avalanche-sdk.mdx (404)
- After:  .../content/docs/tooling/avalanche-sdk/index.mdx (correct)

🔺 Generated by DevRel swarm