### PR TITLE
docs: add Avalanche Deploy IaC documentation

### DIFF
--- a/content/docs/tooling/avalanche-deploy/architecture.mdx
+++ b/content/docs/tooling/avalanche-deploy/architecture.mdx
@@ -1,0 +1,268 @@
+---
+title: Architecture
+description: Infrastructure components, data flow, and project structure for Avalanche Deploy
+---
+
+## Infrastructure Overview
+
+Avalanche Deploy creates a complete L1 infrastructure with the following components:
+
+```
+                         Avalanche Network (Fuji/Mainnet)
+                                    │
+          ┌─────────────────────────┼─────────────────────────┐
+          │                         │                         │
+          ▼                         ▼                         ▼
+    ┌───────────┐            ┌───────────┐            ┌───────────┐
+    │ Validator │◄──── P2P ──►│ Validator │◄─── P2P ──►│    RPC    │
+    │     1     │             │     2     │            │   Node    │
+    │   :9651   │             │   :9651   │            │:9650/:9651│
+    └─────┬─────┘             └─────┬─────┘            └─────┬─────┘
+          │                         │                        │
+          └─────────────────────────┴────────────────────────┘
+                                    │ metrics
+                                    ▼
+                             ┌─────────────┐
+                             │  Monitoring │
+                             │  Prometheus │
+                             │ Grafana:3000│
+                             └─────────────┘
+```
+
+### Component Roles
+
+| Component | Port | Purpose |
+|-----------|------|---------|
+| **Validators** | 9651 (P2P only) | Participate in consensus, produce blocks. No external API access. |
+| **RPC Node** | 9650 (API), 9651 (P2P) | Serve external API requests. Archive mode enabled for full query support. |
+| **Monitoring** | 3000 (Grafana) | Collect metrics from all nodes, provide dashboards. |
+
+### External Access Points
+
+| Service | URL | Notes |
+|---------|-----|-------|
+| L1 RPC API | `http://<rpc-ip>:9650/ext/bc/<chain-id>/rpc` | EVM JSON-RPC endpoint |
+| Blockscout | `http://<rpc-ip>:4001` | Optional block explorer |
+| Grafana | `http://<monitoring-ip>:3000` | Metrics dashboards (admin/admin) |
+
+## Project Structure
+
+```
+avalanche-deploy/
+├── terraform/              # Infrastructure as Code
+│   ├── aws/               # AWS-specific configuration
+│   │   ├── main.tf        # VM definitions, VPC, security groups
+│   │   ├── variables.tf   # Input variables
+│   │   ├── outputs.tf     # IP addresses, SSH key paths
+│   │   └── terraform.tfvars.example
+│   ├── gcp/               # GCP-specific configuration
+│   ├── azure/             # Azure-specific configuration
+│   └── modules/           # Shared compute/networking modules
+│
+├── ansible/               # Configuration Management
+│   ├── playbooks/         # Numbered deployment phases
+│   │   ├── 01-deploy-nodes.yml       # Install avalanchego
+│   │   ├── 02-configure-l1.yml       # Add subnet tracking
+│   │   ├── 03-setup-monitoring.yml   # Prometheus/Grafana
+│   │   ├── 04-deploy-blockscout.yml  # Block explorer
+│   │   └── 05-deploy-safe.yml        # Safe multisig (experimental)
+│   ├── roles/             # Reusable role definitions
+│   │   ├── avalanchego/   # Node installation and config
+│   │   ├── prometheus/    # Metrics collection
+│   │   ├── grafana/       # Dashboards
+│   │   └── blockscout/    # Block explorer
+│   └── inventory/         # Auto-generated host files
+│
+├── tools/create-l1/       # Go CLI for L1 creation
+│   ├── main.go            # Entry point
+│   └── go.mod             # Dependencies (avalanchego SDK)
+│
+├── shared/                # Shared configurations
+│   ├── genesis-templates/ # Clean genesis files
+│   └── safe/              # Safe contract merge scripts
+│
+├── scripts/               # Helper scripts
+│   ├── status.sh          # Node health check
+│   └── wait-for-sync.sh   # Wait for P-Chain sync
+│
+├── genesis.json           # Your L1's genesis configuration
+├── validator-chain-config.json  # Validator-specific chain config
+├── rpc-chain-config.json        # RPC node chain config (archive mode)
+└── Makefile               # Command shortcuts
+```
+
+## Deployment Phases
+
+### Phase 1: Infrastructure (Terraform)
+
+Terraform creates cloud resources and generates Ansible inventory:
+
+```
+terraform apply
+    │
+    ├── Creates VPC and networking
+    ├── Creates security groups (ports 9650, 9651, 22)
+    ├── Launches validator VMs
+    ├── Launches RPC node VM
+    ├── Launches monitoring VM
+    │
+    └── Outputs → ansible/inventory/aws_hosts
+```
+
+The generated inventory file contains:
+
+```ini
+[validators]
+10.0.1.10 ansible_user=ubuntu ansible_ssh_private_key_file=~/.ssh/avalanche-deploy
+10.0.1.11 ansible_user=ubuntu ansible_ssh_private_key_file=~/.ssh/avalanche-deploy
+
+[rpc]
+10.0.1.20 ansible_user=ubuntu ansible_ssh_private_key_file=~/.ssh/avalanche-deploy
+
+[monitoring]
+10.0.1.30 ansible_user=ubuntu ansible_ssh_private_key_file=~/.ssh/avalanche-deploy
+```
+
+### Phase 2: Node Deployment (Ansible)
+
+`01-deploy-nodes.yml` installs and configures avalanchego:
+
+```
+ansible-playbook 01-deploy-nodes.yml
+    │
+    ├── Install avalanchego binary
+    ├── Generate staking keys (BLS + TLS)
+    ├── Configure node.json
+    │   ├── Validators: partial-sync-primary-network=true
+    │   └── RPC: archive mode, debug APIs enabled
+    ├── Start avalanchego service
+    │
+    └── Nodes begin syncing P-Chain
+```
+
+### Phase 3: L1 Creation (Go Tool)
+
+The `create-l1` tool executes P-Chain transactions:
+
+```
+./create-l1 --network=fuji --validators=10.0.1.10,10.0.1.11
+    │
+    ├── CreateSubnetTx → SUBNET_ID
+    ├── CreateChainTx  → CHAIN_ID (deploys genesis)
+    ├── ConvertSubnetToL1Tx (registers validators)
+    │
+    └── Outputs → l1.env
+```
+
+### Phase 4: L1 Configuration (Ansible)
+
+`02-configure-l1.yml` updates nodes to track the new L1:
+
+```
+ansible-playbook 02-configure-l1.yml -e subnet_id=xxx -e chain_id=yyy
+    │
+    ├── Add track-subnets to node config
+    ├── Copy chain-specific config
+    │   ├── Validators: validator-chain-config.json
+    │   └── RPC: rpc-chain-config.json
+    ├── Restart avalanchego
+    │
+    └── Nodes begin syncing L1 chain
+```
+
+## Configuration Files
+
+### Node Configuration
+
+**Validators** (`validator-node-config.json`):
+```json
+{
+  "partial-sync-primary-network": true,
+  "track-subnets": "<SUBNET_ID>"
+}
+```
+
+**RPC Node** (`rpc-node-config.json`):
+```json
+{
+  "partial-sync-primary-network": true,
+  "track-subnets": "<SUBNET_ID>"
+}
+```
+
+### Chain Configuration
+
+**Validators** (`validator-chain-config.json`):
+```json
+{
+  "pruning-enabled": true,
+  "state-sync-enabled": true,
+  "eth-apis": ["eth", "net", "web3"]
+}
+```
+
+**RPC Node** (`rpc-chain-config.json`):
+```json
+{
+  "pruning-enabled": false,
+  "state-sync-enabled": false,
+  "eth-apis": ["eth", "net", "web3", "debug", "txpool"]
+}
+```
+
+### Genesis Configuration
+
+Your L1's genesis configuration lives in `genesis.json`:
+
+```json
+{
+  "config": {
+    "chainId": 99999,
+    "feeConfig": {
+      "gasLimit": 15000000,
+      "targetBlockRate": 2,
+      "minBaseFee": 25000000000,
+      "baseFeeChangeDenominator": 48
+    },
+    "subnetEVMTimestamp": 0,
+    "durangoTimestamp": 0
+  },
+  "alloc": {
+    "0xYourAddress": {
+      "balance": "0x52B7D2DCC80CD2E4000000"
+    }
+  }
+}
+```
+
+See [Genesis Configuration](/docs/avalanche-l1s/evm-configuration/genesis) for detailed options.
+
+## Security Groups
+
+### Default Ports
+
+| Port | Protocol | Source | Purpose |
+|------|----------|--------|---------|
+| 22 | TCP | Your IP | SSH access |
+| 9650 | TCP | 0.0.0.0/0 | API (RPC node only) |
+| 9651 | TCP | 0.0.0.0/0 | P2P consensus |
+| 3000 | TCP | Your IP | Grafana (monitoring only) |
+| 4001 | TCP | 0.0.0.0/0 | Blockscout (if deployed) |
+
+### Security Recommendations
+
+- Restrict SSH access to your IP range
+- Consider putting Grafana behind a VPN
+- Use HTTPS termination (nginx/ALB) for production RPC endpoints
+- Rotate SSH keys periodically
+
+## Cloud Provider Differences
+
+| Aspect | AWS | GCP | Azure |
+|--------|-----|-----|-------|
+| VM Type | t3.xlarge | e2-standard-4 | Standard_D4s_v3 |
+| Storage | gp3 EBS | pd-ssd | Premium SSD |
+| Networking | VPC | VPC | VNet |
+| Config Path | `terraform/aws/` | `terraform/gcp/` | `terraform/azure/` |
+
+All providers use the same Ansible playbooks after infrastructure is created.

--- a/content/docs/tooling/avalanche-deploy/index.mdx
+++ b/content/docs/tooling/avalanche-deploy/index.mdx
@@ -1,0 +1,98 @@
+---
+title: Overview
+description: Deploy production-ready Avalanche L1 blockchains on AWS, GCP, or Azure using Terraform and Ansible
+---
+
+Avalanche Deploy automates the deployment of production-ready Avalanche L1 blockchains on major cloud providers. It handles infrastructure provisioning, node installation, monitoring setup, and optional block explorer deployment—all through simple make commands.
+
+## What You Get
+
+| Component | Default | Purpose |
+|-----------|---------|---------|
+| **Validators** | 2 | Block production, consensus participation |
+| **RPC Node** | 1 | External API queries, block explorer backend |
+| **Monitoring** | 1 | Prometheus metrics + Grafana dashboards |
+
+**Optional Add-ons:**
+- **Blockscout** - Full-featured block explorer for your L1
+- **Safe Multisig** - Gnosis Safe infrastructure (experimental)
+
+## Supported Cloud Providers
+
+| Provider | Command | Monthly Cost Estimate |
+|----------|---------|----------------------|
+| AWS | `make infra` | ~$225 |
+| GCP | `make infra CLOUD=gcp` | ~$195 |
+| Azure | `make infra CLOUD=azure` | ~$420 |
+
+Cost estimates are for 2 validators + 1 RPC node + 1 monitoring instance.
+
+## Deployment Paths
+
+### Terraform + Ansible (Recommended)
+
+Creates cloud VMs from scratch and configures them with avalanchego:
+
+```bash
+make setup      # Install tools
+make infra      # Create cloud VMs
+make deploy     # Install avalanchego
+make create-l1  # Create your L1 blockchain
+make status     # Verify everything works
+```
+
+### Kubernetes (Alternative)
+
+For teams with existing Kubernetes clusters, deploy using Helm charts in the `kubernetes/` directory.
+
+## Key Features
+
+| Feature | Description |
+|---------|-------------|
+| **Multi-Cloud** | Deploy to AWS, GCP, or Azure with the same workflow |
+| **Auto-Generated Inventory** | Terraform outputs feed directly into Ansible |
+| **Production Configs** | Validator vs RPC node configurations optimized for their roles |
+| **Monitoring Included** | Prometheus + Grafana with Avalanche-specific dashboards |
+| **Block Explorer** | Optional Blockscout deployment with one command |
+| **L1 Creation Tool** | Go CLI handles P-Chain transactions (CreateSubnet, CreateChain, ConvertToL1) |
+
+## Quick Commands
+
+| Command | Description |
+|---------|-------------|
+| `make setup` | Install terraform, ansible, aws-cli, jq |
+| `make infra` | Create cloud infrastructure |
+| `make deploy` | Install avalanchego on nodes |
+| `make status` | Check node sync status |
+| `make create-l1` | Build the L1 creation tool |
+| `make configure-l1` | Configure nodes after L1 creation |
+| `make monitoring` | Deploy Prometheus + Grafana |
+| `make deploy-blockscout` | Deploy block explorer |
+| `make destroy` | Tear down infrastructure (stops billing!) |
+
+## Getting Started
+
+<Cards>
+  <Card title="Quick Start" href="/docs/tooling/avalanche-deploy/quickstart">
+    Deploy your first L1 on AWS in under 30 minutes
+  </Card>
+  <Card title="Architecture" href="/docs/tooling/avalanche-deploy/architecture">
+    Understand the infrastructure components and data flow
+  </Card>
+</Cards>
+
+## Prerequisites
+
+Before starting, you'll need:
+
+- **Cloud credentials** - AWS, GCP, or Azure account with appropriate permissions
+- **SSH key** - For accessing the deployed VMs
+- **Funded P-Chain address** - With AVAX on Fuji (testnet) or Mainnet
+- **Local tools** - Terraform, Ansible, Go 1.21+
+
+## Resources
+
+- [GitHub Repository](https://github.com/ava-labs/avalanche-deploy)
+- [Fuji Faucet](https://faucet.avax.network/) - Get test AVAX
+- [Chain List](https://chainlist.org/) - Check chain ID availability
+- [Builder Console](https://build.avax.network/) - Generate genesis configurations

--- a/content/docs/tooling/avalanche-deploy/meta.json
+++ b/content/docs/tooling/avalanche-deploy/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Avalanche Deploy",
+  "description": "Infrastructure as Code for deploying Avalanche L1 blockchains",
+  "root": true,
+  "pages": [
+    "index",
+    "quickstart",
+    "architecture"
+  ]
+}

--- a/content/docs/tooling/avalanche-deploy/quickstart.mdx
+++ b/content/docs/tooling/avalanche-deploy/quickstart.mdx
@@ -1,0 +1,229 @@
+---
+title: Quick Start
+description: Deploy an Avalanche L1 blockchain on AWS with Terraform and Ansible
+---
+
+This guide walks you through deploying a complete Avalanche L1 blockchain on AWS. The same workflow applies to GCP and Azure with minor configuration changes.
+
+## Prerequisites
+
+Install the required tools:
+
+```bash
+# macOS
+brew install terraform ansible awscli jq go
+
+# Or use the setup command
+make setup
+```
+
+**Go private dependency setup** (required for the L1 creation tool):
+
+```bash
+go env -w GOPRIVATE=github.com/ava-labs/platform-cli
+git config --global url."git@github.com:".insteadOf "https://github.com/"
+```
+
+## Step 1: Configure AWS Credentials
+
+```bash
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+export AWS_DEFAULT_REGION="us-east-1"
+```
+
+## Step 2: Generate SSH Key
+
+Create a dedicated SSH key for your deployment:
+
+```bash
+ssh-keygen -t rsa -b 4096 -f ~/.ssh/avalanche-deploy -N ""
+```
+
+## Step 3: Configure Terraform
+
+```bash
+cd terraform/aws
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars`:
+
+```hcl
+name_prefix        = "my-l1"
+environment        = "fuji"        # or "mainnet"
+validator_count    = 2
+rpc_count          = 1
+ssh_public_key     = "ssh-rsa AAAA..."  # contents of ~/.ssh/avalanche-deploy.pub
+ssh_private_key_file = "~/.ssh/avalanche-deploy"
+```
+
+## Step 4: Create Infrastructure
+
+```bash
+terraform init
+terraform apply
+cd ../..
+```
+
+This creates:
+- 2 validator VMs (t3.xlarge)
+- 1 RPC node VM (t3.xlarge)
+- 1 monitoring VM (t3.medium)
+- VPC, security groups, and networking
+
+## Step 5: Deploy Avalanchego
+
+```bash
+make deploy
+```
+
+Wait for nodes to sync. Check progress with:
+
+```bash
+make status
+```
+
+You should see `P:OK` on all nodes before proceeding:
+
+```
+validator-1 (10.0.1.10)
+  P: OK (height: 49823692)
+  Bootstrapped: true
+
+validator-2 (10.0.1.11)
+  P: OK (height: 49823692)
+  Bootstrapped: true
+```
+
+## Step 6: Get a Funded P-Chain Address
+
+You need AVAX on the P-Chain to create your L1.
+
+**Option 1: Core Wallet**
+1. Install [Core Wallet](https://core.app/)
+2. Switch to Fuji testnet
+3. Get AVAX from [Fuji Faucet](https://faucet.avax.network/)
+4. Transfer to P-Chain
+5. Export private key
+
+**Option 2: Avalanche CLI**
+```bash
+avalanche key create mykey
+avalanche key export mykey
+```
+
+Export your private key:
+
+```bash
+export AVALANCHE_PRIVATE_KEY="PrivateKey-ewoqjP7PxY4yr3iLTp..."
+```
+
+Supported formats:
+- CB58: `PrivateKey-ewoqjP7PxY4yr3iLTp...`
+- Hex: `0x56289e99c94b6912bfc12adc...`
+
+## Step 7: Create Your L1
+
+Build the L1 creation tool:
+
+```bash
+make create-l1
+```
+
+Get validator IPs and create the L1:
+
+```bash
+export VALIDATORS=$(cd terraform/aws && terraform output -json validator_ips | jq -r 'join(",")')
+
+./tools/create-l1/create-l1 \
+  --network=fuji \
+  --validators=$VALIDATORS \
+  --chain-name=mychain \
+  --output=l1.env
+```
+
+This executes three P-Chain transactions:
+1. **CreateSubnetTx** - Creates the subnet
+2. **CreateChainTx** - Deploys your chain with genesis config
+3. **ConvertSubnetToL1Tx** - Registers validators as L1 validators
+
+## Step 8: Configure Nodes
+
+Load the L1 configuration and update nodes:
+
+```bash
+source l1.env
+make configure-l1 SUBNET_ID=$SUBNET_ID CHAIN_ID=$CHAIN_ID
+```
+
+Verify all nodes are tracking your L1:
+
+```bash
+make status
+```
+
+## Step 9: Access Your L1
+
+Your L1 RPC endpoint is available at:
+
+```
+http://<rpc-ip>:9650/ext/bc/<CHAIN_ID>/rpc
+```
+
+Get the RPC node IP:
+
+```bash
+cd terraform/aws && terraform output rpc_ip
+```
+
+Test the endpoint:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+  http://<rpc-ip>:9650/ext/bc/$CHAIN_ID/rpc
+```
+
+## Optional: Deploy Monitoring
+
+```bash
+make monitoring
+```
+
+Access Grafana at `http://<monitoring-ip>:3000` (default credentials: admin/admin).
+
+## Optional: Deploy Block Explorer
+
+```bash
+source l1.env
+make deploy-blockscout CHAIN_ID=$CHAIN_ID EVM_CHAIN_ID=99999 CHAIN_NAME="My L1"
+```
+
+Access Blockscout at `http://<rpc-ip>:4001`.
+
+## Cleanup
+
+<Callout type="warn">
+  Remember to destroy infrastructure when done testing to stop billing!
+</Callout>
+
+```bash
+make destroy
+```
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Ansible can't connect | Check SSH key path in `ansible/inventory/aws_hosts` |
+| Nodes not syncing | Run `make logs` to view avalanchego logs |
+| "insufficient funds" | Fund your P-Chain address on Fuji faucet |
+| "illegal name character" | Chain names must be alphanumeric (no hyphens) |
+| Can't reach RPC endpoint | Validators don't expose 9650; use the RPC node |
+
+## Next Steps
+
+- [Architecture](/docs/tooling/avalanche-deploy/architecture) - Understand the infrastructure layout
+- [Genesis Configuration](/docs/avalanche-l1s/evm-configuration/genesis) - Customize your chain's genesis
+- [Cross-Chain Messaging](/docs/cross-chain/interchain-messaging/overview) - Enable ICM for your L1


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for the [avalanche-deploy](https://github.com/ava-labs/avalanche-deploy) repository to the Builders Hub tooling section.

### New Files
- `content/docs/tooling/avalanche-deploy/index.mdx` - Overview page with features, cloud providers, and quick commands
- `content/docs/tooling/avalanche-deploy/quickstart.mdx` - Step-by-step AWS deployment guide  
- `content/docs/tooling/avalanche-deploy/architecture.mdx` - Infrastructure diagram, project structure, and deployment phases
- `content/docs/tooling/avalanche-deploy/meta.json` - Navigation configuration

### Documentation Covers
- Terraform + Ansible deployment workflow
- Multi-cloud support (AWS, GCP, Azure)
- L1 creation tool usage
- Monitoring stack (Prometheus + Grafana)
- Optional Blockscout block explorer
- Security recommendations

## Test plan
- [ ] Verify MDX files render correctly in dev server
- [ ] Check all internal links work
- [ ] Confirm navigation appears in tooling section