### PR TITLE
feat(icm): update ICM Relayer to v1.7.5 and remove vm field

### DIFF
--- a/components/toolbox/console/icm/setup/relayer-config.ts
+++ b/components/toolbox/console/icm/setup/relayer-config.ts
@@ -34,7 +34,6 @@ export const genConfigCommand = (
         "source-blockchains": sources.map(source => ({
             "subnet-id": source.subnetId,
             "blockchain-id": source.blockchainId,
-            "vm": "evm",
             "rpc-endpoint": {
                 "base-url": source.rpcUrl,
             },
@@ -53,7 +52,6 @@ export const genConfigCommand = (
         "destination-blockchains": destinations.map(destination => ({
             "subnet-id": destination.subnetId,
             "blockchain-id": destination.blockchainId,
-            "vm": "evm",
             "rpc-endpoint": {
                 "base-url": destination.rpcUrl
             },
@@ -110,7 +108,6 @@ export const generateRelayerConfig = (
         "source-blockchains": sources.map(source => ({
             "subnet-id": source.subnetId,
             "blockchain-id": source.blockchainId,
-            "vm": "evm",
             "rpc-endpoint": {
                 "base-url": source.rpcUrl,
             },
@@ -129,7 +126,6 @@ export const generateRelayerConfig = (
         "destination-blockchains": destinations.map(destination => ({
             "subnet-id": destination.subnetId,
             "blockchain-id": destination.blockchainId,
-            "vm": "evm",
             "rpc-endpoint": {
                 "base-url": destination.rpcUrl
             },

--- a/content/academy/avalanche-l1/interchain-messaging/09-running-a-relayer/02-relayer-configuration.mdx
+++ b/content/academy/avalanche-l1/interchain-messaging/09-running-a-relayer/02-relayer-configuration.mdx
@@ -48,7 +48,6 @@ Next is the configuration for our source blockchain. This is the configuration o
 	{
       "subnet-id": "11111111111111111111111111111111LpoYY",
       "blockchain-id": "epm5fG6Pn1Y5rBHdTe36aZYeLqpXugreyHLZB5dV81rVTs7Ku",
-      "vm": "evm",
       "rpc-endpoint": {
         "base-url": "http://127.0.0.1:9650/ext/bc/epm5fG6Pn1Y5rBHdTe36aZYeLqpXugreyHLZB5dV81rVTs7Ku/rpc",
         "query-parameters": null,
@@ -82,7 +81,6 @@ Next is the configuration for our source blockchain. This is the configuration o
 
 - **subnet-id:** The Blockchain ID of the L1 that the source blockchain is part of. In this example this is the Blockchain ID of the Primary Network.
 - **blockchain-id:** The blockchain ID of the source. In this example this is the blockchain ID of Fuji's C-Chain.
-- **vm:** A string specifying the virtual machine of the destination L1's blockchain. Currently, only the EVM is supported, but this field has been added in anticipation of communication between blockchains powered by different virtual machines in the future.
 - **rpc-endpoint:** An API Config containing:
 <div class="pl-6">
 - **base-url:** RPC endpoint of the source L1's API node.
@@ -110,7 +108,6 @@ Next is the configuration for our destination blockchain. This is the configurat
     {
       "subnet-id": "11111111111111111111111111111111LpoYY",
       "blockchain-id": "epm5fG6Pn1Y5rBHdTe36aZYeLqpXugreyHLZB5dV81rVTs7Ku",
-      "vm": "evm",
       "rpc-endpoint": {
         "base-url": "http://127.0.0.1:9650/ext/bc/epm5fG6Pn1Y5rBHdTe36aZYeLqpXugreyHLZB5dV81rVTs7Ku/rpc",
         "query-parameters": null,
@@ -128,7 +125,6 @@ For each destination L1, the relayer has the following config parameter:
 
 - **subnet-id:** The ID of the L1 that the destination blockchain is part of. 
 - **blockchain-id:** The blockchain ID of the destination blockchain. This is the Blockchain ID of Fuji's Dispatch L1.
-- **vm:** A string specifying the virtual machine of the destination L1's blockchain. Currently, only the EVM is supported, but this field has been added in anticipation of communication between blockchains powered by different virtual machines in the future.
 - **rpc-endpoint:** The RPC endpoint of the destination L1's API node. Used in favor of api-node-host, api-node-port, and encrypt-connection when constructing the endpoint.
 - **kms-key-id:** The ID of the KMS key to use for signing transactions on the destination blockchain. Only one of account-private-key or kms-key-id should be provided. If kms-key-id is provided, then kms-aws-region is required. Please note that the private key in KMS should be exclusive to the relayer. 
 - **kms-aws-region:** The AWS region in which the KMS key is located. Required if kms-key-id is provided. 

--- a/scripts/versions.json
+++ b/scripts/versions.json
@@ -2,7 +2,7 @@
   "mainnet": {
     "avaplatform/avalanchego": "v1.14.1",
     "avaplatform/subnet-evm_avalanchego": "v0.8.0_v1.14.0",
-    "avaplatform/icm-relayer": "v1.7.4"
+    "avaplatform/icm-relayer": "v1.7.5"
   },
   "testnet": {
     "avaplatform/avalanchego": "v1.14.0-fuji",


### PR DESCRIPTION
## Summary                                                                                                                                                                  
  - Update ICM Relayer mainnet version from v1.7.4 to v1.7.5                                                                                                                  
  - Remove `vm` field from relayer config generator (breaking change in v1.7.5)                                                                                               
  - Update academy documentation to remove `vm` field references                                                                                                              
                                                                                                                                                                              
  ## Test plan                                                                                                                                                                
  - [ ] Navigate to `/console/icm/setup/icm-relayer` and verify generated config JSON does NOT contain `vm` fields                                                            
  - [ ] Verify Docker command shows `v1.7.5` for mainnet                                                                                                                      
  - [ ] Check academy course at `/academy/avalanche-l1/interchain-messaging/running-a-relayer/relayer-configuration` - verify JSON examples don't show `vm` field        