### PR TITLE
feat(build-games): submit 3 updated

### DIFF
--- a/components/build-games/BuildGamesSubmitForm.tsx
+++ b/components/build-games/BuildGamesSubmitForm.tsx
@@ -5,7 +5,7 @@ import { useSession } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useLoginModalTrigger } from "@/hooks/useLoginModal";
 import axios from "axios";
-import { useForm } from "react-hook-form";
+import { useForm, useFieldArray, Controller } from "react-hook-form";
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { z } from "zod";
 import { useToast } from "@/hooks/use-toast";
@@ -25,6 +25,7 @@ import {
   Loader2,
   ChevronDown,
   Lock,
+  X,
 } from "lucide-react";
 import { MultiSelect } from "@/components/ui/multi-select";
 import { MultiLinkInput } from "@/components/hackathons/project-submission/components/MultiLinkInput";
@@ -124,6 +125,11 @@ const FormSchema = z.object({
   bg_game_monetization: z.string().optional().or(z.literal("")),
   bg_game_competitors: z.string().optional().or(z.literal("")),
 
+  // ── Stage 3 — Milestones (all categories) ────────────────────────────────
+  bg_milestones: z
+    .array(z.object({ period: z.string(), description: z.string() }))
+    .optional(),
+
   // ── Stage 4 — Gaming Finals ───────────────────────────────────────────────
   bg_game_metrics: z.string().optional().or(z.literal("")),
   bg_game_vision: z.string().optional().or(z.literal("")),
@@ -199,10 +205,20 @@ export default function BuildGamesSubmitForm({
       bg_game_community: "",
       bg_game_monetization: "",
       bg_game_competitors: "",
+      bg_milestones: [{ period: "", description: "" }],
       bg_game_metrics: "",
       bg_game_vision: "",
     },
   });
+
+  const { fields: milestoneFields, append: appendMilestone, remove: removeMilestone } = useFieldArray({
+    control: form.control,
+    name: "bg_milestones",
+  });
+
+  const handleRemoveMilestone = useCallback((index: number) => {
+    removeMilestone(index);
+  }, [removeMilestone]);
 
   // ── Effects ────────────────────────────────────────────────────────────────
 
@@ -330,6 +346,9 @@ export default function BuildGamesSubmitForm({
             bg_game_community: bg.game_community ?? "",
             bg_game_monetization: bg.game_monetization ?? "",
             bg_game_competitors: bg.game_competitors ?? "",
+            bg_milestones: Array.isArray(bg.milestones) && bg.milestones.length > 0
+              ? bg.milestones
+              : [{ period: "", description: "" }],
             bg_game_metrics: bg.game_metrics ?? "",
             bg_game_vision: bg.game_vision ?? "",
           });
@@ -410,6 +429,9 @@ export default function BuildGamesSubmitForm({
             game_community: data.bg_game_community ?? "",
             game_monetization: data.bg_game_monetization ?? "",
             game_competitors: data.bg_game_competitors ?? "",
+            milestones: (data.bg_milestones ?? []).filter(
+              (m) => (m.period ?? "") !== "" || (m.description ?? "") !== ""
+            ),
             game_metrics: data.bg_game_metrics ?? "",
             game_vision: data.bg_game_vision ?? "",
           },
@@ -1384,6 +1406,40 @@ export default function BuildGamesSubmitForm({
     }
 
     if (n === 3) {
+      const bgCategory = form.watch("project_category");
+      const isGamingConsumer = bgCategory === "Gaming" && form.watch("bg_game_type") === "Consumer Game";
+      const gtm = isGamingConsumer
+        ? {
+            section: "🎮 Gaming GTM",
+            acquisitionLabel: "Player acquisition strategy",
+            acquisitionDesc: "How do you acquire your first 1,000 active players? Which channels — content, influencers, guilds, tournaments, referrals?",
+            acquisitionPlaceholder: "e.g. Partner with 5 gaming guilds on Avalanche for a launch tournament with a $5k prize pool. Micro-influencer campaign on TikTok targeting Web3 gamers. Referral bonus: invite 3 friends → earn a rare NFT item...",
+            communityLabel: "Community & guild strategy",
+            communityDesc: "How are you building your player community? Discord, tournaments, ambassador programs, DAO governance for in-game decisions?",
+            communityPlaceholder: "e.g. Weekly tournaments streamed on Twitch. Discord with 2,000 members and active guild channels. Community votes on new game modes each season via snapshot...",
+            monetizationLabel: "Monetization model",
+            monetizationDesc: "How does the game generate sustainable revenue? Describe primary and secondary market mechanics without compromising gameplay fairness.",
+            monetizationPlaceholder: "e.g. Free-to-play with cosmetic NFT sales (no pay-to-win). 2.5% marketplace fee on player-to-player trades. Season pass ($9.99) for early access to new content. No token required to play...",
+            competitorsLabel: "Competitive landscape",
+            competitorsDesc: "Name 2–3 games you compete with directly. What makes players choose yours over them?",
+            competitorsPlaceholder: "e.g. Gods Unchained (card game, larger player base but Ethereum fees). Pixels (farming game, similar audience but no combat). We differ by combining real-time combat with fully on-chain item ownership at near-zero gas on Avalanche...",
+          }
+        : {
+            section: "📈 Go-to-Market",
+            acquisitionLabel: "User acquisition strategy",
+            acquisitionDesc: "How do you reach and convert your first users? Which channels — content, partnerships, referrals, community, or paid?",
+            acquisitionPlaceholder: "e.g. Developer relations program targeting existing Web3 builders, partnership with 3 protocols for distribution, content marketing via technical blog posts and tutorials...",
+            communityLabel: "Community strategy",
+            communityDesc: "How are you building and engaging your community? Discord, forums, ambassador programs, governance, events?",
+            communityPlaceholder: "e.g. Active Discord with dedicated support channels, monthly community calls, ambassador program rewarding top contributors, DAO governance for protocol decisions...",
+            monetizationLabel: "Revenue & sustainability model",
+            monetizationDesc: "How does your project generate sustainable revenue or value? Describe fees, subscriptions, token mechanics, or other monetization approaches.",
+            monetizationPlaceholder: "e.g. 0.3% protocol fee on transactions, 20% of fees directed to treasury for grants, token holders receive fee-sharing after 12-month lockup...",
+            competitorsLabel: "Competitive landscape",
+            competitorsDesc: "Name 2–3 direct competitors or alternatives. What makes users choose your project over them?",
+            competitorsPlaceholder: "e.g. Competitor A (larger user base but higher fees). Competitor B (similar feature set but no cross-chain). We differ by combining X with Y at near-zero cost on Avalanche...",
+          };
+
       return (
         <div className="space-y-5">
           <FormField
@@ -1392,15 +1448,14 @@ export default function BuildGamesSubmitForm({
             render={({ field }) => (
               <FormItem>
                 <FormLabel className="text-white font-medium">
-                  GTM Plan &amp; Vision
+                  Product Vision
                 </FormLabel>
                 <p className="text-zinc-400 text-sm -mt-1">
-                  Include your go-to-market plan, growth strategy, target user
-                  personas, competitive analysis, and long-term product vision.
+                  Where is your product headed long-term? Describe the future you're building toward.
                 </p>
                 <FormControl>
                   <Textarea
-                    placeholder="Describe your go-to-market strategy, growth plan, target users, competitive landscape, and long-term vision..."
+                    placeholder="e.g. We're building the go-to platform for X. In 3 years we see ourselves as..."
                     className="bg-zinc-900/80 border-zinc-700 text-white placeholder:text-zinc-500 focus:border-[#66acd6] min-h-[200px] resize-none"
                     {...field}
                   />
@@ -1417,105 +1472,159 @@ export default function BuildGamesSubmitForm({
             plainLabel
           />
 
-          {/* ── Gaming GTM — only for consumer games ── */}
-          {form.watch("project_category") === "Gaming" &&
-            form.watch("bg_game_type") === "Consumer Game" && (
-            <>
-              <SectionDivider label="🎮 Gaming GTM" />
+          {/* ── GTM — shown for all categories ── */}
+          <>
+            <SectionDivider label={gtm.section} />
 
-              <FormField
-                control={form.control}
-                name="bg_game_acquisition"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-white font-medium">
-                      Player acquisition strategy
-                    </FormLabel>
-                    <p className="text-zinc-400 text-sm -mt-1">
-                      How do you acquire your first 1,000 active players? Which channels — content, influencers, guilds, tournaments, referrals?
-                    </p>
-                    <FormControl>
-                      <Textarea
-                        placeholder="e.g. Partner with 5 gaming guilds on Avalanche for a launch tournament with a $5k prize pool. Micro-influencer campaign on TikTok targeting Web3 gamers. Referral bonus: invite 3 friends → earn a rare NFT item..."
-                        className="bg-zinc-900/80 border-zinc-700 text-white placeholder:text-zinc-500 focus:border-[#66acd6] min-h-[140px] resize-none"
-                        {...field}
+            <div>
+              <p className="text-white font-medium text-sm mb-1">Milestones &amp; Roadmap</p>
+              <p className="text-zinc-400 text-sm mb-3">
+                Add your key milestones by period.
+              </p>
+              <div className="space-y-2">
+                {milestoneFields.map((mf, index) => (
+                  <div
+                    key={mf.id}
+                    className="rounded-lg border border-zinc-700/60 bg-zinc-900/60 p-4 space-y-2"
+                  >
+                    <div className="flex items-center gap-2">
+                      <Controller
+                        control={form.control}
+                        name={`bg_milestones.${index}.period`}
+                        render={({ field: f }) => (
+                          <Input
+                            {...f}
+                            placeholder='Period — e.g. "Completed", "Q2 2026", "Q3 2026"'
+                            className="flex-1 bg-transparent border-zinc-700 text-white placeholder:text-zinc-600 focus:border-[#66acd6] text-sm font-medium"
+                          />
+                        )}
                       />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveMilestone(index)}
+                        className="shrink-0 p-1.5 rounded text-zinc-600 hover:text-zinc-300 hover:bg-zinc-800 transition-colors"
+                      >
+                        <X className="w-4 h-4" />
+                      </button>
+                    </div>
 
-              <FormField
-                control={form.control}
-                name="bg_game_community"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-white font-medium">
-                      Community &amp; guild strategy
-                    </FormLabel>
-                    <p className="text-zinc-400 text-sm -mt-1">
-                      How are you building your player community? Discord, tournaments, ambassador programs, DAO governance for in-game decisions?
-                    </p>
-                    <FormControl>
-                      <Textarea
-                        placeholder="e.g. Weekly tournaments streamed on Twitch. Discord with 2,000 members and active guild channels. Community votes on new game modes each season via snapshot..."
-                        className="bg-zinc-900/80 border-zinc-700 text-white placeholder:text-zinc-500 focus:border-[#66acd6] min-h-[130px] resize-none"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+                    <Controller
+                      control={form.control}
+                      name={`bg_milestones.${index}.description`}
+                      render={({ field: f }) => (
+                        <Textarea
+                          {...f}
+                          placeholder={"- What you achieved or plan to achieve\n- Key deliverable\n- ..."}
+                          className="bg-transparent border-zinc-700 text-white placeholder:text-zinc-600 focus:border-[#66acd6] min-h-[90px] resize-none text-sm font-mono"
+                        />
+                      )}
+                    />
+                  </div>
+                ))}
 
-              <FormField
-                control={form.control}
-                name="bg_game_monetization"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-white font-medium">
-                      Monetization model
-                    </FormLabel>
-                    <p className="text-zinc-400 text-sm -mt-1">
-                      How does the game generate sustainable revenue? Describe primary and secondary market mechanics without compromising gameplay fairness.
-                    </p>
-                    <FormControl>
-                      <Textarea
-                        placeholder="e.g. Free-to-play with cosmetic NFT sales (no pay-to-win). 2.5% marketplace fee on player-to-player trades. Season pass ($9.99) for early access to new content. No token required to play..."
-                        className="bg-zinc-900/80 border-zinc-700 text-white placeholder:text-zinc-500 focus:border-[#66acd6] min-h-[130px] resize-none"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+                <button
+                  type="button"
+                  onClick={() => appendMilestone({ period: "", description: "" })}
+                  className="flex items-center gap-2 text-sm text-zinc-400 hover:text-white transition-colors py-2"
+                >
+                  <span className="w-5 h-5 rounded border border-zinc-700 flex items-center justify-center text-zinc-400 hover:border-zinc-500">+</span>
+                  Add milestone
+                </button>
+              </div>
+            </div>
 
-              <FormField
-                control={form.control}
-                name="bg_game_competitors"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-white font-medium">
-                      Competitive landscape
-                    </FormLabel>
-                    <p className="text-zinc-400 text-sm -mt-1">
-                      Name 2–3 games you compete with directly. What makes players choose yours over them?
-                    </p>
-                    <FormControl>
-                      <Textarea
-                        placeholder="e.g. Gods Unchained (card game, larger player base but Ethereum fees). Pixels (farming game, similar audience but no combat). We differ by combining real-time combat with fully on-chain item ownership at near-zero gas on Avalanche..."
-                        className="bg-zinc-900/80 border-zinc-700 text-white placeholder:text-zinc-500 focus:border-[#66acd6] min-h-[130px] resize-none"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </>
-          )}
+            <FormField
+              control={form.control}
+              name="bg_game_acquisition"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-white font-medium">
+                    {gtm.acquisitionLabel}
+                  </FormLabel>
+                  <p className="text-zinc-400 text-sm -mt-1">
+                    {gtm.acquisitionDesc}
+                  </p>
+                  <FormControl>
+                    <Textarea
+                      placeholder={gtm.acquisitionPlaceholder}
+                      className="bg-zinc-900/80 border-zinc-700 text-white placeholder:text-zinc-500 focus:border-[#66acd6] min-h-[140px] resize-none"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="bg_game_community"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-white font-medium">
+                    {gtm.communityLabel}
+                  </FormLabel>
+                  <p className="text-zinc-400 text-sm -mt-1">
+                    {gtm.communityDesc}
+                  </p>
+                  <FormControl>
+                    <Textarea
+                      placeholder={gtm.communityPlaceholder}
+                      className="bg-zinc-900/80 border-zinc-700 text-white placeholder:text-zinc-500 focus:border-[#66acd6] min-h-[130px] resize-none"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="bg_game_monetization"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-white font-medium">
+                    {gtm.monetizationLabel}
+                  </FormLabel>
+                  <p className="text-zinc-400 text-sm -mt-1">
+                    {gtm.monetizationDesc}
+                  </p>
+                  <FormControl>
+                    <Textarea
+                      placeholder={gtm.monetizationPlaceholder}
+                      className="bg-zinc-900/80 border-zinc-700 text-white placeholder:text-zinc-500 focus:border-[#66acd6] min-h-[130px] resize-none"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="bg_game_competitors"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-white font-medium">
+                    {gtm.competitorsLabel}
+                  </FormLabel>
+                  <p className="text-zinc-400 text-sm -mt-1">
+                    {gtm.competitorsDesc}
+                  </p>
+                  <FormControl>
+                    <Textarea
+                      placeholder={gtm.competitorsPlaceholder}
+                      className="bg-zinc-900/80 border-zinc-700 text-white placeholder:text-zinc-500 focus:border-[#66acd6] min-h-[130px] resize-none"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </>
         </div>
       );
     }


### PR DESCRIPTION
## Summary

- **GTM section extended to all project categories** — previously the Go-to-Market fields (acquisition, community, monetization, competitive landscape) were only shown for Gaming Consumer Games. They now appear for every category with adaptive labels and placeholders. Gaming Consumer Games keep their gaming-specific copy; all other categories get generic but focused prompts.

- **Structured milestones replace freeform textarea** — `bg_milestones` is now a typed array of `{ period, description }` objects (e.g. `"Q2 2026"`, `"Completed"`) instead of a single text blob. This enables better data analysis per milestone period. Users add milestones via an explicit **"+ Add milestone"** button and can remove any card with the X button inline with the period input.

- **"GTM Plan & Vision" renamed to "Product Vision"** — scoped the free-text field to long-term vision only, removing overlap with the structured GTM fields below it.

## Changed files

- `components/build-games/BuildGamesSubmitForm.tsx`
  - Added `bg_milestones` to Zod schema and `defaultValues`
  - Added `useFieldArray` + `Controller` for dynamic milestone cards
  - GTM fields now render for all categories using a computed `gtm` config object
  - Save payload serializes milestones, filtering out empty trailing cards
  - Restored milestone state from saved `bg.milestones` on form load
