### PR TITLE
docs: add Avalanche Deploy IaC tooling documentation

### DIFF
--- a/content/docs/tooling/avalanche-deploy/architecture.mdx
+++ b/content/docs/tooling/avalanche-deploy/architecture.mdx
@@ -1,0 +1,223 @@
+---
+title: Architecture
+description: Understanding the Avalanche Deploy infrastructure components
+---
+
+Avalanche Deploy creates a complete infrastructure stack for running Avalanche L1 blockchains in production.
+
+## Architecture Overview
+
+```
+                         Avalanche Network (Fuji/Mainnet)
+                                    │
+          ┌─────────────────────────┼─────────────────────────┐
+          │                         │                         │
+          ▼                         ▼                         ▼
+    ┌───────────┐            ┌───────────┐            ┌───────────┐
+    │ Validator │◄──── P2P ──►│ Validator │◄─── P2P ──►│    RPC    │
+    │     1     │             │     2     │            │   Node    │
+    │   :9651   │             │   :9651   │            │:9650/:9651│
+    └─────┬─────┘             └─────┬─────┘            └─────┬─────┘
+          │                         │                        │
+          └─────────────────────────┴────────────────────────┘
+                                    │ metrics
+                                    ▼
+                             ┌─────────────┐
+                             │  Monitoring │
+                             │  Prometheus │
+                             │ Grafana:3000│
+                             └─────────────┘
+
+External Access:
+  • RPC API:    http://<rpc-ip>:9650/ext/bc/<chain>/rpc
+  • Blockscout: http://<rpc-ip>:4001
+  • Grafana:    http://<monitoring-ip>:3000
+```
+
+## Project Structure
+
+```
+avalanche-deploy/
+├── terraform/              # Infrastructure as Code
+│   ├── aws/               # AWS-specific configuration
+│   ├── gcp/               # GCP-specific configuration
+│   ├── azure/             # Azure-specific configuration
+│   └── modules/           # Shared compute/networking modules
+├── ansible/               # Configuration management
+│   ├── playbooks/         # Numbered deployment phases
+│   │   ├── 01-deploy-nodes.yml      # Install avalanchego
+│   │   ├── 02-configure-l1.yml      # Add subnet tracking
+│   │   └── 03-setup-monitoring.yml  # Prometheus/Grafana
+│   └── roles/             # avalanchego, prometheus, grafana
+├── tools/
+│   ├── create-l1/         # Go CLI for L1 creation
+│   └── pchain-cli/        # P-Chain utilities library
+├── shared/                # Genesis templates, configs, dashboards
+└── scripts/               # Helper scripts (status.sh, wait-for-sync.sh)
+```
+
+## Deployment Workflow
+
+### Three-Phase Ansible Deployment
+
+1. **01-deploy-nodes.yml** - Installs avalanchego, generates staking keys, starts syncing with the network
+2. **02-configure-l1.yml** - Adds `track-subnets` configuration after L1 creation
+3. **03-setup-monitoring.yml** - Deploys Prometheus and Grafana monitoring stack
+
+### Terraform to Ansible Integration
+
+Terraform automatically generates Ansible inventory files with node IPs and SSH key paths:
+
+```
+terraform/aws/          →  ansible/inventory/aws_hosts
+terraform/gcp/          →  ansible/inventory/gcp_hosts
+terraform/azure/        →  ansible/inventory/azure_hosts
+```
+
+## Cloud Provider Configuration
+
+### AWS (Default)
+
+```bash
+make infra          # Uses terraform/aws/
+```
+
+Default instance types:
+- Validators: `c5.2xlarge`
+- RPC Node: `c5.2xlarge`
+- Monitoring: `t3.medium`
+
+### GCP
+
+```bash
+make infra CLOUD=gcp
+```
+
+Default machine types:
+- Validators: `n2-standard-8`
+- RPC Node: `n2-standard-8`
+- Monitoring: `e2-medium`
+
+### Azure
+
+```bash
+make infra CLOUD=azure
+```
+
+Default VM sizes:
+- Validators: `Standard_D8s_v3`
+- RPC Node: `Standard_D8s_v3`
+- Monitoring: `Standard_B2s`
+
+## Genesis Configuration
+
+The `genesis.json` file in the project root configures your L1 chain. Key fields:
+
+```json
+{
+  "config": {
+    "chainId": 99999,
+    "feeConfig": {
+      "gasLimit": 15000000,
+      "targetBlockRate": 2,
+      "minBaseFee": 25000000000
+    },
+    "warpConfig": {
+      "blockTimestamp": 0,
+      "quorumNumerator": 67
+    }
+  },
+  "alloc": {
+    "0xYourAddress": {
+      "balance": "0x52B7D2DCC80CD2E4000000"
+    }
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `chainId` | Unique chain ID (check [chainlist.org](https://chainlist.org)) |
+| `gasLimit` | Maximum gas per block |
+| `targetBlockRate` | Target seconds between blocks |
+| `minBaseFee` | Minimum gas price in wei |
+| `alloc` | Pre-funded addresses (balance in wei, hex format) |
+
+## Monitoring
+
+The monitoring stack includes:
+
+- **Prometheus**: Metrics collection from all nodes
+- **Grafana**: Pre-configured dashboards for avalanchego metrics
+
+Access Grafana at `http://<monitoring-ip>:3000` with default credentials `admin/admin`.
+
+### Key Metrics
+
+- Block height and sync status
+- P2P peer connections
+- Transaction throughput
+- Resource utilization (CPU, memory, disk)
+
+## Blockscout
+
+Optional block explorer deployment:
+
+```bash
+make deploy-blockscout CHAIN_ID=$CHAIN_ID EVM_CHAIN_ID=99999
+```
+
+Provides:
+- Transaction explorer
+- Block explorer
+- Address tracking
+- Contract verification
+
+## Tools
+
+### create-l1
+
+Go CLI tool that issues P-Chain transactions to create your L1:
+
+1. `CreateSubnetTx` - Creates a new subnet
+2. `CreateChainTx` - Creates a chain with SubnetEVM and your genesis
+3. `ConvertSubnetToL1Tx` - Registers validators
+
+### pchain-cli
+
+Library and CLI for P-Chain operations:
+
+```bash
+# Build the CLI
+cd tools/pchain-cli && go build -o pchain-cli .
+
+# Check wallet balance
+./pchain-cli wallet balance --private-key "PrivateKey-..."
+
+# Get node information
+./pchain-cli node info --ip 10.0.0.1
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_ACCESS_KEY_ID` | AWS credentials |
+| `AWS_SECRET_ACCESS_KEY` | AWS credentials |
+| `AVALANCHE_PRIVATE_KEY` | P-Chain private key for L1 creation |
+| `L1_VALIDATOR_BALANCE_AVAX` | Initial validator balance (default: 1 AVAX) |
+
+## Commands Reference
+
+| Command | Description |
+|---------|-------------|
+| `make setup` | Install terraform, ansible, jq |
+| `make infra` | Create cloud infrastructure |
+| `make deploy` | Install avalanchego on nodes |
+| `make status` | Check node sync status |
+| `make create-l1` | Build the L1 creation tool |
+| `make configure-l1` | Configure nodes for L1 |
+| `make monitoring` | Deploy Prometheus + Grafana |
+| `make deploy-blockscout` | Deploy block explorer |
+| `make logs` | View avalanchego logs |
+| `make destroy` | Tear down infrastructure |

--- a/content/docs/tooling/avalanche-deploy/index.mdx
+++ b/content/docs/tooling/avalanche-deploy/index.mdx
@@ -1,0 +1,74 @@
+---
+title: Avalanche Deploy
+description: Infrastructure as Code for deploying production-ready Avalanche L1 blockchains on AWS, GCP, or Azure
+---
+
+Avalanche Deploy automates the deployment of production-ready Avalanche L1 blockchains using Infrastructure as Code (IaC). Deploy validator nodes, RPC endpoints, and monitoring infrastructure to major cloud providers with a single command.
+
+## Key Features
+
+- **Multi-Cloud Support**: Deploy to AWS, GCP, or Azure with the same workflow
+- **Automated Node Deployment**: Install and configure avalanchego validators and RPC nodes
+- **L1 Creation**: Create subnets and chains with the integrated `create-l1` tool
+- **Monitoring Stack**: Built-in Prometheus and Grafana dashboards
+- **Block Explorer**: Optional Blockscout deployment for your L1
+
+## Deployment Paths
+
+Avalanche Deploy supports two deployment approaches:
+
+| Approach | Best For | Tools Used |
+|----------|----------|------------|
+| **Terraform + Ansible** | Production deployments on cloud VMs | Terraform (infrastructure), Ansible (configuration) |
+| **Kubernetes** | Existing K8s clusters | Helm charts |
+
+## What You Get
+
+| Component | Default | Purpose |
+|-----------|---------|---------|
+| **Validators** | 2 | Block production, consensus |
+| **RPC Node** | 1 | External queries, block explorer |
+| **Monitoring** | 1 | Prometheus + Grafana dashboards |
+
+## Quick Links
+
+<Cards>
+  <Card title="Quick Start" href="/docs/tooling/avalanche-deploy/quickstart">
+    Deploy your first L1 in minutes
+  </Card>
+  <Card title="Architecture" href="/docs/tooling/avalanche-deploy/architecture">
+    Understand the infrastructure components
+  </Card>
+  <Card title="GitHub Repository" href="https://github.com/ava-labs/avalanche-deploy">
+    View source code and contribute
+  </Card>
+</Cards>
+
+## Cost Estimate
+
+| Provider | Monthly (2 validators + 1 RPC + monitoring) |
+|----------|---------------------------------------------|
+| AWS | ~$225 |
+| GCP | ~$195 |
+| Azure | ~$420 |
+
+<Callout type="warn">
+Remember to run `make destroy` when done testing to stop billing!
+</Callout>
+
+## Comparison with Avalanche-CLI
+
+| Feature | Avalanche Deploy | Avalanche-CLI |
+|---------|-----------------|---------------|
+| **Focus** | Production infrastructure | Development & testing |
+| **Cloud Deployment** | Automated VM provisioning | Manual or requires separate setup |
+| **Monitoring** | Built-in Prometheus/Grafana | Not included |
+| **Block Explorer** | Optional Blockscout | Not included |
+| **Best For** | DevOps teams, production | Developers, local testing |
+
+For local development and testing, consider [Avalanche-CLI](/docs/tooling/avalanche-cli). For production deployments with Infrastructure as Code, use Avalanche Deploy.
+
+## Support
+
+- [GitHub Issues](https://github.com/ava-labs/avalanche-deploy/issues)
+- [Discord Community](https://chat.avalabs.org/)

--- a/content/docs/tooling/avalanche-deploy/meta.json
+++ b/content/docs/tooling/avalanche-deploy/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Avalanche Deploy",
+  "description": "Infrastructure as Code for deploying Avalanche L1 blockchains",
+  "root": true,
+  "pages": [
+    "index",
+    "quickstart",
+    "architecture"
+  ]
+}

--- a/content/docs/tooling/avalanche-deploy/quickstart.mdx
+++ b/content/docs/tooling/avalanche-deploy/quickstart.mdx
@@ -1,0 +1,153 @@
+---
+title: Quick Start
+description: Deploy an Avalanche L1 blockchain on AWS in 5 steps
+---
+
+This guide walks you through deploying a production-ready Avalanche L1 blockchain on AWS using Terraform and Ansible.
+
+## Prerequisites
+
+Install the required tools:
+
+```bash
+brew install terraform ansible awscli jq go
+```
+
+Ensure you have:
+- AWS account with programmatic access
+- SSH key pair for node access
+- Funded P-Chain address on Fuji (for testnet) or Mainnet
+
+## Step 1: Clone and Setup
+
+```bash
+git clone https://github.com/ava-labs/avalanche-deploy.git
+cd avalanche-deploy
+make setup
+```
+
+## Step 2: Configure AWS Credentials
+
+```bash
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+```
+
+## Step 3: Configure Terraform
+
+```bash
+cd terraform/aws
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars`:
+
+```hcl
+name_prefix     = "my-l1"
+environment     = "fuji"
+validator_count = 2
+rpc_count       = 1
+ssh_public_key  = "ssh-rsa AAAA..."
+ssh_private_key_file = "~/.ssh/avalanche-deploy"
+```
+
+## Step 4: Deploy Infrastructure
+
+```bash
+# Create cloud infrastructure
+terraform init && terraform apply
+
+# Return to project root
+cd ../..
+
+# Install avalanchego on nodes
+make deploy
+
+# Wait for nodes to sync (check status)
+make status
+```
+
+<Callout type="info">
+Wait until all nodes show "P:OK" before proceeding. This indicates they've synced with the P-Chain.
+</Callout>
+
+## Step 5: Create Your L1
+
+```bash
+# Set your funded P-Chain private key
+export AVALANCHE_PRIVATE_KEY="PrivateKey-ewoq..."
+
+# Get validator IPs from Terraform
+export VALIDATORS=$(cd terraform/aws && terraform output -json validator_ips | jq -r 'join(",")')
+
+# Build and run the L1 creation tool
+make create-l1
+./tools/create-l1/create-l1 \
+  --network=fuji \
+  --validators=$VALIDATORS \
+  --chain-name=mychain \
+  --output=l1.env
+
+# Configure nodes to track your new L1
+source l1.env
+make configure-l1 SUBNET_ID=$SUBNET_ID CHAIN_ID=$CHAIN_ID
+```
+
+## Your L1 is Running
+
+Your L1 blockchain is now live. Access it via:
+
+```bash
+# RPC endpoint
+curl http://<rpc-ip>:9650/ext/bc/$CHAIN_ID/rpc \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
+```
+
+## Next Steps
+
+<Cards>
+  <Card title="Add Monitoring" href="/docs/tooling/avalanche-deploy/architecture#monitoring">
+    Deploy Prometheus and Grafana dashboards
+  </Card>
+  <Card title="Deploy Block Explorer" href="/docs/tooling/avalanche-deploy/architecture#blockscout">
+    Add Blockscout for transaction visibility
+  </Card>
+  <Card title="Customize Genesis" href="/docs/tooling/avalanche-deploy/architecture#genesis-configuration">
+    Configure chain parameters and pre-funded accounts
+  </Card>
+</Cards>
+
+## Optional: Monitoring
+
+```bash
+make monitoring
+# Access Grafana at http://<monitoring-ip>:3000 (admin/admin)
+```
+
+## Optional: Block Explorer
+
+```bash
+source l1.env
+make deploy-blockscout CHAIN_ID=$CHAIN_ID EVM_CHAIN_ID=99999
+# Access Blockscout at http://<rpc-ip>:4001
+```
+
+## Cleanup
+
+<Callout type="warn">
+Always destroy infrastructure when done testing to stop AWS billing.
+</Callout>
+
+```bash
+make destroy
+```
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Ansible can't connect | Check SSH key path in `ansible/inventory/aws_hosts` |
+| Nodes not syncing | Run `make logs` to view avalanchego errors |
+| "insufficient funds" | Fund your P-Chain address on Fuji faucet |
+| "illegal name character" | Chain names must be alphanumeric only (no hyphens) |


### PR DESCRIPTION
Add Infrastructure as Code documentation for the avalanche-deploy repository:

- index.mdx: Overview, features, cost estimates, comparison with CLI
- quickstart.mdx: Step-by-step AWS deployment guide
- architecture.mdx: Infrastructure components, project structure, commands

This covers deploying production-ready Avalanche L1 blockchains using Terraform and Ansible on AWS, GCP, or Azure.