### PR TITLE
fix: address review comments on validator alerts

### DIFF
--- a/server/services/validator-alert-check.ts
+++ b/server/services/validator-alert-check.ts
@@ -314,19 +314,19 @@ export async function checkSingleAlert(
       );
       if (didSend) sent++;
     } else if (latestRelease.type === 'mandatory') {
+      // No parseable deadline — don't escalate to mandatory tier.
+      // Send as optional with a note that it may be mandatory.
       const didSend = await trySend(
         alert.id,
         alert.email,
-        'version_mandatory',
-        versionMandatoryTemplate({
+        'version_optional',
+        versionOptionalTemplate({
           alertId: alert.id,
           nodeId: alert.node_id,
           label: alert.label,
           currentVersion: validator.version,
-          requiredVersion: latestRelease.tag,
-          deadline: null,
-          acps: latestRelease.acps,
-          urgency: 'notice',
+          latestVersion: latestRelease.tag,
+          maybeMandatory: true,
         }),
         errors,
         alert.node_id

--- a/server/templates/validator-alerts.ts
+++ b/server/templates/validator-alerts.ts
@@ -177,24 +177,36 @@ export function versionOptionalTemplate(params: {
   label: string | null;
   currentVersion: string;
   latestVersion: string;
+  maybeMandatory?: boolean;
 }): { subject: string; html: string; text: string } {
   const name = params.label ? `${params.label} (${params.nodeId})` : params.nodeId;
-  const subject = `AvalancheGo ${params.latestVersion.replace('avalanchego/', 'v')} Available (Optional)`;
-  const text = `Your validator ${name} is running ${params.currentVersion}. A new optional release ${params.latestVersion} is available.`;
+  const mandatoryNote = params.maybeMandatory
+    ? ' — this release may be mandatory, check release notes for details'
+    : '';
+  const subject = params.maybeMandatory
+    ? `AvalancheGo ${params.latestVersion.replace('avalanchego/', 'v')} Available (Possibly Mandatory)`
+    : `AvalancheGo ${params.latestVersion.replace('avalanchego/', 'v')} Available (Optional)`;
+  const text = `Your validator ${name} is running ${params.currentVersion}. A new release ${params.latestVersion} is available${mandatoryNote}.`;
+  const heading = params.maybeMandatory
+    ? 'A new release is available — this release may be mandatory, check release notes for deadline'
+    : 'A new optional release is available (recommended but not required)';
+  const footnote = params.maybeMandatory
+    ? 'This release may be mandatory but no deadline could be determined. Check the release notes. You will not receive another alert for 7 days.'
+    : 'This is an optional update. You will not receive another version alert for 7 days.';
   const html = wrapTemplate(
     'AvalancheGo Update Available',
     section(
-      '#3B82F6',
-      'A new optional release is available (recommended but not required)',
+      params.maybeMandatory ? '#F59E0B' : '#3B82F6',
+      heading,
       dataTable(
         dataRow('Validator', name, 'white') +
         dataRow('Running Version', params.currentVersion, '#F59E0B') +
         dataRow('Latest Version', params.latestVersion, '#34D399')
       ) +
       `<p style="font-size: 13px; margin: 12px 0 0 0;">Release notes: ${releaseLink(params.latestVersion)} | Explorer: ${explorerLink(params.nodeId)}</p>`,
-      'This is an optional update. You will not receive another version alert for 7 days.'
+      footnote
     ),
-    '#3B82F6',
+    params.maybeMandatory ? '#F59E0B' : '#3B82F6',
     params.alertId
   );
   return { subject, html, text };
@@ -234,7 +246,7 @@ export function expiryAlertTemplate(params: {
         dataRow('Expiry Date', params.expiryDate, '#D1D5DB')
       ) +
       `<p style="font-size: 13px; margin: 12px 0 0 0;">View on explorer: ${explorerLink(params.nodeId)}</p>`,
-      `We'll alert you again in ${cooldown} if your validation period is not renewed.`
+      `We'll alert you again in ${cooldown} if your validator is still expiring.`
     ),
     borderColor,
     params.alertId


### PR DESCRIPTION
Fixes the two remaining review comments from #4005:

### 1. ❌ "renewed" → correct Avalanche terminology
**File:** `server/templates/validator-alerts.ts` (line ~238)

Replaced `"if your validation period is not renewed"` with `"if your validator is still expiring"`. Avalanche validators re-register or extend their validation period — "renewed" is not standard terminology.

### 2. ⚠️ Mandatory upgrade without parseable deadline → downgrade to optional tier
**File:** `server/services/validator-alert-check.ts` (line ~316), `server/templates/validator-alerts.ts`

Previously, if a release was detected as mandatory but no deadline could be parsed, it still sent a `version_mandatory` (notice-tier) email with "Deadline not yet announced." This causes unnecessary anxiety.

Now: falls back to `version_optional` tier with a new `maybeMandatory` flag that:
- Changes subject to "(Possibly Mandatory)"
- Uses amber (#F59E0B) accent instead of blue
- Adds heading: "this release may be mandatory, check release notes for deadline"
- Footnote: "This release may be mandatory but no deadline could be determined."

This ensures we don't send mandatory-tier emails without actionable deadline information.

---
**Review:** @owenwahlgren
**Merges into:** `ditto/validator-alerts` (#4005)