### PR TITLE
fix(console): use useChainPublicClient hook for all chain-specific reads

### DIFF
--- a/components/toolbox/components/AllowListComponents.tsx
+++ b/components/toolbox/components/AllowListComponents.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useRef, useEffect } from "react";
 import { useWalletStore } from "../stores/walletStore";
+import { useChainPublicClient } from "../hooks/useChainPublicClient";
 import { useViemChainStore } from "../stores/toolboxStore";
 import { Button } from "./Button";
 import { EVMAddressInput } from "./EVMAddressInput";
@@ -127,7 +128,8 @@ function SetRoleForm({
   onSuccess,
   onFunctionChange,
 }: SetRoleFormProps) {
-  const { publicClient, walletEVMAddress, walletChainId } = useWalletStore();
+  const { walletEVMAddress, walletChainId } = useWalletStore();
+  const publicClient = useChainPublicClient();
   const { walletClient } = useConnectedWallet();
   const viemChain = useViemChainStore();
   const [isProcessing, setIsProcessing] = useState(false);
@@ -137,6 +139,7 @@ function SetRoleForm({
   const [error, setError] = useState<string | null>(null);
 
   const handleSetRole = async () => {
+    if (!publicClient) return;
     setIsProcessing(true);
     setError(null);
     setTxHash(null);
@@ -249,13 +252,14 @@ function ReadRoleForm({
   precompileType = "precompiled contract",
   abi = allowListAbi.abi,
 }: ReadRoleFormProps) {
-  const { publicClient } = useWalletStore();
+  const publicClient = useChainPublicClient();
   const [isReading, setIsReading] = useState(false);
   const [readAddress, setReadAddress] = useState<string>("");
   const [readResult, setReadResult] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const handleRead = async () => {
+    if (!publicClient) return;
     setIsReading(true);
     setError(null);
     setReadResult(null);

--- a/components/toolbox/components/MultisigOption.tsx
+++ b/components/toolbox/components/MultisigOption.tsx
@@ -9,6 +9,7 @@ import validatorManagerAbi from '../../../contracts/icm-contracts/compiled/Valid
 import poaManagerAbi from '../../../contracts/icm-contracts/compiled/PoAManager.json';
 import { useWalletClient } from 'wagmi';
 import { useWalletStore } from '../stores/walletStore';
+import { useChainPublicClient } from '../hooks/useChainPublicClient';
 import { useViemChainStore } from '../stores/toolboxStore';
 import { useSafeAPI, SafeInfo, NonceResponse, AshWalletUrlResponse } from '../hooks/useSafeAPI';
 
@@ -91,7 +92,8 @@ export const MultisigOption: React.FC<MultisigOptionProps> = ({
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
   const [ashWalletUrl, setAshWalletUrl] = useState('');
 
-  const { publicClient, walletEVMAddress } = useWalletStore();
+  const { walletEVMAddress } = useWalletStore();
+  const publicClient = useChainPublicClient();
   const { data: walletClient } = useWalletClient();
   const viemChain = useViemChainStore();
   const { callSafeAPI } = useSafeAPI();
@@ -111,7 +113,7 @@ export const MultisigOption: React.FC<MultisigOptionProps> = ({
   const checkWalletAndOwnership = async () => {
     setIsCheckingOwnership(true);
     try {
-      if (!walletClient?.account) {
+      if (!publicClient || !walletClient?.account) {
         setIsPoaOwner(false);
         return;
       }
@@ -319,11 +321,11 @@ export const MultisigOption: React.FC<MultisigOptionProps> = ({
   };
 
   const executeDirectTransaction = async () => {
+    if (!publicClient) return;
     if (!walletClient) {
       onError('Core wallet not found');
       return;
     }
-
 
     if (!poaManagerAddress) {
       onError('PoAManager address not found');

--- a/components/toolbox/console/icm/setup/TeleporterMessenger.tsx
+++ b/components/toolbox/console/icm/setup/TeleporterMessenger.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { formatEther, parseEther } from 'viem';
 import { useViemChainStore } from "@/components/toolbox/stores/toolboxStore";
 import { useWalletStore } from "@/components/toolbox/stores/walletStore";
+import { useChainPublicClient } from "@/components/toolbox/hooks/useChainPublicClient";
 import TeleporterMessengerDeploymentTransaction from '@/contracts/icm-contracts-releases/v1.0.0/TeleporterMessenger_Deployment_Transaction_v1.0.0.txt.json';
 import TeleporterMessengerDeployerAddress from '@/contracts/icm-contracts-releases/v1.0.0/TeleporterMessenger_Deployer_Address_v1.0.0.txt.json';
 import TeleporterMessengerAddress from '@/contracts/icm-contracts-releases/v1.0.0/TeleporterMessenger_Contract_Address_v1.0.0.txt.json';
@@ -45,7 +46,8 @@ const metadata: ConsoleToolMetadata = {
 
 function TeleporterMessenger({ onSuccess }: BaseConsoleToolProps) {
   const [criticalError, setCriticalError] = useState<Error | null>(null);
-  const { publicClient, walletEVMAddress } = useWalletStore();
+  const { walletEVMAddress } = useWalletStore();
+  const publicClient = useChainPublicClient();
   const { walletClient } = useConnectedWallet();
   const viemChain = useViemChainStore();
   const [isDeploying, setIsDeploying] = useState(false);
@@ -65,6 +67,7 @@ function TeleporterMessenger({ onSuccess }: BaseConsoleToolProps) {
   const expectedContractAddress = TeleporterMessengerAddress.content;
 
   const checkDeployerBalance = async () => {
+    if (!publicClient) return;
     setIsCheckingBalance(true);
     try {
       const balance = await publicClient.getBalance({
@@ -87,9 +90,10 @@ function TeleporterMessenger({ onSuccess }: BaseConsoleToolProps) {
 
   useEffect(() => {
     checkDeployerBalance();
-  }, []);
+  }, [publicClient]);
 
   const handleTopUp = async () => {
+    if (!publicClient) return;
     setIsSending(true);
     try {
       const hash = await walletClient.sendTransaction({
@@ -109,6 +113,7 @@ function TeleporterMessenger({ onSuccess }: BaseConsoleToolProps) {
   };
 
   const handleDeploy = async () => {
+    if (!publicClient) return;
     setIsDeploying(true);
     try {
       const hash = await walletClient.sendRawTransaction({

--- a/components/toolbox/console/icm/setup/TeleporterRegistry.tsx
+++ b/components/toolbox/console/icm/setup/TeleporterRegistry.tsx
@@ -3,6 +3,7 @@
 import { useSelectedL1 } from "@/components/toolbox/stores/l1ListStore";
 import { useToolboxStore, useViemChainStore } from "@/components/toolbox/stores/toolboxStore";
 import { useWalletStore } from "@/components/toolbox/stores/walletStore";
+import { useChainPublicClient } from "@/components/toolbox/hooks/useChainPublicClient";
 import { useState } from "react";
 import TeleporterRegistryBytecode from '@/contracts/icm-contracts-releases/v1.0.0/TeleporterRegistry_Bytecode_v1.0.0.txt.json';
 import TeleporterMessengerAddress from '@/contracts/icm-contracts-releases/v1.0.0/TeleporterMessenger_Contract_Address_v1.0.0.txt.json';
@@ -45,7 +46,8 @@ const metadata: ConsoleToolMetadata = {
 function TeleporterRegistry({ onSuccess }: BaseConsoleToolProps) {
   const [criticalError, setCriticalError] = useState<Error | null>(null);
   const { setTeleporterRegistryAddress, teleporterRegistryAddress } = useToolboxStore();
-  const { publicClient, walletEVMAddress } = useWalletStore();
+  const { walletEVMAddress } = useWalletStore();
+  const publicClient = useChainPublicClient();
   const { walletClient } = useConnectedWallet();
   const [isDeploying, setIsDeploying] = useState(false);
   const viemChain = useViemChainStore();
@@ -60,6 +62,7 @@ function TeleporterRegistry({ onSuccess }: BaseConsoleToolProps) {
   const messengerAddress = TeleporterMessengerAddress.content.trim();
 
   async function handleDeploy() {
+    if (!publicClient) return;
     setIsDeploying(true);
     setTeleporterRegistryAddress("");
     try {

--- a/components/toolbox/console/icm/test-connection/DeployICMDemo.tsx
+++ b/components/toolbox/console/icm/test-connection/DeployICMDemo.tsx
@@ -2,6 +2,7 @@
 
 import { useToolboxStore, useViemChainStore } from "@/components/toolbox/stores/toolboxStore";
 import { useWalletStore } from "@/components/toolbox/stores/walletStore";
+import { useChainPublicClient } from "@/components/toolbox/hooks/useChainPublicClient";
 import { useState, useEffect } from "react";
 import ICMDemoABI from "@/contracts/example-contracts/compiled/ICMDemo.json";
 import TeleporterMessengerAddress from '@/contracts/icm-contracts-releases/v1.0.0/TeleporterMessenger_Contract_Address_v1.0.0.txt.json';
@@ -176,7 +177,8 @@ console.log("Last message:", lastMessage.toString());`,
 
 function DeployICMDemo({ onSuccess }: BaseConsoleToolProps) {
   const { setIcmReceiverAddress, icmReceiverAddress } = useToolboxStore();
-  const { publicClient, walletEVMAddress } = useWalletStore();
+  const { walletEVMAddress } = useWalletStore();
+  const publicClient = useChainPublicClient();
   const { walletClient } = useConnectedWallet();
   const viemChain = useViemChainStore();
   const [isDeploying, setIsDeploying] = useState(false);
@@ -192,6 +194,7 @@ function DeployICMDemo({ onSuccess }: BaseConsoleToolProps) {
 
   useEffect(() => {
     async function checkTeleporterExists() {
+      if (!publicClient) return;
       try {
         const code = await publicClient.getBytecode({
           address: TeleporterMessengerAddress.content as `0x${string}`,
@@ -204,9 +207,10 @@ function DeployICMDemo({ onSuccess }: BaseConsoleToolProps) {
     }
 
     checkTeleporterExists();
-  }, [selectedL1?.evmChainId]);
+  }, [publicClient, selectedL1?.evmChainId]);
 
   async function handleDeploy() {
+    if (!publicClient) return;
     setIsDeploying(true);
     setIcmReceiverAddress("");
     try {

--- a/components/toolbox/console/l1-tokenomics/FeeManager.tsx
+++ b/components/toolbox/console/l1-tokenomics/FeeManager.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useWalletStore } from "@/components/toolbox/stores/walletStore";
+import { useChainPublicClient } from "@/components/toolbox/hooks/useChainPublicClient";
 import { useViemChainStore } from "@/components/toolbox/stores/toolboxStore";
 import { Button } from "@/components/toolbox/components/Button";
 import { Input } from "@/components/toolbox/components/Input";
@@ -119,7 +120,8 @@ function ConfigDisplay({ config, lastChangedAt }: ConfigDisplayProps) {
 }
 
 function FeeManager({ onSuccess }: BaseConsoleToolProps) {
-  const { publicClient, walletEVMAddress } = useWalletStore();
+  const { walletEVMAddress } = useWalletStore();
+  const publicClient = useChainPublicClient();
   const { walletClient } = useConnectedWallet();
   const viemChain = useViemChainStore();
   const [gasLimit, setGasLimit] = useState<string>("20000000");
@@ -140,6 +142,7 @@ function FeeManager({ onSuccess }: BaseConsoleToolProps) {
   const [activeAction, setActiveAction] = useState<"set" | "get" | null>(null);
 
   const handleSetFeeConfig = async () => {
+    if (!publicClient) return;
     setIsSettingConfig(true);
     setActiveAction("set");
 
@@ -177,6 +180,7 @@ function FeeManager({ onSuccess }: BaseConsoleToolProps) {
   };
 
   const handleGetFeeConfig = async () => {
+    if (!publicClient) return;
     setIsReadingConfig(true);
     setActiveAction("get");
 

--- a/components/toolbox/console/l1-tokenomics/NativeMinter.tsx
+++ b/components/toolbox/console/l1-tokenomics/NativeMinter.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useWalletStore } from "@/components/toolbox/stores/walletStore";
+import { useChainPublicClient } from "@/components/toolbox/hooks/useChainPublicClient";
 import { useViemChainStore } from "@/components/toolbox/stores/toolboxStore";
 import { Button } from "@/components/toolbox/components/Button";
 import { Input } from "@/components/toolbox/components/Input";
@@ -31,7 +32,8 @@ const metadata: ConsoleToolMetadata = {
 };
 
 function NativeMinter({ onSuccess }: BaseConsoleToolProps) {
-  const { publicClient, walletEVMAddress } = useWalletStore();
+  const { walletEVMAddress } = useWalletStore();
+  const publicClient = useChainPublicClient();
   const { walletClient } = useConnectedWallet();
   const viemChain = useViemChainStore();
   const [amount, setAmount] = useState<string>("");
@@ -40,6 +42,7 @@ function NativeMinter({ onSuccess }: BaseConsoleToolProps) {
   const [txHash, setTxHash] = useState<string | null>(null);
 
   const handleMint = async () => {
+    if (!publicClient) return;
     setIsMinting(true);
 
     try {

--- a/components/toolbox/console/l1-tokenomics/RewardManager.tsx
+++ b/components/toolbox/console/l1-tokenomics/RewardManager.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useWalletStore } from "@/components/toolbox/stores/walletStore";
+import { useChainPublicClient } from "@/components/toolbox/hooks/useChainPublicClient";
 import { useViemChainStore } from "@/components/toolbox/stores/toolboxStore";
 import { Button } from "@/components/toolbox/components/Button";
 import { EVMAddressInput } from "@/components/toolbox/components/EVMAddressInput";
@@ -81,7 +82,8 @@ function StatusCard({ title, value, status, onRefresh, isRefreshing }: StatusCar
 }
 
 function RewardManager({ onSuccess }: BaseConsoleToolProps) {
-  const { publicClient, walletEVMAddress } = useWalletStore();
+  const { walletEVMAddress } = useWalletStore();
+  const publicClient = useChainPublicClient();
   const { walletClient } = useConnectedWallet();
   const viemChain = useViemChainStore();
 
@@ -105,6 +107,7 @@ function RewardManager({ onSuccess }: BaseConsoleToolProps) {
   const [highlightFunction, setHighlightFunction] = useState<string>("allowFeeRecipients");
 
   const handleAllowFeeRecipients = async () => {
+    if (!publicClient) return;
     if (!walletClient.account) {
       throw new Error("Please connect your wallet first");
     }
@@ -136,6 +139,7 @@ function RewardManager({ onSuccess }: BaseConsoleToolProps) {
   };
 
   const checkFeeRecipientsAllowed = async () => {
+    if (!publicClient) return;
     setIsCheckingFeeRecipients(true);
 
     const result = await publicClient.readContract({
@@ -149,6 +153,7 @@ function RewardManager({ onSuccess }: BaseConsoleToolProps) {
   };
 
   const handleDisableRewards = async () => {
+    if (!publicClient) return;
     if (!walletClient.account) {
       throw new Error("Please connect your wallet first");
     }
@@ -180,6 +185,7 @@ function RewardManager({ onSuccess }: BaseConsoleToolProps) {
   };
 
   const checkCurrentRewardAddress = async () => {
+    if (!publicClient) return;
     setIsCheckingRewardAddress(true);
 
     const result = await publicClient.readContract({
@@ -193,6 +199,7 @@ function RewardManager({ onSuccess }: BaseConsoleToolProps) {
   };
 
   const handleSetRewardAddress = async () => {
+    if (!publicClient) return;
     if (!walletClient.account) {
       throw new Error("Please connect your wallet first");
     }

--- a/components/toolbox/console/utilities/transfer-proxy-admin/TransferProxyAdmin.tsx
+++ b/components/toolbox/console/utilities/transfer-proxy-admin/TransferProxyAdmin.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useWalletStore } from "@/components/toolbox/stores/walletStore";
+import { useChainPublicClient } from "@/components/toolbox/hooks/useChainPublicClient";
 import { useViemChainStore } from "@/components/toolbox/stores/toolboxStore";
 import { useSelectedL1 } from "@/components/toolbox/stores/l1ListStore";
 import { useState, useEffect } from "react";
@@ -32,7 +33,8 @@ function TransferProxyAdmin({ onSuccess }: BaseConsoleToolProps) {
     const [criticalError, setCriticalError] = useState<Error | null>(null);
     const [proxyAdminAddress, setProxyAdminAddress] = useState<`0x${string}` | null>(null);
     const selectedL1 = useSelectedL1()();
-    const { publicClient, walletChainId, walletEVMAddress } = useWalletStore();
+    const { walletChainId, walletEVMAddress } = useWalletStore();
+    const publicClient = useChainPublicClient();
     const { walletClient } = useConnectedWallet();
     const [isTransferring, setIsTransferring] = useState(false);
     const [currentOwner, setCurrentOwner] = useState<string | null>(null);
@@ -72,7 +74,7 @@ function TransferProxyAdmin({ onSuccess }: BaseConsoleToolProps) {
     // Read the proxy admin from storage slot
     async function readProxyAdminSlot(address: string) {
         try {
-            if (!address) return;
+            if (!address || !publicClient) return;
 
             const data = await publicClient.getStorageAt({
                 address: address as `0x${string}`,
@@ -104,7 +106,7 @@ function TransferProxyAdmin({ onSuccess }: BaseConsoleToolProps) {
 
     async function checkCurrentOwner() {
         try {
-            if (!proxyAdminAddress) {
+            if (!publicClient || !proxyAdminAddress) {
                 setCurrentOwner(null);
                 setContractError("Proxy admin address is required");
                 return;
@@ -134,6 +136,9 @@ function TransferProxyAdmin({ onSuccess }: BaseConsoleToolProps) {
 
         if (!proxyAdminAddress) {
             throw new Error('Proxy admin address is required');
+        }
+        if (!publicClient) {
+            throw new Error('Public client not ready');
         }
 
         setIsTransferring(true);

--- a/components/toolbox/console/utilities/vmcMigrateFromV1/MigrateV1ToV2.tsx
+++ b/components/toolbox/console/utilities/vmcMigrateFromV1/MigrateV1ToV2.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useWalletStore } from "@/components/toolbox/stores/walletStore";
+import { useChainPublicClient } from "@/components/toolbox/hooks/useChainPublicClient";
 import {
   useViemChainStore,
   useToolboxStore,
@@ -30,7 +31,8 @@ const metadata: ConsoleToolMetadata = {
 };
 
 function MigrateV1ToV2({ onSuccess }: BaseConsoleToolProps) {
-  const { publicClient, walletEVMAddress } = useWalletStore();
+  const { walletEVMAddress } = useWalletStore();
+  const publicClient = useChainPublicClient();
   const { walletClient } = useConnectedWallet();
   const viemChain = useViemChainStore();
   const { validatorManagerAddress, setValidatorManagerAddress } =
@@ -123,6 +125,7 @@ function MigrateV1ToV2({ onSuccess }: BaseConsoleToolProps) {
 
     try {
       if (!viemChain) throw new Error("Chain not selected");
+      if (!publicClient) throw new Error("Public client not ready");
 
       // Ensure we are on the correct chain
       await walletClient.addChain({ chain: viemChain });

--- a/components/toolbox/hooks/contracts/staking/useERC20TokenStakingManager.ts
+++ b/components/toolbox/hooks/contracts/staking/useERC20TokenStakingManager.ts
@@ -1,4 +1,5 @@
 import { useWalletStore } from '../../../stores/walletStore';
+import { useChainPublicClient } from '../../useChainPublicClient';
 import { useViemChainStore } from '../../../stores/toolboxStore';
 import { readContract } from 'viem/actions';
 import useConsoleNotifications from '@/hooks/useConsoleNotifications';
@@ -66,7 +67,8 @@ export function useERC20TokenStakingManager(
   contractAddress: string | null,
   abi?: any
 ): ERC20TokenStakingManagerHook {
-  const { walletEVMAddress, publicClient } = useWalletStore();
+  const { walletEVMAddress } = useWalletStore();
+  const publicClient = useChainPublicClient();
   const viemChain = useViemChainStore();
   const { notify } = useConsoleNotifications();
   const { avalancheWalletClient } = useWallet();


### PR DESCRIPTION
## Summary

- Migrate all 12 `publicClient` usages from `useWalletStore()` to the existing `useChainPublicClient()` hook across 11 toolbox components
- The wallet store's `publicClient` is hardcoded to Fuji for non-Core wallets, causing `waitForTransactionReceipt` and `readContract` to poll the wrong RPC when targeting custom L1s
- This is a higher-level fix that supersedes #3914 (which only fixed 2 of the 12 affected sites by duplicating the hook logic inline)

## Affected components

| File | Usage fixed |
|------|------------|
| `TeleporterMessenger.tsx` | getBalance, getBytecode, waitForTransactionReceipt |
| `TeleporterRegistry.tsx` | waitForTransactionReceipt |
| `NativeMinter.tsx` | waitForTransactionReceipt |
| `FeeManager.tsx` | waitForTransactionReceipt, readContract |
| `RewardManager.tsx` | waitForTransactionReceipt, readContract |
| `TransferProxyAdmin.tsx` | getStorageAt, readContract, waitForTransactionReceipt |
| `MigrateV1ToV2.tsx` | waitForTransactionReceipt |
| `DeployICMDemo.tsx` | getBytecode, waitForTransactionReceipt |
| `MultisigOption.tsx` | readContract |
| `AllowListComponents.tsx` (×2) | readContract, waitForTransactionReceipt |
| `useERC20TokenStakingManager.ts` | estimateContractGas |

## Test plan

- [ ] Deploy TeleporterMessenger on a custom L1 using Rabby/MetaMask — verify receipt resolves
- [ ] Deploy TeleporterRegistry on a custom L1 using Rabby/MetaMask — verify receipt resolves
- [ ] Mint native tokens on a custom L1 using non-Core wallet
- [ ] Set fee config on a custom L1 using non-Core wallet
- [ ] Verify all flows still work with Core wallet
- [ ] Verify AllowList read/write operations work on custom L1s

Closes #3913
Supersedes #3914