### PR TITLE
fix: remove fallback that sends ICM dots to all L1s on homepage globe

### DIFF
--- a/components/stats/MiniNetworkDiagram.tsx
+++ b/components/stats/MiniNetworkDiagram.tsx
@@ -329,26 +329,6 @@ export default function MiniNetworkDiagram({
       });
     }
     
-    // Fallback: if no ICM data or very few connections, connect to primary
-    if (connections.length < 5) {
-      const primaryIndex = nodes.findIndex(n => n.isPrimary);
-      if (primaryIndex >= 0) {
-        nodes.forEach((_, index) => {
-          if (index !== primaryIndex && !connections.some(c => 
-            (c.from === primaryIndex && c.to === index) || 
-            (c.from === index && c.to === primaryIndex)
-          )) {
-            connections.push({
-              from: primaryIndex,
-              to: index,
-              opacity: 0.12,
-              messageCount: 0,
-            });
-          }
-        });
-      }
-    }
-    
     return connections;
   }, []);
 


### PR DESCRIPTION
## Summary

- Removes the fallback in `MiniNetworkDiagram.tsx` that created fake ICM connections from the primary Avalanche node to **every L1** when fewer than 5 real flows were returned
- The homepage globe now only shows animated message dots between L1s with actual ICM traffic

## Problem

When the `/api/icm-flow` endpoint returned fewer than 5 real ICM connections (due to sparse data or API timeouts), a fallback block in `generateConnections()` created `messageCount: 0` connections to all ~40 L1 nodes. The particle animation system then animated these fake connections, making the globe misleadingly show ICM activity to every L1.

## Fix

Deleted the 18-line fallback block (`connections.length < 5` check) — a pure deletion, no new code added.

Fixes #3843

## Test plan

- [x] Verify the homepage globe only shows animated dots between L1s with real ICM message volume
- [x] Verify the globe renders gracefully when few or no ICM flows are returned (no visual breakage)
- [x] Confirm no regressions in globe rotation, node rendering, or tooltip behavior