### PR TITLE
fix(banner): link ACP-267 to internal docs page

### DIFF
--- a/components/ui/custom-countdown-banner.tsx
+++ b/components/ui/custom-countdown-banner.tsx
@@ -2,8 +2,7 @@
 import { Banner } from "fumadocs-ui/components/banner";
 import Link from "next/link";
 
-const ACP_267_URL =
-  "https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/267-uptime-requirement-increase/README.md";
+const ACP_267_URL = "/docs/acps/267-uptime-requirement-increase";
 
 export function CustomCountdownBanner() {
   return (
@@ -24,8 +23,6 @@ export function CustomCountdownBanner() {
           </span>
           <Link
             href={ACP_267_URL}
-            target="_blank"
-            rel="noreferrer"
             className="underline underline-offset-4 hover:text-[#66acd6] transition-colors"
           >
             Read the proposal


### PR DESCRIPTION
## Summary
- Changes the ACP-267 banner "Read the proposal" link from the GitHub ACP README to the internal docs page at `/docs/acps/267-uptime-requirement-increase`
- Removes `target="_blank"` and `rel="noreferrer"` since it's now an internal navigation

## Test plan
- [x] Verify banner still renders on homepage
- [x] Click "Read the proposal" and confirm it navigates to `/docs/acps/267-uptime-requirement-increase`