### PR TITLE
Fix grammatical error in multi-signature schemes documentation

### DIFF
--- a/content/common/cryptography/multi-signature-schemes.mdx
+++ b/content/common/cryptography/multi-signature-schemes.mdx
@@ -1,4 +1,4 @@
-Multi-signature schemes, also known as multi-sigs, are cryptographic methods enabling multiple parties to collectively authorize a specific action or operation, typically by requiring a predefined number of authorized participants to provide their digital signatures. In a multi-signature scheme, each authorized party possesses their own private key, and to validate the action. A specified subset of these parties must produce their unique signatures.
+Multi-signature schemes, also known as multi-sigs, are cryptographic methods enabling multiple parties to collectively authorize a specific action or operation, typically by requiring a predefined number of authorized participants to provide their digital signatures. In a multi-signature scheme, each authorized party possesses their own private key. To validate the action, a specified subset of these parties must produce their unique signatures.
 
 ![](/common-images/cryptography/multi-signature-schemes.png)
 


### PR DESCRIPTION
Fixed sentence structure by properly splitting a run-on sentence.
