### PR TITLE
fix: pass isTestnet flag when adding networks to Core wallet

### DIFF
--- a/components/toolbox/components/console-header/evm-network-wallet/hooks/useNetworkActions.ts
+++ b/components/toolbox/components/console-header/evm-network-wallet/hooks/useNetworkActions.ts
@@ -70,6 +70,7 @@ export function useNetworkActions() {
                     },
                     rpcUrls: [network.rpcUrl],
                     blockExplorerUrls: network.explorerUrl ? [network.explorerUrl] : undefined,
+                    isTestnet: network.isTestnet,
                   }],
                 })
               } catch (addError) {

--- a/components/toolbox/providers/modals/AddChainModal.tsx
+++ b/components/toolbox/providers/modals/AddChainModal.tsx
@@ -203,7 +203,7 @@ export function AddChainModal() {
             };
 
             await walletClient.addChain({
-                chain: { ...viemChain, testnet: chainData.isTestnet }
+                chain: { ...viemChain, isTestnet: chainData.isTestnet }
             });
 
             await walletClient.switchChain({


### PR DESCRIPTION
## Summary
- Testnet L1s were being added as mainnet networks in Core wallet
- **AddChainModal**: passed `testnet` (viem's property) but the coreViem `addChain` override reads `isTestnet` (Core's proprietary field), so the value was always `undefined` → treated as mainnet
- **useNetworkActions**: the raw EIP-1193 fallback for `wallet_addEthereumChain` omitted `isTestnet` entirely

## Test plan
- [ ] Add a Fuji testnet L1 via the Add Chain modal → verify it appears under testnet in Core wallet
- [ ] Switch to an unknown testnet L1 network via the console header dropdown → verify Core adds it as testnet