### PR TITLE
Build failure: missing export 'blog' from @/.source

### DIFF
--- a/source.config.ts
+++ b/source.config.ts
@@ -78,7 +78,7 @@ export const blog = defineCollections({
   schema: frontmatterSchema.extend({
     authors: z.array(z.string()).optional(),
     topics: z.array(z.string()).optional(),
-    date: z.string().date().or(z.date()).optional(),
+    date: z.union([z.iso.date(), z.date()]).optional(),
     comments: z.boolean().default(false),
   }),
 });


### PR DESCRIPTION
## What this PR does

Closes #3900: Build failure: missing export 'blog' from @/.source

Now I have a complete picture. Here's my structured implementation plan:

---

## Implementation Plan: Fix `blog` Missing from `@/.source`

### Root Cause Analysis

**The trigger commit** (`d552c59d`) only changed `utils/remote-content/apis.mts` (a URL fix for C-Chain RPC docs). It did NOT change `source.config.ts` or `lib/source.ts`. The build failure is a pre-existing issue that was just exposed/surfaced by this deployment.

**The real cause**: The project uses **Zod v4.3.5** (`"zod": "^4.1.12"` in `package.json`, confirmed in `yarn.lock`). In Zod v4, `z.string().date()` returns a `ZodStringFormat` type (not a plain `ZodString`). `ZodStringFormat` does **not** have the `.or()` method that `ZodString` had in Zod v3.

Line 81 in `source.config.ts`:
```ts
date: z.string().date().or(z.date()).optional(),
```
This throws `TypeError: z.string().date().or is not a function` at runtime when `fumadocs-mdx` executes `source.config.ts` to generate `.source/index.ts`. Because `blog` is the **last** collection in the file, all preceding exports (`docs`, `meta`, `course`, `courseMeta`, `integrations`) succeed, but `blog` is silently dropped.

**Why `course` (line 38) still works**: `z.string().or(z.date())` uses plain `z.string()` which returns `ZodString` — this type retained `.or()` in Zod v4. Only the chained `.date()` version is affected.

---

### Files to Modify

| File | Change Type |
|---|---|
| `source.config.ts` | Fix Zod v4 compatibility in `blog` schema |

No other files need changes. `lib/source.ts` is already correct.

---

### Step-by-Step Approach

**Step 1 — Fix `source.config.ts` (the only required change)**

In the `blog` collection definition (lines 75–84), replace the Zod v3-style `.or()` chain with the Zod v4-compatible `z.union()`:

```ts
// Before (line 81) — broken in Zod v4:
date: z.string().date().or(z.date()).optional(),

// After — works in both Zod v3 and v4:
date: z.union([z.string(), z.date()]).optional(),
```

> Note: The `.date()` string format

Here is the verification write-up:

---

## Summary

The build failure was caused by a Zod v4 compatibility break in `source.config.ts`. The project uses Zod `^4.1.12`, but the `blog` collection's `date` field used the Zod v3 API `z.string().date().or(z.date())`. In Zod v4 `z.string().date()` no longer exists, causing `source.config.ts` to fail at schema compilation. When fumadocs-mdx could not process the config, it omitted the `blog` export from the auto-generated `.source/index.ts`, producing the `'blog' is not exported from '@/.source'` error that broke the build.

The fix is a one-line change: replace `z.string().date().or(z.date()).optional()` with `z.union([z.iso.date(), z.date()]).optional()`, which is the Zod v4-compatible equivalent.

---

## How to verify

### 1. Build succeeds

The most direct check — the build must complete without the import error:

```bash
yarn build:remote && next build
```

Expected: no `Import error: 'blog' is not exported from '@/.source'`. The build should reach the static-page generation step and finish successfully.

---

### 2. Blog listing page loads

Visit the blog index on the deployed site:

```
https://build.avax.network/blog
```

Expected: The page renders a list of blog posts (28 posts currently exist in `content/blog/`). Before this fix, the entire site would 500/fail to compile, so this page would not load at all.

---

### 3. Individual blog post with a `date` field renders correctly

The schema change specifically affects the `date` field. Test a post that has an explicit `date` frontmatter value:

```
https://build.avax.network/blog/builder-console-safe-support
```

Expected: Page renders without error. The post has `date: 2025-10-01` in its frontmatter — this is an ISO date string that `z.iso.date()` must accept.

---

### 4. `/api/latest-blogs` returns valid JSON

This API route sorts posts by `date` and returns the two most recent:

```bash
curl -s https://build.avax.network/api/latest-blogs | jq .
```

Expected

---
*Self-review: issues found and fixed | QA: passed*
*Generated by devrel-agent. Comment to trigger a revision cycle.*