### PR TITLE
fix: replace unsupported :::tip MDX directives with <Callout> components

### DIFF
--- a/content/docs/nodes/chain-configs/avalanche-l1s/avalanche-l1-configs.mdx
+++ b/content/docs/nodes/chain-configs/avalanche-l1s/avalanche-l1-configs.mdx
@@ -43,22 +43,20 @@ configuration. If a node sets `validatorOnly` to true, the node exchanges
 messages only with this Subnet's validators. Other peers will not be able to
 learn contents of this Subnet from this node.
 
-:::tip
+<Callout type="info">
 This is a node-specific configuration. Every validator of this Subnet has to use
 this configuration in order to create a full private Subnet.
-
-:::
+</Callout>
 
 #### `allowedNodes` (string list)
 
 If `validatorOnly=true` this allows explicitly specified NodeIDs to be allowed
 to sync the Subnet regardless of validator status. Defaults to be empty.
 
-:::tip
+<Callout type="info">
 This is a node-specific configuration. Every validator of this Subnet has to use
 this configuration in order to properly allow a node in the private Subnet.
-
-:::
+</Callout>
 
 ### Consensus Parameters
 

--- a/content/docs/rpcs/x-chain/api.mdx
+++ b/content/docs/rpcs/x-chain/api.mdx
@@ -771,10 +771,9 @@ This call is made to the wallet API endpoint:
 
 `/ext/bc/X/wallet`
 
-:::caution
+<Callout type="warn">
 Endpoint deprecated as of [**v1.9.12**](https://github.com/ava-labs/avalanchego/releases/tag/v1.9.12).
-
-:::
+</Callout>
 
 **Signature:**
 

--- a/content/docs/rpcs/x-chain/index.mdx
+++ b/content/docs/rpcs/x-chain/index.mdx
@@ -771,10 +771,9 @@ This call is made to the wallet API endpoint:
 
 `/ext/bc/X/wallet`
 
-:::caution
+<Callout type="warn">
 Endpoint deprecated as of [**v1.9.12**](https://github.com/ava-labs/avalanchego/releases/tag/v1.9.12).
-
-:::
+</Callout>
 
 **Signature:**
 

--- a/content/docs/rpcs/x-chain/rpc.mdx
+++ b/content/docs/rpcs/x-chain/rpc.mdx
@@ -771,10 +771,9 @@ This call is made to the wallet API endpoint:
 
 `/ext/bc/X/wallet`
 
-:::caution
+<Callout type="warn">
 Endpoint deprecated as of [**v1.9.12**](https://github.com/ava-labs/avalanchego/releases/tag/v1.9.12).
-
-:::
+</Callout>
 
 **Signature:**
 

--- a/utils/remote-content/parsers/pipelines.mts
+++ b/utils/remote-content/parsers/pipelines.mts
@@ -37,13 +37,26 @@ export const fixRelativeLinks: TransformFunction = (content, meta) => {
 
 export const fixGitHubMarkdown: TransformFunction = (content) => {
   return content
-    .replace(/>\s*\[NOTE\]\s*(.*?)$/gm, ':::note\n$1\n:::')
-    .replace(/>\s*\[TIP\]\s*(.*?)$/gm, ':::tip\n$1\n:::')
-    .replace(/^:::(\s*note|tip|warning|info|caution)\s*$/gm, ':::$1')
+    // Convert GitHub-style alerts to Callout components
+    .replace(/>\s*\[NOTE\]\s*(.*?)$/gm, '<Callout>$1</Callout>')
+    .replace(/>\s*\[TIP\]\s*(.*?)$/gm, '<Callout type="info">$1</Callout>')
+    .replace(/>\s*\[WARNING\]\s*(.*?)$/gm, '<Callout type="warn">$1</Callout>')
+    .replace(/>\s*\[CAUTION\]\s*(.*?)$/gm, '<Callout type="warn">$1</Callout>')
+    // Convert ::: directive blocks to Callout components (handles blank lines around content)
+    .replace(/:::note\s*\n([\s\S]*?)\n\s*:::/gm, (_, content) => `<Callout>${content.trim()}</Callout>`)
+    .replace(/:::tip\s*\n([\s\S]*?)\n\s*:::/gm, (_, content) => `<Callout type="info">${content.trim()}</Callout>`)
+    .replace(/:::warning\s*\n([\s\S]*?)\n\s*:::/gm, (_, content) => `<Callout type="warn">${content.trim()}</Callout>`)
+    .replace(/:::info\s*\n([\s\S]*?)\n\s*:::/gm, (_, content) => `<Callout type="info">${content.trim()}</Callout>`)
+    .replace(/:::caution\s*\n([\s\S]*?)\n\s*:::/gm, (_, content) => `<Callout type="warn">${content.trim()}</Callout>`)
+    // Convert images (but not links)
     .replace(/(?<!\[)!\[(.*?)\]\((.*?)\)/g, '<img alt="$1" src="$2" />')
-    .replace(/^!!!\s+(\w+)\s*\n/gm, ':::$1\n')
-    .replace(/^!!\s+(\w+)\s*\n/gm, '::$1\n')
+    // Convert admonition syntax (!!!, !!) to Callout
+    .replace(/^!!!\s+note\s*\n([\s\S]*?)(?=^!!!|\n\n|$)/gm, '<Callout>$1</Callout>\n')
+    .replace(/^!!!\s+tip\s*\n([\s\S]*?)(?=^!!!|\n\n|$)/gm, '<Callout type="info">$1</Callout>\n')
+    .replace(/^!!!\s+warning\s*\n([\s\S]*?)(?=^!!!|\n\n|$)/gm, '<Callout type="warn">$1</Callout>\n')
+    // Remove stray exclamation marks that aren't images or admonitions
     .replace(/^!([^[{].*?)$/gm, '$1')
+    // Convert HTML comments to MDX comments
     .replace(/<!--(.*?)-->/g, '{/* $1 */}');
 };
 


### PR DESCRIPTION
## Summary

- Updates the remote content parser to convert `:::tip`, `:::note`, `:::warning`, `:::info`, and `:::caution` directive syntax to `<Callout>` components during sync
- Fixes existing manual content files that had unsupported directive syntax
- The `<Callout>` component is globally available via `mdx-components.tsx`, so no imports are needed

## Problem

The `:::tip` syntax (Docusaurus-style markdown directives) is not supported by Fumadocs. These blocks were rendering as raw text instead of styled callout boxes.

## Changes

### Parser (`utils/remote-content/parsers/pipelines.mts`)
- Updated `fixGitHubMarkdown` transform to convert `:::` directive blocks to `<Callout>` components
- Added proper whitespace handling for source files that have blank lines around content

### Content Files
| File | Change |
|------|--------|
| `content/docs/nodes/chain-configs/avalanche-l1s/avalanche-l1-configs.mdx` | `:::tip` → `<Callout type="info">` |
| `content/docs/rpcs/x-chain/api.mdx` | `:::caution` → `<Callout type="warn">` |
| `content/docs/rpcs/x-chain/rpc.mdx` | `:::caution` → `<Callout type="warn">` |
| `content/docs/rpcs/x-chain/index.mdx` | `:::caution` → `<Callout type="warn">` |

## Type Mapping
- `note` → `<Callout>` (default)
- `tip`, `info` → `<Callout type="info">`
- `warning`, `caution` → `<Callout type="warn">`

## Test Plan
- [ ] Verify the affected pages render callouts correctly
- [ ] Run remote content sync to confirm parser handles upstream `:::tip` blocks