### PR TITLE
fix(Badge): showcase fixed

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -53,7 +53,7 @@ const quickLinks = [
   { href: "/console", label: "Console", icon: Terminal, description: "Developer tools" },
 ];
 
-export default function NotFound({ isAComponent =false}: { isAComponent: boolean }) {
+export default function NotFound({ isAComponent = false, hideReportIssue = false, skipTracking = false}: { isAComponent?: boolean, hideReportIssue?: boolean, skipTracking?: boolean }) {
   const [currentPath, setCurrentPath] = useState<string | null>(null);
   const [suggestedPath, setSuggestedPath] = useState<string | null>(null);
   const [mounted, setMounted] = useState(false);
@@ -68,23 +68,25 @@ export default function NotFound({ isAComponent =false}: { isAComponent: boolean
       const nearest = findNearestAvailablePath(path);
       setSuggestedPath(nearest);
 
-      // Track 404 with PostHog if available
-      try {
-        import('posthog-js').then((posthogModule) => {
-          const posthog = posthogModule.default;
-          if (posthog && typeof posthog.capture === 'function') {
-            posthog.capture('404_page_not_found', {
-              path: path,
-              referrer: referrer || 'direct',
-              url: window.location.href,
-              suggested_path: nearest,
-            });
-          }
-        }).catch(() => {
+      // Track 404 with PostHog if available and tracking is not disabled
+      if (!skipTracking) {
+        try {
+          import('posthog-js').then((posthogModule) => {
+            const posthog = posthogModule.default;
+            if (posthog && typeof posthog.capture === 'function') {
+              posthog.capture('404_page_not_found', {
+                path: path,
+                referrer: referrer || 'direct',
+                url: window.location.href,
+                suggested_path: nearest,
+              });
+            }
+          }).catch(() => {
+            // PostHog not available, silently ignore
+          });
+        } catch {
           // PostHog not available, silently ignore
-        });
-      } catch {
-        // PostHog not available, silently ignore
+        }
       }
     }
   }, []);
@@ -164,17 +166,18 @@ export default function NotFound({ isAComponent =false}: { isAComponent: boolean
               Back to Home
             </Button>
           </Link>
-          
-          <Link href={issueURL} target="_blank">
-            <Button
-              variant="outline"
-              size="lg"
-              className="w-full sm:w-auto gap-2 px-6"
-            >
-              <Github className="w-4 h-4" />
-              Report Issue
-            </Button>
-          </Link>
+          {!hideReportIssue && (
+            <Link href={issueURL} target="_blank">
+              <Button
+                variant="outline"
+                size="lg"
+                className="w-full sm:w-auto gap-2 px-6"
+              >
+                <Github className="w-4 h-4" />
+                Report Issue
+              </Button>
+            </Link>
+          )}
         </div>
 
         {/* Quick Links */}

--- a/components/showcase/ProjectCard.tsx
+++ b/components/showcase/ProjectCard.tsx
@@ -23,7 +23,6 @@ export type Props = {
 
 export function ProjectCard({ project, isFromProfile = false }: Props) {
   const router = useRouter();
-  const [confirmOpen, setConfirmOpen] = useState(false);
   const [isAssignBadgeOpen, setIsAssignBadgeOpen] = useState(false);
 
   // Memoize computed values to prevent unnecessary recalculations
@@ -65,7 +64,7 @@ export function ProjectCard({ project, isFromProfile = false }: Props) {
   };
 
   const handleCardClick = useCallback((e: React.MouseEvent) => {
-    if (confirmOpen || isAssignBadgeOpen) return;
+    if (isAssignBadgeOpen) return;
     const isInteractive = (e.target as HTMLElement).closest(
       '[data-interactive="true"]'
     );
@@ -81,7 +80,7 @@ export function ProjectCard({ project, isFromProfile = false }: Props) {
     } else {
       router.push(`/showcase/${project.id}`);
     }
-  }, [confirmOpen, isAssignBadgeOpen, router, project.id, isFromProfile]);
+  }, [isAssignBadgeOpen, router, project.id]);
   return (
     <Card
       className="group relative w-full h-[420px] flex flex-col overflow-hidden rounded-2xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 hover:border-zinc-300 dark:hover:border-zinc-700 transition-all duration-300 cursor-pointer hover:shadow-lg"
@@ -101,8 +100,6 @@ export function ProjectCard({ project, isFromProfile = false }: Props) {
           <div className="bg-white/90 dark:bg-zinc-900/90 backdrop-blur-sm rounded-lg p-1">
             <ProjectOptions
               project={project}
-              confirmOpen={confirmOpen}
-              setConfirmOpen={setConfirmOpen}
               isAssignBadgeOpen={isAssignBadgeOpen}
               setIsAssignBadgeOpen={setIsAssignBadgeOpen}
               isFromProfile={isFromProfile}

--- a/components/showcase/ProjectOptions.tsx
+++ b/components/showcase/ProjectOptions.tsx
@@ -8,67 +8,26 @@ import {
 } from "../ui/dropdown-menu";
 import { Button } from "../ui/button";
 import { EllipsisVertical } from "lucide-react";
-import {
-  AlertDialog,
-  AlertDialogFooter,
-  AlertDialogDescription,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogCancel,
-  AlertDialogAction,
-} from "../ui/alert-dialog";
-import axios from "axios";
-import { useToast } from "@/hooks/use-toast";
 import { Toaster } from "../ui/toaster";
 import { AssignBadge } from "./assign-badge";
 import { useRouter } from "next/navigation";
 
 export const ProjectOptions = ({
   project,
-  confirmOpen,
-  setConfirmOpen,
   isAssignBadgeOpen,
   setIsAssignBadgeOpen,
   isFromProfile = false,
 }: Props & {
-  confirmOpen: boolean;
-  setConfirmOpen: React.Dispatch<React.SetStateAction<boolean>>;
   isAssignBadgeOpen: boolean;
   setIsAssignBadgeOpen: React.Dispatch<React.SetStateAction<boolean>>;
   isFromProfile?: boolean;
 }) => {
   const router = useRouter();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const { toast } = useToast();
-  const handleSetWinner = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    const response = await axios.put(`/api/project/set-winner`, {
-      project_id: project.id,
-      isWinner: true,
-    });
-
-    if (response.data.success) {
-      toast({
-        title: "Project winner set successfully",
-        description: "The project has been marked as the winner",
-        duration: 3000,
-      });
-    } else {
-      toast({
-        title: "Failed to set project winner",
-        description: "Unable to mark project as winner. Please try again.",
-        variant: "destructive",
-        duration: 3000,
-      });
-    }
-    setConfirmOpen(false);
-  };
 
   const handleAssignBadge = (e: React.MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
-   
     setIsAssignBadgeOpen(true);
   };
 
@@ -113,63 +72,22 @@ export const ProjectOptions = ({
               Edit
             </DropdownMenuItem>
           ) : (
-            <>
-              {!project.is_winner ? (
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    e.stopPropagation();
-                  }}
-                  onSelect={(e) => {
-                    e.stopPropagation();
-                    setIsDropdownOpen(false);
-                    setConfirmOpen(true);
-                  }}
-                >
-                  Set Winner
-                </DropdownMenuItem>
-              ) : 
-              (<DropdownMenuItem
-                  onClick={(e) => {
-                    e.stopPropagation();
-                  }}
-                  onSelect={(e) => {
-                    e.stopPropagation();
-                    setIsDropdownOpen(false);
-                    handleAssignBadge(e as any);
-                  }}
-                >
-                  Assign Badge
-                </DropdownMenuItem>)
-              }
-            </>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+              onSelect={(e) => {
+                e.stopPropagation();
+                setIsDropdownOpen(false);
+                handleAssignBadge(e as any);
+              }}
+            >
+              Assign Badge
+            </DropdownMenuItem>
           )}
         </DropdownMenuContent>
       </DropdownMenu>
 
-      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <AlertDialogContent onPointerDownCapture={(e) => e.stopPropagation()}>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Confirm Winner?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Do you want to mark "{project.project_name}" as winner? This
-              action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={(e) => e.stopPropagation()}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={(e) => {
-                e.stopPropagation();
-                handleSetWinner(e);
-              }}
-            >
-              Confirm
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
       <AssignBadge
         isOpen={isAssignBadgeOpen}
         onOpenChange={setIsAssignBadgeOpen}

--- a/components/showcase/ShowCaseCard.tsx
+++ b/components/showcase/ShowCaseCard.tsx
@@ -217,7 +217,7 @@ export default function ShowCaseCard({
 
   // Show NotFound if not logged in or doesn't have required role
   if (isLoggedIn === false) {
-    return <NotFound isAComponent={true} />;
+    return <NotFound isAComponent={true} hideReportIssue={true} skipTracking={true} />;
   }
 
   return (

--- a/components/showcase/assign-badge.tsx
+++ b/components/showcase/assign-badge.tsx
@@ -8,6 +8,7 @@ import { BadgeCategory } from "@/server/services/badge";
 import { useToast } from "@/hooks/use-toast";
 import { LoadingButton } from "../ui/loading-button";
 import { Toaster } from "../ui/toaster";
+import { useRouter } from "next/navigation";
 type showAssignBadgeProps = {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
@@ -21,6 +22,7 @@ export const AssignBadge = ({
   const [optionsWithLabel, setOptionsWithLabel] = useState<
     { label: string; value: string }[]
   >([]);
+  const router = useRouter();
   const { toast } = useToast();
   const [selectedBadges, setSelectedBadges] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -38,7 +40,11 @@ export const AssignBadge = ({
     const fetchBadges = async () => {
       const response = await axios.get("/api/badge/get-all");
       const filteredBadges = response.data.filter(
-        (badge: Badge) => badge.category == "hackathon"
+        (badge: Badge) =>
+          badge.category == "hackathon" &&
+          badge.requirements?.some(
+            (req: any) => req.hackathon == project.hackaton_id
+          )
       );
 
       // Filter out badges that are already assigned
@@ -75,6 +81,8 @@ export const AssignBadge = ({
         description: "The badges have been assigned to the project",
         duration: 3000,
       });
+      handleClose();
+      router.refresh();
     } else {
       toast({
         title: "Failed to assign badges",
@@ -82,8 +90,8 @@ export const AssignBadge = ({
         variant: "destructive",
         duration: 3000,
       });
+      handleClose();
     }
-    handleClose();
   };
 
   const multiSelectCard = (

--- a/components/showcase/sections/TeamMembers.tsx
+++ b/components/showcase/sections/TeamMembers.tsx
@@ -31,7 +31,7 @@ export default function TeamMembers({ members, projectName, badges }: Props) {
               <TooltipTrigger asChild>
                 <div className="flex flex-col justify-center items-center gap-4  hover:scale-105 transition-transform duration-200">
                   <Image
-                    src={member.user.image ?? ''}
+                    src={member.user.image || "/wolfie/wolfie-hack.png"}
                     alt={member.user.user_name ?? ''}
                     width={150}
                     height={150}

--- a/server/services/project-badge.ts
+++ b/server/services/project-badge.ts
@@ -65,21 +65,17 @@ export async function assignBadgeProject(
   if (!userProject) {
     return badgeToReturn;
   }
-  // Validate that the project is a winner before assigning badges
-  if (!userProject.is_winner) {
-    return {
-      success: false,
-      message: "Badges can only be assigned to winning projects",
-      badge_id: "",
-      user_id: "",
-      badges: [],
-    };
-  }
 
   const userProjectMembers = userProject.members;
 
   try {
     const result = await prisma.$transaction(async (tx) => {
+      // Set the project as winner atomically with badge assignment
+      await tx.project.update({
+        where: { id: body.projectId! },
+        data: { is_winner: true },
+      });
+
       const awardedBadges: BadgeData[] = [];
       const errors: string[] = [];
 


### PR DESCRIPTION
## Summary

- **Always show "Assign Badge"** in the project card dropdown menu, replacing the previous two-step flow (`Set Winner` → `Assign Badge`) with a single unified action
- **Badge validation by hackathon**: the modal now only lists badges whose requirements match the project's hackathon (`hackaton_id`), ensuring only relevant badges can be assigned
- **Atomic winner + badge assignment**: when a badge is assigned, the backend automatically sets `is_winner: true` on the project within the same DB transaction, removing the need to manually set a winner first
- **Auto page refresh**: after a successful badge assignment, `router.refresh()` is called so the card reflects the updated winner status and new badges without a full page reload

## Files changed

- `components/showcase/ProjectOptions.tsx` — removed `Set Winner` menu item and confirmation dialog; dropdown always shows `Assign Badge`
- `components/showcase/ProjectCard.tsx` — removed `confirmOpen` state and related props; cleaned up `useCallback` dependencies
- `components/showcase/assign-badge.tsx` — filters badges by `project.hackaton_id` via requirements; calls `router.refresh()` on success
- `server/services/project-badge.ts` — removed `is_winner` guard; added `tx.project.update({ is_winner: true })` inside the assignment transaction