### PR TITLE
fix(console): stats link on homepage → /stats/overview

### DIFF
--- a/app/console/page.tsx
+++ b/app/console/page.tsx
@@ -502,14 +502,12 @@ function ConsoleDashboard() {
             <h3 className="text-sm font-medium text-zinc-400 dark:text-zinc-500">
               Built on Avalanche
             </h3>
-            <a
-              href="https://build.avax.network/stats/l1"
-              target="_blank"
-              rel="noopener noreferrer"
+            <Link
+              href="/stats/overview"
               className="text-xs text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
             >
               View all →
-            </a>
+            </Link>
           </div>
           <EcosystemMarquee chains={ecosystemChains} rows={2} />
         </motion.div>


### PR DESCRIPTION
## Summary
- Console homepage "View all →" link was pointing to `/stats/l1` (doesn't exist)
- Updated to `/stats/overview`
- Converted from external `<a>` to internal `<Link>` for client-side navigation

## Test plan
- [ ] Navigate to `/console`, click "View all →" under "Built on Avalanche" — should go to `/stats/overview`