### PR TITLE
fix(stats): timezone-safe date parsing in remaining charts

### DIFF
--- a/app/(home)/stats/avax-token/page.tsx
+++ b/app/(home)/stats/avax-token/page.tsx
@@ -12,6 +12,7 @@ import { L1BubbleNav } from "@/components/stats/l1-bubble.config";
 import { AvalancheLogo } from "@/components/navigation/avalanche-logo";
 import { ChartWatermark } from "@/components/stats/ChartWatermark";
 import { LiveBlockBurns } from "@/components/stats/LiveBlockBurns";
+import { parseDateString } from "@/components/stats/chart-axis-utils";
 
 interface AvaxSupplyData {
   totalSupply: string;
@@ -188,18 +189,18 @@ export default function AvaxTokenPage() {
     >();
 
     mergedData.forEach((point) => {
-      const date = new Date(point.date);
+      const [year, month, day] = point.date.split("-").map(Number);
       let key: string;
 
       if (period === "W") {
-        const weekStart = new Date(date);
-        weekStart.setDate(date.getDate() - date.getDay());
-        key = weekStart.toISOString().split("T")[0];
+        const weekStart = new Date(year, month - 1, day);
+        weekStart.setDate(weekStart.getDate() - weekStart.getDay());
+        const wy = weekStart.getFullYear();
+        const wm = String(weekStart.getMonth() + 1).padStart(2, "0");
+        const wd = String(weekStart.getDate()).padStart(2, "0");
+        key = `${wy}-${wm}-${wd}`;
       } else {
-        key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
-          2,
-          "0"
-        )}`;
+        key = `${year}-${String(month).padStart(2, "0")}`;
       }
 
       if (!grouped.has(key)) {
@@ -240,7 +241,7 @@ export default function AvaxTokenPage() {
   const displayData = brushIndexes ? aggregatedFeeData.slice(brushIndexes.startIndex, brushIndexes.endIndex + 1) : aggregatedFeeData;
 
   const formatXAxis = (value: string) => {
-    const date = new Date(value);
+    const date = parseDateString(value);
     if (period === "M") {
       return date.toLocaleDateString("en-US", {
         month: "short",
@@ -251,7 +252,7 @@ export default function AvaxTokenPage() {
   };
 
   const formatTooltipDate = (value: string) => {
-    const date = new Date(value);
+    const date = parseDateString(value);
 
     if (period === "M") {
       return date.toLocaleDateString("en-US", {
@@ -261,7 +262,7 @@ export default function AvaxTokenPage() {
     }
 
     if (period === "W") {
-      const endDate = new Date(date);
+      const endDate = new Date(date.getTime());
       endDate.setDate(date.getDate() + 6);
 
       const startMonth = date.toLocaleDateString("en-US", { month: "long" });

--- a/components/stats/image-export/ImageExportStudio.tsx
+++ b/components/stats/image-export/ImageExportStudio.tsx
@@ -57,6 +57,7 @@ import { AnnotationOverlay } from "./AnnotationOverlay";
 import type { ChartExportData, PresetType, Period, ChartType, DateRangePreset, BrushRange, ExportMode, CollageMetricConfig, CollageSettings, CustomAspectRatio } from "./types";
 import { DATE_RANGE_PRESETS } from "./constants";
 import { cn } from "@/lib/utils";
+import { parseDateString } from "@/components/stats/chart-axis-utils";
 import { ChartWatermark } from "@/components/stats/ChartWatermark";
 
 // Chart data point interface
@@ -987,7 +988,7 @@ export function ImageExportStudio({
   // Format X axis labels based on period
   const formatXAxis = (value: string) => {
     if (!value) return "";
-    const date = new Date(value);
+    const date = parseDateString(value);
     if (isNaN(date.getTime())) return value;
 
     // Format based on current period

--- a/components/stats/image-export/hooks/useCollageMetrics.ts
+++ b/components/stats/image-export/hooks/useCollageMetrics.ts
@@ -14,28 +14,32 @@ const aggregateByPeriod = (
 
   data.forEach((point) => {
     const dateStr = point.date || point.day || "";
-    const date = new Date(dateStr);
-    if (isNaN(date.getTime())) return;
+    const parts = dateStr.split("-").map(Number);
+    if (parts.length < 3 || parts.some(isNaN)) return;
+    const [year, month, day] = parts;
 
     let key: string;
     switch (period) {
       case "W": {
         // Sunday-based week calculation (matching ChainMetricsPage.tsx)
-        const weekStart = new Date(date);
-        weekStart.setDate(date.getDate() - date.getDay());
-        key = weekStart.toISOString().split("T")[0];
+        const weekStart = new Date(year, month - 1, day);
+        weekStart.setDate(weekStart.getDate() - weekStart.getDay());
+        const wy = weekStart.getFullYear();
+        const wm = String(weekStart.getMonth() + 1).padStart(2, "0");
+        const wd = String(weekStart.getDate()).padStart(2, "0");
+        key = `${wy}-${wm}-${wd}`;
         break;
       }
       case "M":
-        key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+        key = `${year}-${String(month).padStart(2, "0")}`;
         break;
       case "Q": {
-        const quarter = Math.floor(date.getMonth() / 3) + 1;
-        key = `${date.getFullYear()}-Q${quarter}`;
+        const quarter = Math.floor((month - 1) / 3) + 1;
+        key = `${year}-Q${quarter}`;
         break;
       }
       case "Y":
-        key = `${date.getFullYear()}`;
+        key = `${year}`;
         break;
       default:
         key = dateStr;
@@ -163,18 +167,22 @@ export function useCollageMetrics(
             // API returns dates like "2025-11-01", we need "2025-11" for monthly
             aggregatedData = chartData.map((point) => {
               const dateStr = point.date || "";
-              const date = new Date(dateStr);
-              if (isNaN(date.getTime())) return point;
+              const dateParts = dateStr.split("-").map(Number);
+              if (dateParts.length < 3 || dateParts.some(isNaN)) return point;
+              const [yr, mo, dy] = dateParts;
 
               let normalizedDate: string;
               if (period === "W") {
                 // Sunday-based week start (matching other metrics)
-                const weekStart = new Date(date);
-                weekStart.setDate(date.getDate() - date.getDay());
-                normalizedDate = weekStart.toISOString().split("T")[0];
+                const weekStart = new Date(yr, mo - 1, dy);
+                weekStart.setDate(weekStart.getDate() - weekStart.getDay());
+                const wy = weekStart.getFullYear();
+                const wm = String(weekStart.getMonth() + 1).padStart(2, "0");
+                const wd = String(weekStart.getDate()).padStart(2, "0");
+                normalizedDate = `${wy}-${wm}-${wd}`;
               } else {
                 // Monthly format: "YYYY-MM"
-                normalizedDate = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+                normalizedDate = `${yr}-${String(mo).padStart(2, "0")}`;
               }
 
               return { ...point, date: normalizedDate };


### PR DESCRIPTION
## Summary

  Follow-up to #3800 which fixed `ChainMetricsPage.tsx`. The same timezone bug (`new Date("YYYY-MM-DD")` → UTC midnight → local getters shift the day for
  negative-UTC users) existed in 3 more files:

  - **`avax-token/page.tsx`** — Aggregation (W/M grouping keys), `formatXAxis`, and `formatTooltipDate` all used `new Date(value)`. Replaced with string-split
  local-Date construction for aggregation and `parseDateString()` for display formatting.
  - **`useCollageMetrics.ts`** — `aggregateByPeriod` and activeAddresses normalization block used `new Date(dateStr)` then `.toISOString()` for week keys and
  `.getMonth()` for month/quarter keys. Replaced with string-split local-Date construction and manual key formatting.
  - **`ImageExportStudio.tsx`** — `formatXAxis` used `new Date(value)`. Replaced with `parseDateString()` from `chart-axis-utils.ts`.

  No changes needed for `CollagePreview`, `ImagePreview`, `ConfigurableChart`, or `ChainMetricsPage` (already fixed or not affected).

  ## Test plan

  - [x] Open `/stats/avax-token` with browser timezone set to `America/Los_Angeles` (UTC-8) — tooltip on the last bar should show today's date, not yesterday's
  - [x] Switch to W and M periods — verify grouping keys are correct (no off-by-one month/week boundaries)
  - [x] Open Image Export Studio from any stats chart — x-axis labels should match the main chart
  - [x] Open a collage export — date labels should be consistent across metrics
  - [x] verified with vpn in usa and japan, same results as eu