### PR TITLE
fix(console): add missing VM_ID env var to L1 Docker run command

### DIFF
--- a/components/toolbox/console/layer-1/node-config.ts
+++ b/components/toolbox/console/layer-1/node-config.ts
@@ -519,6 +519,7 @@ export const generateDockerCommand = (
         `-p ${isRPC ? "" : "127.0.0.1:"}9650:9650 -p 9651:9651`,
         "-v ~/.avalanchego:/root/.avalanchego",
         "-e AVAGO_CONFIG_FILE=/root/.avalanchego/configs/node.json",
+        `-e VM_ID=${vmId}`,
         `avaplatform/subnet-evm_avalanchego:${versions['avaplatform/subnet-evm_avalanchego']}`
     ];
 


### PR DESCRIPTION
## Summary

Adds the `VM_ID` environment variable to the generated `docker run` command in the L1 Node Docker Setup tool.

Closes #4034

## Problem

The `generateDockerCommand()` function in `node-config.ts` receives `vmId` as a parameter but never includes it in the Docker command output. The `avaplatform/subnet-evm_avalanchego` image uses `VM_ID` to auto-configure VM aliases at container startup. Without it, L1s with custom VM IDs fail to bootstrap.

## Fix

One-line addition — `-e VM_ID=${vmId}` added to the docker run command chunks.

## Reference

- Beam node setup (correct usage): https://docs.onbeam.com/nodes/run_node/method2

## Testing

Verified the generated Docker command now includes `-e VM_ID=<vmId>` for both standard subnet-evm and custom VM IDs.