### PR TITLE
docs: clarify delegation weight example in staking docs

### DIFF
--- a/content/docs/primary-network/validate/how-to-stake.mdx
+++ b/content/docs/primary-network/validate/how-to-stake.mdx
@@ -21,7 +21,7 @@ Staking rewards are sent to your wallet address at the end of the staking term *
 - The minimum amount of time one can stake funds for delegation is 2 weeks
 - The maximum amount of time one can stake funds for delegation is 1 year
 - The minimum delegation fee rate is 2%
-- The maximum weight of a validator (their own stake + stake delegated to them) is the minimum of 3 million AVAX and 5 times the amount the validator staked. For example, if you staked 2,000 AVAX to become a validator, only 8000 AVAX can be delegated to your node total (not per delegator)
+- The maximum weight of a validator (their own stake + stake delegated to them) is the minimum of 3 million AVAX and 5 times the amount the validator staked. For example, if you staked 2,000 AVAX to become a validator, the maximum total weight is 10,000 AVAX (5 × 2,000), meaning up to 8,000 AVAX can be delegated to your node (not per delegator)
 
 A validator will receive a staking reward if they are online and response for more than 80% of their validation period, as measured by a majority of validators, weighted by stake. **You should aim for your validator be online and responsive 100% of the time.**
 


### PR DESCRIPTION
## Summary

The staking docs example for maximum validator weight was misleading. It stated:

> *if you staked 2,000 AVAX to become a validator, only 8000 AVAX can be delegated to your node total*

After describing a **5x** multiplier, showing an example with only **8,000 AVAX** in delegations (which is 4x) caused confusion — it reads like a typo.

## Fix

Added the explicit total weight calculation to the example:

> *the maximum total weight is 10,000 AVAX (5 × 2,000), meaning up to 8,000 AVAX can be delegated to your node*

This makes it clear that:
- **5x** = total weight factor (own stake + delegations)
- **4x** = resulting delegation capacity (total weight minus own stake)

Both numbers are correct — the original wording just made it easy to confuse them.

## Note

The same misleading wording exists on the [Validator FAQ](https://support.avax.network/en/articles/6187511-validator-faq) (support.avax.network), which is outside this repo. That page should also be updated separately.