### PR TITLE
feat: WalletGuard A/B experiment — reduce console action errors

### DIFF
--- a/components/toolbox/components/CoreWalletTransactionButton.tsx
+++ b/components/toolbox/components/CoreWalletTransactionButton.tsx
@@ -5,6 +5,7 @@ import { Button } from "./Button";
 import { cn } from "../lib/utils";
 import { useWalletStore } from "../stores/walletStore";
 import { Loader2, Terminal, Copy, Check, ExternalLink, ArrowRight, Download } from "lucide-react";
+import { WalletGuard } from "./WalletGuard";
 
 interface DownloadFileConfig {
   data: string;
@@ -99,7 +100,7 @@ export function CoreWalletTransactionButton({
 
   if (hasCoreWallet) {
     return (
-      <>
+      <WalletGuard context="core-wallet-transaction">
         <div className={cn("space-y-2", className)}>
           <button
             onClick={onClick}
@@ -144,7 +145,7 @@ export function CoreWalletTransactionButton({
             <CliCommandBlock command={cliCommand} />
           </div>
         )}
-      </>
+      </WalletGuard>
     );
   }
 

--- a/components/toolbox/components/WalletGuard.tsx
+++ b/components/toolbox/components/WalletGuard.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { useWalletStore } from "@/components/toolbox/stores/walletStore";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
+import { usePostHog } from "posthog-js/react";
+import { Wallet } from "lucide-react";
+
+interface WalletGuardProps {
+  children: ReactNode;
+  /** Optional context label for analytics (e.g. "deploy-erc20", "mint-native") */
+  context?: string;
+}
+
+/**
+ * WalletGuard — A/B tested wrapper for console action buttons.
+ *
+ * Uses the `wallet-guard-experiment` multivariate feature flag:
+ * - "control" variant → renders children as-is (current behavior)
+ * - "test" variant + no wallet → replaces children with "Connect Wallet" prompt
+ * - Flag not loaded / undefined → renders children as-is (safe default)
+ */
+export function WalletGuard({ children, context }: WalletGuardProps) {
+  const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
+  const { openConnectModal } = useConnectModal();
+  const posthog = usePostHog();
+  const hasTracked = useRef(false);
+  const [variant, setVariant] = useState<string | undefined>(undefined);
+
+  // Get the multivariate flag variant (returns "control" | "test" | undefined)
+  useEffect(() => {
+    if (!posthog) return;
+
+    const checkVariant = () => {
+      const v = posthog.getFeatureFlag("wallet-guard-experiment");
+      if (typeof v === "string") setVariant(v);
+    };
+
+    checkVariant();
+    const unsub = posthog.onFeatureFlags(() => checkVariant());
+    return () => { if (typeof unsub === "function") unsub(); };
+  }, [posthog]);
+
+  const isConnected = !!walletEVMAddress;
+  const shouldGuard = variant === "test" && !isConnected;
+
+  // Track when the guard activates (once per mount)
+  useEffect(() => {
+    if (shouldGuard && !hasTracked.current) {
+      hasTracked.current = true;
+      posthog?.capture("wallet_guard_shown", { context: context ?? "unknown" });
+    }
+  }, [shouldGuard, posthog, context]);
+
+  // Flag OFF or wallet connected → render children normally
+  if (!shouldGuard) return <>{children}</>;
+
+  // Flag ON + wallet disconnected → show inline connect prompt
+  return (
+    <button
+      onClick={() => openConnectModal?.()}
+      className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-medium
+        bg-blue-50 text-blue-700 border border-blue-200 hover:bg-blue-100
+        dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800 dark:hover:bg-blue-900/50
+        transition-colors cursor-pointer"
+    >
+      <Wallet className="h-4 w-4" />
+      Connect Wallet to Continue
+    </button>
+  );
+}

--- a/components/toolbox/console/icm/setup/TeleporterMessenger.tsx
+++ b/components/toolbox/console/icm/setup/TeleporterMessenger.tsx
@@ -8,6 +8,7 @@ import TeleporterMessengerDeploymentTransaction from '@/contracts/icm-contracts-
 import TeleporterMessengerDeployerAddress from '@/contracts/icm-contracts-releases/v1.0.0/TeleporterMessenger_Deployer_Address_v1.0.0.txt.json';
 import TeleporterMessengerAddress from '@/contracts/icm-contracts-releases/v1.0.0/TeleporterMessenger_Contract_Address_v1.0.0.txt.json';
 import { WalletRequirementsConfigKey } from "@/components/toolbox/hooks/useWalletRequirements";
+import { WalletGuard } from "@/components/toolbox/components/WalletGuard";
 import { BaseConsoleToolProps, ConsoleToolMetadata, withConsoleToolMetadata } from "../../../components/WithConsoleToolMetadata";
 import { useConnectedWallet } from "@/components/toolbox/contexts/ConnectedWalletContext";
 import versions from '@/scripts/versions.json';
@@ -287,14 +288,16 @@ function TeleporterMessenger({ onSuccess }: BaseConsoleToolProps) {
               </p>
             </div>
           ) : (
-            <button
-              onClick={handleDeploy}
-              disabled={isDeploying || !hasEnoughBalance}
-              className="w-full py-2.5 text-sm font-medium rounded-lg bg-blue-500 hover:bg-blue-600 text-white disabled:opacity-50 transition-colors flex items-center justify-center gap-2"
-            >
-              <Rocket className="w-4 h-4" />
-              {isDeploying ? 'Deploying...' : 'Deploy TeleporterMessenger'}
-            </button>
+            <WalletGuard context="deploy-teleporter-messenger">
+              <button
+                onClick={handleDeploy}
+                disabled={isDeploying || !hasEnoughBalance}
+                className="w-full py-2.5 text-sm font-medium rounded-lg bg-blue-500 hover:bg-blue-600 text-white disabled:opacity-50 transition-colors flex items-center justify-center gap-2"
+              >
+                <Rocket className="w-4 h-4" />
+                {isDeploying ? 'Deploying...' : 'Deploy TeleporterMessenger'}
+              </button>
+            </WalletGuard>
           )}
         </div>
 

--- a/components/toolbox/console/ictt/setup/DeployERC20TokenRemote.tsx
+++ b/components/toolbox/console/ictt/setup/DeployERC20TokenRemote.tsx
@@ -14,6 +14,7 @@ import { useWalletStore } from "@/components/toolbox/stores/walletStore";
 import { useWalletClient } from 'wagmi';
 import { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/toolbox/components/Button";
+import { WalletGuard } from "@/components/toolbox/components/WalletGuard";
 import { Success } from "@/components/toolbox/components/Success";
 import { Input, Suggestion } from "@/components/toolbox/components/Input";
 import { EVMAddressInput } from "@/components/toolbox/components/EVMAddressInput";
@@ -362,25 +363,27 @@ function DeployERC20TokenRemote() {
         value={erc20TokenRemoteAddress || ""}
       />
 
-      <Button
-        variant={erc20TokenRemoteAddress ? "secondary" : "primary"}
-        onClick={handleDeploy}
-        loading={isDeploying}
-        disabled={
-          isDeploying ||
-          !tokenHomeAddress ||
-          !tokenHomeBlockchainIDHex ||
-          tokenDecimals === "0" ||
-          !tokenName ||
-          !tokenSymbol ||
-          !teleporterRegistryAddress ||
-          !!sourceChainError
-        }
-      >
-        {erc20TokenRemoteAddress
-          ? "Re-Deploy ERC20 Token Remote"
-          : "Deploy ERC20 Token Remote"}
-      </Button>
+      <WalletGuard context="deploy-erc20-token-remote">
+        <Button
+          variant={erc20TokenRemoteAddress ? "secondary" : "primary"}
+          onClick={handleDeploy}
+          loading={isDeploying}
+          disabled={
+            isDeploying ||
+            !tokenHomeAddress ||
+            !tokenHomeBlockchainIDHex ||
+            tokenDecimals === "0" ||
+            !tokenName ||
+            !tokenSymbol ||
+            !teleporterRegistryAddress ||
+            !!sourceChainError
+          }
+        >
+          {erc20TokenRemoteAddress
+            ? "Re-Deploy ERC20 Token Remote"
+            : "Deploy ERC20 Token Remote"}
+        </Button>
+      </WalletGuard>
       </LockedContent>
       </div>
     </ContractDeployViewer>

--- a/components/toolbox/console/ictt/setup/DeployExampleERC20.tsx
+++ b/components/toolbox/console/ictt/setup/DeployExampleERC20.tsx
@@ -5,6 +5,7 @@ import { useToolboxStore } from "@/components/toolbox/stores/toolboxStore";
 import { useWalletStore } from "@/components/toolbox/stores/walletStore";
 import { useState } from "react";
 import { Button } from "@/components/toolbox/components/Button";
+import { WalletGuard } from "@/components/toolbox/components/WalletGuard";
 import { Success } from "@/components/toolbox/components/Success";
 import { generateConsoleToolGitHubUrl } from "@/components/toolbox/utils/github-url";
 import { ExternalLink } from "lucide-react";
@@ -83,14 +84,16 @@ function DeployExampleERC20() {
           </p>
         </div>
 
-        <Button
-          variant={exampleErc20Address ? "secondary" : "primary"}
-          onClick={handleDeploy}
-          loading={isDeploying}
-          disabled={isDeploying}
-        >
-          {exampleErc20Address ? "Re-Deploy ERC20 Token" : "Deploy ERC20 Token"}
-        </Button>
+        <WalletGuard context="deploy-example-erc20">
+          <Button
+            variant={exampleErc20Address ? "secondary" : "primary"}
+            onClick={handleDeploy}
+            loading={isDeploying}
+            disabled={isDeploying}
+          >
+            {exampleErc20Address ? "Re-Deploy ERC20 Token" : "Deploy ERC20 Token"}
+          </Button>
+        </WalletGuard>
 
         <Success
           label="ERC20 Token Address"

--- a/components/toolbox/console/ictt/setup/DeployTokenHome.tsx
+++ b/components/toolbox/console/ictt/setup/DeployTokenHome.tsx
@@ -10,6 +10,7 @@ import { useWrappedNativeToken, WellKnownERC20 } from "@/components/toolbox/stor
 import { useWalletStore } from "@/components/toolbox/stores/walletStore";
 import { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/toolbox/components/Button";
+import { WalletGuard } from "@/components/toolbox/components/WalletGuard";
 import { Success } from "@/components/toolbox/components/Success";
 import { Input, Suggestion } from "@/components/toolbox/components/Input";
 import { EVMAddressInput } from "@/components/toolbox/components/EVMAddressInput";
@@ -334,16 +335,18 @@ function DeployTokenHome() {
 
       <Success label="Token Home Address" value={getTokenHomeAddress() || ""} />
 
-      <Button
-        variant={getTokenHomeAddress() ? "secondary" : "primary"}
-        onClick={handleDeploy}
-        loading={isDeploying}
-        disabled={
-          !teleporterRegistryAddress || !tokenAddress || tokenDecimals === "0"
-        }
-      >
-        {getTokenHomeAddress() ? "Re-Deploy Token Home" : "Deploy Token Home"}
-      </Button>
+      <WalletGuard context="deploy-token-home">
+        <Button
+          variant={getTokenHomeAddress() ? "secondary" : "primary"}
+          onClick={handleDeploy}
+          loading={isDeploying}
+          disabled={
+            !teleporterRegistryAddress || !tokenAddress || tokenDecimals === "0"
+          }
+        >
+          {getTokenHomeAddress() ? "Re-Deploy Token Home" : "Deploy Token Home"}
+        </Button>
+      </WalletGuard>
       </div>
     </ContractDeployViewer>
   );

--- a/components/toolbox/console/l1-tokenomics/FeeManager.tsx
+++ b/components/toolbox/console/l1-tokenomics/FeeManager.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useWalletStore } from "@/components/toolbox/stores/walletStore";
 import { useViemChainStore } from "@/components/toolbox/stores/toolboxStore";
 import { Button } from "@/components/toolbox/components/Button";
+import { WalletGuard } from "@/components/toolbox/components/WalletGuard";
 import { Input } from "@/components/toolbox/components/Input";
 import { ResultField } from "@/components/toolbox/components/ResultField";
 import feeManagerAbi from "@/contracts/precompiles/FeeManager.json";
@@ -364,15 +365,17 @@ function FeeManager({ onSuccess }: BaseConsoleToolProps) {
 
           {/* Actions */}
           <div className="flex flex-col sm:flex-row gap-3 pt-2">
-            <Button
-              onClick={handleSetFeeConfig}
-              loading={isSettingConfig}
-              variant="primary"
-              disabled={!canSetFeeConfig}
-              className="flex-1"
-            >
-              Set Fee Configuration
-            </Button>
+            <WalletGuard context="fee-manager-set">
+              <Button
+                onClick={handleSetFeeConfig}
+                loading={isSettingConfig}
+                variant="primary"
+                disabled={!canSetFeeConfig}
+                className="flex-1"
+              >
+                Set Fee Configuration
+              </Button>
+            </WalletGuard>
             <Button
               onClick={handleGetFeeConfig}
               loading={isReadingConfig}

--- a/components/toolbox/console/l1-tokenomics/NativeMinter.tsx
+++ b/components/toolbox/console/l1-tokenomics/NativeMinter.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useWalletStore } from "@/components/toolbox/stores/walletStore";
 import { useViemChainStore } from "@/components/toolbox/stores/toolboxStore";
 import { Button } from "@/components/toolbox/components/Button";
+import { WalletGuard } from "@/components/toolbox/components/WalletGuard";
 import { Input } from "@/components/toolbox/components/Input";
 import { ResultField } from "@/components/toolbox/components/ResultField";
 import { EVMAddressInput } from "@/components/toolbox/components/EVMAddressInput";
@@ -136,16 +137,18 @@ function NativeMinter({ onSuccess }: BaseConsoleToolProps) {
             />
           )}
 
-          <Button
-            variant="primary"
-            onClick={handleMint}
-            loading={isMinting}
-            disabled={!canMint}
-          >
-            {!walletEVMAddress
-              ? "Connect Wallet to Mint"
-              : "Mint Native Tokens"}
-          </Button>
+          <WalletGuard context="native-minter">
+            <Button
+              variant="primary"
+              onClick={handleMint}
+              loading={isMinting}
+              disabled={!canMint}
+            >
+              {!walletEVMAddress
+                ? "Connect Wallet to Mint"
+                : "Mint Native Tokens"}
+            </Button>
+          </WalletGuard>
         </div>
       </PrecompileCodeViewer>
     </CheckPrecompile>

--- a/components/toolbox/console/l1-tokenomics/RewardManager.tsx
+++ b/components/toolbox/console/l1-tokenomics/RewardManager.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useWalletStore } from "@/components/toolbox/stores/walletStore";
 import { useViemChainStore } from "@/components/toolbox/stores/toolboxStore";
 import { Button } from "@/components/toolbox/components/Button";
+import { WalletGuard } from "@/components/toolbox/components/WalletGuard";
 import { EVMAddressInput } from "@/components/toolbox/components/EVMAddressInput";
 import { AllowlistComponent } from "@/components/toolbox/components/AllowListComponents";
 import { ResultField } from "@/components/toolbox/components/ResultField";
@@ -333,16 +334,18 @@ function RewardManager({ onSuccess }: BaseConsoleToolProps) {
                   Allow validators to specify their own fee recipient address. When enabled, each validator
                   can direct transaction fees to their preferred address.
                 </p>
-                <Button
-                  variant="primary"
-                  onClick={handleAllowFeeRecipients}
-                  disabled={!walletEVMAddress || isAnyOperationInProgress}
-                  loading={isAllowingFeeRecipients}
-                  className="w-full"
-                >
-                  <Users className="w-4 h-4 mr-2" />
-                  Allow Fee Recipients
-                </Button>
+                <WalletGuard context="reward-manager-allow">
+                  <Button
+                    variant="primary"
+                    onClick={handleAllowFeeRecipients}
+                    disabled={!walletEVMAddress || isAnyOperationInProgress}
+                    loading={isAllowingFeeRecipients}
+                    className="w-full"
+                  >
+                    <Users className="w-4 h-4 mr-2" />
+                    Allow Fee Recipients
+                  </Button>
+                </WalletGuard>
               </div>
             )}
 
@@ -358,16 +361,18 @@ function RewardManager({ onSuccess }: BaseConsoleToolProps) {
                   onChange={setRewardAddress}
                   disabled={isSettingRewardAddress}
                 />
-                <Button
-                  variant="primary"
-                  onClick={handleSetRewardAddress}
-                  disabled={!canSetRewardAddress}
-                  loading={isSettingRewardAddress}
-                  className="w-full"
-                >
-                  <MapPin className="w-4 h-4 mr-2" />
-                  Set Reward Address
-                </Button>
+                <WalletGuard context="reward-manager-set">
+                  <Button
+                    variant="primary"
+                    onClick={handleSetRewardAddress}
+                    disabled={!canSetRewardAddress}
+                    loading={isSettingRewardAddress}
+                    className="w-full"
+                  >
+                    <MapPin className="w-4 h-4 mr-2" />
+                    Set Reward Address
+                  </Button>
+                </WalletGuard>
               </div>
             )}
 
@@ -382,16 +387,18 @@ function RewardManager({ onSuccess }: BaseConsoleToolProps) {
                     <strong>Warning:</strong> This will prevent any rewards from being distributed.
                   </p>
                 </div>
-                <Button
-                  variant="secondary"
-                  onClick={handleDisableRewards}
-                  disabled={!walletEVMAddress || isAnyOperationInProgress}
-                  loading={isDisablingRewards}
-                  className="w-full"
-                >
-                  <XCircle className="w-4 h-4 mr-2" />
-                  Disable Rewards
-                </Button>
+                <WalletGuard context="reward-manager-disable">
+                  <Button
+                    variant="secondary"
+                    onClick={handleDisableRewards}
+                    disabled={!walletEVMAddress || isAnyOperationInProgress}
+                    loading={isDisablingRewards}
+                    className="w-full"
+                  >
+                    <XCircle className="w-4 h-4 mr-2" />
+                    Disable Rewards
+                  </Button>
+                </WalletGuard>
               </div>
             )}
           </div>

--- a/components/toolbox/console/permissioned-l1s/validator-manager-setup/DeployValidatorManager.tsx
+++ b/components/toolbox/console/permissioned-l1s/validator-manager-setup/DeployValidatorManager.tsx
@@ -5,6 +5,7 @@ import { useWalletStore } from "@/components/toolbox/stores/walletStore";
 import { useState } from "react";
 import { createPublicClient, http } from "viem";
 import { Button } from "@/components/toolbox/components/Button";
+import { WalletGuard } from "@/components/toolbox/components/WalletGuard";
 import ValidatorManagerABI from "@/contracts/icm-contracts/compiled/ValidatorManager.json";
 import ValidatorMessagesABI from "@/contracts/icm-contracts/compiled/ValidatorMessages.json";
 import { WalletRequirementsConfigKey } from "@/components/toolbox/hooks/useWalletRequirements";
@@ -197,15 +198,17 @@ function DeployValidatorContracts({ onSuccess }: BaseConsoleToolProps) {
                     />
                   </div>
                 ) : (
-                  <Button
-                    variant="primary"
-                    onClick={deployValidatorMessages}
-                    loading={isDeployingMessages}
-                    disabled={isDeployingMessages}
-                    className="mt-3"
-                  >
-                    Deploy Library
-                  </Button>
+                  <WalletGuard context="deploy-validator-messages">
+                    <Button
+                      variant="primary"
+                      onClick={deployValidatorMessages}
+                      loading={isDeployingMessages}
+                      disabled={isDeployingMessages}
+                      className="mt-3"
+                    >
+                      Deploy Library
+                    </Button>
+                  </WalletGuard>
                 )}
               </div>
             </div>
@@ -286,15 +289,17 @@ function DeployValidatorContracts({ onSuccess }: BaseConsoleToolProps) {
                     />
                   </div>
                 ) : (
-                  <Button
-                    variant="primary"
-                    onClick={deployValidatorManager}
-                    loading={isDeployingManager}
-                    disabled={isDeployingManager || !step1Complete}
-                    className="mt-3"
-                  >
-                    Deploy Contract
-                  </Button>
+                  <WalletGuard context="deploy-validator-manager">
+                    <Button
+                      variant="primary"
+                      onClick={deployValidatorManager}
+                      loading={isDeployingManager}
+                      disabled={isDeployingManager || !step1Complete}
+                      className="mt-3"
+                    >
+                      Deploy Contract
+                    </Button>
+                  </WalletGuard>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Problem

PostHog analytics (30 days ending March 26, 2026) show that **27 unique users/month** hit unhandled wallet-related errors across console tool pages:

| Error | Users | Events |
|-------|-------|--------|
| Wallet not connected ($exception) | 13 | 230 |
| Please login first | 8 | 9 |
| Account not authorized | 6 | 6 |

These errors throw unhandled exceptions instead of showing a connect prompt. **57% of all users who hit any console error never complete a successful action** — wallet crashes are the most preventable cause.

Baseline: **9.1%** of non-faucet console users hit `console_action_error` events (133 of 1,454 users).

## Solution

A `WalletGuard` wrapper component that:
- Checks wallet connection state via `useWalletStore`
- If connected → renders children normally (no change)
- If NOT connected → shows an inline "Connect Wallet" prompt that triggers RainbowKit's connect modal
- All behind the `wallet-guard-experiment` PostHog multivariate flag (50/50 control/test)

### Components wrapped:
- `CoreWalletTransactionButton` (shared — covers many console pages)
- ICM: TeleporterMessenger
- ICTT: DeployExampleERC20, DeployTokenHome, DeployERC20TokenRemote
- L1 Tokenomics: FeeManager, NativeMinter, RewardManager
- Validator Manager: DeployValidatorManager

### Analytics:
- Tracks `wallet_guard_shown` event with context label when the guard activates
- Flag variant checked via `posthog.getFeatureFlag()` — only `test` variant activates the guard

## A/B Experiment

| Setting | Value |
|---------|-------|
| PostHog Experiment | [#363418](https://us.posthog.com/project/88909/experiments/363418) |
| Feature flag | `wallet-guard-experiment` |
| Split | 50% control / 50% test |
| Duration | March 27 → April 3 (1 week) |
| Primary metric | `console_action_error` rate per user (non-faucet) |
| Secondary metric | `wallet_guard_shown` count |
| Expected traffic | ~362 users per variant |

## Files changed (10)

- **New:** `components/toolbox/components/WalletGuard.tsx` — the guard component (~70 lines)
- **Modified:** 9 console page components — surgical wrapping of action buttons

## Review notes

- Zero new dependencies — uses existing `walletStore`, `posthog-js/react`, `@rainbow-me/rainbowkit`, `lucide-react`
- Safe default: if flag is not loaded or undefined, children render as-is (no guard)
- Control group sees zero code path changes
- `ensure_experience_continuity` is ON — users stay in their assigned variant across sessions