### PR TITLE
fix: add missing /docs/ prefix to Open in AI URLs

### DIFF
--- a/components/ui/sidebar-actions.tsx
+++ b/components/ui/sidebar-actions.tsx
@@ -28,13 +28,14 @@ export function SidebarActions({
   const [isCopyingMarkdown, setIsCopyingMarkdown] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
 
+  // Ensure pagePath includes the pageType prefix (e.g. /docs or /academy)
+  const fullPath = pagePath.startsWith(`/${pageType}`) ? pagePath : `/${pageType}${pagePath}`;
+
   const handleCopyMarkdown = async () => {
     setIsCopyingMarkdown(true);
     setIsCopied(false);
 
     try {
-      // Construct the full path and append .md for markdown content
-      const fullPath = pagePath.startsWith(`/${pageType}`) ? pagePath : `/${pageType}${pagePath}`;
       const apiUrl = `${window.location.origin}${fullPath}.md`;
       const response = await fetch(apiUrl);
 
@@ -67,14 +68,14 @@ export function SidebarActions({
   };
 
   const openInChatGPT = () => {
-    const mdUrl = `${typeof window !== 'undefined' ? window.location.origin : 'https://build.avax.network'}${pagePath}.md`;
+    const mdUrl = `${typeof window !== 'undefined' ? window.location.origin : 'https://build.avax.network'}${fullPath}.md`;
     const prompt = `Read ${mdUrl}, I want to ask questions about it.`;
     const chatGPTUrl = `https://chat.openai.com/?q=${encodeURIComponent(prompt)}`;
     window.open(chatGPTUrl, '_blank', 'noopener,noreferrer');
   };
 
   const openInClaude = () => {
-    const mdUrl = `${typeof window !== 'undefined' ? window.location.origin : 'https://build.avax.network'}${pagePath}.md`;
+    const mdUrl = `${typeof window !== 'undefined' ? window.location.origin : 'https://build.avax.network'}${fullPath}.md`;
     const prompt = `Read ${mdUrl}, I want to ask questions about it.`;
     const claudeUrl = `https://claude.ai/new?q=${encodeURIComponent(prompt)}`;
     window.open(claudeUrl, '_blank', 'noopener,noreferrer');


### PR DESCRIPTION
## Summary
- Fixes "Open in Claude" and "Open in ChatGPT" sidebar buttons generating broken URLs (missing `/docs/` path prefix)
- Hoists the `fullPath` computation from `handleCopyMarkdown` to component scope so all three URL-building functions share the same prefix logic

## Root Cause
`pagePath` is passed as `/${params.slug.join("/")}` from `app/docs/[...slug]/page.tsx` — without the `/docs` prefix. The `handleCopyMarkdown` function correctly added the prefix, but `openInClaude` and `openInChatGPT` used `pagePath` raw, producing URLs like `build.avax.network/primary-network.md` (404) instead of `build.avax.network/docs/primary-network.md`.

## Test plan
- [ ] Navigate to a docs page (e.g. `/docs/primary-network`)
- [ ] Click "Open in AI" → "Claude" — verify URL contains `/docs/` prefix
- [ ] Click "Open in AI" → "ChatGPT" — verify URL contains `/docs/` prefix
- [ ] Click "Copy Markdown" — verify it still works correctly
- [ ] Navigate to an academy page and repeat the above checks

Closes #3840