### PR TITLE
feat(auth): add redirect option for embeded browsers auth handling

### DIFF
--- a/components/login/EmbeddedBrowserWarning.tsx
+++ b/components/login/EmbeddedBrowserWarning.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { isEmbeddedBrowser, getEmbeddedBrowserName, openInExternalBrowser } from '@/lib/utils/browserDetection';
+import { ExternalLink, AlertCircle } from 'lucide-react';
+
+export function EmbeddedBrowserWarning() {
+  const [isEmbedded, setIsEmbedded] = useState(false);
+  const [browserName, setBrowserName] = useState<string | null>(null);
+
+  useEffect(() => {
+    const embedded = isEmbeddedBrowser();
+    setIsEmbedded(embedded);
+    if (embedded) {
+      setBrowserName(getEmbeddedBrowserName());
+    }
+  }, []);
+
+  if (!isEmbedded) return null;
+
+  return (
+    <div className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-900 rounded-lg p-4 mb-4">
+      <div className="flex items-start gap-3">
+        <AlertCircle className="w-5 h-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+        <div className="flex-1 space-y-2">
+          <p className="text-sm text-amber-800 dark:text-amber-200 font-medium">
+            Opening from {browserName}
+          </p>
+          <p className="text-xs text-amber-700 dark:text-amber-300">
+            For security, Google and other providers require you to sign in from a regular browser like Safari or Chrome.
+          </p>
+          <button
+            onClick={openInExternalBrowser}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-amber-900 dark:text-amber-100 bg-amber-100 dark:bg-amber-900/50 hover:bg-amber-200 dark:hover:bg-amber-900/70 border border-amber-300 dark:border-amber-700 rounded-md transition-colors"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            Open in Browser
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/login/LoginModal.tsx
+++ b/components/login/LoginModal.tsx
@@ -13,6 +13,7 @@ import { LoadingButton } from "../ui/loading-button";
 import SocialLogin from "./social-login/SocialLogin";
 import { VerifyEmail } from "./verify/VerifyEmail";
 import { useLoginModalState } from '@/hooks/useLoginModal';
+import { EmbeddedBrowserWarning } from './EmbeddedBrowserWarning';
 
 const formSchema = z.object({
   email: z.string().email("Please enter a valid email address"),
@@ -103,6 +104,9 @@ export function LoginModal() {
                     Enter your email to receive a sign-in code
                   </p>
                 </div>
+
+                {/* Embedded Browser Warning */}
+                <EmbeddedBrowserWarning />
 
                 {/* Form */}
                 <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">

--- a/lib/utils/browserDetection.ts
+++ b/lib/utils/browserDetection.ts
@@ -1,0 +1,84 @@
+/**
+ * Detects if the user is browsing from an embedded browser (in-app browser)
+ * Common embedded browsers: Twitter/X, Facebook, Instagram, LinkedIn, etc.
+ */
+export function isEmbeddedBrowser(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  const ua = navigator.userAgent || '';
+
+  // Twitter/X in-app browser
+  if (ua.includes('Twitter') || ua.includes('FBAN') || ua.includes('FBAV')) {
+    return true;
+  }
+
+  // Facebook in-app browser
+  if (ua.includes('FBAN') || ua.includes('FBAV') || ua.includes('FB_IAB')) {
+    return true;
+  }
+
+  // Instagram in-app browser
+  if (ua.includes('Instagram')) {
+    return true;
+  }
+
+  // LinkedIn in-app browser
+  if (ua.includes('LinkedInApp')) {
+    return true;
+  }
+
+  // Line in-app browser
+  if (ua.includes('Line/')) {
+    return true;
+  }
+
+  // Generic WebView detection (Android)
+  if (ua.includes('wv') && ua.includes('Android')) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Gets the name of the embedded browser
+ */
+export function getEmbeddedBrowserName(): string | null {
+  if (typeof window === 'undefined') return null;
+
+  const ua = navigator.userAgent || '';
+
+  if (ua.includes('Twitter')) return 'X (Twitter)';
+  if (ua.includes('FBAN') || ua.includes('FBAV') || ua.includes('FB_IAB')) return 'Facebook';
+  if (ua.includes('Instagram')) return 'Instagram';
+  if (ua.includes('LinkedInApp')) return 'LinkedIn';
+  if (ua.includes('Line/')) return 'Line';
+
+  return 'in-app browser';
+}
+
+/**
+ * Opens the current URL in the system browser (forces external browser)
+ */
+export function openInExternalBrowser(): void {
+  if (typeof window === 'undefined') return;
+
+  const currentUrl = window.location.href;
+
+  // Try multiple methods to open in external browser
+  // Method 1: Use intent:// URL scheme for Android
+  const isAndroid = /Android/i.test(navigator.userAgent);
+  if (isAndroid) {
+    window.location.href = `intent://${currentUrl.replace(/^https?:\/\//, '')}#Intent;scheme=https;end`;
+    return;
+  }
+
+  // Method 2: For iOS, just opening with target _blank often works
+  const link = document.createElement('a');
+  link.href = currentUrl;
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}


### PR DESCRIPTION
## Add embedded browser detection and warning for OAuth login                                                                                  
                                                                                                                                                 
  ### Problem                                                                                                                                    
  Users accessing BuilderHub from in-app browsers (X/Twitter, Facebook, Instagram, etc.) encounter "Error 403: disallowed_useragent" when attempting OAuth login with Google or other providers. This creates a frustrating experience with no clear guidance.

  ### Solution
  Added embedded browser detection that displays a warning banner in the login modal when users access from in-app browsers, guiding them to open the site in their regular browser (Safari, Chrome, etc.).

  ### Changes
  - Created `lib/utils/browserDetection.ts` with detection logic for major in-app browsers
  - Created `EmbeddedBrowserWarning` component with user-friendly warning and "Open in Browser" action
  - Integrated warning banner into `LoginModal` component

  ### Supported Platforms
  - X (Twitter)
  - Facebook
  - Instagram
  - LinkedIn
  - Line
  - Generic Android WebViews

  ### User Experience
  When detected, users see:
  - Clear explanation of the issue
  - "Open in Browser" button for easy resolution
  - Warning appears before login attempt (prevents error)