### PR TITLE
fix(docs): disable duplicate search and theme toggles in DocsLayout

### DIFF
--- a/app/docs/docs-layout-wrapper.tsx
+++ b/app/docs/docs-layout-wrapper.tsx
@@ -100,6 +100,14 @@ export function DocsLayoutWrapper({
     nav: {
       enabled: false,
     },
+    // Disable fumadocs search toggle - we use our own search in the main header
+    searchToggle: {
+      enabled: false,
+    },
+    // Disable fumadocs theme switch - we use our own in the main header
+    themeSwitch: {
+      enabled: false,
+    },
     sidebar: {
       tabs: isMobile ? sidebarOptions.tabs : false,
       side: 'left', // Open sidebar from left on mobile


### PR DESCRIPTION
## Summary

- Disables fumadocs `searchToggle` in DocsLayout - prevents duplicate search bar from appearing
- Disables fumadocs `themeSwitch` in DocsLayout - prevents duplicate theme toggle from appearing

## Problem

The fumadocs `DocsLayout` (notebook variant) renders its own `SearchToggle` and `ThemeSwitch` components even when `nav.enabled: false` is set. This caused duplicate UI elements to appear below the custom `DocsSubNav` component - a second search bar and theme toggle that conflicted with the ones in the main header.

## Solution

Explicitly disable `searchToggle` and `themeSwitch` in the DocsLayout options since we use our own implementations in the main navigation header.

## Test plan

- [x] Verify no duplicate search bar appears on docs pages
- [x] Verify no duplicate theme toggle appears on docs pages
- [x] Verify main header search still works correctly
- [x] Verify main header theme toggle still works correctly
- [x] Test on both desktop and mobile viewports