### PR TITLE
Improve homepage with rotating taglines and reorganized quick links

### DIFF
--- a/components/landing/hero.tsx
+++ b/components/landing/hero.tsx
@@ -155,6 +155,55 @@ if (typeof document !== 'undefined') {
   document.head.appendChild(styleSheet);
 }
 
+// Random taglines (Minecraft splash style)
+const taglines = [
+  // The journey
+  "From your first contract to your own blockchain.",
+  "C-Chain for day one. Your own L1 when you outgrow it.",
+  "Start permissionless. Go sovereign when ready.",
+  "The only network where your app can graduate to its own blockchain.",
+  "The network that grows with you.",
+
+  // Choice/flexibility
+  "Deploy a contract or deploy a blockchain.",
+  "Shared chain or sovereign chain. You decide.",
+  "Build on ours or build your own.",
+  "Your chain, your rules, your fees.",
+
+  // Speed/performance
+  "Sub-second finality. No compromises.",
+  "Same finality whether you're on C-Chain or your own chain.",
+  "Instant finality changes everything.",
+  "EVM compatible. Avalanche fast.",
+
+  // Builder attitude
+  "Why rent blockspace when you can own the block?",
+  "Stop fighting for gas. Get your own chain.",
+  "No gas wars. Just building.",
+  "Your app deserves its own chain.",
+  "Where serious builders ship.",
+  "Ship fast. Scale faster.",
+
+  // Cheeky
+  "Launch a chain before lunch.",
+  "Blockchains shouldn't be hard.",
+  "Yes, you can have your own blockchain.",
+];
+
+function Tagline() {
+  const [tagline, setTagline] = useState(taglines[0]);
+
+  useEffect(() => {
+    setTagline(taglines[Math.floor(Math.random() * taglines.length)]);
+  }, []);
+
+  return (
+    <p className="text-lg sm:text-xl text-slate-600 dark:text-slate-400 leading-relaxed max-w-lg mx-auto lg:mx-0">
+      {tagline}
+    </p>
+  );
+}
+
 // Rotating Text Component
 function RotatingText() {
   const words = ['Documentation', 'Academy', 'Console', 'Hackathons', 'Bounties', 'Events', 'Grants', 'Stats'];
@@ -226,14 +275,12 @@ export default function Hero() {
                 Builder Hub
                 </span>
               </h1>
-              
+
               <h2 className="text-3xl sm:text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight leading-[1.2] flex items-center justify-center lg:justify-start min-h-[1.5em]">
                 <RotatingText />
               </h2>
-              
-              {/* <p className="text-xl sm:text-2xl lg:text-2xl xl:text-3xl text-slate-600 dark:text-slate-300 font-light leading-[1.5] tracking-[-0.025em] max-w-2xl mx-auto lg:mx-0 text-balance">
-                Everything you need to go from idea to impact.
-              </p> */}
+
+              <Tagline />
             </div>
 
             {/* CTA Buttons */}

--- a/components/landing/quicklinks.tsx
+++ b/components/landing/quicklinks.tsx
@@ -4,7 +4,6 @@ import {
   Droplet,
   Wrench,
   BookOpen,
-  ArrowRight,
   Computer,
   ArrowLeftRight,
   GitBranch,
@@ -16,127 +15,121 @@ import {
 import { cn } from "@/utils/cn";
 import Link from "next/link";
 
-const quickLinks = [
+const sections = [
   {
-    id: 1,
-    title: "Faucet",
-    description: "Get testnet AVAX",
-    icon: Droplet,
-    href: "/console/primary-network/faucet"
+    title: "Get Started",
+    links: [
+      {
+        title: "Avalanche Fundamentals",
+        description: "Learn the basics",
+        icon: Triangle,
+        href: "/academy/avalanche-fundamentals"
+      },
+      {
+        title: "Create an L1",
+        description: "Launch your own chain",
+        icon: Wrench,
+        href: "/console/layer-1/create"
+      },
+      {
+        title: "Testnet Faucet",
+        description: "Get test AVAX",
+        icon: Droplet,
+        href: "/console/primary-network/faucet"
+      },
+    ]
   },
   {
-    id: 2,
-    title: "Create New L1",
-    description: "Create a blockchain with the Builder Console",
-    icon: Wrench,
-    href: "/console/layer-1/create"
+    title: "Build",
+    links: [
+      {
+        title: "Run a Node",
+        description: "Hardware or cloud",
+        icon: Computer,
+        href: "/docs/nodes/run-a-node/using-docker"
+      },
+      {
+        title: "RPC Reference",
+        description: "C-Chain, P-Chain, X-Chain",
+        icon: ArrowLeftRight,
+        href: "/docs/rpcs/c-chain"
+      },
+      {
+        title: "API Reference",
+        description: "Data and webhooks",
+        icon: BookOpen,
+        href: "/docs/api-reference"
+      },
+      {
+        title: "Developer Tools",
+        description: "SDKs and CLIs",
+        icon: CodeIcon,
+        href: "/docs/tooling"
+      },
+    ]
   },
   {
-    id: 3,
-    title: "Setup a Node",
-    description: "Run a node on your own hardware or cloud provider.",
-    icon: Computer,
-    href: "/docs/nodes/run-a-node/using-docker"
-  },
-  {
-    id: 4,
-    title: "RPC References",
-    description: "Explore the RPC Methods for the C-Chain, P-Chain, and X-Chain.",
-    icon: ArrowLeftRight,
-    href: "/docs/rpcs/c-chain"
-  },
-  {
-    id: 5,
-    title: "API References",
-    description: "Avalanche Data, Metrics, and Webhook APIs",
-    icon: BookOpen,
-    href: "/docs/api-reference"
-  },
-  {
-    id: 6,
-    title: "Avalanche Fundamentals",
-    description: "Learn about the basics of Avalanche.",
-    icon: Triangle,
-    href: "/academy/avalanche-fundamentals"
-  },
-  {
-    id: 7,
-    title: "Network Stats",
-    description: "View the latest metrics for the Avalanche Network.",
-    icon: ActivityIcon,
-    href: "/stats/overview"
-  },
-  {
-    id: 8,
-    title: "ACPs",
-    description: "Explore Avalanche's Community Proposals (ACPs) for network improvements and best practices.",
-    icon: GitBranch,
-    href: "/docs/acps"
-  },
-  {
-    id: 9,
-    title: "Integrations",
-    description: "Explore the integrations with Avalanche.",
-    icon: PackageIcon,
-    href: "/integrations"
-  },
-  {
-    id: 10,
-    title: "Developer Tools",
-    description: "Explore the developer tools for Avalanche.",
-    icon: CodeIcon,
-    href: "/docs/tooling"
-  },
+    title: "Ecosystem",
+    links: [
+      {
+        title: "Network Stats",
+        description: "Live metrics",
+        icon: ActivityIcon,
+        href: "/stats/overview"
+      },
+      {
+        title: "Integrations",
+        description: "Oracles, indexers, tools",
+        icon: PackageIcon,
+        href: "/integrations"
+      },
+      {
+        title: "ACPs",
+        description: "Community proposals",
+        icon: GitBranch,
+        href: "/docs/acps"
+      },
+    ]
+  }
 ];
 
 export default function QuickLinks() {
   return (
-    <div className="flex flex-col px-4 mb-20">
-      <div className="flex items-center gap-3 mb-6 mx-auto max-w-7xl w-full">
-        <h2 className="text-sm font-medium tracking-wider text-zinc-500 dark:text-zinc-400 uppercase">
-          Quick Links
-        </h2>
-      </div>
-      
-      <div className="mx-auto font-geist relative max-w-7xl w-full">
-        <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-3">
-          {quickLinks.map((link, index) => (
-            <Link
-              key={link.id}
-              href={link.href}
-              className={cn(
-                "group block p-4 rounded-lg transition-all duration-150",
-                "bg-zinc-50/50 dark:bg-zinc-900/50",
-                "border border-zinc-200/50 dark:border-zinc-800/50",
-                "hover:bg-zinc-100/50 dark:hover:bg-zinc-800/50",
-                "hover:border-zinc-300/50 dark:hover:border-zinc-700/50"
-              )}
-            >
-              <div className="h-full min-h-[100px] flex flex-col">
-                {/* Icon */}
-                <div className="mb-3">
-                  <link.icon className="w-5 h-5 text-zinc-600 dark:text-zinc-400" />
-                </div>
-                
-                {/* Content */}
-                <div className="flex-1">
-                  <h3 className="text-base font-medium mb-1 text-zinc-900 dark:text-zinc-100">
-                    {link.title}
-                  </h3>
-                  
-                  <p className="text-xs text-zinc-500 dark:text-zinc-500 leading-snug">
-                    {link.description}
-                  </p>
-                </div>
-                
-                {/* Arrow */}
-                <div className="mt-3 flex justify-end">
-                  <ArrowRight className="w-3.5 h-3.5 text-zinc-300 dark:text-zinc-600 group-hover:text-zinc-500 dark:group-hover:text-zinc-500 transition-colors" />
-                </div>
-              </div>
-            </Link>
-          ))}
-        </div>
+    <div className="px-4 mb-20">
+      <div className="mx-auto max-w-7xl space-y-10">
+        {sections.map((section) => (
+          <div key={section.title}>
+            <h2 className="text-sm font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-4">
+              {section.title}
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+              {section.links.map((link) => (
+                <Link
+                  key={link.title}
+                  href={link.href}
+                  className={cn(
+                    "group flex items-start gap-3 p-4 rounded-lg",
+                    "bg-zinc-50/50 dark:bg-zinc-900/50",
+                    "border border-zinc-200/50 dark:border-zinc-800/50",
+                    "hover:bg-zinc-100/50 dark:hover:bg-zinc-800/50",
+                    "hover:border-zinc-300/50 dark:hover:border-zinc-700/50",
+                    "transition-colors"
+                  )}
+                >
+                  <link.icon className="w-5 h-5 text-zinc-400 dark:text-zinc-500 mt-0.5 shrink-0" />
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                      {link.title}
+                    </div>
+                    <div className="text-xs text-zinc-500 dark:text-zinc-500">
+                      {link.description}
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Added random rotating taglines (22 variations) that change on each page load, Minecraft splash style
- Reorganized quick links into logical sections: Get Started, Build, Ecosystem
- Cleaned up visual styling - removed clutter, kept it minimal

## Tagline Categories
- **Journey**: "From your first contract to your own blockchain", etc.
- **Choice/Flexibility**: "Deploy a contract or deploy a blockchain", etc.
- **Speed/Performance**: "Sub-second finality. No compromises.", etc.
- **Builder Attitude**: "Why rent blockspace when you can own the block?", etc.
- **Cheeky**: "Launch a chain before lunch.", etc.

## Test Plan
- [x] Refresh homepage multiple times to see different taglines
- [x] Verify quick links are grouped correctly
- [x] Check mobile responsiveness