### PR TITLE
fix(docs): update Alchemy signup link with tracked attribution

### DIFF
--- a/content/integrations/alchemy.mdx
+++ b/content/integrations/alchemy.mdx
@@ -23,7 +23,7 @@ Alchemy is a blockchain development platform that provides tools and services fo
 
 ## Getting Started
 
-1. **Sign Up**: Create an account on [Alchemy](https://www.alchemy.com/).
+1. **Sign Up**: Create an account on [Alchemy](https://dashboard.alchemy.com/?utm_source=chain_partner&utm_medium=referral&utm_campaign=avalanche).
 2. **Create an App**: After signing in, create a new application in your Alchemy dashboard. Choose the blockchain network you want to connect to.
 3. **Get API Key**: Once your application is set up, you’ll be provided with an API key. This key is used to authenticate your requests to the Alchemy RPC node.
 4. **Integrate with Your Project**: Use the API key to connect your blockchain application to the Alchemy network. You can integrate using the provided SDKs or directly via HTTP requests.


### PR DESCRIPTION
## What this PR does

Updates the Alchemy signup link in `content/integrations/alchemy.mdx` to use the tracked dashboard URL with UTM parameters for partner attribution.

Closes #3996

**Change:**
- `https://www.alchemy.com/` → `https://dashboard.alchemy.com/?utm_source=chain_partner&utm_medium=referral&utm_campaign=avalanche`

Same destination, adds attribution so Alchemy can track signups from Avalanche docs.

Requested by Alchemy partner team.

---
*Generated by devrel-agent.*