### PR TITLE
Update C-Chain block time reference from 2s to 1s

### DIFF
--- a/content/academy/avalanche-l1/customizing-evm/05-genesis-configuration/05-gas-fee-configuration.mdx
+++ b/content/academy/avalanche-l1/customizing-evm/05-genesis-configuration/05-gas-fee-configuration.mdx
@@ -46,7 +46,7 @@ You might notice that the `gasLimit` field appears twice. This is because Avalan
 
 ### `targetBlockRate`
 
-Specifies the target rate of block production in seconds. For instance, a target of 2 aims to produce a block every 2 seconds. If blocks are produced faster than this rate, it signals that more blocks are being issued to the network than anticipated, leading to an increase in base fees. For C-Chain, this value is set to 2.
+Specifies the target rate of block production in seconds. For instance, a target of 2 aims to produce a block every 2 seconds. If blocks are produced faster than this rate, it signals that more blocks are being issued to the network than anticipated, leading to an increase in base fees. For C-Chain, this value is set to 1.
 
 ### `minBaseFee`
 


### PR DESCRIPTION
## Summary

- Updates C-Chain `targetBlockRate` reference from 2 to 1 in the academy gas fee configuration documentation
- The C-Chain block time has been reduced to 1 second as of today

## Changes

- `content/academy/avalanche-l1/customizing-evm/05-genesis-configuration/05-gas-fee-configuration.mdx`: Changed "For C-Chain, this value is set to 2" → "For C-Chain, this value is set to 1"

## Notes

- The ACP-226 file (`content/docs/acps/226-dynamic-minimum-block-times.mdx`) also references 2 seconds but is auto-generated and listed in `.gitignore` - the source of truth is in the [ACPs repository](https://github.com/avalanche-foundation/ACPs)
- Example JSON configs in other files still show `"targetBlockRate": 2` which is correct since L1s/subnets are independent and use 2s as the default template
- The cortina blog post already has an inline note explaining the change

## Test plan

- [x] Verify the academy page renders correctly
- [x] Confirm no other C-Chain block time references were missed