### PR TITLE
feat(console): improve fee config UX and restore performance monitor

### DIFF
--- a/app/console/layer-1/performance-monitor/page.tsx
+++ b/app/console/layer-1/performance-monitor/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import PerformanceMonitor from "@/components/toolbox/console/layer-1/PerformanceMonitor/PerformanceMonitor";
+
+export default function PerformanceMonitorPage() {
+    return <PerformanceMonitor />;
+}

--- a/components/console/console-sidebar.tsx
+++ b/components/console/console-sidebar.tsx
@@ -31,7 +31,8 @@ import {
   HandCoins,
   ExternalLink,
   BookKey,
-  ShieldOff
+  ShieldOff,
+  Activity
 } from "lucide-react";
 
 import {
@@ -128,6 +129,11 @@ const data = {
           title: "Explorer Setup",
           url: "/console/layer-1/explorer-setup",
           icon: Telescope,
+        },
+        {
+          title: "Performance Monitor",
+          url: "/console/layer-1/performance-monitor",
+          icon: Activity,
         },
       ],
     },

--- a/components/toolbox/components/genesis/FeeConfig.tsx
+++ b/components/toolbox/components/genesis/FeeConfig.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { RawInput } from "../Input";
-import { Info } from "lucide-react";
+import { Info, Zap, Building2, Settings2, HelpCircle } from "lucide-react";
 import { ValidationMessages } from "./types";
 import { useGenesisHighlight } from "./GenesisHighlightContext";
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 // Helper function to convert gwei to wei
 const gweiToWei = (gwei: number): number => gwei * 1000000000;
@@ -20,15 +21,120 @@ type FeeConfigType = {
 type FeeConfigProps = {
   gasLimit: number;
   setGasLimit: (value: number) => void;
-  targetBlockRate: number;
+  targetBlockRate: number; // Still needed for static pricing calculation, but not editable here
   setTargetBlockRate: (value: number) => void;
-  feeConfig: FeeConfigType; // Receive the current detailed fee config
-  onFeeConfigChange: (config: FeeConfigType) => void; // Callback to update detailed fee config in parent
+  feeConfig: FeeConfigType;
+  onFeeConfigChange: (config: FeeConfigType) => void;
   validationMessages: ValidationMessages;
   compact?: boolean;
 };
 
-// Field component defined outside to prevent recreation on each render
+// Preset configurations
+type PresetType = 'testnet' | 'mainnet' | 'custom';
+
+const PRESETS = {
+  testnet: {
+    name: 'Testnet (Fast & Cheap)',
+    description: 'Optimized for development and testing. Low fees, high throughput, static pricing.',
+    icon: Zap,
+    gasLimit: 100000000,        // 100M - high throughput
+    feeConfig: {
+      baseFeeChangeDenominator: 48,
+      blockGasCostStep: 0,       // Disable dynamic fees
+      maxBlockGasCost: 0,        // Disable dynamic fees
+      minBaseFee: 1000000000,    // 1 gwei - cheap
+      minBlockGasCost: 0,
+      targetGas: 100000000       // Match gas limit for static pricing
+    }
+  },
+  mainnet: {
+    name: 'Mainnet (Production)',
+    description: 'Balanced for production use. Standard fees with congestion protection.',
+    icon: Building2,
+    gasLimit: 15000000,         // 15M - standard
+    feeConfig: {
+      baseFeeChangeDenominator: 48,
+      blockGasCostStep: 200000,
+      maxBlockGasCost: 1000000,
+      minBaseFee: 25000000000,   // 25 gwei
+      minBlockGasCost: 0,
+      targetGas: 15000000
+    }
+  }
+};
+
+// Field descriptions for tooltips
+const FIELD_DESCRIPTIONS = {
+  preset: {
+    title: 'Configuration Preset',
+    description: 'Choose a preset optimized for your use case, or customize each parameter manually.',
+  },
+  gasLimit: {
+    title: 'Gas Limit',
+    description: 'Maximum gas allowed per block. Higher values allow more transactions per block but require more validator resources.',
+    recommendation: 'Testnet: 100M for high throughput. Mainnet: 15-30M for balanced performance.',
+    unit: 'gas units'
+  },
+  minBaseFee: {
+    title: 'Minimum Base Fee',
+    description: 'The lowest possible transaction fee. This is the floor that fees cannot go below, even during low network activity.',
+    recommendation: 'Testnet: 1 gwei (cheap). Mainnet: 25+ gwei (spam protection).',
+    unit: 'gwei'
+  },
+  baseFeeChangeDenominator: {
+    title: 'Base Fee Change Denominator',
+    description: 'Controls how quickly fees adjust to congestion. Lower values = faster fee changes. The fee can change by at most 1/denominator per block.',
+    recommendation: '48 is standard. Lower (8-24) for more reactive fees, higher (100+) for stability.',
+    unit: 'denominator'
+  },
+  targetGas: {
+    title: 'Target Gas (per 10s)',
+    description: 'Target gas consumption over a 10-second window. When actual usage exceeds this, fees increase. Set higher than (gasLimit × 10 ÷ blockRate) for static pricing.',
+    recommendation: 'For static fees: set to gasLimit or higher. For dynamic fees: set to 50-100% of gasLimit.',
+    unit: 'gas units'
+  },
+  minBlockGasCost: {
+    title: 'Min Block Gas Cost',
+    description: 'Minimum additional gas cost added to each block. Part of the dynamic fee mechanism that adjusts based on block fullness.',
+    recommendation: 'Usually 0. Only increase if you need a minimum fee floor that rises with usage.',
+    unit: 'gas units'
+  },
+  maxBlockGasCost: {
+    title: 'Max Block Gas Cost',
+    description: 'Maximum additional gas cost per block. Caps how high dynamic fees can go. Set to 0 to disable dynamic fee adjustments.',
+    recommendation: 'Testnet: 0 (disabled). Mainnet: 1M for moderate fee ceiling.',
+    unit: 'gas units'
+  },
+  blockGasCostStep: {
+    title: 'Block Gas Cost Step',
+    description: 'How much the block gas cost changes per block based on fullness. Set to 0 to disable dynamic fee adjustments entirely.',
+    recommendation: 'Testnet: 0 (static fees). Mainnet: 200K for gradual adjustments.',
+    unit: 'gas units per block'
+  }
+};
+
+// Tooltip component for field labels
+const FieldTooltip = ({ field }: { field: keyof typeof FIELD_DESCRIPTIONS }) => {
+  const info = FIELD_DESCRIPTIONS[field];
+  return (
+    <Tooltip>
+      <TooltipTrigger className="inline-flex ml-1">
+        <HelpCircle className="h-3.5 w-3.5 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300" />
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">
+        <div className="space-y-2">
+          <p className="font-medium text-xs">{info.title}</p>
+          <p className="text-xs text-zinc-300">{info.description}</p>
+          {'recommendation' in info && (
+            <p className="text-xs text-blue-300">💡 {info.recommendation}</p>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+// Field component with integrated tooltip
 const Field = ({
   id,
   label,
@@ -40,6 +146,8 @@ const Field = ({
   warning,
   onFocus,
   onBlur,
+  tooltipField,
+  suffix,
 }: {
   id?: string;
   label: string;
@@ -51,27 +159,131 @@ const Field = ({
   warning?: string;
   onFocus?: () => void;
   onBlur?: () => void;
+  tooltipField?: keyof typeof FIELD_DESCRIPTIONS;
+  suffix?: string;
 }) => (
   <div className="space-y-1 text-[13px]">
-    <label className="block text-sm font-medium text-zinc-800 dark:text-zinc-200" htmlFor={id}>{label}</label>
-    <RawInput
-      id={id}
-      type="text"
-      value={value}
-      onChange={(e) => onChange((e.target as HTMLInputElement).value)}
-      onMouseDown={(e) => e.stopPropagation()}
-      onClick={(e) => e.stopPropagation()}
-      onPointerDownCapture={(e) => e.stopPropagation()}
-      onFocus={onFocus}
-      onBlur={onBlur}
-      placeholder={placeholder}
-      className="py-2 text-[14px]"
-      inputMode={type === "text" ? "decimal" : "numeric"}
-      autoComplete="off"
-    />
+    <label className="flex items-center text-sm font-medium text-zinc-800 dark:text-zinc-200" htmlFor={id}>
+      {label}
+      {tooltipField && <FieldTooltip field={tooltipField} />}
+    </label>
+    <div className="relative">
+      <RawInput
+        id={id}
+        type="text"
+        value={value}
+        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+        onPointerDownCapture={(e) => e.stopPropagation()}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        className={`py-2 text-[14px] ${suffix ? 'pr-16' : ''}`}
+        inputMode={type === "text" ? "decimal" : "numeric"}
+        autoComplete="off"
+      />
+      {suffix && (
+        <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-zinc-400 pointer-events-none">
+          {suffix}
+        </span>
+      )}
+    </div>
     <div className="min-h-[16px]">
-    {error && <div className="text-xs text-red-500">{error}</div>}
-    {!error && warning && <div className="text-xs text-amber-500">⚠️ {warning}</div>}
+      {error && <div className="text-xs text-red-500">{error}</div>}
+      {!error && warning && <div className="text-xs text-amber-500">⚠️ {warning}</div>}
+    </div>
+  </div>
+);
+
+// Preset selector component
+const PresetSelector = ({
+  selected,
+  onSelect
+}: {
+  selected: PresetType;
+  onSelect: (preset: PresetType) => void;
+}) => (
+  <div className="space-y-2">
+    <div className="flex items-center gap-1">
+      <span className="text-sm font-medium text-zinc-800 dark:text-zinc-200">Configuration Preset</span>
+      <FieldTooltip field="preset" />
+    </div>
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+      {/* Testnet Preset */}
+      <button
+        type="button"
+        onClick={() => onSelect('testnet')}
+        className={`flex items-start gap-3 p-3 rounded-lg border-2 transition-all text-left ${
+          selected === 'testnet'
+            ? 'border-green-500 bg-green-50 dark:bg-green-950/30'
+            : 'border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600'
+        }`}
+      >
+        <Zap className={`h-5 w-5 mt-0.5 flex-shrink-0 ${
+          selected === 'testnet' ? 'text-green-600 dark:text-green-400' : 'text-zinc-400'
+        }`} />
+        <div className="min-w-0">
+          <div className={`font-medium text-sm ${
+            selected === 'testnet' ? 'text-green-700 dark:text-green-300' : 'text-zinc-700 dark:text-zinc-300'
+          }`}>
+            Testnet
+          </div>
+          <div className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
+            Low fees, high throughput
+          </div>
+        </div>
+      </button>
+
+      {/* Mainnet Preset */}
+      <button
+        type="button"
+        onClick={() => onSelect('mainnet')}
+        className={`flex items-start gap-3 p-3 rounded-lg border-2 transition-all text-left ${
+          selected === 'mainnet'
+            ? 'border-blue-500 bg-blue-50 dark:bg-blue-950/30'
+            : 'border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600'
+        }`}
+      >
+        <Building2 className={`h-5 w-5 mt-0.5 flex-shrink-0 ${
+          selected === 'mainnet' ? 'text-blue-600 dark:text-blue-400' : 'text-zinc-400'
+        }`} />
+        <div className="min-w-0">
+          <div className={`font-medium text-sm ${
+            selected === 'mainnet' ? 'text-blue-700 dark:text-blue-300' : 'text-zinc-700 dark:text-zinc-300'
+          }`}>
+            Mainnet
+          </div>
+          <div className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
+            Production-ready defaults
+          </div>
+        </div>
+      </button>
+
+      {/* Custom Preset */}
+      <button
+        type="button"
+        onClick={() => onSelect('custom')}
+        className={`flex items-start gap-3 p-3 rounded-lg border-2 transition-all text-left ${
+          selected === 'custom'
+            ? 'border-purple-500 bg-purple-50 dark:bg-purple-950/30'
+            : 'border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600'
+        }`}
+      >
+        <Settings2 className={`h-5 w-5 mt-0.5 flex-shrink-0 ${
+          selected === 'custom' ? 'text-purple-600 dark:text-purple-400' : 'text-zinc-400'
+        }`} />
+        <div className="min-w-0">
+          <div className={`font-medium text-sm ${
+            selected === 'custom' ? 'text-purple-700 dark:text-purple-300' : 'text-zinc-700 dark:text-zinc-300'
+          }`}>
+            Custom
+          </div>
+          <div className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
+            Fine-tune all parameters
+          </div>
+        </div>
+      </button>
     </div>
   </div>
 );
@@ -79,7 +291,7 @@ const Field = ({
 function FeeConfigBase({
   gasLimit,
   setGasLimit,
-  targetBlockRate,
+  targetBlockRate, // Used for static pricing calculation only
   feeConfig,
   onFeeConfigChange,
   validationMessages,
@@ -88,6 +300,8 @@ function FeeConfigBase({
   const { setHighlightPath } = useGenesisHighlight();
 
   const [focusedField, setFocusedField] = useState<string | null>(null);
+  const [selectedPreset, setSelectedPreset] = useState<PresetType>('testnet');
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const handleFocus = (path: string) => {
     setHighlightPath(path);
@@ -103,7 +317,48 @@ function FeeConfigBase({
   const [blockGasCostStepInput, setBlockGasCostStepInput] = useState(feeConfig.blockGasCostStep.toString());
   const [targetGasInput, setTargetGasInput] = useState(feeConfig.targetGas.toString());
 
-  // Sync local strings from props when not actively editing the field
+  // Detect current preset based on values
+  useEffect(() => {
+    const isTestnet =
+      gasLimit === PRESETS.testnet.gasLimit &&
+      feeConfig.minBaseFee === PRESETS.testnet.feeConfig.minBaseFee &&
+      feeConfig.maxBlockGasCost === PRESETS.testnet.feeConfig.maxBlockGasCost;
+
+    const isMainnet =
+      gasLimit === PRESETS.mainnet.gasLimit &&
+      feeConfig.minBaseFee === PRESETS.mainnet.feeConfig.minBaseFee &&
+      feeConfig.maxBlockGasCost === PRESETS.mainnet.feeConfig.maxBlockGasCost;
+
+    if (isTestnet) {
+      setSelectedPreset('testnet');
+    } else if (isMainnet) {
+      setSelectedPreset('mainnet');
+    } else {
+      setSelectedPreset('custom');
+    }
+  }, [gasLimit, feeConfig]);
+
+  // Handle preset selection
+  const handlePresetSelect = useCallback((preset: PresetType) => {
+    setSelectedPreset(preset);
+
+    if (preset === 'testnet' || preset === 'mainnet') {
+      const presetConfig = PRESETS[preset];
+      setGasLimit(presetConfig.gasLimit);
+      onFeeConfigChange(presetConfig.feeConfig);
+
+      // Update local inputs
+      setGasLimitInput(presetConfig.gasLimit.toString());
+      setMinBaseFeeInput((presetConfig.feeConfig.minBaseFee / 1000000000).toString());
+      setBaseFeeChangeDenominatorInput(presetConfig.feeConfig.baseFeeChangeDenominator.toString());
+      setMinBlockGasCostInput(presetConfig.feeConfig.minBlockGasCost.toString());
+      setMaxBlockGasCostInput(presetConfig.feeConfig.maxBlockGasCost.toString());
+      setBlockGasCostStepInput(presetConfig.feeConfig.blockGasCostStep.toString());
+      setTargetGasInput(presetConfig.feeConfig.targetGas.toString());
+    }
+  }, [setGasLimit, onFeeConfigChange]);
+
+  // Sync local strings from props when not actively editing
   useEffect(() => {
     if (focusedField !== 'gasLimit') setGasLimitInput(gasLimit.toString());
   }, [gasLimit, focusedField]);
@@ -126,7 +381,7 @@ function FeeConfigBase({
     if (focusedField !== 'targetGas') setTargetGasInput(feeConfig.targetGas.toString());
   }, [feeConfig.targetGas, focusedField]);
 
-  // Change handlers: update local immediately and parent when valid number
+  // Change handlers
   const handleGasLimitChange = useCallback((value: string) => {
     setGasLimitInput(value);
     const parsed = parseInt(value);
@@ -143,7 +398,7 @@ function FeeConfigBase({
     }
   }, [feeConfig, onFeeConfigChange]);
 
-  const handleFeeConfigNumberChange = useCallback((key: keyof FeeConfigType, value: string, min: number = 0) => {
+  const handleFeeConfigNumberChange = useCallback((key: keyof FeeConfigType, value: string) => {
     const setLocal = (v: string) => {
       switch (key) {
         case 'baseFeeChangeDenominator': setBaseFeeChangeDenominatorInput(v); break;
@@ -160,7 +415,7 @@ function FeeConfigBase({
     }
   }, [feeConfig, onFeeConfigChange]);
 
-  // Blur handlers: normalize empty/invalid to current committed value
+  // Blur handlers
   const normalizeOnBlur = useCallback((field: string) => {
     switch (field) {
       case 'gasLimit': {
@@ -202,125 +457,210 @@ function FeeConfigBase({
     setFocusedField(null);
   }, [gasLimitInput, gasLimit, minBaseFeeInput, feeConfig, baseFeeChangeDenominatorInput, minBlockGasCostInput, maxBlockGasCostInput, blockGasCostStepInput, targetGasInput]);
 
+  // Calculate static gas pricing threshold (uses targetBlockRate from validator config, default 2s)
+  const staticGasThreshold = Math.ceil((gasLimit * 10) / targetBlockRate);
+  const isStaticPricing = feeConfig.targetGas >= staticGasThreshold;
+
+  // Format large numbers for display
+  const formatNumber = (num: number) => {
+    if (num >= 1000000) return `${(num / 1000000).toFixed(0)}M`;
+    if (num >= 1000) return `${(num / 1000).toFixed(0)}K`;
+    return num.toString();
+  };
+
   return (
     <div className="space-y-6">
-      {/* Advanced Mode with All Fields */}
-        <div className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 rounded-md p-3">
-          <h4 className="text-[13px] font-medium mb-2">Fee Configuration</h4>
-          <div className={`grid grid-cols-1 md:grid-cols-2 ${compact ? 'gap-3' : 'gap-4'}`}>
-          <div key="gasLimit">
-            <Field
-              id="gasLimit"
-              label="Gas Limit"
-              value={gasLimitInput}
-              onChange={handleGasLimitChange}
-              onFocus={() => handleFocus('gasLimit')}
-              onBlur={() => normalizeOnBlur('gasLimit')}
-              placeholder="15000000"
-              error={validationMessages.errors.gasLimit}
-              warning={validationMessages.warnings.gasLimit}
-            />
-          </div>
-          <div key="minBaseFee">
-            <Field
-              id="minBaseFee"
-              label="Min Base Fee (gwei)"
-              value={minBaseFeeInput}
-              onChange={handleMinBaseFeeChange}
-              onFocus={() => handleFocus('minBaseFee')}
-              onBlur={() => normalizeOnBlur('minBaseFee')}
-              placeholder="25"
-              type="text"
-              error={validationMessages.errors.minBaseFee}
-              warning={validationMessages.warnings.minBaseFee}
-            />
-          </div>
-          <div key="baseFeeChangeDenominator">
-            <Field
-              id="baseFeeChangeDenominator"
-              label="Base Fee Change Denominator"
-              value={baseFeeChangeDenominatorInput}
-              onChange={(v) => handleFeeConfigNumberChange('baseFeeChangeDenominator', v, 2)}
-              onFocus={() => handleFocus('baseFeeChangeDenominator')}
-              onBlur={() => normalizeOnBlur('baseFeeChangeDenominator')}
-              placeholder="48"
-              error={validationMessages.errors.baseFeeChangeDenominator}
-              warning={validationMessages.warnings.baseFeeChangeDenominator}
-            />
-          </div>
-          <div key="minBlockGasCost">
-            <Field
-              id="minBlockGasCost"
-              label="Min Block Gas Cost"
-              value={minBlockGasCostInput}
-              onChange={(v) => handleFeeConfigNumberChange('minBlockGasCost', v, 0)}
-              onFocus={() => handleFocus('minBlockGasCost')}
-              onBlur={() => normalizeOnBlur('minBlockGasCost')}
-              placeholder="0"
-              error={validationMessages.errors.minBlockGasCost}
-              warning={validationMessages.warnings.minBlockGasCost}
-            />
-          </div>
-          <div key="maxBlockGasCost">
-            <Field
-              id="maxBlockGasCost"
-              label="Max Block Gas Cost"
-              value={maxBlockGasCostInput}
-              onChange={(v) => handleFeeConfigNumberChange('maxBlockGasCost', v, feeConfig.minBlockGasCost)}
-              onFocus={() => handleFocus('maxBlockGasCost')}
-              onBlur={() => normalizeOnBlur('maxBlockGasCost')}
-              placeholder="1000000"
-              error={validationMessages.errors.maxBlockGasCost}
-              warning={validationMessages.warnings.maxBlockGasCost}
-            />
-          </div>
-          <div key="blockGasCostStep">
-            <Field
-              id="blockGasCostStep"
-              label="Block Gas Cost Step"
-              value={blockGasCostStepInput}
-              onChange={(v) => handleFeeConfigNumberChange('blockGasCostStep', v, 0)}
-              onFocus={() => handleFocus('blockGasCostStep')}
-              onBlur={() => normalizeOnBlur('blockGasCostStep')}
-              placeholder="200000"
-              error={validationMessages.errors.blockGasCostStep}
-              warning={validationMessages.warnings.blockGasCostStep}
-            />
-          </div>
-          <div key="targetGas">
-            <Field
-              id="targetGas"
-              label="Target Gas (per 10s window)"
-              value={targetGasInput}
-              onChange={(v) => handleFeeConfigNumberChange('targetGas', v, 100000)}
-              onFocus={() => handleFocus('targetGas')}
-              onBlur={() => normalizeOnBlur('targetGas')}
-              placeholder="15000000"
-              error={validationMessages.errors.targetGas}
-              warning={validationMessages.warnings.targetGas}
-            />
-          </div>
-        </div>
+      {/* Preset Selector */}
+      <PresetSelector selected={selectedPreset} onSelect={handlePresetSelect} />
 
-      {/* Static Gas Price Info */}
-        <div className="bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800/50 rounded-md p-3 mt-3">
-          <div className="flex gap-2">
-            <Info className="h-4 w-4 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
-            <div className="text-xs space-y-1">
-              <div className="font-medium text-blue-900 dark:text-blue-100">Tip: Static Gas Price</div>
-              <div className="text-blue-800 dark:text-blue-200">
-                For static gas pricing (no congestion-based adjustments), set Target Gas &gt; (Gas Limit × 10 ÷ Block Time).
-                Current threshold: &gt;{Math.ceil((gasLimit * 10) / targetBlockRate)} gas (~{Math.ceil((gasLimit * 10) / targetBlockRate / 1000000)}M).
-                Useful for permissioned chains where congestion pricing isn't needed.
+      {/* Preset Description */}
+      {selectedPreset !== 'custom' && (
+        <div className={`rounded-lg p-4 ${
+          selectedPreset === 'testnet'
+            ? 'bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800/50'
+            : 'bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/50'
+        }`}>
+          <div className="flex items-start gap-3">
+            {selectedPreset === 'testnet' ? (
+              <Zap className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" />
+            ) : (
+              <Building2 className="h-5 w-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
+            )}
+            <div className="space-y-2">
+              <div className={`font-medium text-sm ${
+                selectedPreset === 'testnet' ? 'text-green-800 dark:text-green-200' : 'text-blue-800 dark:text-blue-200'
+              }`}>
+                {PRESETS[selectedPreset].name}
+              </div>
+              <div className={`text-xs ${
+                selectedPreset === 'testnet' ? 'text-green-700 dark:text-green-300' : 'text-blue-700 dark:text-blue-300'
+              }`}>
+                {PRESETS[selectedPreset].description}
+              </div>
+              <div className={`text-xs space-y-1 pt-1 ${
+                selectedPreset === 'testnet' ? 'text-green-600 dark:text-green-400' : 'text-blue-600 dark:text-blue-400'
+              }`}>
+                <div>• Gas limit: <strong>{formatNumber(PRESETS[selectedPreset].gasLimit)}</strong></div>
+                <div>• Min fee: <strong>{PRESETS[selectedPreset].feeConfig.minBaseFee / 1000000000} gwei</strong></div>
+                <div>• Fee model: <strong>{PRESETS[selectedPreset].feeConfig.maxBlockGasCost === 0 ? 'Static (consistent)' : 'Dynamic (congestion-based)'}</strong></div>
               </div>
             </div>
           </div>
         </div>
+      )}
+
+      {/* Core Parameters - Always visible */}
+      <div className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 rounded-lg p-4">
+        <h4 className="text-sm font-medium mb-4 text-zinc-800 dark:text-zinc-200">
+          Core Parameters
+        </h4>
+        <div className={`grid grid-cols-1 md:grid-cols-2 ${compact ? 'gap-3' : 'gap-4'}`}>
+          <Field
+            id="gasLimit"
+            label="Gas Limit per Block"
+            value={gasLimitInput}
+            onChange={handleGasLimitChange}
+            onFocus={() => handleFocus('gasLimit')}
+            onBlur={() => normalizeOnBlur('gasLimit')}
+            placeholder="15000000"
+            tooltipField="gasLimit"
+            suffix={formatNumber(parseInt(gasLimitInput) || 0)}
+            error={validationMessages.errors.gasLimit}
+            warning={validationMessages.warnings.gasLimit}
+          />
+          <Field
+            id="minBaseFee"
+            label="Minimum Transaction Fee"
+            value={minBaseFeeInput}
+            onChange={handleMinBaseFeeChange}
+            onFocus={() => handleFocus('minBaseFee')}
+            onBlur={() => normalizeOnBlur('minBaseFee')}
+            placeholder="1"
+            type="text"
+            tooltipField="minBaseFee"
+            suffix="gwei"
+            error={validationMessages.errors.minBaseFee}
+            warning={validationMessages.warnings.minBaseFee}
+          />
+          <Field
+            id="targetGas"
+            label="Target Gas (10s window)"
+            value={targetGasInput}
+            onChange={(v) => handleFeeConfigNumberChange('targetGas', v)}
+            onFocus={() => handleFocus('targetGas')}
+            onBlur={() => normalizeOnBlur('targetGas')}
+            placeholder="15000000"
+            tooltipField="targetGas"
+            suffix={formatNumber(parseInt(targetGasInput) || 0)}
+            error={validationMessages.errors.targetGas}
+            warning={validationMessages.warnings.targetGas}
+          />
+        </div>
       </div>
-      {/* Dynamic fee/reward sections removed; these are now configured under Precompiles. */}
+
+      {/* Pricing Model Indicator */}
+      <div className={`rounded-lg p-3 ${
+        isStaticPricing
+          ? 'bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800/50'
+          : 'bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800/50'
+      }`}>
+        <div className="flex gap-2">
+          <Info className={`h-4 w-4 flex-shrink-0 mt-0.5 ${
+            isStaticPricing ? 'text-green-600 dark:text-green-400' : 'text-amber-600 dark:text-amber-400'
+          }`} />
+          <div className="text-xs space-y-1">
+            <div className={`font-medium ${
+              isStaticPricing ? 'text-green-900 dark:text-green-100' : 'text-amber-900 dark:text-amber-100'
+            }`}>
+              {isStaticPricing ? '✓ Static Fee Pricing Active' : '⚡ Dynamic Fee Pricing Active'}
+            </div>
+            <div className={isStaticPricing ? 'text-green-800 dark:text-green-200' : 'text-amber-800 dark:text-amber-200'}>
+              {isStaticPricing
+                ? 'Transaction fees will remain constant regardless of network activity. Ideal for testnets and predictable costs.'
+                : `Fees will adjust based on network congestion. Target gas threshold: ${formatNumber(staticGasThreshold)}.`
+              }
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Advanced Settings Toggle */}
+      <button
+        type="button"
+        onClick={() => setShowAdvanced(!showAdvanced)}
+        className="flex items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-800 dark:hover:text-zinc-200 transition-colors"
+      >
+        <Settings2 className="h-4 w-4" />
+        {showAdvanced ? 'Hide' : 'Show'} Advanced Fee Settings
+        <span className={`transform transition-transform ${showAdvanced ? 'rotate-180' : ''}`}>
+          ▼
+        </span>
+      </button>
+
+      {/* Advanced Settings */}
+      {showAdvanced && (
+        <div className="bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg p-4 space-y-4">
+          <div className="flex items-center gap-2 text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            <Settings2 className="h-4 w-4" />
+            Dynamic Fee Adjustment Parameters
+          </div>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+            These parameters control how fees react to network congestion. Set all to 0 for completely static pricing.
+          </p>
+          <div className={`grid grid-cols-1 md:grid-cols-2 ${compact ? 'gap-3' : 'gap-4'}`}>
+            <Field
+              id="baseFeeChangeDenominator"
+              label="Fee Change Rate"
+              value={baseFeeChangeDenominatorInput}
+              onChange={(v) => handleFeeConfigNumberChange('baseFeeChangeDenominator', v)}
+              onFocus={() => handleFocus('baseFeeChangeDenominator')}
+              onBlur={() => normalizeOnBlur('baseFeeChangeDenominator')}
+              placeholder="48"
+              tooltipField="baseFeeChangeDenominator"
+              error={validationMessages.errors.baseFeeChangeDenominator}
+              warning={validationMessages.warnings.baseFeeChangeDenominator}
+            />
+            <Field
+              id="blockGasCostStep"
+              label="Block Gas Cost Step"
+              value={blockGasCostStepInput}
+              onChange={(v) => handleFeeConfigNumberChange('blockGasCostStep', v)}
+              onFocus={() => handleFocus('blockGasCostStep')}
+              onBlur={() => normalizeOnBlur('blockGasCostStep')}
+              placeholder="0"
+              tooltipField="blockGasCostStep"
+              error={validationMessages.errors.blockGasCostStep}
+              warning={validationMessages.warnings.blockGasCostStep}
+            />
+            <Field
+              id="minBlockGasCost"
+              label="Min Block Gas Cost"
+              value={minBlockGasCostInput}
+              onChange={(v) => handleFeeConfigNumberChange('minBlockGasCost', v)}
+              onFocus={() => handleFocus('minBlockGasCost')}
+              onBlur={() => normalizeOnBlur('minBlockGasCost')}
+              placeholder="0"
+              tooltipField="minBlockGasCost"
+              error={validationMessages.errors.minBlockGasCost}
+              warning={validationMessages.warnings.minBlockGasCost}
+            />
+            <Field
+              id="maxBlockGasCost"
+              label="Max Block Gas Cost"
+              value={maxBlockGasCostInput}
+              onChange={(v) => handleFeeConfigNumberChange('maxBlockGasCost', v)}
+              onFocus={() => handleFocus('maxBlockGasCost')}
+              onBlur={() => normalizeOnBlur('maxBlockGasCost')}
+              placeholder="0"
+              tooltipField="maxBlockGasCost"
+              error={validationMessages.errors.maxBlockGasCost}
+              warning={validationMessages.warnings.maxBlockGasCost}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }
 
-// Export the component directly
 export default FeeConfigBase;

--- a/components/toolbox/components/genesis/GenesisWizard.tsx
+++ b/components/toolbox/components/genesis/GenesisWizard.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect, ReactNode } from "react";
+import { useState, useEffect, ReactNode, useCallback } from "react";
 import { JsonPreviewPanel } from "./JsonPreviewPanel";
 import { GenesisHighlightProvider, useGenesisHighlight } from "./GenesisHighlightContext";
-import { SyntaxHighlightedJSON } from "./SyntaxHighlightedJSON";
+import { Settings2, FileJson, Upload, AlertCircle, CheckCircle2, Copy, Download } from "lucide-react";
 
 interface GenesisWizardProps {
     children: ReactNode;
@@ -14,13 +14,370 @@ interface GenesisWizardProps {
     embedded?: boolean;
 }
 
+type GenesisMode = 'builder' | 'custom';
+
+// Mode toggle component
+function ModeToggle({
+    mode,
+    onModeChange
+}: {
+    mode: GenesisMode;
+    onModeChange: (mode: GenesisMode) => void;
+}) {
+    return (
+        <div className="flex items-center gap-2 p-1 bg-zinc-100 dark:bg-zinc-800 rounded-lg">
+            <button
+                type="button"
+                onClick={() => onModeChange('builder')}
+                className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-all ${
+                    mode === 'builder'
+                        ? 'bg-white dark:bg-zinc-700 text-zinc-900 dark:text-zinc-100 shadow-sm'
+                        : 'text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200'
+                }`}
+            >
+                <Settings2 className="h-4 w-4" />
+                Builder
+            </button>
+            <button
+                type="button"
+                onClick={() => onModeChange('custom')}
+                className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-all ${
+                    mode === 'custom'
+                        ? 'bg-white dark:bg-zinc-700 text-zinc-900 dark:text-zinc-100 shadow-sm'
+                        : 'text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200'
+                }`}
+            >
+                <FileJson className="h-4 w-4" />
+                Custom JSON
+            </button>
+        </div>
+    );
+}
+
+// JSON validation result
+interface JsonValidation {
+    valid: boolean;
+    error?: string;
+    size: number;
+    hasRequiredFields: boolean;
+    missingFields: string[];
+}
+
+function validateGenesisJson(json: string): JsonValidation {
+    const result: JsonValidation = {
+        valid: false,
+        size: new Blob([json]).size,
+        hasRequiredFields: false,
+        missingFields: []
+    };
+
+    if (!json || json.trim() === '') {
+        result.error = 'Genesis JSON is required';
+        return result;
+    }
+
+    try {
+        const parsed = JSON.parse(json);
+        result.valid = true;
+
+        // Check for common required fields in Subnet-EVM genesis
+        const requiredFields = ['config', 'alloc', 'gasLimit'];
+        const recommendedFields = ['chainId', 'timestamp'];
+
+        for (const field of requiredFields) {
+            if (!(field in parsed) && !('config' in parsed && field in parsed.config)) {
+                result.missingFields.push(field);
+            }
+        }
+
+        // Check config sub-fields
+        if (parsed.config) {
+            if (!parsed.config.chainId) {
+                result.missingFields.push('config.chainId');
+            }
+            if (!parsed.config.feeConfig) {
+                result.missingFields.push('config.feeConfig');
+            }
+        }
+
+        result.hasRequiredFields = result.missingFields.length === 0;
+
+    } catch (e) {
+        result.valid = false;
+        result.error = (e as Error).message;
+    }
+
+    return result;
+}
+
+// Custom JSON Editor component
+function CustomJsonEditor({
+    value,
+    onChange,
+    validation
+}: {
+    value: string;
+    onChange: (value: string) => void;
+    validation: JsonValidation;
+}) {
+    const [isDragging, setIsDragging] = useState(false);
+    const [copied, setCopied] = useState(false);
+
+    const handleDrop = useCallback((e: React.DragEvent) => {
+        e.preventDefault();
+        setIsDragging(false);
+
+        const file = e.dataTransfer.files[0];
+        if (file && file.type === 'application/json') {
+            const reader = new FileReader();
+            reader.onload = (event) => {
+                const content = event.target?.result as string;
+                onChange(content);
+            };
+            reader.readAsText(file);
+        }
+    }, [onChange]);
+
+    const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = (event) => {
+                const content = event.target?.result as string;
+                onChange(content);
+            };
+            reader.readAsText(file);
+        }
+    }, [onChange]);
+
+    const handleCopy = useCallback(() => {
+        navigator.clipboard.writeText(value);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    }, [value]);
+
+    const handleDownload = useCallback(() => {
+        const blob = new Blob([value], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'genesis.json';
+        a.click();
+        URL.revokeObjectURL(url);
+    }, [value]);
+
+    const handleFormat = useCallback(() => {
+        try {
+            const parsed = JSON.parse(value);
+            onChange(JSON.stringify(parsed, null, 2));
+        } catch {
+            // Can't format invalid JSON
+        }
+    }, [value, onChange]);
+
+    return (
+        <div className="space-y-4">
+            {/* Info banner */}
+            <div className="bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800/50 rounded-lg p-4">
+                <div className="flex items-start gap-3">
+                    <FileJson className="h-5 w-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
+                    <div className="space-y-1">
+                        <div className="font-medium text-sm text-blue-800 dark:text-blue-200">
+                            Custom Genesis JSON
+                        </div>
+                        <div className="text-xs text-blue-700 dark:text-blue-300">
+                            Paste your pre-configured genesis JSON or drag & drop a genesis.json file.
+                            This is useful for importing configurations from other tools or deploying
+                            previously saved genesis files.
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* Drop zone / File upload */}
+            <div
+                onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
+                onDragLeave={() => setIsDragging(false)}
+                onDrop={handleDrop}
+                className={`relative border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
+                    isDragging
+                        ? 'border-blue-500 bg-blue-50 dark:bg-blue-950/20'
+                        : 'border-zinc-300 dark:border-zinc-700 hover:border-zinc-400 dark:hover:border-zinc-600'
+                }`}
+            >
+                <input
+                    type="file"
+                    accept=".json,application/json"
+                    onChange={handleFileSelect}
+                    className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                />
+                <Upload className={`h-8 w-8 mx-auto mb-2 ${
+                    isDragging ? 'text-blue-500' : 'text-zinc-400'
+                }`} />
+                <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                    <span className="font-medium text-zinc-900 dark:text-zinc-200">Click to upload</span> or drag and drop
+                </p>
+                <p className="text-xs text-zinc-500 dark:text-zinc-500 mt-1">
+                    genesis.json file
+                </p>
+            </div>
+
+            {/* JSON Editor */}
+            <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                    <label className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                        Genesis JSON
+                    </label>
+                    <div className="flex items-center gap-2">
+                        {value && (
+                            <>
+                                <button
+                                    type="button"
+                                    onClick={handleFormat}
+                                    className="text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+                                    disabled={!validation.valid}
+                                >
+                                    Format
+                                </button>
+                                <span className="text-zinc-300 dark:text-zinc-600">|</span>
+                                <button
+                                    type="button"
+                                    onClick={handleCopy}
+                                    className="flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+                                >
+                                    <Copy className="h-3 w-3" />
+                                    {copied ? 'Copied!' : 'Copy'}
+                                </button>
+                                <span className="text-zinc-300 dark:text-zinc-600">|</span>
+                                <button
+                                    type="button"
+                                    onClick={handleDownload}
+                                    className="flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+                                >
+                                    <Download className="h-3 w-3" />
+                                    Download
+                                </button>
+                            </>
+                        )}
+                    </div>
+                </div>
+                <textarea
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    placeholder='{"config": {"chainId": 12345, "feeConfig": {...}}, "alloc": {...}, "gasLimit": "0x..."}'
+                    className={`w-full h-80 px-4 py-3 bg-zinc-900 dark:bg-zinc-950 text-zinc-100 rounded-lg border font-mono text-xs resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
+                        value && !validation.valid
+                            ? 'border-red-500'
+                            : value && validation.valid
+                            ? 'border-green-500'
+                            : 'border-zinc-700 dark:border-zinc-800'
+                    }`}
+                    spellCheck={false}
+                />
+            </div>
+
+            {/* Validation status */}
+            {value && (
+                <div className={`rounded-lg p-3 ${
+                    validation.valid
+                        ? validation.hasRequiredFields
+                            ? 'bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800/50'
+                            : 'bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800/50'
+                        : 'bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800/50'
+                }`}>
+                    <div className="flex items-start gap-2">
+                        {validation.valid ? (
+                            validation.hasRequiredFields ? (
+                                <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" />
+                            ) : (
+                                <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+                            )
+                        ) : (
+                            <AlertCircle className="h-4 w-4 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
+                        )}
+                        <div className="flex-1 space-y-1">
+                            {validation.valid ? (
+                                <>
+                                    <div className={`text-sm font-medium ${
+                                        validation.hasRequiredFields
+                                            ? 'text-green-800 dark:text-green-200'
+                                            : 'text-amber-800 dark:text-amber-200'
+                                    }`}>
+                                        {validation.hasRequiredFields
+                                            ? '✓ Valid Genesis JSON'
+                                            : '⚠ Valid JSON with warnings'
+                                        }
+                                    </div>
+                                    <div className={`text-xs ${
+                                        validation.hasRequiredFields
+                                            ? 'text-green-700 dark:text-green-300'
+                                            : 'text-amber-700 dark:text-amber-300'
+                                    }`}>
+                                        Size: {(validation.size / 1024).toFixed(2)} KiB
+                                        {validation.size > 64 * 1024 && (
+                                            <span className="ml-2 text-red-600 dark:text-red-400">
+                                                (exceeds 64 KiB P-Chain limit!)
+                                            </span>
+                                        )}
+                                    </div>
+                                    {!validation.hasRequiredFields && validation.missingFields.length > 0 && (
+                                        <div className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+                                            Missing recommended fields: {validation.missingFields.join(', ')}
+                                        </div>
+                                    )}
+                                </>
+                            ) : (
+                                <>
+                                    <div className="text-sm font-medium text-red-800 dark:text-red-200">
+                                        ✗ Invalid JSON
+                                    </div>
+                                    <div className="text-xs text-red-700 dark:text-red-300 font-mono">
+                                        {validation.error}
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
 function GenesisWizardContent({ children, genesisData, onGenesisDataChange, footer, embedded = false }: GenesisWizardProps) {
     const { highlightPath } = useGenesisHighlight();
     const [isMobile, setIsMobile] = useState(false);
+    const [mode, setMode] = useState<GenesisMode>('builder');
+    const [customJson, setCustomJson] = useState('');
+
+    // Sync customJson with genesisData when switching modes
+    const handleModeChange = (newMode: GenesisMode) => {
+        if (newMode === 'custom' && mode === 'builder') {
+            // Switching to custom - populate with current genesis
+            setCustomJson(genesisData);
+        } else if (newMode === 'builder' && mode === 'custom') {
+            // Switching back to builder - the builder will regenerate
+            // Clear custom JSON to avoid confusion
+        }
+        setMode(newMode);
+    };
+
+    // When custom JSON changes, update genesis data
+    const handleCustomJsonChange = (json: string) => {
+        setCustomJson(json);
+        // Only update parent if valid JSON
+        try {
+            JSON.parse(json);
+            onGenesisDataChange(json);
+        } catch {
+            // Invalid JSON - don't update parent yet
+        }
+    };
+
+    const validation = validateGenesisJson(customJson);
 
     useEffect(() => {
         const checkMobile = () => {
-            // Force single column layout if embedded or on mobile
             setIsMobile(embedded || window.innerWidth < 1024);
         };
 
@@ -31,52 +388,87 @@ function GenesisWizardContent({ children, genesisData, onGenesisDataChange, foot
     }, [embedded]);
 
     if (isMobile) {
-        // Mobile/Embedded layout - stacked view with always-visible JSON preview and scroll-to-highlight
+        // Mobile/Embedded layout
         return (
-            <div className="space-y-6">
-                <div className="bg-white dark:bg-zinc-950 rounded-lg border border-zinc-200 dark:border-zinc-800 p-6">
-                    {children}
+            <div className="space-y-4">
+                {/* Mode Toggle */}
+                <div className="flex justify-center">
+                    <ModeToggle mode={mode} onModeChange={handleModeChange} />
                 </div>
 
-                {genesisData && genesisData.length > 0 && !genesisData.startsWith("Error:") && (
-                    <div className="bg-white dark:bg-zinc-950 rounded-lg border border-zinc-200 dark:border-zinc-800">
-                        <div className="px-4 py-3 border-b border-zinc-200 dark:border-zinc-800 flex items-center justify-between bg-zinc-50 dark:bg-zinc-900/50">
-                            <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">Genesis JSON Preview</span>
-                            <span className="text-xs text-zinc-500 dark:text-zinc-400">
-                                {(new Blob([genesisData]).size / 1024).toFixed(2)} KiB
-                            </span>
+                {mode === 'builder' ? (
+                    <>
+                        <div className="bg-white dark:bg-zinc-950 rounded-lg border border-zinc-200 dark:border-zinc-800 p-6">
+                            {children}
                         </div>
-                        <div className="w-full overflow-x-auto">
-                            <JsonPreviewPanel
-                                jsonData={genesisData}
-                                onJsonUpdate={onGenesisDataChange}
-                                highlightPath={highlightPath || undefined}
-                            />
-                        </div>
+
+                        {genesisData && genesisData.length > 0 && !genesisData.startsWith("Error:") && (
+                            <div className="bg-white dark:bg-zinc-950 rounded-lg border border-zinc-200 dark:border-zinc-800">
+                                <div className="px-4 py-3 border-b border-zinc-200 dark:border-zinc-800 flex items-center justify-between bg-zinc-50 dark:bg-zinc-900/50">
+                                    <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">Genesis JSON Preview</span>
+                                    <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                                        {(new Blob([genesisData]).size / 1024).toFixed(2)} KiB
+                                    </span>
+                                </div>
+                                <div className="w-full overflow-x-auto">
+                                    <JsonPreviewPanel
+                                        jsonData={genesisData}
+                                        onJsonUpdate={onGenesisDataChange}
+                                        highlightPath={highlightPath || undefined}
+                                    />
+                                </div>
+                            </div>
+                        )}
+                    </>
+                ) : (
+                    <div className="bg-white dark:bg-zinc-950 rounded-lg border border-zinc-200 dark:border-zinc-800 p-6">
+                        <CustomJsonEditor
+                            value={customJson}
+                            onChange={handleCustomJsonChange}
+                            validation={validation}
+                        />
                     </div>
                 )}
             </div>
         );
     }
 
-    // Desktop layout - split view with global footer
+    // Desktop layout
     return (
         <div className="flex flex-col bg-white dark:bg-zinc-950 rounded-lg border border-zinc-200 dark:border-zinc-800">
-            <div className="flex">
-                {/* Left Panel - Configuration */}
-                <div className="flex-1 p-5 bg-white dark:bg-zinc-950 text-[13px]">
-                    {children}
-                </div>
+            {/* Mode Toggle Header */}
+            <div className="px-5 py-3 border-b border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 flex items-center justify-between">
+                <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Genesis Configuration
+                </span>
+                <ModeToggle mode={mode} onModeChange={handleModeChange} />
+            </div>
 
-                {/* Right Panel - JSON Preview */}
-                <div className="w-[640px] xl:w-[720px] border-l border-zinc-200 dark:border-zinc-800 sticky top-4 self-start">
-                    <JsonPreviewPanel
-                        jsonData={genesisData}
-                        onJsonUpdate={onGenesisDataChange}
-                        highlightPath={highlightPath || undefined}
+            {mode === 'builder' ? (
+                <div className="flex">
+                    {/* Left Panel - Configuration */}
+                    <div className="flex-1 p-5 bg-white dark:bg-zinc-950 text-[13px]">
+                        {children}
+                    </div>
+
+                    {/* Right Panel - JSON Preview */}
+                    <div className="w-[640px] xl:w-[720px] border-l border-zinc-200 dark:border-zinc-800 sticky top-4 self-start">
+                        <JsonPreviewPanel
+                            jsonData={genesisData}
+                            onJsonUpdate={onGenesisDataChange}
+                            highlightPath={highlightPath || undefined}
+                        />
+                    </div>
+                </div>
+            ) : (
+                <div className="p-6">
+                    <CustomJsonEditor
+                        value={customJson}
+                        onChange={handleCustomJsonChange}
+                        validation={validation}
                     />
                 </div>
-            </div>
+            )}
 
             {footer && (
                 <div className="border-t border-zinc-200 dark:border-zinc-800 bg-white/80 dark:bg-zinc-950/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:supports-[backdrop-filter]:bg-zinc-950/60">

--- a/components/toolbox/console/layer-1/PerformanceMonitor/BlockWatcher.ts
+++ b/components/toolbox/console/layer-1/PerformanceMonitor/BlockWatcher.ts
@@ -1,0 +1,123 @@
+import { PublicClient } from 'viem';
+
+export interface BlockInfo {
+    blockNumber: number;
+    transactionCount: number;
+    gasUsed: bigint;
+    timestamp: number; // Unix timestamp in seconds
+}
+
+export class BlockWatcher {
+    private publicClient: PublicClient;
+    private callback: (blockInfo: BlockInfo) => void;
+    private isRunning: boolean = false;
+
+    constructor(publicClient: PublicClient, callback: (blockInfo: BlockInfo) => void) {
+        this.publicClient = publicClient;
+        this.callback = callback;
+    }
+
+    async start(startFromBlock: number, blockHistory: number) {
+        if (this.isRunning) return;
+        this.isRunning = true;
+
+        let currentBlockNumber = BigInt(startFromBlock);
+        console.log('Starting from block', currentBlockNumber);
+
+        const maxBatchSize = 200;
+
+        // First, fetch historical blocks
+        try {
+            const latestBlock = await this.publicClient.getBlockNumber();
+            const historicalStartBlock = Math.max(
+                Number(latestBlock) - blockHistory,
+                1
+            );
+
+            console.log(`Fetching ${blockHistory} historical blocks from ${historicalStartBlock} to ${latestBlock}`);
+
+            // Process historical blocks in batches
+            for (let i = historicalStartBlock; i < Number(latestBlock) && this.isRunning; i += maxBatchSize) {
+                const endBlock = Math.min(i + maxBatchSize, Number(latestBlock));
+                const blockPromises = [];
+
+                for (let j = i; j < endBlock; j++) {
+                    blockPromises.push(this.publicClient.getBlock({
+                        blockNumber: BigInt(j)
+                    }));
+                }
+
+                const blocks = await Promise.all(blockPromises);
+
+                blocks.forEach((block) => {
+                    this.callback({
+                        blockNumber: Number(block.number),
+                        transactionCount: block.transactions.length,
+                        gasUsed: block.gasUsed,
+                        timestamp: Number(block.timestamp)
+                    });
+                });
+
+                console.log(`Processed historical blocks ${i} to ${endBlock - 1}`);
+            }
+
+            // Set current block number to latest after historical sync
+            currentBlockNumber = latestBlock;
+            console.log('Historical sync complete, now watching for new blocks');
+        } catch (error) {
+            console.error('Error fetching historical blocks:', error);
+        }
+
+        // Now start monitoring new blocks
+        while (this.isRunning) {
+            try {
+                let lastBlock = await this.publicClient.getBlockNumber();
+
+                while (lastBlock === currentBlockNumber) {
+                    console.log('Reached end of chain');
+                    await new Promise(resolve => setTimeout(resolve, 1000));
+                    lastBlock = await this.publicClient.getBlockNumber();
+                }
+
+                const endBlock = currentBlockNumber + BigInt(maxBatchSize) < BigInt(lastBlock)
+                    ? currentBlockNumber + BigInt(maxBatchSize)
+                    : BigInt(lastBlock);
+
+                const blockPromises = [];
+                for (let i = currentBlockNumber; i < endBlock; i++) {
+                    blockPromises.push(this.publicClient.getBlock({
+                        blockNumber: i
+                    }));
+                }
+
+                const blocks = await Promise.all(blockPromises);
+
+                // Send block info to callback
+                blocks.forEach((block, index) => {
+                    this.callback({
+                        blockNumber: Number(currentBlockNumber) + index,
+                        transactionCount: block.transactions.length,
+                        gasUsed: block.gasUsed,
+                        timestamp: Number(block.timestamp)
+                    });
+                });
+
+                console.log('Synced blocks', currentBlockNumber, 'to', endBlock);
+                currentBlockNumber = endBlock;
+            } catch (error) {
+                if (error instanceof Error &&
+                    error.message.includes('cannot query unfinalized data')) {
+                    console.log(`Block ${currentBlockNumber} not finalized yet, waiting...`);
+                    await new Promise(resolve => setTimeout(resolve, 1000));
+                } else {
+                    console.error('Error fetching block:', error);
+                    await new Promise(resolve => setTimeout(resolve, 1000));
+                }
+            }
+        }
+    }
+
+    stop() {
+        this.isRunning = false;
+    }
+}

--- a/components/toolbox/console/layer-1/PerformanceMonitor/ChainInfo.tsx
+++ b/components/toolbox/console/layer-1/PerformanceMonitor/ChainInfo.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AlertCircle, Users, Fuel } from "lucide-react";
+
+export type BenchmarkChainInfo = {
+    peers: string[];
+    gasLimit: number;
+    peerFlags: string[];
+}
+
+const countryFlagCache = new Map<string, Promise<string>>();
+
+async function getCountryFlag(ip: string): Promise<string> {
+    // Check in-memory cache first
+    if (countryFlagCache.has(ip)) {
+        return countryFlagCache.get(ip)!;
+    }
+
+    // Check localStorage
+    const storageKey = `flag-${ip}`;
+    if (typeof window !== 'undefined') {
+        const storedFlag = localStorage.getItem(storageKey);
+        if (storedFlag) {
+            return storedFlag;
+        }
+    }
+
+    const flagPromise = (async () => {
+        try {
+            const response = await fetch(`https://ipwho.is/${ip}`);
+            const data = await response.json();
+            const flag = data.flag?.emoji || '🌐';
+
+            // Store in localStorage only on success
+            if (typeof window !== 'undefined') {
+                localStorage.setItem(storageKey, flag);
+            }
+            return flag;
+        } catch {
+            return '🌐';
+        }
+    })();
+
+    countryFlagCache.set(ip, flagPromise);
+    return flagPromise;
+}
+
+async function rpcRequest<T>(rpcUrl: string, method: string, params: unknown[]): Promise<T> {
+    const response = await fetch(rpcUrl, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', method: method, params: params, id: 1 }),
+    });
+    const data = await response.json();
+    if ('result' in data) {
+        return data.result;
+    }
+    if ('error' in data) {
+        throw new Error(typeof data.error === 'object' ? JSON.stringify(data.error) : data.error);
+    }
+    throw new Error(JSON.stringify(data));
+}
+
+export async function getChainInfo(rpcUrl: string, subnetId: string, chainID: string): Promise<BenchmarkChainInfo> {
+    rpcUrl = rpcUrl.replace(/^ws/, 'http').replace(/\/$/, '');
+
+    const peers = await rpcRequest<{
+        numPeers: string;
+        peers: Array<{
+            ip: string;
+            publicIP: string;
+            nodeID: string;
+            version: string;
+            lastSent: string;
+            lastReceived: string;
+            observedUptime: string;
+            trackedSubnets: string[];
+            supportedACPs: number[];
+            objectedACPs: number[];
+            benched: number[];
+        }>;
+    }>(rpcUrl + "/ext/info", 'info.peers', [{ nodeIDs: [] }]);
+
+    const peerIpPorts = peers.peers.filter(peer => peer.trackedSubnets.includes(subnetId)).map(peer => peer.ip);
+    const currentNodeIp = (await rpcRequest<{ ip: string }>(rpcUrl + "/ext/info", 'info.getNodeIP', [])).ip;
+    peerIpPorts.push(currentNodeIp);
+
+    const peerIps = peerIpPorts.map(peerIpPort => peerIpPort.split(':')[0]);
+    const peerFlags = await Promise.all(peerIps.map(ip => getCountryFlag(ip)));
+
+    // Get latest block from EVM chain
+    const evmRpcUrl = rpcUrl + "/ext/bc/" + chainID + "/rpc";
+    const blockResponse = await rpcRequest<{
+        gasLimit: `0x${string}`;
+    }>(evmRpcUrl, 'eth_getBlockByNumber', ['latest', true]);
+
+    const gasLimit = parseInt(blockResponse.gasLimit, 16);
+
+    return {
+        peers: peerIps,
+        gasLimit: gasLimit,
+        peerFlags: peerFlags,
+    }
+}
+
+interface ChainInfoProps {
+    rpcUrl: string;
+    subnetId: string;
+    chainID: string;
+}
+
+export function ChainInfo({ rpcUrl, subnetId, chainID }: ChainInfoProps) {
+    const [chainInfo, setChainInfo] = useState<BenchmarkChainInfo | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        if (!rpcUrl || !subnetId || !chainID) {
+            setChainInfo(null);
+            setError(null);
+            return;
+        }
+
+        setIsLoading(true);
+        setError(null);
+
+        getChainInfo(rpcUrl, subnetId, chainID)
+            .then(info => {
+                setChainInfo(info);
+                setIsLoading(false);
+            })
+            .catch(err => {
+                setError(err instanceof Error ? err.message : String(err));
+                setIsLoading(false);
+            });
+    }, [rpcUrl, subnetId, chainID]);
+
+    if (!rpcUrl || !subnetId || !chainID) {
+        return null;
+    }
+
+    if (isLoading) {
+        return (
+            <div className="mb-4 p-4 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg">
+                <div className="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+                    <div className="animate-spin h-4 w-4 border-2 border-zinc-300 dark:border-zinc-600 border-t-zinc-600 dark:border-t-zinc-300 rounded-full"></div>
+                    Loading chain info...
+                </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="mb-4 p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800/50 rounded-lg">
+                <div className="flex items-start gap-2">
+                    <AlertCircle className="h-4 w-4 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
+                    <div className="text-sm text-red-700 dark:text-red-300">
+                        <strong>Error loading chain info:</strong> {error}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    if (!chainInfo) {
+        return null;
+    }
+
+    return (
+        <div className="mb-4 p-4 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg">
+            <div className="flex flex-wrap items-center gap-4 text-sm">
+                <div className="flex items-center gap-2">
+                    <Fuel className="h-4 w-4 text-zinc-500 dark:text-zinc-400" />
+                    <span className="text-zinc-600 dark:text-zinc-300">
+                        Gas Limit: <strong>{(chainInfo.gasLimit / 1_000_000).toFixed(1)}M</strong> per block
+                    </span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Users className="h-4 w-4 text-zinc-500 dark:text-zinc-400" />
+                    <span className="text-zinc-600 dark:text-zinc-300">
+                        <strong>{chainInfo.peers.length}</strong> validators online:
+                        <span className="ml-1">{chainInfo.peerFlags.join(' ')}</span>
+                    </span>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/components/toolbox/console/layer-1/PerformanceMonitor/PerformanceMonitor.tsx
+++ b/components/toolbox/console/layer-1/PerformanceMonitor/PerformanceMonitor.tsx
@@ -1,0 +1,591 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { createPublicClient, http } from 'viem';
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine } from 'recharts';
+import { Play, Square, Activity, Fuel, Blocks, Clock, AlertCircle } from "lucide-react";
+import { BlockWatcher, BlockInfo } from "./BlockWatcher";
+import { Button } from "@/components/toolbox/components/Button";
+import { RPCURLInput } from "@/components/toolbox/components/RPCURLInput";
+
+interface BucketedData {
+    transactions: number;
+    gasUsed: bigint;
+    blockCount: number;
+}
+
+interface ChartDataPoint {
+    time: string;
+    timestamp: number;
+    transactions: number;
+    gasUsed: number;
+    blockCount: number;
+}
+
+const TIME_RANGE_OPTIONS = [
+    { value: "60", label: "1 minute" },
+    { value: "300", label: "5 minutes" },
+    { value: "900", label: "15 minutes" },
+    { value: "1800", label: "30 minutes" },
+    { value: "3600", label: "1 hour" },
+    { value: "10800", label: "3 hours" },
+];
+
+const BLOCK_HISTORY_OPTIONS = [
+    { value: "100", label: "100 blocks" },
+    { value: "500", label: "500 blocks" },
+    { value: "1000", label: "1,000 blocks" },
+    { value: "5000", label: "5,000 blocks" },
+    { value: "10000", label: "10,000 blocks" },
+];
+
+export default function PerformanceMonitor() {
+    const [rpcUrl, setRpcUrl] = useState('');
+    const [isMonitoring, setIsMonitoring] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [timeRange, setTimeRange] = useState("60");
+    const [blockHistory, setBlockHistory] = useState("100");
+
+    const [dataMap, setDataMap] = useState<Map<number, BucketedData>>(new Map());
+    const [chartData, setChartData] = useState<ChartDataPoint[]>([]);
+    const [recentBlocks, setRecentBlocks] = useState<BlockInfo[]>([]);
+    const [gasLimit, setGasLimit] = useState<number | null>(null);
+
+    const blockWatcherRef = useRef<BlockWatcher | null>(null);
+    const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+    // Get bucket resolution based on selected time range
+    const getBucketResolution = useCallback((): { seconds: number, label: string } => {
+        switch (timeRange) {
+            case "60":
+            case "300":
+                return { seconds: 1, label: "second" };
+            case "900":
+            case "1800":
+            case "3600":
+            case "10800":
+                return { seconds: 60, label: "minute" };
+            default:
+                return { seconds: 1, label: "second" };
+        }
+    }, [timeRange]);
+
+    const getBucketTimestamp = useCallback((timestamp: number): number => {
+        const { seconds } = getBucketResolution();
+        return Math.floor(timestamp / seconds) * seconds;
+    }, [getBucketResolution]);
+
+    const formatTimestamp = useCallback((timestamp: number): string => {
+        const date = new Date(timestamp * 1000);
+        const { label } = getBucketResolution();
+
+        if (label === "minute") {
+            return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        } else {
+            return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+        }
+    }, [getBucketResolution]);
+
+    // Update chart data
+    useEffect(() => {
+        if (!isMonitoring) return;
+
+        const updateChartData = () => {
+            const now = Math.floor(Date.now() / 1000);
+            const timeRangeSeconds = Number(timeRange);
+            const { seconds: bucketResolution } = getBucketResolution();
+
+            const endTime = getBucketTimestamp(now - 5);
+            const numBuckets = Math.floor(timeRangeSeconds / bucketResolution);
+            const timelineStart = endTime - (numBuckets - 1) * bucketResolution;
+
+            const completeTimeline: number[] = Array.from(
+                { length: numBuckets },
+                (_, i) => timelineStart + i * bucketResolution
+            );
+
+            const newChartData = completeTimeline.map(timestamp => {
+                const data = dataMap.get(timestamp) || {
+                    transactions: 0,
+                    gasUsed: BigInt(0),
+                    blockCount: 0
+                };
+
+                const secondsInBucket = bucketResolution;
+                const transactionsPerSecond = data.transactions / secondsInBucket;
+                const gasUsedPerSecond = Number(data.gasUsed) / secondsInBucket;
+                const blocksPerSecond = data.blockCount / secondsInBucket;
+
+                return {
+                    time: formatTimestamp(timestamp),
+                    timestamp,
+                    transactions: transactionsPerSecond,
+                    gasUsed: gasUsedPerSecond,
+                    blockCount: blocksPerSecond
+                };
+            });
+
+            setChartData(newChartData);
+        };
+
+        updateChartData();
+
+        const updateInterval = getBucketResolution().seconds * 1000 / 2;
+        timerRef.current = setInterval(updateChartData, Math.min(updateInterval, 1000));
+
+        return () => {
+            if (timerRef.current) {
+                clearInterval(timerRef.current);
+                timerRef.current = null;
+            }
+        };
+    }, [isMonitoring, dataMap, timeRange, getBucketResolution, getBucketTimestamp, formatTimestamp]);
+
+    // Cleanup on unmount
+    useEffect(() => {
+        return () => {
+            if (blockWatcherRef.current) {
+                blockWatcherRef.current.stop();
+                blockWatcherRef.current = null;
+            }
+            if (timerRef.current) {
+                clearInterval(timerRef.current);
+                timerRef.current = null;
+            }
+        };
+    }, []);
+
+    async function startMonitoring() {
+        if (!rpcUrl) {
+            setError("Please enter an RPC URL");
+            return;
+        }
+
+        try {
+            setError(null);
+            setIsMonitoring(true);
+            setDataMap(new Map());
+            setChartData([]);
+            setRecentBlocks([]);
+            setGasLimit(null);
+
+            const publicClient = createPublicClient({
+                transport: http(rpcUrl),
+            });
+
+            // Test connection and get gas limit from latest block
+            const latestBlock = await publicClient.getBlock({ blockTag: 'latest' });
+            setGasLimit(Number(latestBlock.gasLimit));
+
+            const lastBlock = Number(latestBlock.number);
+            const blockHistoryNum = parseInt(blockHistory);
+            const startFromBlock = Math.max(lastBlock - 10, 1);
+
+            const blockWatcher = new BlockWatcher(publicClient, (blockInfo) => {
+                const bucketTime = getBucketTimestamp(blockInfo.timestamp);
+
+                setDataMap(prevMap => {
+                    const newMap = new Map(prevMap);
+                    const existingData = newMap.get(bucketTime) || {
+                        transactions: 0,
+                        gasUsed: BigInt(0),
+                        blockCount: 0
+                    };
+
+                    newMap.set(bucketTime, {
+                        transactions: existingData.transactions + blockInfo.transactionCount,
+                        gasUsed: existingData.gasUsed + blockInfo.gasUsed,
+                        blockCount: existingData.blockCount + 1
+                    });
+
+                    return newMap;
+                });
+
+                setRecentBlocks(prevBlocks => {
+                    const newBlocks = [blockInfo, ...prevBlocks];
+                    return newBlocks.slice(0, 10);
+                });
+            });
+
+            blockWatcherRef.current = blockWatcher;
+            blockWatcher.start(startFromBlock, blockHistoryNum);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+            setIsMonitoring(false);
+        }
+    }
+
+    function stopMonitoring() {
+        if (blockWatcherRef.current) {
+            blockWatcherRef.current.stop();
+            blockWatcherRef.current = null;
+        }
+        if (timerRef.current) {
+            clearInterval(timerRef.current);
+            timerRef.current = null;
+        }
+        setIsMonitoring(false);
+    }
+
+    const avgTransactions = chartData.length > 0
+        ? chartData.reduce((sum, point) => sum + point.transactions, 0) / chartData.length
+        : 0;
+    const avgGas = chartData.length > 0
+        ? chartData.reduce((sum, point) => sum + point.gasUsed, 0) / chartData.length
+        : 0;
+    const avgBlocks = chartData.length > 0
+        ? chartData.reduce((sum, point) => sum + point.blockCount, 0) / chartData.length
+        : 0;
+
+    return (
+        <div className="space-y-6">
+            {/* Header */}
+            <div>
+                <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                    EVM Chain Performance Monitor
+                </h2>
+                <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1">
+                    Monitor blockchain performance metrics in real-time. Enter any EVM RPC URL to start.
+                </p>
+            </div>
+
+            {/* Configuration */}
+            <div className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 rounded-lg p-4 space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="md:col-span-1">
+                        <RPCURLInput
+                            label="EVM RPC URL"
+                            value={rpcUrl}
+                            onChange={setRpcUrl}
+                            disabled={isMonitoring}
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <label className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                            Time Range
+                        </label>
+                        <select
+                            value={timeRange}
+                            onChange={(e) => setTimeRange(e.target.value)}
+                            disabled={isMonitoring}
+                            className="w-full px-3 py-2 bg-white dark:bg-zinc-900 border border-zinc-300 dark:border-zinc-700 rounded-lg text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                        >
+                            {TIME_RANGE_OPTIONS.map(opt => (
+                                <option key={opt.value} value={opt.value}>{opt.label}</option>
+                            ))}
+                        </select>
+                    </div>
+
+                    <div className="space-y-1">
+                        <label className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                            Historical Blocks
+                        </label>
+                        <select
+                            value={blockHistory}
+                            onChange={(e) => setBlockHistory(e.target.value)}
+                            disabled={isMonitoring}
+                            className="w-full px-3 py-2 bg-white dark:bg-zinc-900 border border-zinc-300 dark:border-zinc-700 rounded-lg text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                        >
+                            {BLOCK_HISTORY_OPTIONS.map(opt => (
+                                <option key={opt.value} value={opt.value}>{opt.label}</option>
+                            ))}
+                        </select>
+                    </div>
+                </div>
+
+                {/* Control Buttons */}
+                <div className="flex gap-3 pt-2">
+                    <Button
+                        onClick={startMonitoring}
+                        disabled={!rpcUrl || isMonitoring}
+                    >
+                        <Play className="h-4 w-4 mr-2" />
+                        Start Monitoring
+                    </Button>
+                    <Button
+                        onClick={stopMonitoring}
+                        disabled={!isMonitoring}
+                        variant="secondary"
+                    >
+                        <Square className="h-4 w-4 mr-2" />
+                        Stop
+                    </Button>
+                </div>
+            </div>
+
+            {/* Chain Info */}
+            {gasLimit && (
+                <div className="bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg p-4">
+                    <div className="flex items-center gap-2 text-sm">
+                        <Fuel className="h-4 w-4 text-zinc-500" />
+                        <span className="text-zinc-600 dark:text-zinc-300">
+                            Gas Limit: <strong>{(gasLimit / 1_000_000).toFixed(1)}M</strong> per block
+                        </span>
+                    </div>
+                </div>
+            )}
+
+            {/* Error Display */}
+            {error && (
+                <div className="p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800/50 rounded-lg">
+                    <div className="flex items-start gap-2">
+                        <AlertCircle className="h-4 w-4 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
+                        <div className="text-sm text-red-700 dark:text-red-300">
+                            <strong>Error:</strong> {error}
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Charts */}
+            {chartData.length > 0 && (
+                <div className="space-y-6">
+                    {/* Transactions Per Second Chart */}
+                    <div className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 rounded-lg p-4">
+                        <div className="flex items-center justify-between mb-4">
+                            <div className="flex items-center gap-2">
+                                <Activity className="h-5 w-5 text-purple-500" />
+                                <h3 className="font-medium text-zinc-900 dark:text-zinc-100">Transactions per Second</h3>
+                            </div>
+                            <div className="text-sm text-zinc-500 dark:text-zinc-400">
+                                Avg: <span className="text-purple-500 font-medium">{avgTransactions.toFixed(2)} TPS</span>
+                            </div>
+                        </div>
+                        <ResponsiveContainer width="100%" height={220}>
+                            <AreaChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+                                <defs>
+                                    <linearGradient id="tpsGradient" x1="0" y1="0" x2="0" y2="1">
+                                        <stop offset="5%" stopColor="#8b5cf6" stopOpacity={0.3} />
+                                        <stop offset="95%" stopColor="#8b5cf6" stopOpacity={0} />
+                                    </linearGradient>
+                                </defs>
+                                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="currentColor" className="opacity-10" />
+                                <XAxis
+                                    dataKey="time"
+                                    tick={{ fontSize: 11, fill: '#71717a' }}
+                                    axisLine={false}
+                                    tickLine={false}
+                                    dy={10}
+                                />
+                                <YAxis
+                                    tickFormatter={(value: number) => value.toFixed(1)}
+                                    tick={{ fontSize: 11, fill: '#71717a' }}
+                                    axisLine={false}
+                                    tickLine={false}
+                                    dx={-10}
+                                    width={50}
+                                />
+                                <Tooltip
+                                    formatter={(value: number) => [value.toFixed(2), 'TPS']}
+                                    contentStyle={{
+                                        backgroundColor: 'rgba(24, 24, 27, 0.95)',
+                                        border: '1px solid rgba(63, 63, 70, 0.5)',
+                                        borderRadius: '8px',
+                                        boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+                                    }}
+                                    labelStyle={{ color: '#a1a1aa', marginBottom: '4px' }}
+                                    itemStyle={{ color: '#e4e4e7' }}
+                                />
+                                <Area
+                                    type="monotone"
+                                    dataKey="transactions"
+                                    stroke="#8b5cf6"
+                                    strokeWidth={2}
+                                    fill="url(#tpsGradient)"
+                                    isAnimationActive={false}
+                                />
+                                <ReferenceLine
+                                    y={avgTransactions}
+                                    stroke="#22c55e"
+                                    strokeDasharray="5 5"
+                                    strokeOpacity={0.7}
+                                />
+                            </AreaChart>
+                        </ResponsiveContainer>
+                    </div>
+
+                    {/* Gas Usage Chart */}
+                    <div className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 rounded-lg p-4">
+                        <div className="flex items-center justify-between mb-4">
+                            <div className="flex items-center gap-2">
+                                <Fuel className="h-5 w-5 text-orange-500" />
+                                <h3 className="font-medium text-zinc-900 dark:text-zinc-100">Gas Usage per Second</h3>
+                            </div>
+                            <div className="text-sm text-zinc-500 dark:text-zinc-400">
+                                Avg: <span className="text-orange-500 font-medium">{(avgGas / 1_000_000).toFixed(2)}M</span>
+                            </div>
+                        </div>
+                        <ResponsiveContainer width="100%" height={220}>
+                            <AreaChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+                                <defs>
+                                    <linearGradient id="gasGradient" x1="0" y1="0" x2="0" y2="1">
+                                        <stop offset="5%" stopColor="#f97316" stopOpacity={0.3} />
+                                        <stop offset="95%" stopColor="#f97316" stopOpacity={0} />
+                                    </linearGradient>
+                                </defs>
+                                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="currentColor" className="opacity-10" />
+                                <XAxis
+                                    dataKey="time"
+                                    tick={{ fontSize: 11, fill: '#71717a' }}
+                                    axisLine={false}
+                                    tickLine={false}
+                                    dy={10}
+                                />
+                                <YAxis
+                                    tickFormatter={(value: number) => `${(value / 1_000_000).toFixed(1)}M`}
+                                    tick={{ fontSize: 11, fill: '#71717a' }}
+                                    axisLine={false}
+                                    tickLine={false}
+                                    dx={-10}
+                                    width={50}
+                                />
+                                <Tooltip
+                                    formatter={(value: number) => [`${(value / 1_000_000).toFixed(2)}M`, 'Gas/sec']}
+                                    contentStyle={{
+                                        backgroundColor: 'rgba(24, 24, 27, 0.95)',
+                                        border: '1px solid rgba(63, 63, 70, 0.5)',
+                                        borderRadius: '8px',
+                                        boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+                                    }}
+                                    labelStyle={{ color: '#a1a1aa', marginBottom: '4px' }}
+                                    itemStyle={{ color: '#e4e4e7' }}
+                                />
+                                <Area
+                                    type="monotone"
+                                    dataKey="gasUsed"
+                                    stroke="#f97316"
+                                    strokeWidth={2}
+                                    fill="url(#gasGradient)"
+                                    isAnimationActive={false}
+                                />
+                                <ReferenceLine
+                                    y={avgGas}
+                                    stroke="#22c55e"
+                                    strokeDasharray="5 5"
+                                    strokeOpacity={0.7}
+                                />
+                            </AreaChart>
+                        </ResponsiveContainer>
+                    </div>
+
+                    {/* Blocks Per Second Chart */}
+                    <div className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 rounded-lg p-4">
+                        <div className="flex items-center justify-between mb-4">
+                            <div className="flex items-center gap-2">
+                                <Blocks className="h-5 w-5 text-cyan-500" />
+                                <h3 className="font-medium text-zinc-900 dark:text-zinc-100">Blocks per Second</h3>
+                            </div>
+                            <div className="text-sm text-zinc-500 dark:text-zinc-400">
+                                Avg: <span className="text-cyan-500 font-medium">{avgBlocks.toFixed(2)}</span>
+                            </div>
+                        </div>
+                        <ResponsiveContainer width="100%" height={220}>
+                            <AreaChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+                                <defs>
+                                    <linearGradient id="blocksGradient" x1="0" y1="0" x2="0" y2="1">
+                                        <stop offset="5%" stopColor="#06b6d4" stopOpacity={0.3} />
+                                        <stop offset="95%" stopColor="#06b6d4" stopOpacity={0} />
+                                    </linearGradient>
+                                </defs>
+                                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="currentColor" className="opacity-10" />
+                                <XAxis
+                                    dataKey="time"
+                                    tick={{ fontSize: 11, fill: '#71717a' }}
+                                    axisLine={false}
+                                    tickLine={false}
+                                    dy={10}
+                                />
+                                <YAxis
+                                    tickFormatter={(value: number) => value.toFixed(2)}
+                                    tick={{ fontSize: 11, fill: '#71717a' }}
+                                    axisLine={false}
+                                    tickLine={false}
+                                    dx={-10}
+                                    width={50}
+                                />
+                                <Tooltip
+                                    formatter={(value: number) => [value.toFixed(2), 'Blocks/sec']}
+                                    contentStyle={{
+                                        backgroundColor: 'rgba(24, 24, 27, 0.95)',
+                                        border: '1px solid rgba(63, 63, 70, 0.5)',
+                                        borderRadius: '8px',
+                                        boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+                                    }}
+                                    labelStyle={{ color: '#a1a1aa', marginBottom: '4px' }}
+                                    itemStyle={{ color: '#e4e4e7' }}
+                                />
+                                <Area
+                                    type="monotone"
+                                    dataKey="blockCount"
+                                    stroke="#06b6d4"
+                                    strokeWidth={2}
+                                    fill="url(#blocksGradient)"
+                                    isAnimationActive={false}
+                                />
+                                <ReferenceLine
+                                    y={avgBlocks}
+                                    stroke="#22c55e"
+                                    strokeDasharray="5 5"
+                                    strokeOpacity={0.7}
+                                />
+                            </AreaChart>
+                        </ResponsiveContainer>
+                    </div>
+
+                    {/* Recent Blocks Table */}
+                    <div className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+                        <div className="px-4 py-3 border-b border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50">
+                            <div className="flex items-center gap-2">
+                                <Clock className="h-5 w-5 text-zinc-500" />
+                                <h3 className="font-medium text-zinc-900 dark:text-zinc-100">Recent Blocks</h3>
+                            </div>
+                        </div>
+                        <div className="overflow-x-auto">
+                            <table className="w-full text-sm">
+                                <thead>
+                                    <tr className="bg-zinc-50 dark:bg-zinc-900/30">
+                                        <th className="py-3 px-4 text-left font-medium text-zinc-600 dark:text-zinc-400">Block</th>
+                                        <th className="py-3 px-4 text-left font-medium text-zinc-600 dark:text-zinc-400">Txs</th>
+                                        <th className="py-3 px-4 text-left font-medium text-zinc-600 dark:text-zinc-400">Gas Used</th>
+                                        <th className="py-3 px-4 text-left font-medium text-zinc-600 dark:text-zinc-400">Time</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {recentBlocks.map((block) => (
+                                        <tr key={block.blockNumber} className="border-t border-zinc-100 dark:border-zinc-800 hover:bg-zinc-50 dark:hover:bg-zinc-900/30">
+                                            <td className="py-3 px-4 font-mono text-zinc-900 dark:text-zinc-100">{block.blockNumber.toLocaleString()}</td>
+                                            <td className="py-3 px-4 text-zinc-700 dark:text-zinc-300">{block.transactionCount}</td>
+                                            <td className="py-3 px-4 text-zinc-700 dark:text-zinc-300">{(Number(block.gasUsed) / 1_000_000).toFixed(2)}M</td>
+                                            <td className="py-3 px-4 text-zinc-500 dark:text-zinc-400">{new Date(block.timestamp * 1000).toLocaleTimeString()}</td>
+                                        </tr>
+                                    ))}
+                                    {recentBlocks.length === 0 && (
+                                        <tr>
+                                            <td colSpan={4} className="py-8 text-center text-zinc-500 dark:text-zinc-400">
+                                                Waiting for blocks...
+                                            </td>
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Empty State */}
+            {!isMonitoring && chartData.length === 0 && (
+                <div className="bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg p-8 text-center">
+                    <Activity className="h-12 w-12 mx-auto text-zinc-300 dark:text-zinc-600 mb-4" />
+                    <h3 className="text-lg font-medium text-zinc-700 dark:text-zinc-300 mb-2">
+                        Ready to Monitor
+                    </h3>
+                    <p className="text-sm text-zinc-500 dark:text-zinc-400 max-w-md mx-auto">
+                        Enter any EVM RPC URL (e.g., https://api.avax.network/ext/bc/C/rpc) and click "Start Monitoring" to track real-time performance.
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/components/toolbox/console/layer-1/PerformanceMonitor/index.ts
+++ b/components/toolbox/console/layer-1/PerformanceMonitor/index.ts
@@ -1,0 +1,5 @@
+export { default as PerformanceMonitor } from './PerformanceMonitor';
+export { BlockWatcher } from './BlockWatcher';
+export { ChainInfo } from './ChainInfo';
+export type { BlockInfo } from './BlockWatcher';
+export type { BenchmarkChainInfo } from './ChainInfo';


### PR DESCRIPTION
## Summary

- **Genesis Builder Fee Config Improvements**: Added presets (Low/Standard/High Throughput), tooltips for each parameter, removed block time field, and added Custom JSON mode for advanced users
- **Performance Monitor Restoration**: Restored the deleted Performance Monitor tool with simplified single RPC URL input and smooth gradient area charts
- **Console Sidebar**: Added Performance Monitor to Layer 1 section

## Changes

### Genesis Builder
- Fee configuration presets dropdown (Low, Standard, High Throughput, Custom)
- Informative tooltips explaining each fee parameter's impact
- Removed block time field (handled separately in validator config)
- Custom JSON mode for advanced users to paste raw genesis configuration
- Collapsible accordion sections for better layout

### Performance Monitor
- Simplified from 4 inputs (node URL, blockchain ID, subnet ID, websocket) to single RPC URL input
- Real-time charts with gradient-filled area visualization
- Metrics: TPS, Gas Usage/sec, Blocks/sec
- Recent blocks table
- Uses HTTP polling (no WebSocket complexity)

## Test plan

- [ ] Visit `/console/layer-1/create` and test fee config presets
- [ ] Verify tooltips appear on hover for fee parameters
- [ ] Test Custom JSON mode toggle and paste functionality
- [ ] Navigate to `/console/layer-1/performance-monitor`
- [ ] Enter an RPC URL (e.g., `https://api.avax.network/ext/bc/C/rpc`) and start monitoring
- [ ] Verify charts render smoothly without animation jank