### PR TITLE
fix: security hardening — file upload, JWT, CORS, headers

### DIFF
--- a/app/api/file/route.ts
+++ b/app/api/file/route.ts
@@ -20,6 +20,25 @@ export const POST = withAuth(async (request: Request, context: any, session: any
 
     const typedFile = file as File;
 
+    // Validate file type
+    const ALLOWED_MIME_TYPES = [
+      'image/png',
+      'image/jpeg',
+      'image/gif',
+      'image/webp',
+      'image/svg+xml',
+      'application/pdf',
+      'video/mp4',
+      'video/quicktime',
+    ];
+
+    if (!ALLOWED_MIME_TYPES.includes(typedFile.type)) {
+      return NextResponse.json(
+        { error: `File type "${typedFile.type}" is not allowed. Accepted types: images, PDFs, and videos.` },
+        { status: 400 }
+      );
+    }
+
     // Validate file size (max 10MB)
     if (!isValidFileSize(typedFile, 10)) {
       return NextResponse.json(

--- a/app/api/validate-jwt-token/route.ts
+++ b/app/api/validate-jwt-token/route.ts
@@ -43,7 +43,6 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({
       valid: true,
       sub,
-      payload: decoded,
     });
   } catch (err: unknown) {
     return NextResponse.json(

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -60,6 +60,50 @@ const config = {
       },
     ],
   },
+  async headers() {
+    return [
+      {
+        // Security headers for all routes
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+        ],
+      },
+      {
+        // Restrict CORS on authenticated API routes
+        source: '/api/:path*',
+        headers: [
+          {
+            key: 'Access-Control-Allow-Origin',
+            value: 'https://build.avax.network',
+          },
+          {
+            key: 'Vary',
+            value: 'Origin',
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
## Summary

Batch security fix addressing 4 issues. All changes are minimal and low-risk.

## Changes

### 1. File upload MIME type validation (#3972)
Adds an allowlist of accepted file types to `POST /api/file`:
- Images: `png`, `jpeg`, `gif`, `webp`, `svg+xml`
- Documents: `pdf`
- Video: `mp4`, `quicktime`

Rejects uploads with unrecognized MIME types to prevent storage of executable content (HTML, JS, etc.) on public blob storage.

### 2. JWT validation response trimming (#3974)
`POST /api/validate-jwt-token` no longer returns the full decoded token `payload`. Response now contains only `valid` and `sub` fields.

### 3. CORS scoping on API routes (#3973)
Restricts `Access-Control-Allow-Origin` on `/api/*` routes to `https://build.avax.network` (was `*`). Adds `Vary: Origin` header to prevent cache poisoning.

### 4. Security headers (#3967)
Adds standard security headers for all routes:
- `Strict-Transport-Security`: 2-year max-age with preload
- `X-Content-Type-Options`: nosniff
- `X-Frame-Options`: DENY
- `Referrer-Policy`: strict-origin-when-cross-origin
- `Permissions-Policy`: deny camera, microphone, geolocation

## Testing

- File upload: existing uploads with valid types unaffected; test with a `.html` file to verify rejection
- JWT endpoint: callers that relied on `payload` field will need updating (check if any exist)
- CORS: verify Builders Hub frontend still works (same-origin requests unaffected). External consumers of public API routes (stats, validators) will be blocked — if any exist, those routes may need exemption
- Headers: no functional impact, purely additive

## Risk

**Low**. The CORS change is the most impactful — if external sites legitimately consume `/api/*`, they will break. Worth auditing before merge.

Resolves #3967, #3972, #3973, #3974
Supersedes #3968