### PR TITLE
fix(evaluate): add evaluate link to authorized user profile dropdown

### DIFF
--- a/components/login/user-button/UserButton.tsx
+++ b/components/login/user-button/UserButton.tsx
@@ -133,6 +133,13 @@ export function UserButton() {
                 </DropdownMenuItem>
               )
             }
+            {
+              (session?.user?.custom_attributes.includes('devrel') || session?.user?.custom_attributes?.includes('judge')) && (
+                <DropdownMenuItem asChild className='cursor-pointer'>
+                  <Link href='/evaluate'>Evaluate Hackathons</Link>
+                </DropdownMenuItem>
+              )
+            }
             {/* <DropdownMenuItem asChild className='cursor-pointer'>
               <Link href='/profile#settings'>Settings</Link>
             </DropdownMenuItem> */}


### PR DESCRIPTION
- Add "Evaluate Hackathons" link to user dropdown menu                                                                                                        
  - Visible only to users with `devrel` or `judge` role                                                                                      
  - Missing from PR #4016 which added the /evaluate route and dashboard                                                                                           
                                                                                                                                                                  
  ## Test plan                                                                                                                                                    
  - [ ] Log in as user with `devrel` attribute → link appears in dropdown                                                                                         
  - [ ] Log in as user with `judge` attribute → link appears in dropdown                                                                                        
  - [ ] Log in as regular user → link does not appear                                                                                                             
  - [ ] Click link → navigates to /evaluate