### PR TITLE
fix: add security headers to next.config.mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -60,6 +60,35 @@ const config = {
       },
     ],
   },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
## Summary

Adds standard security headers for all routes via `next.config.mjs` `headers()` function.

Resolves #3967

## Headers Added

| Header | Value | Purpose |
|--------|-------|---------|
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | Enforce HTTPS for 2 years |
| `X-Content-Type-Options` | `nosniff` | Prevent MIME type sniffing |
| `X-Frame-Options` | `DENY` | Prevent clickjacking via iframes |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limit referrer leakage |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Restrict browser APIs |

## What This Does NOT Change

- **CORS** (`access-control-allow-origin: *`) — this may be intentional for the public API. Flagged in the issue for discussion.
- **CSP** — Content Security Policy requires careful tuning to avoid breaking inline scripts/styles. Recommend adding in a follow-up PR after testing.

## Testing

These are standard Next.js headers that apply at the response level. No functional changes to the app. Verifiable via `curl -I https://build.avax.network/` after deploy.