### PR TITLE
docs: move AvalancheGo releases to Getting Started section

### DIFF
--- a/content/docs/nodes/meta.json
+++ b/content/docs/nodes/meta.json
@@ -7,6 +7,7 @@
     "index",
     "---Getting Started---",
     "system-requirements",
+    "releases",
     "run-a-node",
     "---AvalancheGo Configuration---",
     "configure/configs-flags",

--- a/utils/remote-content/releases.mts
+++ b/utils/remote-content/releases.mts
@@ -126,7 +126,7 @@ export async function getReleasesConfigs(): Promise<FileConfig[]> {
   return [
     {
       sourceUrl: 'https://api.github.com/repos/ava-labs/avalanchego/releases',
-      outputPath: 'content/docs/nodes/maintain/releases.mdx',
+      outputPath: 'content/docs/nodes/releases.mdx',
       title: 'AvalancheGo Releases',
       description: 'Track AvalancheGo releases, network upgrades, and version compatibility for your node.',
       contentUrl: 'https://github.com/ava-labs/avalanchego/releases',


### PR DESCRIPTION
## Summary

- Updates the remote-content config to generate `releases.mdx` at `content/docs/nodes/releases.mdx` instead of `content/docs/nodes/maintain/releases.mdx`
- Updates `meta.json` navigation to display releases in the Getting Started section

## Changes

- `utils/remote-content/releases.mts` - Changed `outputPath` to `content/docs/nodes/releases.mdx`
- `content/docs/nodes/meta.json` - Added `releases` entry to Getting Started section

## Why?

Placing the releases/version information in the Getting Started section improves discoverability. Users setting up nodes should see version requirements early in their journey, not buried in the Maintenance section.

## Test plan

- [x] Run `npm run remote-content` to regenerate the releases page at the new location
- [x] Verify the releases page appears in Getting Started navigation
- [x] Confirm the `.gitignore` is updated with the new path (handled automatically by remote-content script)
- [x] Check that old path is removed from `.gitignore`