### PR TITLE
fix(console): dashboard health status, copy buttons, validator count …

### DIFF
--- a/app/api/chain-validators/[subnetId]/route.ts
+++ b/app/api/chain-validators/[subnetId]/route.ts
@@ -76,13 +76,13 @@ async function fetchValidatorVersions(): Promise<Map<string, string>> {
   }
 }
 
-async function fetchAllValidators(subnetId: string, versionMap: Map<string, string>): Promise<ValidatorData[]> {
-  const avalanche = new Avalanche({ network: "mainnet" });
+async function fetchAllValidators(subnetId: string, versionMap: Map<string, string>, network: "mainnet" | "fuji" = "mainnet"): Promise<ValidatorData[]> {
+  const avalanche = new Avalanche({ network });
   const validators: ValidatorData[] = [];
-  
+
   try {
     const isPrimaryNetwork = subnetId === "11111111111111111111111111111111LpoYY";
-    
+
     let result;
     if (isPrimaryNetwork) {
       // Use listValidators for Primary Network
@@ -90,14 +90,14 @@ async function fetchAllValidators(subnetId: string, versionMap: Map<string, stri
         pageSize: PAGE_SIZE,
         validationStatus: "active",
         subnetId: subnetId,
-        network: "mainnet",
+        network,
       });
     } else {
       // Use listL1Validators for L1 subnets
       result = await avalanche.data.primaryNetwork.listL1Validators({
         pageSize: PAGE_SIZE,
         subnetId: subnetId,
-        network: "mainnet",
+        network,
         includeInactiveL1Validators: false,
       });
     }
@@ -208,7 +208,9 @@ export async function GET(
 ) {
   try {
     const { subnetId } = await params;
-    
+    const url = new URL(_request.url);
+    const network: "mainnet" | "fuji" = url.searchParams.get('network') === 'testnet' || url.searchParams.get('network') === 'fuji' ? 'fuji' : 'mainnet';
+
     if (!subnetId) {
       return NextResponse.json(
         { error: "Subnet ID is required" },
@@ -216,8 +218,9 @@ export async function GET(
       );
     }
 
+    const cacheKey = `${network}:${subnetId}`;
     const now = Date.now();
-    const cachedData = cacheStore.get(subnetId);
+    const cachedData = cacheStore.get(cacheKey);
 
     if (cachedData && (now - cachedData.timestamp) < CACHE_DURATION) {
       return NextResponse.json(
@@ -237,17 +240,17 @@ export async function GET(
     }
 
     const versionMap = await fetchValidatorVersions();
-    
+
     const validators = await Promise.race([
-      fetchAllValidators(subnetId, versionMap),
-      new Promise<ValidatorData[]>((_, reject) => 
+      fetchAllValidators(subnetId, versionMap, network),
+      new Promise<ValidatorData[]>((_, reject) =>
         setTimeout(() => reject(new Error('Request timeout')), FETCH_TIMEOUT)
       )
     ]);
     
     const versionBreakdown = calculateVersionBreakdown(validators);
     
-    cacheStore.set(subnetId, {
+    cacheStore.set(cacheKey, {
       data: validators,
       timestamp: now,
       versionBreakdown,

--- a/app/console/my-l1/page.tsx
+++ b/app/console/my-l1/page.tsx
@@ -16,6 +16,8 @@ import {
   BarChart3,
   ExternalLink,
   RefreshCw,
+  Copy,
+  Check,
 } from "lucide-react";
 import { useL1Dashboard, type L1HealthStatus } from "@/hooks/useL1Dashboard";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -23,6 +25,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 
 // Health status badge component
 function HealthStatusBadge({ status, size = "default" }: { status: L1HealthStatus; size?: "default" | "large" }) {
@@ -36,6 +39,11 @@ function HealthStatusBadge({ status, size = "default" }: { status: L1HealthStatu
       label: "Degraded",
       className: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
       dot: "bg-yellow-500",
+    },
+    stale: {
+      label: "Stale",
+      className: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400",
+      dot: "bg-orange-500",
     },
     offline: {
       label: "Offline",
@@ -194,6 +202,8 @@ export default function MyL1DashboardPage() {
     setupProgressPercent,
     isLoading,
   } = useL1Dashboard();
+
+  const { copiedId, copyToClipboard } = useCopyToClipboard();
 
   // If not connected to an L1, show the not connected state
   if (!isConnected || !isConnectedToL1 || !currentL1) {
@@ -385,46 +395,100 @@ export default function MyL1DashboardPage() {
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            <div className="p-3 rounded-lg bg-muted/50">
+            <div className="p-3 rounded-lg bg-muted/50 group">
               <p className="text-xs text-muted-foreground mb-1">RPC URL</p>
-              <p className="text-sm font-mono text-foreground truncate" title={currentL1.rpcUrl}>
-                {currentL1.rpcUrl}
-              </p>
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-mono text-foreground truncate flex-1" title={currentL1.rpcUrl}>
+                  {currentL1.rpcUrl}
+                </p>
+                <button
+                  onClick={() => copyToClipboard(currentL1.rpcUrl, "rpc-url")}
+                  className="p-1 rounded hover:bg-muted transition-colors shrink-0"
+                  title="Copy RPC URL"
+                >
+                  {copiedId === "rpc-url" ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />}
+                </button>
+              </div>
             </div>
-            <div className="p-3 rounded-lg bg-muted/50">
+            <div className="p-3 rounded-lg bg-muted/50 group">
               <p className="text-xs text-muted-foreground mb-1">Subnet ID</p>
-              <p className="text-sm font-mono text-foreground truncate" title={currentL1.subnetId}>
-                {currentL1.subnetId}
-              </p>
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-mono text-foreground truncate flex-1" title={currentL1.subnetId}>
+                  {currentL1.subnetId}
+                </p>
+                <button
+                  onClick={() => copyToClipboard(currentL1.subnetId, "subnet-id")}
+                  className="p-1 rounded hover:bg-muted transition-colors shrink-0"
+                  title="Copy Subnet ID"
+                >
+                  {copiedId === "subnet-id" ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />}
+                </button>
+              </div>
             </div>
-            <div className="p-3 rounded-lg bg-muted/50">
+            <div className="p-3 rounded-lg bg-muted/50 group">
               <p className="text-xs text-muted-foreground mb-1">Blockchain ID</p>
-              <p className="text-sm font-mono text-foreground truncate" title={currentL1.id}>
-                {currentL1.id}
-              </p>
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-mono text-foreground truncate flex-1" title={currentL1.id}>
+                  {currentL1.id}
+                </p>
+                <button
+                  onClick={() => copyToClipboard(currentL1.id, "blockchain-id")}
+                  className="p-1 rounded hover:bg-muted transition-colors shrink-0"
+                  title="Copy Blockchain ID"
+                >
+                  {copiedId === "blockchain-id" ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />}
+                </button>
+              </div>
             </div>
             {currentL1.validatorManagerAddress && (
-              <div className="p-3 rounded-lg bg-muted/50">
+              <div className="p-3 rounded-lg bg-muted/50 group">
                 <p className="text-xs text-muted-foreground mb-1">Validator Manager</p>
-                <p className="text-sm font-mono text-foreground truncate" title={currentL1.validatorManagerAddress}>
-                  {currentL1.validatorManagerAddress}
-                </p>
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-mono text-foreground truncate flex-1" title={currentL1.validatorManagerAddress}>
+                    {currentL1.validatorManagerAddress}
+                  </p>
+                  <button
+                    onClick={() => copyToClipboard(currentL1.validatorManagerAddress, "validator-manager")}
+                    className="p-1 rounded hover:bg-muted transition-colors shrink-0"
+                    title="Copy Validator Manager Address"
+                  >
+                    {copiedId === "validator-manager" ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />}
+                  </button>
+                </div>
               </div>
             )}
             {currentL1.wellKnownTeleporterRegistryAddress && (
-              <div className="p-3 rounded-lg bg-muted/50">
+              <div className="p-3 rounded-lg bg-muted/50 group">
                 <p className="text-xs text-muted-foreground mb-1">Teleporter Registry</p>
-                <p className="text-sm font-mono text-foreground truncate" title={currentL1.wellKnownTeleporterRegistryAddress}>
-                  {currentL1.wellKnownTeleporterRegistryAddress}
-                </p>
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-mono text-foreground truncate flex-1" title={currentL1.wellKnownTeleporterRegistryAddress}>
+                    {currentL1.wellKnownTeleporterRegistryAddress}
+                  </p>
+                  <button
+                    onClick={() => copyToClipboard(currentL1.wellKnownTeleporterRegistryAddress!, "teleporter-registry")}
+                    className="p-1 rounded hover:bg-muted transition-colors shrink-0"
+                    title="Copy Teleporter Registry Address"
+                  >
+                    {copiedId === "teleporter-registry" ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />}
+                  </button>
+                </div>
               </div>
             )}
             {currentL1.wrappedTokenAddress && (
-              <div className="p-3 rounded-lg bg-muted/50">
+              <div className="p-3 rounded-lg bg-muted/50 group">
                 <p className="text-xs text-muted-foreground mb-1">Wrapped Token</p>
-                <p className="text-sm font-mono text-foreground truncate" title={currentL1.wrappedTokenAddress}>
-                  {currentL1.wrappedTokenAddress}
-                </p>
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-mono text-foreground truncate flex-1" title={currentL1.wrappedTokenAddress}>
+                    {currentL1.wrappedTokenAddress}
+                  </p>
+                  <button
+                    onClick={() => copyToClipboard(currentL1.wrappedTokenAddress, "wrapped-token")}
+                    className="p-1 rounded hover:bg-muted transition-colors shrink-0"
+                    title="Copy Wrapped Token Address"
+                  >
+                    {copiedId === "wrapped-token" ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />}
+                  </button>
+                </div>
               </div>
             )}
           </div>

--- a/components/console/my-l1-card.tsx
+++ b/components/console/my-l1-card.tsx
@@ -19,6 +19,11 @@ function HealthStatusBadge({ status }: { status: L1HealthStatus }) {
       className: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
       dot: "bg-yellow-500",
     },
+    stale: {
+      label: "Stale",
+      className: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400",
+      dot: "bg-orange-500",
+    },
     offline: {
       label: "Offline",
       className: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",

--- a/components/toolbox/console/permissioned-l1s/AddValidator.tsx
+++ b/components/toolbox/console/permissioned-l1s/AddValidator.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/toolbox/components/Button';
 import SelectSubnetId from '@/components/toolbox/components/SelectSubnetId';
@@ -129,7 +129,7 @@ const AddValidatorExpert: React.FC<BaseConsoleToolProps> = ({ onSuccess }) => {
   const [evmTxHash, setEvmTxHash] = useState<string>('');
 
   // Form state with local persistence
-  const { walletEVMAddress, pChainAddress, isTestnet } = useWalletStore();
+  const { pChainAddress, isTestnet } = useWalletStore();
   const createChainStoreSubnetId = useCreateChainStore()(state => state.subnetId);
   const [subnetIdL1, setSubnetIdL1] = useState<string>(createChainStoreSubnetId || "");
   const [resetKey, setResetKey] = useState<number>(0);
@@ -177,7 +177,9 @@ const AddValidatorExpert: React.FC<BaseConsoleToolProps> = ({ onSuccess }) => {
     isLoadingL1Weight,
     ownershipError,
     ownerType,
-    isDetectingOwnerType
+    isDetectingOwnerType,
+    ownershipStatus,
+    refetchOwnership
   } = useValidatorManagerDetails({ subnetId: subnetIdL1 });
 
   // Restore intermediate state from persisted validators data when available
@@ -202,30 +204,6 @@ const AddValidatorExpert: React.FC<BaseConsoleToolProps> = ({ onSuccess }) => {
       setValidatorBalance('');
     }
   }, [validators]);
-
-  // Simple ownership check - direct computation
-  const isContractOwner = useMemo(() => {
-    return contractOwner && walletEVMAddress
-      ? walletEVMAddress.toLowerCase() === contractOwner.toLowerCase()
-      : null;
-  }, [contractOwner, walletEVMAddress]);
-
-  // Determine UI state based on ownership:
-  // Case 1: Contract is owned by another contract → show MultisigOption
-  // Case 2: Contract is owned by current wallet → show regular button
-  // Case 3: Contract is owned by different EOA → show error
-  const ownershipState = useMemo(() => {
-    if (isOwnerContract) {
-      return 'contract'; // Case 1: Show MultisigOption
-    }
-    if (isContractOwner === true) {
-      return 'currentWallet'; // Case 2: Show regular button
-    }
-    if (isContractOwner === false) {
-      return 'differentEOA'; // Case 3: Show error
-    }
-    return 'loading'; // Still determining ownership
-  }, [isOwnerContract, isContractOwner]);
 
   const handleReset = () => {
     setGlobalError(null);
@@ -330,7 +308,9 @@ const AddValidatorExpert: React.FC<BaseConsoleToolProps> = ({ onSuccess }) => {
                   subnetId={subnetIdL1}
                   validatorManagerAddress={validatorManagerAddress}
                   validators={validators}
-                  ownershipState={ownershipState}
+                  ownershipState={ownershipStatus}
+                  refetchOwnership={refetchOwnership}
+                  ownershipError={ownershipError}
                   contractTotalWeight={contractTotalWeight}
                   l1WeightError={l1WeightError}
                   onSuccess={(data) => {
@@ -386,7 +366,7 @@ const AddValidatorExpert: React.FC<BaseConsoleToolProps> = ({ onSuccess }) => {
                   signingSubnetId={signingSubnetId}
                   managerType="PoA"
                   managerAddress={validatorManagerAddress}
-                  ownershipState={ownershipState}
+                  ownershipState={ownershipStatus}
                   contractOwner={contractOwner}
                   isLoadingOwnership={isLoadingOwnership}
                   ownerType={ownerType}

--- a/components/toolbox/console/permissioned-l1s/AddValidator/InitiateValidatorRegistration.tsx
+++ b/components/toolbox/console/permissioned-l1s/AddValidator/InitiateValidatorRegistration.tsx
@@ -25,9 +25,11 @@ interface InitiateValidatorRegistrationProps {
     blsProofOfPossession: string;
   }) => void;
   onError: (message: string) => void;
-  ownershipState: 'contract' | 'currentWallet' | 'differentEOA' | 'loading';
+  ownershipState: 'contract' | 'currentWallet' | 'differentEOA' | 'loading' | 'error';
   contractTotalWeight: bigint;
   l1WeightError: string | null;
+  refetchOwnership?: () => void;
+  ownershipError?: string | null;
 }
 
 const InitiateValidatorRegistration: React.FC<InitiateValidatorRegistrationProps> = ({
@@ -38,6 +40,8 @@ const InitiateValidatorRegistration: React.FC<InitiateValidatorRegistrationProps
   onError,
   ownershipState,
   contractTotalWeight,
+  refetchOwnership,
+  ownershipError,
 }) => {
   const { walletEVMAddress: connectedAddress } = useWalletStore();
   const chainPublicClient = useChainPublicClient();
@@ -331,19 +335,32 @@ const InitiateValidatorRegistration: React.FC<InitiateValidatorRegistrationProps
         </Button>
       )}
 
-      {(ownershipState === 'differentEOA' || ownershipState === 'loading') && (
+      {ownershipState === 'differentEOA' && (
         <Button
           onClick={handleInitiateValidatorRegistration}
           disabled={true}
-          error={
-            ownershipState === 'differentEOA'
-              ? "You are not the owner of this contract. Only the contract owner can add validators."
-              : ownershipState === 'loading'
-                ? "Verifying ownership..."
-                : (!validatorManagerAddress && subnetId ? "Could not find Validator Manager for this L1." : undefined)
-          }
+          error="You are not the owner of this contract. Only the contract owner can add validators."
         >
-          {ownershipState === 'loading' ? 'Verifying...' : 'Initiate Validator Registration'}
+          Initiate Validator Registration
+        </Button>
+      )}
+
+      {ownershipState === 'loading' && (
+        <Button
+          onClick={handleInitiateValidatorRegistration}
+          disabled={true}
+          error="Verifying ownership..."
+        >
+          Verifying...
+        </Button>
+      )}
+
+      {ownershipState === 'error' && (
+        <Button
+          onClick={() => refetchOwnership?.()}
+          error={ownershipError || "Failed to verify contract ownership. Click to retry."}
+        >
+          Retry Ownership Check
         </Button>
       )}
 

--- a/components/toolbox/console/permissioned-l1s/ChangeWeight.tsx
+++ b/components/toolbox/console/permissioned-l1s/ChangeWeight.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, { useState, useMemo } from 'react';
+import React, { useState } from 'react';
 import { Button } from '@/components/toolbox/components/Button';
 import { Alert } from '@/components/toolbox/components/Alert';
 import SelectSubnetId from '@/components/toolbox/components/SelectSubnetId';
@@ -7,7 +7,6 @@ import { ValidatorManagerDetails } from '@/components/toolbox/components/Validat
 import { useValidatorManagerDetails } from '@/components/toolbox/hooks/useValidatorManagerDetails';
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Success } from '@/components/toolbox/components/Success';
-import { useWalletStore } from '@/components/toolbox/stores/walletStore';
 
 import InitiateChangeWeight from '@/components/toolbox/console/permissioned-l1s/ChangeWeight/InitiateChangeWeight';
 import SubmitPChainTxWeightUpdate from '@/components/toolbox/console/shared/SubmitPChainTxWeightUpdate';
@@ -102,7 +101,6 @@ const ChangeWeightStateless: React.FC<BaseConsoleToolProps> = ({ onSuccess }) =>
   const [pChainTxId, setPChainTxId] = useState<string>('');
 
   // Form state
-  const { walletEVMAddress } = useWalletStore();
   const { walletClient } = useConnectedWallet();
   const createChainStoreSubnetId = useCreateChainStore()(state => state.subnetId);
   const [subnetIdL1, setSubnetIdL1] = useState<string>(createChainStoreSubnetId || "");
@@ -126,32 +124,17 @@ const ChangeWeightStateless: React.FC<BaseConsoleToolProps> = ({ onSuccess }) =>
     isLoadingL1Weight,
     ownershipError,
     ownerType,
-    isDetectingOwnerType
+    isDetectingOwnerType,
+    ownershipStatus,
+    refetchOwnership
   } = useValidatorManagerDetails({ subnetId: subnetIdL1 });
 
-  // Simple ownership check - direct computation
-  const isContractOwner = useMemo(() => {
-    return contractOwner && walletEVMAddress
-      ? walletEVMAddress.toLowerCase() === contractOwner.toLowerCase()
+  // Derive isContractOwner for CompletePChainWeightUpdate from centralized ownershipStatus
+  const isContractOwner = ownershipStatus === 'currentWallet'
+    ? true
+    : ownershipStatus === 'differentEOA'
+      ? false
       : null;
-  }, [contractOwner, walletEVMAddress]);
-
-  // Determine UI state based on ownership:
-  // Case 1: Contract is owned by another contract → show MultisigOption
-  // Case 2: Contract is owned by current wallet → show regular button
-  // Case 3: Contract is owned by different EOA → show error
-  const ownershipState = useMemo(() => {
-    if (isOwnerContract) {
-      return 'contract'; // Case 1: Show MultisigOption
-    }
-    if (isContractOwner === true) {
-      return 'currentWallet'; // Case 2: Show regular button
-    }
-    if (isContractOwner === false) {
-      return 'differentEOA'; // Case 3: Show error
-    }
-    return 'loading'; // Still determining ownership
-  }, [isOwnerContract, isContractOwner]);
 
   const handleReset = () => {
     setGlobalError(null);
@@ -226,7 +209,9 @@ const ChangeWeightStateless: React.FC<BaseConsoleToolProps> = ({ onSuccess }) =>
                   initialNodeId={nodeId}
                   initialValidationId={validationId}
                   initialWeight={newWeight}
-                  ownershipState={ownershipState}
+                  ownershipState={ownershipStatus}
+                  refetchOwnership={refetchOwnership}
+                  ownershipError={ownershipError}
                   contractTotalWeight={contractTotalWeight}
                   onSuccess={(data) => {
                     setNodeId(data.nodeId);

--- a/components/toolbox/console/permissioned-l1s/ChangeWeight/InitiateChangeWeight.tsx
+++ b/components/toolbox/console/permissioned-l1s/ChangeWeight/InitiateChangeWeight.tsx
@@ -25,8 +25,10 @@ interface InitiateChangeWeightProps {
   initialNodeId?: string;
   initialValidationId?: string;
   initialWeight?: string;
-  ownershipState: 'contract' | 'currentWallet' | 'differentEOA' | 'loading';
+  ownershipState: 'contract' | 'currentWallet' | 'differentEOA' | 'loading' | 'error';
   contractTotalWeight: bigint;
+  refetchOwnership?: () => void;
+  ownershipError?: string | null;
 }
 
 const InitiateChangeWeight: React.FC<InitiateChangeWeightProps> = ({
@@ -40,6 +42,8 @@ const InitiateChangeWeight: React.FC<InitiateChangeWeightProps> = ({
   initialWeight,
   ownershipState,
   contractTotalWeight,
+  refetchOwnership,
+  ownershipError,
 }) => {
   const { walletEVMAddress: connectedAddress } = useWalletStore();
   const chainPublicClient = useChainPublicClient();
@@ -97,6 +101,9 @@ const InitiateChangeWeight: React.FC<InitiateChangeWeightProps> = ({
     }
     if (ownershipState === 'loading') {
       setErrorState("Verifying contract ownership... please wait."); return;
+    }
+    if (ownershipState === 'error') {
+      setErrorState("Ownership verification failed. Please retry."); return;
     }
 
     setIsProcessing(true);
@@ -243,19 +250,32 @@ const InitiateChangeWeight: React.FC<InitiateChangeWeightProps> = ({
         </Button>
       )}
 
-      {(ownershipState === 'differentEOA' || ownershipState === 'loading') && (
+      {ownershipState === 'differentEOA' && (
         <Button
           onClick={handleInitiateChangeWeight}
           disabled={true}
-          error={
-            ownershipState === 'differentEOA'
-              ? "You are not the owner of this contract. Only the contract owner can change validator weights."
-              : ownershipState === 'loading'
-                ? "Verifying ownership..."
-                : (!validatorManagerAddress && subnetId ? "Could not find Validator Manager for this L1." : undefined)
-          }
+          error="You are not the owner of this contract. Only the contract owner can change validator weights."
         >
-          {ownershipState === 'loading' ? 'Verifying...' : 'Initiate Change Weight'}
+          Initiate Change Weight
+        </Button>
+      )}
+
+      {ownershipState === 'loading' && (
+        <Button
+          onClick={handleInitiateChangeWeight}
+          disabled={true}
+          error="Verifying ownership..."
+        >
+          Verifying...
+        </Button>
+      )}
+
+      {ownershipState === 'error' && (
+        <Button
+          onClick={() => refetchOwnership?.()}
+          error={ownershipError || "Failed to verify contract ownership. Click to retry."}
+        >
+          Retry Ownership Check
         </Button>
       )}
 

--- a/components/toolbox/console/permissioned-l1s/RemoveValidator.tsx
+++ b/components/toolbox/console/permissioned-l1s/RemoveValidator.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, { useState, useMemo } from 'react'
+import React, { useState } from 'react'
 import { Button } from "@/components/toolbox/components/Button"
 import { Alert } from '@/components/toolbox/components/Alert'
 import SelectSubnetId from "@/components/toolbox/components/SelectSubnetId"
@@ -7,7 +7,6 @@ import { ValidatorManagerDetails } from "@/components/toolbox/components/Validat
 import { Success } from "@/components/toolbox/components/Success"
 
 import { useCreateChainStore } from "@/components/toolbox/stores/createChainStore"
-import { useWalletStore } from "@/components/toolbox/stores/walletStore"
 import { useValidatorManagerDetails } from "@/components/toolbox/hooks/useValidatorManagerDetails"
 
 import InitiateValidatorRemoval from "@/components/toolbox/console/permissioned-l1s/RemoveValidator/InitiateValidatorRemoval"
@@ -104,7 +103,6 @@ const RemoveValidatorExpert: React.FC<BaseConsoleToolProps> = ({ onSuccess }) =>
   const [pChainTxId, setPChainTxId] = useState<string>("")
 
   // Form state
-  const { walletEVMAddress } = useWalletStore()
   const { walletClient } = useConnectedWallet()
   const createChainStoreSubnetId = useCreateChainStore()(state => state.subnetId)
   const [subnetIdL1, setSubnetIdL1] = useState<string>(createChainStoreSubnetId || "")
@@ -127,28 +125,10 @@ const RemoveValidatorExpert: React.FC<BaseConsoleToolProps> = ({ onSuccess }) =>
     isLoadingL1Weight,
     ownershipError,
     ownerType,
-    isDetectingOwnerType
+    isDetectingOwnerType,
+    ownershipStatus,
+    refetchOwnership
   } = useValidatorManagerDetails({ subnetId: subnetIdL1 })
-
-  // Simple ownership check - direct computation
-  const isContractOwner = useMemo(() => {
-    return contractOwner && walletEVMAddress
-      ? walletEVMAddress.toLowerCase() === contractOwner.toLowerCase()
-      : null;
-  }, [contractOwner, walletEVMAddress]);
-
-  const ownershipState = useMemo(() => {
-    if (isOwnerContract) {
-      return 'contract';
-    }
-    if (isContractOwner === true) {
-      return 'currentWallet';
-    }
-    if (isContractOwner === false) {
-      return 'differentEOA';
-    }
-    return 'loading';
-  }, [isOwnerContract, isContractOwner]);
 
   const handleReset = () => {
     setGlobalError(null)
@@ -220,7 +200,9 @@ const RemoveValidatorExpert: React.FC<BaseConsoleToolProps> = ({ onSuccess }) =>
                 resetForm={resetInitiateForm}
                 initialNodeId={nodeId}
                 initialValidationId={validationId}
-                ownershipState={ownershipState}
+                ownershipState={ownershipStatus}
+                refetchOwnership={refetchOwnership}
+                ownershipError={ownershipError}
                 onSuccess={(data) => {
                   setNodeId(data.nodeId)
                   setValidationId(data.validationId)
@@ -271,7 +253,7 @@ const RemoveValidatorExpert: React.FC<BaseConsoleToolProps> = ({ onSuccess }) =>
                 validationId={validationId}
                 pChainTxId={pChainTxId}
                 eventData={null}
-                isContractOwner={isContractOwner}
+                isContractOwner={ownershipStatus === 'currentWallet' ? true : ownershipStatus === 'differentEOA' ? false : null}
                 validatorManagerAddress={validatorManagerAddress}
                 signingSubnetId={signingSubnetId}
                 contractOwner={contractOwner}

--- a/components/toolbox/console/permissioned-l1s/RemoveValidator/InitiateValidatorRemoval.tsx
+++ b/components/toolbox/console/permissioned-l1s/RemoveValidator/InitiateValidatorRemoval.tsx
@@ -20,7 +20,9 @@ interface InitiateValidatorRemovalProps {
   resetForm?: boolean;
   initialNodeId?: string;
   initialValidationId?: string;
-  ownershipState: 'contract' | 'currentWallet' | 'differentEOA' | 'loading';
+  ownershipState: 'contract' | 'currentWallet' | 'differentEOA' | 'loading' | 'error';
+  refetchOwnership?: () => void;
+  ownershipError?: string | null;
 }
 
 const InitiateValidatorRemoval: React.FC<InitiateValidatorRemovalProps> = ({
@@ -32,6 +34,8 @@ const InitiateValidatorRemoval: React.FC<InitiateValidatorRemovalProps> = ({
   initialNodeId,
   initialValidationId,
   ownershipState,
+  refetchOwnership,
+  ownershipError,
 }) => {
   const { walletEVMAddress: connectedAddress } = useWalletStore();
   const chainPublicClient = useChainPublicClient();
@@ -80,6 +84,11 @@ const InitiateValidatorRemoval: React.FC<InitiateValidatorRemovalProps> = ({
 
     if (ownershipState === 'loading') {
       setErrorState("Verifying contract ownership... please wait.");
+      return false;
+    }
+
+    if (ownershipState === 'error') {
+      setErrorState("Ownership verification failed. Please retry.");
       return false;
     }
 
@@ -251,19 +260,32 @@ const InitiateValidatorRemoval: React.FC<InitiateValidatorRemovalProps> = ({
         </Button>
       )}
 
-      {(ownershipState === 'differentEOA' || ownershipState === 'loading') && (
+      {ownershipState === 'differentEOA' && (
         <Button
           onClick={handleInitiateRemoval}
           disabled={true}
-          error={
-            ownershipState === 'differentEOA'
-              ? "You are not the owner of this contract. Only the contract owner can remove validators."
-              : ownershipState === 'loading'
-                ? "Verifying ownership..."
-                : (!validatorManagerAddress && subnetId ? "Could not find Validator Manager for this L1." : undefined)
-          }
+          error="You are not the owner of this contract. Only the contract owner can remove validators."
         >
-          {ownershipState === 'loading' ? 'Verifying...' : 'Initiate Validator Removal'}
+          Initiate Validator Removal
+        </Button>
+      )}
+
+      {ownershipState === 'loading' && (
+        <Button
+          onClick={handleInitiateRemoval}
+          disabled={true}
+          error="Verifying ownership..."
+        >
+          Verifying...
+        </Button>
+      )}
+
+      {ownershipState === 'error' && (
+        <Button
+          onClick={() => refetchOwnership?.()}
+          error={ownershipError || "Failed to verify contract ownership. Click to retry."}
+        >
+          Retry Ownership Check
         </Button>
       )}
 

--- a/components/toolbox/console/shared/CompletePChainRegistration.tsx
+++ b/components/toolbox/console/shared/CompletePChainRegistration.tsx
@@ -36,7 +36,7 @@ export interface CompletePChainRegistrationProps {
     managerAddress: string;
     
     // For PoA: ownership and multisig
-    ownershipState?: 'contract' | 'currentWallet' | 'differentEOA' | 'loading';
+    ownershipState?: 'contract' | 'currentWallet' | 'differentEOA' | 'loading' | 'error';
     contractOwner?: string | null;
     isLoadingOwnership?: boolean;
     ownerType?: OwnerType;

--- a/components/toolbox/hooks/contracts/core/useValidatorManager.ts
+++ b/components/toolbox/hooks/contracts/core/useValidatorManager.ts
@@ -81,6 +81,7 @@ export interface ValidatorManagerHook {
   // Metadata
   contractAddress: string | null;
   isReady: boolean;
+  isReadReady: boolean;
 }
 
 /**
@@ -100,6 +101,7 @@ export function useValidatorManager(
 
   const contractAbi = abi ?? ValidatorManagerAbi.abi;
   const isReady = Boolean(contractAddress && walletClient && viemChain);
+  const isReadReady = Boolean(contractAddress && chainPublicClient);
 
   // Read functions
   const getValidator = async (validationID: string): Promise<ValidatorData> => {
@@ -502,6 +504,7 @@ export function useValidatorManager(
 
     // Metadata
     contractAddress,
-    isReady
+    isReady,
+    isReadReady
   };
 }

--- a/components/toolbox/hooks/contracts/governance/usePoAManager.ts
+++ b/components/toolbox/hooks/contracts/governance/usePoAManager.ts
@@ -31,6 +31,7 @@ export interface PoAManagerHook {
   // Metadata
   contractAddress: string | null;
   isReady: boolean;
+  isReadReady: boolean;
 }
 
 /**
@@ -50,6 +51,7 @@ export function usePoAManager(
 
   const contractAbi = abi ?? PoAManagerAbi.abi;
   const isReady = Boolean(contractAddress && walletClient && viemChain);
+  const isReadReady = Boolean(contractAddress && chainPublicClient);
 
   // Read functions
   const owner = async (): Promise<string> => {
@@ -302,6 +304,7 @@ export function usePoAManager(
 
     // Metadata
     contractAddress,
-    isReady
+    isReady,
+    isReadReady
   };
 }

--- a/components/toolbox/hooks/useValidatorManagerDetails.ts
+++ b/components/toolbox/hooks/useValidatorManagerDetails.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { networkIDs } from "@avalabs/avalanchejs";
 import { getSubnetInfoForNetwork, getBlockchainInfoForNetwork } from "../coreViem/utils/glacier";
 import { useWalletStore } from "../stores/walletStore";
@@ -22,6 +22,8 @@ interface ValidatorManagerDetails {
     isOwnerContract: boolean;
     ownerType: 'PoAManager' | 'StakingManager' | 'EOA' | null;
     isDetectingOwnerType: boolean;
+    ownershipStatus: 'loading' | 'currentWallet' | 'differentEOA' | 'contract' | 'error';
+    refetchOwnership: () => void;
 }
 
 interface UseValidatorManagerDetailsProps {
@@ -29,7 +31,7 @@ interface UseValidatorManagerDetailsProps {
 }
 
 export function useValidatorManagerDetails({ subnetId }: UseValidatorManagerDetailsProps): ValidatorManagerDetails {
-    const { avalancheNetworkID } = useWalletStore();
+    const { avalancheNetworkID, walletEVMAddress } = useWalletStore();
     const viemChain = useViemChainStore();
     const chainPublicClient = useChainPublicClient();
 
@@ -57,6 +59,7 @@ export function useValidatorManagerDetails({ subnetId }: UseValidatorManagerDeta
     // Owner contract type detection states
     const [ownerType, setOwnerType] = useState<'PoAManager' | 'StakingManager' | 'EOA' | null>(null);
     const [isDetectingOwnerType, setIsDetectingOwnerType] = useState(false);
+    const [refetchCounter, setRefetchCounter] = useState(0);
 
     // Cache to store fetched details for each subnetId to avoid redundant API calls
     const subnetCache = useRef<Record<string, {
@@ -179,7 +182,7 @@ export function useValidatorManagerDetails({ subnetId }: UseValidatorManagerDeta
             setL1WeightError(null); // Clear previous errors before fetching
 
             try {
-                if (!validatorManager.isReady) {
+                if (!validatorManager.isReadReady) {
                     throw new Error('Validator manager not ready');
                 }
 
@@ -210,7 +213,7 @@ export function useValidatorManagerDetails({ subnetId }: UseValidatorManagerDeta
         };
 
         fetchL1TotalWeight();
-    }, [validatorManagerAddress, chainPublicClient]);
+    }, [validatorManagerAddress, chainPublicClient, validatorManager.isReadReady]);
 
     // Fetch contract owner (no ownership verification, just fetch the owner address)
     useEffect(() => {
@@ -244,7 +247,7 @@ export function useValidatorManagerDetails({ subnetId }: UseValidatorManagerDeta
             }, 15000);
 
             try {
-                if (!validatorManager.isReady) {
+                if (!validatorManager.isReadReady) {
                     throw new Error('Validator manager not ready');
                 }
 
@@ -293,7 +296,7 @@ export function useValidatorManagerDetails({ subnetId }: UseValidatorManagerDeta
 
         fetchContractOwner();
         return () => { cancelled = true; };
-    }, [validatorManagerAddress, chainPublicClient]);
+    }, [validatorManagerAddress, chainPublicClient, validatorManager.isReadReady, refetchCounter]);
 
     // Detect owner contract type when owner is a contract
     useEffect(() => {
@@ -352,7 +355,7 @@ export function useValidatorManagerDetails({ subnetId }: UseValidatorManagerDeta
                 // getStakingManagerSettings() failed — not a StakingManager.
                 // Try owner() via PoAManager hook to confirm it's a PoAManager.
                 try {
-                    if (poaManager.isReady) {
+                    if (poaManager.isReadReady) {
                         const ownerAddress = await poaManager.owner();
                         clearTimeout(timeoutId);
                         if (!cancelled) {
@@ -376,7 +379,23 @@ export function useValidatorManagerDetails({ subnetId }: UseValidatorManagerDeta
 
         detectOwnerType();
         return () => { cancelled = true; };
-    }, [isOwnerContract, contractOwner, chainPublicClient]);
+    }, [isOwnerContract, contractOwner, chainPublicClient, poaManager.isReadReady]);
+
+    const refetchOwnership = useCallback(() => {
+        setRefetchCounter(c => c + 1);
+    }, []);
+
+    const ownershipStatus = useMemo(() => {
+        if (isLoadingOwnership) return 'loading' as const;
+        if (ownershipError) return 'error' as const;
+        if (isOwnerContract) return 'contract' as const;
+        if (contractOwner && walletEVMAddress) {
+            return walletEVMAddress.toLowerCase() === contractOwner.toLowerCase()
+                ? 'currentWallet' as const : 'differentEOA' as const;
+        }
+        if (!isLoadingOwnership && validatorManagerAddress && !contractOwner) return 'error' as const;
+        return 'loading' as const;
+    }, [isLoadingOwnership, ownershipError, isOwnerContract, contractOwner, walletEVMAddress, validatorManagerAddress]);
 
     return {
         validatorManagerAddress,
@@ -392,6 +411,8 @@ export function useValidatorManagerDetails({ subnetId }: UseValidatorManagerDeta
         isLoadingOwnership,
         isOwnerContract,
         ownerType,
-        isDetectingOwnerType
+        isDetectingOwnerType,
+        ownershipStatus,
+        refetchOwnership
     };
 } 

--- a/hooks/useL1Dashboard.ts
+++ b/hooks/useL1Dashboard.ts
@@ -1,15 +1,16 @@
 "use client";
 
-import { useMemo, useEffect, useState } from "react";
+import { useMemo, useEffect, useState, useRef } from "react";
 import { useWalletStore, useNetworkInfo } from "@/components/toolbox/stores/walletStore";
 import { useL1List, type L1ListItem } from "@/components/toolbox/stores/l1ListStore";
 import { createPublicClient, http, formatEther } from "viem";
+const GLACIER_API = "https://glacier-api.avax.network";
 
 // C-Chain IDs
 const C_CHAIN_FUJI = 43113;
 const C_CHAIN_MAINNET = 43114;
 
-export type L1HealthStatus = "healthy" | "degraded" | "offline" | "unknown";
+export type L1HealthStatus = "healthy" | "degraded" | "stale" | "offline" | "unknown";
 
 export interface L1DashboardData {
   // Connection status
@@ -54,6 +55,7 @@ export function useL1Dashboard(): L1DashboardData {
   const [healthStatus, setHealthStatus] = useState<L1HealthStatus>("unknown");
   const [blockTime, setBlockTime] = useState<number | null>(null);
   const [gasPrice, setGasPrice] = useState<string | null>(null);
+  const [validatorCount, setValidatorCount] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
 
   // Determine if connected
@@ -81,12 +83,55 @@ export function useL1Dashboard(): L1DashboardData {
     return 0;
   }, [isConnectedToCChain, currentL1, balances, walletChainId]);
 
-  // Calculate validator count from features (simplified for now)
-  const validatorCount = useMemo(() => {
-    if (!currentL1) return 0;
-    // In a real implementation, this would query the validator manager contract
-    // For now, return a default based on whether validatorManagerAddress exists
-    return currentL1.validatorManagerAddress ? 3 : 0;
+  // Request-id guard for validator count (separate from health check)
+  const validatorRequestIdRef = useRef(0);
+
+  // Fetch real validator count directly from Glacier API
+  useEffect(() => {
+    if (!currentL1 || currentL1.subnetId === "11111111111111111111111111111111LpoYY") {
+      setValidatorCount(0);
+      return;
+    }
+
+    const requestId = ++validatorRequestIdRef.current;
+    const network = currentL1.isTestnet ? 'testnet' : 'mainnet';
+
+    const fetchValidatorCount = async () => {
+      try {
+        // Step 1: Resolve subnetId
+        let subnetId = currentL1.subnetId;
+        if (!subnetId) {
+          const blockchainId = currentL1.id
+            || currentL1.rpcUrl?.match(/\/ext\/bc\/([^/]+)\/rpc/)?.[1]
+            || '';
+          if (!blockchainId) { setValidatorCount(0); return; }
+
+          const bcRes = await fetch(`${GLACIER_API}/v1/networks/${network}/blockchains/${blockchainId}`);
+          if (!bcRes.ok) { setValidatorCount(0); return; }
+          const bcData = await bcRes.json();
+          subnetId = bcData?.subnetId ?? '';
+        }
+        if (!subnetId) { setValidatorCount(0); return; }
+
+        // Step 2: Fetch L1 validators directly from Glacier
+        const valRes = await fetch(`${GLACIER_API}/v1/networks/${network}/l1Validators?subnetId=${subnetId}&pageSize=100`);
+        if (!valRes.ok) { if (requestId === validatorRequestIdRef.current) setValidatorCount(0); return; }
+        const valData = await valRes.json();
+        const activeValidators = (valData?.validators ?? []).filter((v: { remainingBalance?: number }) => !v.remainingBalance || v.remainingBalance > 0);
+
+        if (requestId === validatorRequestIdRef.current) {
+          setValidatorCount(activeValidators.length);
+        }
+      } catch {
+        if (requestId === validatorRequestIdRef.current) {
+          setValidatorCount(0);
+        }
+      }
+    };
+
+    fetchValidatorCount();
+    const interval = setInterval(fetchValidatorCount, 30000);
+    return () => clearInterval(interval);
   }, [currentL1]);
 
   // Calculate setup progress
@@ -117,6 +162,9 @@ export function useL1Dashboard(): L1DashboardData {
     return Math.round((completed / steps.length) * 100);
   }, [setupProgress]);
 
+  // Request-id guard to prevent stale responses from overwriting state
+  const healthRequestIdRef = useRef(0);
+
   // Fetch network health data
   useEffect(() => {
     if (!currentL1 || !currentL1.rpcUrl) {
@@ -126,6 +174,8 @@ export function useL1Dashboard(): L1DashboardData {
       return;
     }
 
+    const requestId = ++healthRequestIdRef.current;
+
     const fetchHealthData = async () => {
       setIsLoading(true);
       try {
@@ -133,37 +183,86 @@ export function useL1Dashboard(): L1DashboardData {
           transport: http(currentL1.rpcUrl),
         });
 
-        // Get latest block
-        const block = await client.getBlock();
-        const previousBlock = await client.getBlock({ blockNumber: block.number - 1n });
+        // Liveness probe: verify chain ID matches
+        const chainId = await client.getChainId();
+        if (chainId !== currentL1.evmChainId) {
+          if (requestId === healthRequestIdRef.current) {
+            setHealthStatus("offline");
+            setBlockTime(null);
+            setGasPrice(null);
+            setIsLoading(false);
+          }
+          return;
+        }
 
-        // Calculate block time
-        const timeDiff = Number(block.timestamp - previousBlock.timestamp);
-        setBlockTime(timeDiff);
+        // Fetch block and gas price independently so one failure doesn't affect the other
+        const [blockResult, gasPriceResult] = await Promise.allSettled([
+          client.getBlock(),
+          client.getGasPrice(),
+        ]);
 
-        // Get gas price
-        const gasPriceWei = await client.getGasPrice();
-        setGasPrice(formatEther(gasPriceWei));
+        if (requestId !== healthRequestIdRef.current) return;
 
-        // Set health status based on block time
-        if (timeDiff <= 5) {
+        // Handle gas price independently
+        if (gasPriceResult.status === "fulfilled") {
+          setGasPrice(formatEther(gasPriceResult.value));
+        } else {
+          setGasPrice(null);
+        }
+
+        // Block fetch is required for status determination
+        if (blockResult.status === "rejected") {
+          setHealthStatus("offline");
+          setBlockTime(null);
+          setIsLoading(false);
+          return;
+        }
+
+        const block = blockResult.value;
+
+        // Compute time since last block for status determination
+        const lastBlockAge = Math.floor(Date.now() / 1000) - Number(block.timestamp);
+
+        if (lastBlockAge <= 120) {
           setHealthStatus("healthy");
-        } else if (timeDiff <= 30) {
+        } else if (lastBlockAge <= 600) {
           setHealthStatus("degraded");
         } else {
-          setHealthStatus("offline");
+          setHealthStatus("stale");
         }
-      } catch (error) {
-        console.error("Failed to fetch L1 health data:", error);
-        setHealthStatus("offline");
+
+        // Compute inter-block gap as informational blockTime (only when not genesis-only)
+        if (block.number > 0n) {
+          try {
+            const previousBlock = await client.getBlock({ blockNumber: block.number - 1n });
+            if (requestId === healthRequestIdRef.current) {
+              const timeDiff = Number(block.timestamp - previousBlock.timestamp);
+              setBlockTime(timeDiff);
+            }
+          } catch {
+            if (requestId === healthRequestIdRef.current) {
+              setBlockTime(null);
+            }
+          }
+        } else {
+          setBlockTime(null);
+        }
+      } catch {
+        if (requestId === healthRequestIdRef.current) {
+          setHealthStatus("offline");
+          setBlockTime(null);
+          setGasPrice(null);
+        }
       } finally {
-        setIsLoading(false);
+        if (requestId === healthRequestIdRef.current) {
+          setIsLoading(false);
+        }
       }
     };
 
     fetchHealthData();
 
-    // Refresh every 30 seconds
+    // Poll every 30 seconds, clear previous interval on chain switch
     const interval = setInterval(fetchHealthData, 30000);
     return () => clearInterval(interval);
   }, [currentL1]);


### PR DESCRIPTION
## Summary
  - **Dashboard health status**: Rewrote health check logic to use time since last block instead of inter-block gap. On-demand chains no longer show "Offline"
  incorrectly. Added `stale` status for chains with responsive RPC but no recent blocks (>10min). Added chain ID validation, `Promise.allSettled` for independent
  metric fetching, and genesis-only chain handling.
  - **Validator count**: Replaced hardcoded placeholder (`validatorManagerAddress ? 3 : 0`) with real count fetched from Glacier L1 validators API. Resolves
  subnet ID from blockchain ID (parsed from RPC URL) when not stored. Works for both testnet and mainnet.
  - **Network Details copy**: Added copy-to-clipboard buttons to all Network Details fields (RPC URL, Subnet ID, Blockchain ID, Validator Manager, Teleporter
  Registry, Wrapped Token) using existing `useCopyToClipboard` hook.
  - **Validator ownership verification**: Fixed "Verifying ownership..." stuck forever by adding `isReadReady` to `useValidatorManager` and `usePoAManager` hooks
  (reads don't need wallet client). Centralized ownership state machine in `useValidatorManagerDetails` with `refetchOwnership()`. Added `error` state with retry
  button to all validator management flows (Add, Remove, ChangeWeight).
  - **API route**: Added testnet/fuji network support to `/api/chain-validators/[subnetId]` with network-scoped caching.

  ## Test plan
  - [x] Connect wallet to testnet L1 → health status shows Healthy/Degraded/Stale (not Offline)
  - [x] Dashboard shows correct validator count (not hardcoded 3 or 0)
  - [x] Click copy icon on Network Details fields → value copied to clipboard
  - [x] Add Validator page → ownership resolves without getting stuck on "Verifying..."
  - [x] If ownership check fails → shows error with "Retry" button
  - [x] Verify RemoveValidator and ChangeWeight pages work the same
  - [x] Switch between chains → no stale data from previous chain

<img width="2194" height="927" alt="image" src="https://github.com/user-attachments/assets/7b7a3b75-e7b6-40a5-93ba-82656dbc852b" />
