### PR TITLE
fix(console): set allow-unfinalized-queries to false by default

### DIFF
--- a/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
+++ b/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
@@ -157,7 +157,7 @@ function AvalanchegoDockerInner() {
             // RPC node defaults - optimized for query performance
             setPruningEnabled(false); // RPC nodes typically need full history
             setLogLevel("info");
-            setAllowUnfinalizedQueries(true); // Enable real-time queries
+            setAllowUnfinalizedQueries(false); // Default to finalized queries for safety
             setStateSyncEnabled(false); // RPC nodes need full historical data
             // Larger caches for better RPC performance
             setTrieCleanCache(1024); // 2x for better read performance
@@ -171,7 +171,7 @@ function AvalanchegoDockerInner() {
             setPruningEnabled(false); // Need full history for RPC queries
             setLogLevel("info");
             setMinDelayTarget(500); // Block production timing
-            setAllowUnfinalizedQueries(true); // Enable real-time queries
+            setAllowUnfinalizedQueries(false); // Default to finalized queries for safety
             setStateSyncEnabled(false); // Need full historical data for RPC queries
             // Larger caches for RPC performance while validating
             setTrieCleanCache(1024);


### PR DESCRIPTION
## Summary
- Changed the default value for `allow-unfinalized-queries` from `true` to `false` for both **Public RPC** and **Validator+RPC** node types in the L1 Node Setup wizard

## Why
Setting `allow-unfinalized-queries: true` lets RPC nodes return data from blocks that haven't been finalized yet. While this provides faster real-time responses, it can lead to issues if the data gets rolled back during a chain reorganization.

Setting the default to `false` ensures users receive only finalized/confirmed block data, which is safer for production applications. Users who specifically need real-time unfinalized queries can still enable this option manually via the checkbox in Advanced Settings.

## Test plan
- [x] Navigate to Console → L1 Node Setup
- [x] Select "Public RPC Node" type → verify `allow-unfinalized-queries` is unchecked by default
- [x] Select "Validator + Public RPC" type → verify `allow-unfinalized-queries` is unchecked by default
- [x] Select "Validator Node" type → verify behavior unchanged (was already `false`)
- [x] Toggle the checkbox in Advanced Settings → verify it still works correctly