### PR TITLE
feat(mcp): structured ACP lookup and expanded coverage

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -592,11 +592,24 @@ export async function POST(req: Request) {
     },
     tools: {
       github_search_code: tool({
-        description: 'Search for code in Avalanche repositories (avalanchego, icm-services, builders-hub). Use this to find functions, types, implementations, or understand how Avalanche works internally. Returns file paths and code snippets.',
+        description: 'Search for code in core Avalanche repositories including avalanchego, subnet-evm, coreth, avalanche-cli, platform-cli, icm-services, avalanche-network-runner, icm-contracts, hypersdk, libevm, and builders-hub. Use this to find functions, types, implementations, or understand how Avalanche works internally.',
         inputSchema: z.object({
           query: z.string().describe('Search query - keywords, function names, type names, or concepts'),
-          repo: z.enum(['avalanchego', 'icm-services', 'builders-hub', 'all']).default('all').describe('Which repository to search'),
-          language: z.enum(['go', 'solidity', 'typescript', 'any']).default('any').describe('Filter by programming language'),
+          repo: z.enum([
+            'avalanchego',
+            'subnet-evm',
+            'coreth',
+            'avalanche-cli',
+            'platform-cli',
+            'icm-services',
+            'avalanche-network-runner',
+            'icm-contracts',
+            'hypersdk',
+            'libevm',
+            'builders-hub',
+            'all',
+          ]).default('all').describe('Which repository to search'),
+          language: z.enum(['go', 'solidity', 'typescript', 'javascript', 'python', 'rust', 'shell', 'markdown', 'yaml', 'json', 'any']).default('any').describe('Filter by programming language'),
         }),
         execute: async (input) => {
           const { query, repo, language } = input;
@@ -611,9 +624,21 @@ export async function POST(req: Request) {
       }),
 
       github_get_file: tool({
-        description: 'Read the contents of a specific file from avalanchego, icm-services, or builders-hub. Use this after searching to read the full code of a relevant file.',
+        description: 'Read the contents of a specific file from a covered Avalanche repository. Use this after searching to read the full code of a relevant file.',
         inputSchema: z.object({
-          repo: z.enum(['avalanchego', 'icm-services', 'builders-hub']).describe('Repository name'),
+          repo: z.enum([
+            'avalanchego',
+            'subnet-evm',
+            'coreth',
+            'avalanche-cli',
+            'platform-cli',
+            'icm-services',
+            'avalanche-network-runner',
+            'icm-contracts',
+            'hypersdk',
+            'libevm',
+            'builders-hub',
+          ]).describe('Repository name'),
           path: z.string().describe('File path within the repository (e.g., "vms/platformvm/block/builder.go")'),
         }),
         execute: async (input) => {
@@ -733,7 +758,7 @@ You are the quick-help bubble on the Builders Hub. Your job is to help users FIN
 - **metrics_lookup**: For stats questions (active accounts, TPS, validators, etc.), call \`metrics_lookup\` first to get numbers, then \`render_component("OverviewStats")\` to show visually. For burns → \`render_component("LiveBlockBurns")\`, ICM traffic → \`render_component("ICMFlowDiagram")\`, ICTT → \`render_component("ICTTDashboard")\`.
 - **YouTube**: Embed with \`render_component("YouTubeEmbed", { videoId, title })\`. Never paste bare YouTube links.
 - **blockchain_lookup_***: For tx hashes, addresses, validators, subnets, chains. Follow up on \`_lookupHints\` in results.
-- **github_search_code / github_get_file**: Search avalanchego, icm-services, builders-hub. Check pre-indexed code context below first. **Max 3 searches per question.**
+- **github_search_code / github_get_file**: Search core Avalanche repos: avalanchego, subnet-evm, coreth, avalanche-cli, platform-cli, icm-services, avalanche-network-runner, icm-contracts, hypersdk, libevm, and builders-hub. Check pre-indexed code context below first. **Max 3 searches per question.**
 - **suggest_followups**: ALWAYS call this after answering. Suggest 2-3 relevant follow-up questions specific to the conversation.
 - **DocImage**: When documentation context contains images like \`![alt](/images/...)\`, call \`render_component("DocImage", { src: "/images/...", alt: "..." })\` to show them inline. Diagrams and screenshots help developers understand faster.
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -134,24 +134,29 @@ async function getValidUrls(): Promise<string[]> {
 }
 
 // Use MCP server for better search quality — calls the handler directly (no HTTP round-trip)
+// Parses formatSearchResults output: numbered list `1. [Title](https://build.avax.network/path) (source[, chunk N])`
 async function searchDocsViaMcp(query: string): Promise<Array<{ url: string; title: string; description?: string; source: string }>> {
   try {
     const toolResult = await docsTools.handlers.docs_search({ query, limit: 10 });
     const text = toolResult.content?.[0]?.text || '';
 
     const results: Array<{ url: string; title: string; description?: string; source: string }> = [];
-    const lines = text.split('\n').filter((l: string) => l.startsWith('- ['));
+    const seenUrls = new Set<string>();
+    const itemRegex = /^\d+\.\s+\[(.+?)\]\(https:\/\/build\.avax\.network(.+?)\)\s+\(([^,)]+)(?:,[^)]*)?\)/gm;
 
-    for (const line of lines) {
-      const match = line.match(/- \[(.+?)\]\(https:\/\/build\.avax\.network(.+?)\) \((.+?)\)(?:\n\s+(.+))?/);
-      if (match) {
-        results.push({
-          title: match[1],
-          url: match[2],
-          source: match[3],
-          description: match[4]
-        });
-      }
+    let match: RegExpExecArray | null;
+    while ((match = itemRegex.exec(text)) !== null) {
+      const url = match[2];
+      // Per-page dedup at the chat layer (the MCP handler already caps at 2 chunks/page,
+      // but chat only needs one entry per URL since it fetches the full page).
+      if (seenUrls.has(url)) continue;
+      seenUrls.add(url);
+
+      results.push({
+        title: match[1],
+        url,
+        source: match[3].trim(),
+      });
     }
 
     console.log(`MCP search found ${results.length} results for "${query}"`);
@@ -644,7 +649,7 @@ export async function POST(req: Request) {
         execute: async (input) => {
           const { repo, path } = input;
           try {
-            const toolResult = await githubTools.handlers.github_get_file({ repo, path, owner: 'ava-labs' });
+            const toolResult = await githubTools.handlers.github_get_file({ repo, path });
             const text = toolResult.content?.[0]?.text;
             if (!text) return { error: 'No result' };
             const data = JSON.parse(text);
@@ -659,6 +664,90 @@ export async function POST(req: Request) {
             return data;
           } catch (error) {
             return { error: 'Failed to fetch file', details: String(error) };
+          }
+        },
+      }),
+
+      cli_lookup_command: tool({
+        description:
+          'Look up Avalanche CLI, Platform CLI, or tmpnet command guidance from the docs. Use this when the user asks about a specific CLI command, flag, or task (e.g. "how do I add a validator with avalanche-cli?"). Returns cited command references.',
+        inputSchema: z.object({
+          query: z.string().describe('Command, flag, or task to look up'),
+          cli: z
+            .enum(['avalanche-cli', 'platform-cli', 'tmpnet', 'all'])
+            .default('all')
+            .describe('Which CLI surface to search'),
+          limit: z.number().int().min(1).max(20).default(8).describe('Max results (default 8)'),
+        }),
+        execute: async (input) => {
+          try {
+            const result = await docsTools.handlers.cli_lookup_command(input as Record<string, unknown>);
+            return { text: result.content?.[0]?.text || '', isError: !!result.isError };
+          } catch (error) {
+            return { error: 'cli_lookup_command failed', details: String(error) };
+          }
+        },
+      }),
+
+      rpc_lookup_method: tool({
+        description:
+          'Look up Avalanche RPC methods and API guides across C-Chain, P-Chain, X-Chain, Subnet-EVM, and node RPC docs. Use this for any RPC method question (e.g. "how do I call platform.getCurrentValidators?").',
+        inputSchema: z.object({
+          query: z.string().describe('RPC method, namespace, or task to look up'),
+          chain: z
+            .enum(['p-chain', 'c-chain', 'x-chain', 'subnet-evm', 'other', 'all'])
+            .default('all')
+            .describe('Which chain RPC docs to search'),
+          limit: z.number().int().min(1).max(20).default(8).describe('Max results (default 8)'),
+        }),
+        execute: async (input) => {
+          try {
+            const result = await docsTools.handlers.rpc_lookup_method(input as Record<string, unknown>);
+            return { text: result.content?.[0]?.text || '', isError: !!result.isError };
+          } catch (error) {
+            return { error: 'rpc_lookup_method failed', details: String(error) };
+          }
+        },
+      }),
+
+      acp_lookup: tool({
+        description:
+          'Look up an Avalanche Community Proposal (ACP) by number, title, or topic. When the user supplies an ACP number, this returns the structured record — title, status (Activated/Implementable/Proposed/Stale/Withdrawn), track, authors, replaces/superseded-by/updates cross-references — plus matching docs excerpts. Use this for any ACP-specific question.',
+        inputSchema: z.object({
+          query: z.string().optional().describe('ACP title, topic, or keyword'),
+          number: z.number().int().positive().optional().describe('ACP number, if known'),
+          limit: z.number().int().min(1).max(20).default(8).describe('Max results (default 8)'),
+        }),
+        execute: async (input) => {
+          try {
+            const result = await docsTools.handlers.acp_lookup(input as Record<string, unknown>);
+            return { text: result.content?.[0]?.text || '', isError: !!result.isError };
+          } catch (error) {
+            return { error: 'acp_lookup failed', details: String(error) };
+          }
+        },
+      }),
+
+      acp_list: tool({
+        description:
+          'List Avalanche Community Proposals with structured fields, optionally filtered by status (Activated, Implementable, Proposed, Stale, Withdrawn) or track (Standards, Best Practices, Meta, Subnet). Use this for "which ACPs are activated?" / "show me all standards-track ACPs" / similar discovery questions.',
+        inputSchema: z.object({
+          status: z
+            .enum(['Proposed', 'Implementable', 'Activated', 'Stale', 'Withdrawn', 'Unknown'])
+            .optional()
+            .describe('Filter by ACP status'),
+          track: z
+            .enum(['Standards', 'Best Practices', 'Meta', 'Subnet'])
+            .optional()
+            .describe('Filter by ACP track'),
+          limit: z.number().int().min(1).max(100).default(50).describe('Max ACPs (default 50)'),
+        }),
+        execute: async (input) => {
+          try {
+            const result = await docsTools.handlers.acp_list(input as Record<string, unknown>);
+            return { text: result.content?.[0]?.text || '', isError: !!result.isError };
+          } catch (error) {
+            return { error: 'acp_list failed', details: String(error) };
           }
         },
       }),
@@ -759,6 +848,10 @@ You are the quick-help bubble on the Builders Hub. Your job is to help users FIN
 - **YouTube**: Embed with \`render_component("YouTubeEmbed", { videoId, title })\`. Never paste bare YouTube links.
 - **blockchain_lookup_***: For tx hashes, addresses, validators, subnets, chains. Follow up on \`_lookupHints\` in results.
 - **github_search_code / github_get_file**: Search core Avalanche repos: avalanchego, subnet-evm, coreth, avalanche-cli, platform-cli, icm-services, avalanche-network-runner, icm-contracts, hypersdk, libevm, and builders-hub. Check pre-indexed code context below first. **Max 3 searches per question.**
+- **cli_lookup_command**: For any Avalanche CLI / Platform CLI / tmpnet question (commands, flags, workflows). Faster and more accurate than generic docs search.
+- **rpc_lookup_method**: For any RPC method / namespace question across C-Chain, P-Chain, X-Chain, Subnet-EVM, or node APIs.
+- **acp_lookup**: For any ACP-specific question. Pass \`number\` when known to get the structured record (status, track, authors, cross-references). Otherwise pass \`query\`.
+- **acp_list**: For ACP discovery (e.g. "what ACPs are activated?", "list all standards-track ACPs"). Filter by \`status\` and/or \`track\`.
 - **suggest_followups**: ALWAYS call this after answering. Suggest 2-3 relevant follow-up questions specific to the conversation.
 - **DocImage**: When documentation context contains images like \`![alt](/images/...)\`, call \`render_component("DocImage", { src: "/images/...", alt: "..." })\` to show them inline. Diagrams and screenshots help developers understand faster.
 

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -100,6 +100,16 @@ export async function POST(request: NextRequest) {
     return new NextResponse(rateLimitResponse.body, { status: rateLimitResponse.status, headers });
   }
 
+  // Reject oversized request bodies before parsing JSON.
+  const contentLength = Number(request.headers.get('content-length') || '0');
+  const MAX_BODY_BYTES = 256 * 1024; // 256 KB
+  if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+    return NextResponse.json(
+      { jsonrpc: '2.0', id: null, error: { code: -32600, message: 'Request body too large' } },
+      { status: 413, headers: getCORSHeaders(origin) }
+    );
+  }
+
   try {
     const body = await request.json();
     const useSSE = wantsSSE(request);
@@ -121,7 +131,8 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json(result, { headers: allHeaders });
-  } catch {
+  } catch (err) {
+    console.error('[mcp] failed to parse JSON-RPC request body', err);
     const errorResponse = { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } };
     const corsHeaders = getCORSHeaders(origin);
     const rateLimitHeaders = await getRateLimitHeaders(request);

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -11,9 +11,9 @@ import { docsResources } from '@/lib/mcp/resources';
 
 const server = new MCPServer({
   name: 'avalanche-mcp',
-  version: '2.0.0',
+  version: '2.1.0',
   protocolVersion: '2024-11-05',
-  description: 'Unified MCP server for Avalanche — docs, blockchain, GitHub, P-Chain, and Info API',
+  description: 'Unified read-only MCP server for Avalanche docs, CLI/RPC/ACP lookup, GitHub code search, blockchain lookups, P-Chain, and Info API',
 });
 
 server.registerToolDomain(docsTools);
@@ -46,7 +46,7 @@ function createSSEResponse(data: unknown, eventId?: string): Response {
 }
 
 // ---------------------------------------------------------------------------
-// GET — server info + capabilities, or 405 for Streamable HTTP polling
+// GET - server info + capabilities, or 405 for Streamable HTTP polling
 // ---------------------------------------------------------------------------
 
 export async function GET(request: NextRequest) {

--- a/content/docs/tooling/ai-llm/mcp-server.mdx
+++ b/content/docs/tooling/ai-llm/mcp-server.mdx
@@ -1,29 +1,62 @@
 ---
 title: MCP Server
-description: Search and retrieve Avalanche documentation dynamically via Model Context Protocol
+description: Search Avalanche docs, code, RPCs, CLI commands, ACPs, and public network data via Model Context Protocol
 ---
 
-The [Model Context Protocol](https://modelcontextprotocol.io/) server enables AI systems to search and retrieve documentation dynamically.
+The Avalanche MCP server gives AI clients a read-only interface to Builders Hub knowledge and public Avalanche tooling context.
 
 **Endpoint:** `https://build.avax.network/api/mcp`
 
-## Tools
+## Scope
 
-| Tool | Purpose |
-| :--- | :------ |
-| `avalanche_docs_search` | Search docs by query with optional source filter |
-| `avalanche_docs_fetch` | Get a specific page by URL path |
-| `avalanche_docs_list_sections` | List all sections with page counts |
+| Surface | Tools |
+| :--- | :--- |
+| Documentation | `docs_search`, `docs_fetch`, `docs_list_sections` |
+| Task lookup | `cli_lookup_command`, `rpc_lookup_method`, `acp_lookup`, `acp_list` |
+| GitHub | `github_search_code`, `github_get_file`, `github_list_repositories` |
+| Public blockchain lookup | `blockchain_get_native_balance`, `blockchain_get_contract_info`, `blockchain_lookup_*` |
+| P-Chain RPC | `platform_get_*` |
+| Info API | `info_get_*`, `info_is_bootstrapped`, `info_peers`, `info_acps` |
+
+`docs_search` searches body-level chunks across documentation, academy courses, integrations, and blog posts. Results include source URLs, chunk numbers, and matching excerpts.
+
+The older `avalanche_docs_search`, `avalanche_docs_fetch`, and `avalanche_docs_list_sections` names remain available as compatibility aliases. Prefer the shorter canonical names for new clients.
+
+## GitHub Coverage
+
+The GitHub tools cover these repositories:
+
+- `ava-labs/avalanchego`
+- `ava-labs/subnet-evm`
+- `ava-labs/coreth`
+- `ava-labs/avalanche-cli`
+- `ava-labs/platform-cli`
+- `ava-labs/icm-services`
+- `ava-labs/avalanche-network-runner`
+- `ava-labs/icm-contracts`
+- `ava-labs/hypersdk`
+- `ava-labs/libevm`
+- `ava-labs/builders-hub`
+
+## Resources
+
+| Resource | Purpose |
+| :--- | :--- |
+| `docs://index` | All documentation pages |
+| `academy://index` | Academy pages |
+| `integrations://index` | Integration pages |
+| `blog://index` | Blog posts |
+| `rpcs://index` | RPC method and API docs |
+| `cli://index` | Avalanche CLI, Platform CLI, and tmpnet docs |
+| `acps://index` | ACP docs |
 
 ## Claude Code Setup
-
-Add the MCP server to your project:
 
 ```bash
 claude mcp add avalanche-docs --transport http https://build.avax.network/api/mcp
 ```
 
-Or add to your `.claude/settings.json`:
+Or add it to `.claude/settings.json`:
 
 ```json
 {
@@ -40,7 +73,7 @@ Or add to your `.claude/settings.json`:
 
 ## Claude Desktop Setup
 
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+Add this to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```json
 {
@@ -55,36 +88,9 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 }
 ```
 
-## JSON-RPC Protocol
+## JSON-RPC Examples
 
-The MCP server uses JSON-RPC 2.0 for communication:
-
-```bash
-curl -X POST https://build.avax.network/api/mcp \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"avalanche_docs_search","arguments":{"query":"create L1","limit":5}}}'
-```
-
-**Response format:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "content": [
-      {
-        "type": "text",
-        "text": "[{\"title\":\"Create an L1\",\"url\":\"/docs/avalanche-l1s/create\",\"description\":\"...\",\"score\":45}]"
-      }
-    ]
-  }
-}
-```
-
-## Search Examples
-
-**Search all documentation:**
+Search docs:
 
 ```bash
 curl -X POST https://build.avax.network/api/mcp \
@@ -94,19 +100,18 @@ curl -X POST https://build.avax.network/api/mcp \
     "id": 1,
     "method": "tools/call",
     "params": {
-      "name": "avalanche_docs_search",
+      "name": "docs_search",
       "arguments": {
-        "query": "smart contracts",
-        "limit": 10
+        "query": "create an L1 with a custom precompile",
+        "limit": 5
       }
     }
   }'
 ```
 
-**Filter by source:**
+Look up a CLI task:
 
 ```bash
-# Search only academy content
 curl -X POST https://build.avax.network/api/mcp \
   -H "Content-Type: application/json" \
   -d '{
@@ -114,17 +119,16 @@ curl -X POST https://build.avax.network/api/mcp \
     "id": 2,
     "method": "tools/call",
     "params": {
-      "name": "avalanche_docs_search",
+      "name": "cli_lookup_command",
       "arguments": {
-        "query": "blockchain basics",
-        "source": "academy",
-        "limit": 5
+        "query": "add validator",
+        "cli": "avalanche-cli"
       }
     }
   }'
 ```
 
-**Fetch specific page:**
+Look up an RPC method:
 
 ```bash
 curl -X POST https://build.avax.network/api/mcp \
@@ -134,10 +138,81 @@ curl -X POST https://build.avax.network/api/mcp \
     "id": 3,
     "method": "tools/call",
     "params": {
-      "name": "avalanche_docs_fetch",
+      "name": "rpc_lookup_method",
       "arguments": {
-        "url": "/docs/primary-network/overview"
+        "query": "platform_getCurrentValidators",
+        "chain": "p-chain"
       }
     }
   }'
+```
+
+Look up a specific ACP and list activated standards-track ACPs:
+
+```bash
+# Structured lookup of ACP-77 with full table fields
+curl -X POST https://build.avax.network/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "tools/call",
+    "params": {
+      "name": "acp_lookup",
+      "arguments": { "number": 77 }
+    }
+  }'
+
+# All Activated ACPs on the Standards track
+curl -X POST https://build.avax.network/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 5,
+    "method": "tools/call",
+    "params": {
+      "name": "acp_list",
+      "arguments": { "status": "Activated", "track": "Standards" }
+    }
+  }'
+```
+
+Search code:
+
+```bash
+curl -X POST https://build.avax.network/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 6,
+    "method": "tools/call",
+    "params": {
+      "name": "github_search_code",
+      "arguments": {
+        "query": "TransformSubnetTx",
+        "repo": "avalanchego",
+        "language": "go"
+      }
+    }
+  }'
+```
+
+List server tools:
+
+```bash
+curl -X POST https://build.avax.network/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":7,"method":"tools/list"}'
+```
+
+## Safety Boundary
+
+The hosted MCP server is read-only. It does not execute local shell commands, run Avalanche CLI commands, modify node state, or access private files. Local/operator execution is tracked separately in the public roadmap issue: [ava-labs/builders-hub#4070](https://github.com/ava-labs/builders-hub/issues/4070).
+
+For AvaCloud and Chainkit API surfaces, use companion MCP servers alongside this hosted server:
+
+```bash
+claude mcp add avalanche-docs --transport http https://build.avax.network/api/mcp
+claude mcp add avalanche-chainkit --command "npx -y @avalanche-sdk/chainkit mcp-server"
+claude mcp add avalanche-avacloud --command "npx -y @avalabs/avacloud-sdk mcp-server --apikey $AVACLOUD_API_KEY"
 ```

--- a/content/docs/tooling/ai-llm/mcp-server.mdx
+++ b/content/docs/tooling/ai-llm/mcp-server.mdx
@@ -53,7 +53,7 @@ The GitHub tools cover these repositories:
 ## Claude Code Setup
 
 ```bash
-claude mcp add avalanche-docs --transport http https://build.avax.network/api/mcp
+claude mcp add avalanche-mcp --transport http https://build.avax.network/api/mcp
 ```
 
 Or add it to `.claude/settings.json`:
@@ -61,7 +61,7 @@ Or add it to `.claude/settings.json`:
 ```json
 {
   "mcpServers": {
-    "avalanche-docs": {
+    "avalanche-mcp": {
       "transport": {
         "type": "http",
         "url": "https://build.avax.network/api/mcp"
@@ -78,7 +78,7 @@ Add this to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ```json
 {
   "mcpServers": {
-    "avalanche-docs": {
+    "avalanche-mcp": {
       "transport": {
         "type": "http",
         "url": "https://build.avax.network/api/mcp"
@@ -212,7 +212,7 @@ The hosted MCP server is read-only. It does not execute local shell commands, ru
 For AvaCloud and Chainkit API surfaces, use companion MCP servers alongside this hosted server:
 
 ```bash
-claude mcp add avalanche-docs --transport http https://build.avax.network/api/mcp
+claude mcp add avalanche-mcp --transport http https://build.avax.network/api/mcp
 claude mcp add avalanche-chainkit --command "npx -y @avalanche-sdk/chainkit mcp-server"
 claude mcp add avalanche-avacloud --command "npx -y @avalabs/avacloud-sdk mcp-server --apikey $AVACLOUD_API_KEY"
 ```

--- a/lib/mcp-server.ts
+++ b/lib/mcp-server.ts
@@ -7,13 +7,23 @@
 
 import { documentation, academy, integration, blog } from '@/lib/source';
 import { getLLMText } from '@/lib/llm-utils';
+import {
+  countOccurrences,
+  makeExcerpt,
+  matchesPathPrefix,
+  normalizeForSearch,
+  scoreChunk,
+  splitIntoChunks,
+  tokenizeQuery,
+} from '@/lib/mcp/search-utils';
 
 // Cache for documentation content
 const docsCache: Map<string, { content: string; timestamp: number }> = new Map();
 const CACHE_DURATION = 60 * 60 * 1000; // 1 hour
-const CHUNK_WORDS = 180;
-const CHUNK_OVERLAP_WORDS = 35;
 const MAX_RESULTS = 50;
+// Concurrency cap for the cold-start index build. Prevents Promise.all from issuing
+// a thousand simultaneous getLLMText calls and overwhelming the event loop / memory.
+const INDEX_BUILD_CONCURRENCY = 8;
 
 type SourceName = 'docs' | 'academy' | 'integrations' | 'blog';
 
@@ -61,143 +71,70 @@ function getSourceGroups(source?: string): SourceGroup[] {
   return groups;
 }
 
-function normalizeForSearch(value: string): string {
-  return value.toLowerCase().replace(/\s+/g, ' ').trim();
-}
+async function processWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
 
-function tokenizeQuery(query: string): string[] {
-  return normalizeForSearch(query)
-    .split(/[^a-z0-9_/-]+/)
-    .map((term) => term.trim())
-    .filter((term) => term.length >= 2);
-}
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index]);
+    }
+  });
 
-function splitIntoChunks(content: string): string[] {
-  const words = content
-    .replace(/\r\n/g, '\n')
-    .split(/\s+/)
-    .map((word) => word.trim())
-    .filter(Boolean);
-
-  if (words.length === 0) return [];
-  if (words.length <= CHUNK_WORDS) return [words.join(' ')];
-
-  const chunks: string[] = [];
-  const step = CHUNK_WORDS - CHUNK_OVERLAP_WORDS;
-
-  for (let start = 0; start < words.length; start += step) {
-    const chunk = words.slice(start, start + CHUNK_WORDS).join(' ');
-    if (chunk) chunks.push(chunk);
-    if (start + CHUNK_WORDS >= words.length) break;
-  }
-
-  return chunks;
+  await Promise.all(runners);
+  return results;
 }
 
 async function buildDocsSearchIndex(): Promise<SearchChunk[]> {
   const groups = getSourceGroups();
-  const chunksByPage = await Promise.all(
-    groups.flatMap(({ name, pages }) =>
-      pages.map(async (page) => {
-        let content = '';
-
-        try {
-          content = await getLLMText(page as Parameters<typeof getLLMText>[0]);
-        } catch (error) {
-          console.error(`Error indexing content for ${page.url}:`, error);
-        }
-
-        if (content) {
-          docsCache.set(page.url, { content, timestamp: Date.now() });
-        }
-
-        return splitIntoChunks(content).map((chunk, chunkIndex) => ({
-          url: page.url,
-          title: page.data.title || 'Untitled',
-          description: page.data.description,
-          source: name,
-          chunkIndex,
-          text: chunk,
-          normalizedText: normalizeForSearch(chunk),
-        }));
-      })
-    )
+  const tasks = groups.flatMap(({ name, pages }) =>
+    pages.map((page) => ({ name, page }))
   );
+
+  const chunksByPage = await processWithConcurrency(tasks, INDEX_BUILD_CONCURRENCY, async ({ name, page }) => {
+    let content = '';
+
+    try {
+      content = await getLLMText(page as Parameters<typeof getLLMText>[0]);
+    } catch (error) {
+      console.error(`Error indexing content for ${page.url}:`, error);
+    }
+
+    if (content) {
+      docsCache.set(page.url, { content, timestamp: Date.now() });
+    }
+
+    return splitIntoChunks(content).map((chunk, chunkIndex) => ({
+      url: page.url,
+      title: page.data.title || 'Untitled',
+      description: page.data.description,
+      source: name,
+      chunkIndex,
+      text: chunk,
+      normalizedText: normalizeForSearch(chunk),
+    }));
+  });
 
   return chunksByPage.flat();
 }
 
 async function getDocsSearchIndex(): Promise<SearchChunk[]> {
   if (!docsSearchIndexPromise) {
-    docsSearchIndexPromise = buildDocsSearchIndex();
+    // Capture rejection so a transient build failure doesn't cache forever; a subsequent
+    // call will rebuild instead of permanently returning the same rejection.
+    docsSearchIndexPromise = buildDocsSearchIndex().catch((error) => {
+      docsSearchIndexPromise = null;
+      throw error;
+    });
   }
 
   return docsSearchIndexPromise;
-}
-
-function countOccurrences(haystack: string, needle: string): number {
-  if (!needle) return 0;
-
-  let count = 0;
-  let index = haystack.indexOf(needle);
-
-  while (index !== -1) {
-    count += 1;
-    index = haystack.indexOf(needle, index + needle.length);
-  }
-
-  return count;
-}
-
-function scoreChunk(chunk: SearchChunk, normalizedQuery: string, queryTerms: string[]): number {
-  const title = normalizeForSearch(chunk.title);
-  const description = normalizeForSearch(chunk.description || '');
-  const url = normalizeForSearch(chunk.url);
-  let score = 0;
-
-  if (title.includes(normalizedQuery)) score += 80;
-  if (description.includes(normalizedQuery)) score += 45;
-  if (url.includes(normalizedQuery)) score += 30;
-  if (chunk.normalizedText.includes(normalizedQuery)) score += 60;
-
-  for (const term of queryTerms) {
-    if (title.includes(term)) score += 18;
-    if (description.includes(term)) score += 10;
-    if (url.includes(term)) score += 6;
-
-    const bodyMatches = countOccurrences(chunk.normalizedText, term);
-    if (bodyMatches > 0) {
-      score += Math.min(bodyMatches, 6) * 5;
-    }
-  }
-
-  if (queryTerms.length > 1 && queryTerms.every((term) => chunk.normalizedText.includes(term))) {
-    score += 25;
-  }
-
-  return score;
-}
-
-function makeExcerpt(text: string, normalizedQuery: string, queryTerms: string[]): string {
-  const collapsed = text.replace(/\s+/g, ' ').trim();
-  const lower = collapsed.toLowerCase();
-  const matchCandidates = [normalizedQuery, ...queryTerms].filter(Boolean);
-  const firstMatch = matchCandidates
-    .map((term) => lower.indexOf(term))
-    .filter((index) => index >= 0)
-    .sort((a, b) => a - b)[0] ?? 0;
-
-  const start = Math.max(0, firstMatch - 140);
-  const end = Math.min(collapsed.length, firstMatch + 360);
-  const prefix = start > 0 ? '...' : '';
-  const suffix = end < collapsed.length ? '...' : '';
-
-  return `${prefix}${collapsed.slice(start, end)}${suffix}`;
-}
-
-function matchesPathPrefix(url: string, pathPrefixes?: string[]): boolean {
-  if (!pathPrefixes || pathPrefixes.length === 0) return true;
-  return pathPrefixes.some((prefix) => url.startsWith(prefix));
 }
 
 /**
@@ -345,14 +282,3 @@ export function clearCache() {
   docsCache.clear();
   docsSearchIndexPromise = null;
 }
-
-/**
- * MCP Server configuration
- */
-export const MCP_SERVER_CONFIG = {
-  name: 'avalanche-mcp',
-  version: '2.1.0',
-  protocolVersion: '2024-11-05',
-  description: 'Unified read-only MCP server for Avalanche docs, CLI/RPC/ACP lookup, GitHub code search, blockchain lookups, P-Chain, and Info API',
-  baseUrl: 'https://build.avax.network',
-};

--- a/lib/mcp-server.ts
+++ b/lib/mcp-server.ts
@@ -97,12 +97,15 @@ async function buildDocsSearchIndex(): Promise<SearchChunk[]> {
     pages.map((page) => ({ name, page }))
   );
 
+  let failedCount = 0;
+
   const chunksByPage = await processWithConcurrency(tasks, INDEX_BUILD_CONCURRENCY, async ({ name, page }) => {
     let content = '';
 
     try {
       content = await getLLMText(page as Parameters<typeof getLLMText>[0]);
     } catch (error) {
+      failedCount += 1;
       console.error(`Error indexing content for ${page.url}:`, error);
     }
 
@@ -120,6 +123,18 @@ async function buildDocsSearchIndex(): Promise<SearchChunk[]> {
       normalizedText: normalizeForSearch(chunk),
     }));
   });
+
+  // Surface high failure rates so silent index degradation is visible in logs —
+  // bounded concurrency prevents resource exhaustion, but per-page errors still
+  // drop pages from the index.
+  if (failedCount > 0 && tasks.length > 0) {
+    const failureRate = failedCount / tasks.length;
+    if (failureRate > 0.05 || failedCount >= 10) {
+      console.warn(
+        `[mcp/docs-index] ${failedCount}/${tasks.length} pages failed to index (${(failureRate * 100).toFixed(1)}%) — searches may return incomplete results`,
+      );
+    }
+  }
 
   return chunksByPage.flat();
 }

--- a/lib/mcp-server.ts
+++ b/lib/mcp-server.ts
@@ -11,6 +11,194 @@ import { getLLMText } from '@/lib/llm-utils';
 // Cache for documentation content
 const docsCache: Map<string, { content: string; timestamp: number }> = new Map();
 const CACHE_DURATION = 60 * 60 * 1000; // 1 hour
+const CHUNK_WORDS = 180;
+const CHUNK_OVERLAP_WORDS = 35;
+const MAX_RESULTS = 50;
+
+type SourceName = 'docs' | 'academy' | 'integrations' | 'blog';
+
+type SourcePage = {
+  url: string;
+  data: {
+    title?: string;
+    description?: string;
+  };
+};
+
+interface SourceGroup {
+  name: SourceName;
+  pages: SourcePage[];
+}
+
+interface SearchChunk {
+  url: string;
+  title: string;
+  description?: string;
+  source: SourceName;
+  chunkIndex: number;
+  text: string;
+  normalizedText: string;
+}
+
+let docsSearchIndexPromise: Promise<SearchChunk[]> | null = null;
+
+function getSourceGroups(source?: string): SourceGroup[] {
+  const groups: SourceGroup[] = [];
+
+  if (!source || source === 'docs') {
+    groups.push({ name: 'docs', pages: documentation.getPages() as unknown as SourcePage[] });
+  }
+  if (!source || source === 'academy') {
+    groups.push({ name: 'academy', pages: academy.getPages() as unknown as SourcePage[] });
+  }
+  if (!source || source === 'integrations') {
+    groups.push({ name: 'integrations', pages: integration.getPages() as unknown as SourcePage[] });
+  }
+  if (!source || source === 'blog') {
+    groups.push({ name: 'blog', pages: blog.getPages() as unknown as SourcePage[] });
+  }
+
+  return groups;
+}
+
+function normalizeForSearch(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function tokenizeQuery(query: string): string[] {
+  return normalizeForSearch(query)
+    .split(/[^a-z0-9_/-]+/)
+    .map((term) => term.trim())
+    .filter((term) => term.length >= 2);
+}
+
+function splitIntoChunks(content: string): string[] {
+  const words = content
+    .replace(/\r\n/g, '\n')
+    .split(/\s+/)
+    .map((word) => word.trim())
+    .filter(Boolean);
+
+  if (words.length === 0) return [];
+  if (words.length <= CHUNK_WORDS) return [words.join(' ')];
+
+  const chunks: string[] = [];
+  const step = CHUNK_WORDS - CHUNK_OVERLAP_WORDS;
+
+  for (let start = 0; start < words.length; start += step) {
+    const chunk = words.slice(start, start + CHUNK_WORDS).join(' ');
+    if (chunk) chunks.push(chunk);
+    if (start + CHUNK_WORDS >= words.length) break;
+  }
+
+  return chunks;
+}
+
+async function buildDocsSearchIndex(): Promise<SearchChunk[]> {
+  const groups = getSourceGroups();
+  const chunksByPage = await Promise.all(
+    groups.flatMap(({ name, pages }) =>
+      pages.map(async (page) => {
+        let content = '';
+
+        try {
+          content = await getLLMText(page as Parameters<typeof getLLMText>[0]);
+        } catch (error) {
+          console.error(`Error indexing content for ${page.url}:`, error);
+        }
+
+        if (content) {
+          docsCache.set(page.url, { content, timestamp: Date.now() });
+        }
+
+        return splitIntoChunks(content).map((chunk, chunkIndex) => ({
+          url: page.url,
+          title: page.data.title || 'Untitled',
+          description: page.data.description,
+          source: name,
+          chunkIndex,
+          text: chunk,
+          normalizedText: normalizeForSearch(chunk),
+        }));
+      })
+    )
+  );
+
+  return chunksByPage.flat();
+}
+
+async function getDocsSearchIndex(): Promise<SearchChunk[]> {
+  if (!docsSearchIndexPromise) {
+    docsSearchIndexPromise = buildDocsSearchIndex();
+  }
+
+  return docsSearchIndexPromise;
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+
+  let count = 0;
+  let index = haystack.indexOf(needle);
+
+  while (index !== -1) {
+    count += 1;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+
+  return count;
+}
+
+function scoreChunk(chunk: SearchChunk, normalizedQuery: string, queryTerms: string[]): number {
+  const title = normalizeForSearch(chunk.title);
+  const description = normalizeForSearch(chunk.description || '');
+  const url = normalizeForSearch(chunk.url);
+  let score = 0;
+
+  if (title.includes(normalizedQuery)) score += 80;
+  if (description.includes(normalizedQuery)) score += 45;
+  if (url.includes(normalizedQuery)) score += 30;
+  if (chunk.normalizedText.includes(normalizedQuery)) score += 60;
+
+  for (const term of queryTerms) {
+    if (title.includes(term)) score += 18;
+    if (description.includes(term)) score += 10;
+    if (url.includes(term)) score += 6;
+
+    const bodyMatches = countOccurrences(chunk.normalizedText, term);
+    if (bodyMatches > 0) {
+      score += Math.min(bodyMatches, 6) * 5;
+    }
+  }
+
+  if (queryTerms.length > 1 && queryTerms.every((term) => chunk.normalizedText.includes(term))) {
+    score += 25;
+  }
+
+  return score;
+}
+
+function makeExcerpt(text: string, normalizedQuery: string, queryTerms: string[]): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  const lower = collapsed.toLowerCase();
+  const matchCandidates = [normalizedQuery, ...queryTerms].filter(Boolean);
+  const firstMatch = matchCandidates
+    .map((term) => lower.indexOf(term))
+    .filter((index) => index >= 0)
+    .sort((a, b) => a - b)[0] ?? 0;
+
+  const start = Math.max(0, firstMatch - 140);
+  const end = Math.min(collapsed.length, firstMatch + 360);
+  const prefix = start > 0 ? '...' : '';
+  const suffix = end < collapsed.length ? '...' : '';
+
+  return `${prefix}${collapsed.slice(start, end)}${suffix}`;
+}
+
+function matchesPathPrefix(url: string, pathPrefixes?: string[]): boolean {
+  if (!pathPrefixes || pathPrefixes.length === 0) return true;
+  return pathPrefixes.some((prefix) => url.startsWith(prefix));
+}
 
 /**
  * Get page content with caching
@@ -50,69 +238,58 @@ export interface SearchResult {
   description?: string;
   source: string;
   score: number;
+  excerpt?: string;
+  chunk?: string;
+  chunkIndex?: number;
 }
 
 /**
- * Search function that searches across all documentation
+ * Search function that searches across all documentation content.
  */
-export function searchDocs(
+export async function searchDocs(
   query: string,
-  options: { source?: string; limit?: number } = {}
-): SearchResult[] {
-  const { source, limit = 10 } = options;
-  const queryLower = query.toLowerCase();
-  const queryTerms = queryLower.split(/\s+/).filter((t) => t.length > 2);
+  options: { source?: string; limit?: number; pathPrefixes?: string[] } = {}
+): Promise<SearchResult[]> {
+  const { source, pathPrefixes } = options;
+  const limit = Math.min(Math.max(Math.floor(options.limit || 10), 1), MAX_RESULTS);
+  const normalizedQuery = normalizeForSearch(query);
+  const queryTerms = tokenizeQuery(query);
+
+  if (!normalizedQuery) return [];
+
+  const index = await getDocsSearchIndex();
+  const scoredResults = index
+    .filter((chunk) => (!source || chunk.source === source) && matchesPathPrefix(chunk.url, pathPrefixes))
+    .map((chunk) => ({
+      chunk,
+      score: scoreChunk(chunk, normalizedQuery, queryTerms),
+    }))
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score);
 
   const results: SearchResult[] = [];
+  const perPageCounts = new Map<string, number>();
 
-  const sources: Array<{
-    name: string;
-    pages: Array<{ url: string; data: { title: string; description?: string } }>;
-  }> = [];
+  for (const { chunk, score } of scoredResults) {
+    const pageCount = perPageCounts.get(chunk.url) || 0;
+    if (pageCount >= 2) continue;
 
-  if (!source || source === 'docs') {
-    sources.push({ name: 'docs', pages: documentation.getPages() });
-  }
-  if (!source || source === 'academy') {
-    sources.push({ name: 'academy', pages: academy.getPages() });
-  }
-  if (!source || source === 'integrations') {
-    sources.push({ name: 'integrations', pages: integration.getPages() });
-  }
-  if (!source || source === 'blog') {
-    sources.push({ name: 'blog', pages: blog.getPages() });
-  }
+    results.push({
+      url: chunk.url,
+      title: chunk.title,
+      description: chunk.description,
+      source: chunk.source,
+      score,
+      excerpt: makeExcerpt(chunk.text, normalizedQuery, queryTerms),
+      chunk: chunk.text,
+      chunkIndex: chunk.chunkIndex,
+    });
 
-  for (const { name, pages } of sources) {
-    for (const page of pages) {
-      const titleLower = page.data.title?.toLowerCase() || '';
-      const descLower = page.data.description?.toLowerCase() || '';
-      const urlLower = page.url.toLowerCase();
-
-      let score = 0;
-
-      for (const term of queryTerms) {
-        if (titleLower.includes(term)) score += 20;
-        if (descLower.includes(term)) score += 10;
-        if (urlLower.includes(term)) score += 5;
-      }
-
-      if (titleLower.includes(queryLower)) score += 30;
-      if (descLower.includes(queryLower)) score += 15;
-
-      if (score > 0) {
-        results.push({
-          url: page.url,
-          title: page.data.title || 'Untitled',
-          description: page.data.description,
-          source: name,
-          score,
-        });
-      }
-    }
+    perPageCounts.set(chunk.url, pageCount + 1);
+    if (results.length >= limit) break;
   }
 
-  return results.sort((a, b) => b.score - a.score).slice(0, limit);
+  return results;
 }
 
 /**
@@ -166,15 +343,16 @@ export function getDocStats() {
  */
 export function clearCache() {
   docsCache.clear();
+  docsSearchIndexPromise = null;
 }
 
 /**
  * MCP Server configuration
  */
 export const MCP_SERVER_CONFIG = {
-  name: 'avalanche-docs',
-  version: '1.0.0',
+  name: 'avalanche-mcp',
+  version: '2.1.0',
   protocolVersion: '2024-11-05',
-  description: 'MCP server for Avalanche documentation',
+  description: 'Unified read-only MCP server for Avalanche docs, CLI/RPC/ACP lookup, GitHub code search, blockchain lookups, P-Chain, and Info API',
   baseUrl: 'https://build.avax.network',
 };

--- a/lib/mcp/acps/filter.ts
+++ b/lib/mcp/acps/filter.ts
@@ -1,0 +1,30 @@
+import type { AcpEntry } from './parser';
+
+export interface ListOptions {
+  status?: string;
+  track?: string;
+  limit?: number;
+}
+
+/**
+ * Pure filter helper used by listAcps. Track matching is case-insensitive and
+ * matches if any of the entry's tracks starts with the requested value, so
+ * callers can pass "Standards" to also pick up the combined "Standards,
+ * Subnet" tracks.
+ */
+export function filterAcps(entries: readonly AcpEntry[], options: ListOptions = {}): AcpEntry[] {
+  const { status, track, limit } = options;
+  const lowerStatus = status?.toLowerCase().trim();
+  const lowerTrack = track?.toLowerCase().trim();
+
+  const filtered = entries.filter((entry) => {
+    if (lowerStatus && entry.status.toLowerCase() !== lowerStatus) return false;
+    if (lowerTrack && !entry.tracks.some((t) => t.toLowerCase().startsWith(lowerTrack))) return false;
+    return true;
+  });
+
+  if (typeof limit === 'number' && Number.isFinite(limit) && limit > 0) {
+    return filtered.slice(0, Math.floor(limit));
+  }
+  return filtered;
+}

--- a/lib/mcp/acps/index.ts
+++ b/lib/mcp/acps/index.ts
@@ -1,0 +1,10 @@
+export { parseAcpDocument, normalizeStatus, normalizeTracks, ACP_STATUSES } from './parser';
+export type { AcpEntry, AcpStatus } from './parser';
+export { filterAcps } from './filter';
+export type { ListOptions } from './filter';
+export {
+  getAcpRegistry,
+  listAcps,
+  findAcpByNumber,
+  __resetAcpRegistryForTests,
+} from './registry';

--- a/lib/mcp/acps/parser.ts
+++ b/lib/mcp/acps/parser.ts
@@ -130,7 +130,12 @@ function parseAuthors(value: string): string[] {
 
 function parseDiscussionUrl(value: string): string | undefined {
   const match = value.match(/Discussion\]\(([^)]+)\)/i);
-  return match ? match[1] : undefined;
+  if (!match) return undefined;
+  // Allowlist: only http(s) URLs. ACP markdown is upstream-community-authored,
+  // so we neutralize javascript:/data:/file: schemes before they flow into AI clients.
+  const url = match[1].trim();
+  if (/^https?:\/\//i.test(url)) return url;
+  return undefined;
 }
 
 function parseAcpNumberFromUrl(url: string): number | undefined {
@@ -154,15 +159,23 @@ function parseTitleFromFrontmatter(title: string | undefined): string | undefine
   return stripped || undefined;
 }
 
+// Cap raw doc content before parsing to bound regex / split costs on a hostile or oversized doc.
+const MAX_PARSE_CHARS = 1_000_000;
+
 /**
  * Parse an ACP markdown document into a structured record.
  *
  * The parser is tolerant of small formatting variations (extra spaces,
  * variable separator widths, missing optional fields). When fields cannot
  * be derived from the body, it falls back to the frontmatter or URL.
+ *
+ * Returns `null` when no ACP number can be derived from the body, frontmatter,
+ * or URL — callers should treat that as "not a real ACP page" rather than
+ * polluting the registry with phantom ACP-0 entries.
  */
-export function parseAcpDocument(content: string, url: string): AcpEntry {
-  const { body, frontmatter } = stripFrontmatter(content);
+export function parseAcpDocument(content: string, url: string): AcpEntry | null {
+  const safeContent = content.length > MAX_PARSE_CHARS ? content.slice(0, MAX_PARSE_CHARS) : content;
+  const { body, frontmatter } = stripFrontmatter(safeContent);
   const rows = parseTableRows(body);
 
   const tableNumber = rows.get('acp');
@@ -171,6 +184,8 @@ export function parseAcpDocument(content: string, url: string): AcpEntry {
     parseAcpNumberFromTitle(frontmatter.title) ||
     parseAcpNumberFromUrl(url) ||
     0;
+
+  if (number <= 0) return null;
 
   const tableTitle = rows.get('title');
   const title = tableTitle || parseTitleFromFrontmatter(frontmatter.title) || 'Untitled ACP';

--- a/lib/mcp/acps/parser.ts
+++ b/lib/mcp/acps/parser.ts
@@ -1,0 +1,209 @@
+/**
+ * Structured parser for Avalanche Community Proposal (ACP) markdown documents.
+ *
+ * ACP source files live under content/docs/acps/*.mdx. Each file follows the
+ * upstream `avalanche-foundation/ACPs` README format: a frontmatter block plus
+ * a leading metadata table that exposes ACP number, title, authors, status,
+ * track, and optional cross-references (Replaces / Superseded-By / Updates /
+ * Updated-By).
+ *
+ * This module turns the raw markdown into a typed record so AI clients can
+ * filter and answer ACP questions without re-parsing markdown each call.
+ */
+
+export const ACP_STATUSES = [
+  'Proposed',
+  'Implementable',
+  'Activated',
+  'Stale',
+  'Withdrawn',
+] as const;
+
+export type AcpStatus = (typeof ACP_STATUSES)[number] | 'Unknown';
+
+export interface AcpEntry {
+  number: number;
+  title: string;
+  status: AcpStatus;
+  rawStatus: string;
+  tracks: string[];
+  authors: string[];
+  replaces?: number[];
+  supersededBy?: number[];
+  updates?: number[];
+  updatedBy?: number[];
+  description?: string;
+  discussionUrl?: string;
+  url: string;
+}
+
+const STATUS_LOOKUP: Record<string, AcpStatus> = {
+  proposed: 'Proposed',
+  implementable: 'Implementable',
+  activated: 'Activated',
+  stale: 'Stale',
+  withdrawn: 'Withdrawn',
+};
+
+export function normalizeStatus(value: string): AcpStatus {
+  const lower = value.toLowerCase().trim();
+  if (!lower) return 'Unknown';
+  for (const [key, status] of Object.entries(STATUS_LOOKUP)) {
+    if (lower.startsWith(key)) return status;
+  }
+  return 'Unknown';
+}
+
+export function normalizeTracks(value: string): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((part) => part.trim().replace(/\s+Track$/i, ''))
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function stripFrontmatter(content: string): { body: string; frontmatter: Record<string, string> } {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!match) return { body: content, frontmatter: {} };
+
+  const frontmatter: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    const sep = line.indexOf(':');
+    if (sep === -1) continue;
+    const key = line.slice(0, sep).trim();
+    const value = line.slice(sep + 1).trim().replace(/^"|"$/g, '');
+    if (key) frontmatter[key] = value;
+  }
+
+  return { body: content.slice(match[0].length), frontmatter };
+}
+
+function parseTableRows(body: string): Map<string, string> {
+  const rows = new Map<string, string>();
+  const lines = body.split('\n');
+
+  for (const line of lines) {
+    if (!line.startsWith('|')) continue;
+    if (/^\|[\s:|-]+\|/.test(line)) continue; // separator row
+
+    const cells = line
+      .split('|')
+      .slice(1, -1)
+      .map((cell) => cell.trim());
+    if (cells.length < 2) continue;
+
+    const key = cells[0].replace(/\*\*/g, '').replace(/[:\s]+$/, '').trim().toLowerCase();
+    const value = cells.slice(1).join(' | ').trim();
+    if (key && !rows.has(key)) rows.set(key, value);
+  }
+
+  return rows;
+}
+
+function parseAcpReferences(value: string): number[] {
+  if (!value) return [];
+  const numbers: number[] = [];
+  const seen = new Set<number>();
+
+  const matches = value.matchAll(/ACP-?(\d+)/gi);
+  for (const match of matches) {
+    const n = Number.parseInt(match[1], 10);
+    if (Number.isFinite(n) && !seen.has(n)) {
+      seen.add(n);
+      numbers.push(n);
+    }
+  }
+
+  return numbers;
+}
+
+function parseAuthors(value: string): string[] {
+  if (!value) return [];
+  // Author names appear before any handle/link metadata, which begins with
+  // either '(' (e.g. "(@handle)") or '[' (e.g. "[github.com/...]").
+  return value
+    .split(',')
+    .map((part) => part.split(/[(\[]/)[0].replace(/\s+/g, ' ').trim())
+    .filter(Boolean);
+}
+
+function parseDiscussionUrl(value: string): string | undefined {
+  const match = value.match(/Discussion\]\(([^)]+)\)/i);
+  return match ? match[1] : undefined;
+}
+
+function parseAcpNumberFromUrl(url: string): number | undefined {
+  const match = url.match(/\/(\d+)-/);
+  if (!match) return undefined;
+  const n = Number.parseInt(match[1], 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function parseAcpNumberFromTitle(title: string | undefined): number | undefined {
+  if (!title) return undefined;
+  const match = title.match(/ACP-?(\d+)/i);
+  if (!match) return undefined;
+  const n = Number.parseInt(match[1], 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function parseTitleFromFrontmatter(title: string | undefined): string | undefined {
+  if (!title) return undefined;
+  const stripped = title.replace(/^ACP-?\d+:\s*/i, '').trim();
+  return stripped || undefined;
+}
+
+/**
+ * Parse an ACP markdown document into a structured record.
+ *
+ * The parser is tolerant of small formatting variations (extra spaces,
+ * variable separator widths, missing optional fields). When fields cannot
+ * be derived from the body, it falls back to the frontmatter or URL.
+ */
+export function parseAcpDocument(content: string, url: string): AcpEntry {
+  const { body, frontmatter } = stripFrontmatter(content);
+  const rows = parseTableRows(body);
+
+  const tableNumber = rows.get('acp');
+  const number =
+    (tableNumber ? Number.parseInt(tableNumber, 10) : Number.NaN) ||
+    parseAcpNumberFromTitle(frontmatter.title) ||
+    parseAcpNumberFromUrl(url) ||
+    0;
+
+  const tableTitle = rows.get('title');
+  const title = tableTitle || parseTitleFromFrontmatter(frontmatter.title) || 'Untitled ACP';
+
+  const rawStatus = rows.get('status') || '';
+  const status = normalizeStatus(rawStatus);
+
+  const trackValue = rows.get('track') || '';
+  const tracks = normalizeTracks(trackValue);
+
+  const authors = parseAuthors(rows.get('author(s)') || rows.get('authors') || '');
+
+  const replaces = parseAcpReferences(rows.get('replaces') || '');
+  const supersededBy = parseAcpReferences(rows.get('superseded-by') || rows.get('superseded by') || '');
+  const updates = parseAcpReferences(rows.get('updates') || '');
+  const updatedBy = parseAcpReferences(rows.get('updated-by') || rows.get('updated by') || '');
+
+  const entry: AcpEntry = {
+    number,
+    title,
+    status,
+    rawStatus,
+    tracks,
+    authors,
+    description: frontmatter.description,
+    discussionUrl: parseDiscussionUrl(rawStatus),
+    url,
+  };
+
+  if (replaces.length > 0) entry.replaces = replaces;
+  if (supersededBy.length > 0) entry.supersededBy = supersededBy;
+  if (updates.length > 0) entry.updates = updates;
+  if (updatedBy.length > 0) entry.updatedBy = updatedBy;
+
+  return entry;
+}

--- a/lib/mcp/acps/registry.ts
+++ b/lib/mcp/acps/registry.ts
@@ -32,6 +32,8 @@ async function loadAcpEntry(page: { url: string }): Promise<AcpEntry | null> {
     const fullPage = page as { url: string; absolutePath?: string; data?: { getText?: (k: string) => Promise<string> } };
     const content = await getLLMText(fullPage as Parameters<typeof getLLMText>[0]);
     if (!content) return null;
+    // parseAcpDocument now returns null when no ACP number can be derived; we propagate that
+    // upward so the registry only contains real numbered ACPs.
     return parseAcpDocument(content, page.url);
   } catch (error) {
     console.error(`[mcp/acps] failed to load ${page.url}`, error);

--- a/lib/mcp/acps/registry.ts
+++ b/lib/mcp/acps/registry.ts
@@ -1,0 +1,80 @@
+/**
+ * Lazy registry of Avalanche Community Proposals (ACPs).
+ *
+ * The registry walks every page under /docs/acps, reads the markdown via the
+ * fumadocs source loader, and caches parsed AcpEntry records for the lifetime
+ * of the module. An optional in-process refresh helper is exposed for tests.
+ */
+
+import { documentation } from '@/lib/source';
+import { getLLMText } from '@/lib/llm-utils';
+import { parseAcpDocument, type AcpEntry } from './parser';
+import { filterAcps, type ListOptions } from './filter';
+
+const ACP_URL_PREFIX = '/docs/acps';
+const INDEX_PAGE_URL = `${ACP_URL_PREFIX}`;
+
+let registryPromise: Promise<AcpEntry[]> | null = null;
+
+function isAcpPage(url: string): boolean {
+  if (!url.startsWith(ACP_URL_PREFIX)) return false;
+  if (url === INDEX_PAGE_URL || url === `${ACP_URL_PREFIX}/`) return false;
+  // Skip pages whose final segment does not start with a digit; the upstream
+  // ACP repo uses `<number>-<slug>` for proposals, while sibling pages such
+  // as /docs/acps/index do not.
+  const segments = url.split('/').filter(Boolean);
+  const last = segments[segments.length - 1];
+  return /^\d+/.test(last);
+}
+
+async function loadAcpEntry(page: { url: string }): Promise<AcpEntry | null> {
+  try {
+    const fullPage = page as { url: string; absolutePath?: string; data?: { getText?: (k: string) => Promise<string> } };
+    const content = await getLLMText(fullPage as Parameters<typeof getLLMText>[0]);
+    if (!content) return null;
+    return parseAcpDocument(content, page.url);
+  } catch (error) {
+    console.error(`[mcp/acps] failed to load ${page.url}`, error);
+    return null;
+  }
+}
+
+async function buildRegistry(): Promise<AcpEntry[]> {
+  const pages = documentation.getPages().filter((p) => isAcpPage(p.url));
+  const entries = await Promise.all(pages.map((p) => loadAcpEntry(p)));
+  return entries
+    .filter((entry): entry is AcpEntry => entry !== null)
+    .sort((a, b) => b.number - a.number);
+}
+
+export async function getAcpRegistry(): Promise<AcpEntry[]> {
+  if (!registryPromise) {
+    registryPromise = buildRegistry();
+  }
+  return registryPromise;
+}
+
+/**
+ * Find a single ACP by its number. Useful for exact lookups in the
+ * `acp_lookup` MCP tool.
+ */
+export async function findAcpByNumber(number: number): Promise<AcpEntry | undefined> {
+  const registry = await getAcpRegistry();
+  return registry.find((entry) => entry.number === number);
+}
+
+/**
+ * List ACPs, optionally filtered by status and / or track. See `filterAcps`
+ * in ./filter for the matching rules.
+ */
+export async function listAcps(options: ListOptions = {}): Promise<AcpEntry[]> {
+  const registry = await getAcpRegistry();
+  return filterAcps(registry, options);
+}
+
+/**
+ * Reset the cached registry (test-only helper).
+ */
+export function __resetAcpRegistryForTests(): void {
+  registryPromise = null;
+}

--- a/lib/mcp/resources/docs.ts
+++ b/lib/mcp/resources/docs.ts
@@ -1,14 +1,40 @@
 /**
  * MCP resource domain for Avalanche documentation.
  *
- * Provides three resources:
- *   docs://index        — list of all documentation pages
- *   academy://index     — list of all academy course pages
- *   integrations://index — list of all integration pages
+ * Provides structured indexes over Avalanche documentation surfaces.
  */
 
-import { documentation, academy, integration } from '@/lib/source';
+import { documentation, academy, integration, blog } from '@/lib/source';
 import type { ResourceDomain } from '../types';
+
+type IndexPage = {
+  url: string;
+  data: {
+    title?: string;
+    description?: string;
+  };
+};
+
+type PageList = IndexPage[];
+
+function toIndexPages(pages: unknown): PageList {
+  return pages as PageList;
+}
+
+function formatPageIndex(title: string, pages: PageList): string {
+  const content = pages
+    .map(
+      (page) =>
+        `- [${page.data.title}](${page.url})${page.data.description ? `: ${page.data.description}` : ''}`
+    )
+    .join('\n');
+
+  return `# ${title}\n\n${content}`;
+}
+
+function filterDocsByPrefix(prefix: string): PageList {
+  return toIndexPages(documentation.getPages().filter((page) => page.url.startsWith(prefix)));
+}
 
 export const docsResources: ResourceDomain = {
   resources: [
@@ -30,62 +56,127 @@ export const docsResources: ResourceDomain = {
       description: 'Index of all Avalanche integrations',
       mimeType: 'text/markdown',
     },
+    {
+      uri: 'blog://index',
+      name: 'Blog Index',
+      description: 'Index of all Avalanche Builders Hub blog posts',
+      mimeType: 'text/markdown',
+    },
+    {
+      uri: 'rpcs://index',
+      name: 'RPC Documentation Index',
+      description: 'Index of Avalanche RPC method and API documentation',
+      mimeType: 'text/markdown',
+    },
+    {
+      uri: 'cli://index',
+      name: 'CLI Documentation Index',
+      description: 'Index of Avalanche CLI, Platform CLI, and tmpnet documentation',
+      mimeType: 'text/markdown',
+    },
+    {
+      uri: 'acps://index',
+      name: 'ACP Index',
+      description: 'Index of Avalanche Community Proposal documentation',
+      mimeType: 'text/markdown',
+    },
   ],
 
   handler: async (uri: string) => {
     switch (uri) {
       case 'docs://index': {
-        const pages = documentation.getPages();
-        const content = pages
-          .map(
-            (p) =>
-              `- [${p.data.title}](${p.url})${p.data.description ? `: ${p.data.description}` : ''}`
-          )
-          .join('\n');
+        const pages = toIndexPages(documentation.getPages());
         return {
           contents: [
             {
               uri,
               mimeType: 'text/markdown',
-              text: `# Avalanche Documentation Index\n\n${content}`,
+              text: formatPageIndex('Avalanche Documentation Index', pages),
             },
           ],
         };
       }
 
       case 'academy://index': {
-        const pages = academy.getPages();
-        const content = pages
-          .map(
-            (p) =>
-              `- [${p.data.title}](${p.url})${p.data.description ? `: ${p.data.description}` : ''}`
-          )
-          .join('\n');
+        const pages = toIndexPages(academy.getPages());
         return {
           contents: [
             {
               uri,
               mimeType: 'text/markdown',
-              text: `# Avalanche Academy Courses\n\n${content}`,
+              text: formatPageIndex('Avalanche Academy Courses', pages),
             },
           ],
         };
       }
 
       case 'integrations://index': {
-        const pages = integration.getPages();
-        const content = pages
-          .map(
-            (p) =>
-              `- [${p.data.title}](${p.url})${p.data.description ? `: ${p.data.description}` : ''}`
-          )
-          .join('\n');
+        const pages = toIndexPages(integration.getPages());
         return {
           contents: [
             {
               uri,
               mimeType: 'text/markdown',
-              text: `# Avalanche Integrations\n\n${content}`,
+              text: formatPageIndex('Avalanche Integrations', pages),
+            },
+          ],
+        };
+      }
+
+      case 'blog://index': {
+        const pages = toIndexPages(blog.getPages());
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: 'text/markdown',
+              text: formatPageIndex('Avalanche Blog Posts', pages),
+            },
+          ],
+        };
+      }
+
+      case 'rpcs://index': {
+        const pages = filterDocsByPrefix('/docs/rpcs');
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: 'text/markdown',
+              text: formatPageIndex('Avalanche RPC Documentation Index', pages),
+            },
+          ],
+        };
+      }
+
+      case 'cli://index': {
+        const pages = toIndexPages(
+          documentation.getPages().filter(
+            (page) =>
+              page.url.startsWith('/docs/tooling/avalanche-cli') ||
+              page.url.startsWith('/docs/tooling/platform-cli') ||
+              page.url.startsWith('/docs/tooling/tmpnet')
+          )
+        );
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: 'text/markdown',
+              text: formatPageIndex('Avalanche CLI Documentation Index', pages),
+            },
+          ],
+        };
+      }
+
+      case 'acps://index': {
+        const pages = filterDocsByPrefix('/docs/acps');
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: 'text/markdown',
+              text: formatPageIndex('Avalanche Community Proposals', pages),
             },
           ],
         };

--- a/lib/mcp/search-utils.ts
+++ b/lib/mcp/search-utils.ts
@@ -1,0 +1,170 @@
+/**
+ * Pure search utilities (chunking, normalization, scoring, excerpt extraction).
+ *
+ * Kept dependency-free so tests can import these helpers without pulling in
+ * fumadocs source loaders.
+ */
+
+export const CHUNK_WORDS = 180;
+export const CHUNK_OVERLAP_WORDS = 35;
+
+// ---------------------------------------------------------------------------
+// Reflection sanitization — applied to text that flows from docs/ACP content
+// to AI clients. Even though the docs corpus is mostly maintainer-controlled,
+// ACP markdown comes from an upstream community repo and external doc PRs
+// land regularly, so we neutralize the most common prompt-injection vectors.
+// ---------------------------------------------------------------------------
+
+// Zero-width / bidi characters used to hide text or alter rendering order:
+//   U+200B-U+200D zero-width space/joiner/non-joiner
+//   U+200E-U+200F LTR/RTL marks
+//   U+202A-U+202E embedding/override
+//   U+2060        word joiner
+//   U+2061-U+2064 invisible operators
+//   U+FEFF        zero-width no-break space (BOM)
+const ZERO_WIDTH_REGEX = /[​-‏‪-‮⁠-⁤﻿]/g;
+// ASCII control chars (excluding \t, \n, \r which we want to preserve in excerpts).
+const CONTROL_CHARS_REGEX = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+// Markdown links pointing at dangerous URL schemes. Replace with the link text only.
+// Use [^\s]* greedy so nested parens inside the URL (e.g. javascript:alert(1)) are consumed
+// up to the final closing paren before whitespace.
+const DANGEROUS_LINK_REGEX = /\[([^\]]*)\]\(\s*(?:javascript|data|vbscript|file):[^\s]*\)/gi;
+// Bare dangerous URLs (not wrapped in markdown link syntax) — neutralize the scheme.
+const BARE_DANGEROUS_SCHEME_REGEX = /\b(?:javascript|data|vbscript|file):/gi;
+
+export function sanitizeForReflection(text: string): string {
+  if (typeof text !== 'string') return '';
+  return text
+    .replace(ZERO_WIDTH_REGEX, '')
+    .replace(CONTROL_CHARS_REGEX, '')
+    .replace(DANGEROUS_LINK_REGEX, '$1')
+    .replace(BARE_DANGEROUS_SCHEME_REGEX, '[blocked-scheme]:');
+}
+
+/**
+ * Allowlist URL filter — returns the URL only if it points at http(s) or an
+ * internal site path. Anything else (javascript:, data:, file:, mailto:, etc.)
+ * is rejected.
+ */
+export function sanitizeUrl(url: string | undefined): string | undefined {
+  if (typeof url !== 'string') return undefined;
+  const trimmed = url.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) return trimmed;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return undefined;
+}
+
+export function normalizeForSearch(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+export function tokenizeQuery(query: string): string[] {
+  return normalizeForSearch(query)
+    .split(/[^a-z0-9_/-]+/)
+    .map((term) => term.trim())
+    .filter((term) => term.length >= 2);
+}
+
+export function splitIntoChunks(content: string): string[] {
+  const words = content
+    .replace(/\r\n/g, '\n')
+    .split(/\s+/)
+    .map((word) => word.trim())
+    .filter(Boolean);
+
+  if (words.length === 0) return [];
+  if (words.length <= CHUNK_WORDS) return [words.join(' ')];
+
+  const chunks: string[] = [];
+  const step = CHUNK_WORDS - CHUNK_OVERLAP_WORDS;
+
+  for (let start = 0; start < words.length; start += step) {
+    const chunk = words.slice(start, start + CHUNK_WORDS).join(' ');
+    if (chunk) chunks.push(chunk);
+    if (start + CHUNK_WORDS >= words.length) break;
+    // Skip producing a tail chunk that is fully covered by the previous window.
+    // (E.g., for `words.length = step + k` with `k <= CHUNK_OVERLAP_WORDS`.)
+    if (start + step + CHUNK_OVERLAP_WORDS >= words.length) break;
+  }
+
+  return chunks;
+}
+
+export function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+
+  let count = 0;
+  let index = haystack.indexOf(needle);
+
+  while (index !== -1) {
+    count += 1;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+
+  return count;
+}
+
+export interface ScorableChunk {
+  url: string;
+  title: string;
+  description?: string;
+  normalizedText: string;
+}
+
+export function scoreChunk(
+  chunk: ScorableChunk,
+  normalizedQuery: string,
+  queryTerms: string[]
+): number {
+  const title = normalizeForSearch(chunk.title);
+  const description = normalizeForSearch(chunk.description || '');
+  const url = normalizeForSearch(chunk.url);
+  let score = 0;
+
+  if (title.includes(normalizedQuery)) score += 80;
+  if (description.includes(normalizedQuery)) score += 45;
+  if (url.includes(normalizedQuery)) score += 30;
+  if (chunk.normalizedText.includes(normalizedQuery)) score += 60;
+
+  for (const term of queryTerms) {
+    if (title.includes(term)) score += 18;
+    if (description.includes(term)) score += 10;
+    if (url.includes(term)) score += 6;
+
+    const bodyMatches = countOccurrences(chunk.normalizedText, term);
+    if (bodyMatches > 0) {
+      score += Math.min(bodyMatches, 6) * 5;
+    }
+  }
+
+  if (queryTerms.length > 1 && queryTerms.every((term) => chunk.normalizedText.includes(term))) {
+    score += 25;
+  }
+
+  return score;
+}
+
+export function makeExcerpt(text: string, normalizedQuery: string, queryTerms: string[]): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  const lower = collapsed.toLowerCase();
+  const matchCandidates = [normalizedQuery, ...queryTerms].filter(Boolean);
+  const firstMatch = matchCandidates
+    .map((term) => lower.indexOf(term))
+    .filter((index) => index >= 0)
+    .sort((a, b) => a - b)[0] ?? 0;
+
+  const start = Math.max(0, firstMatch - 140);
+  const end = Math.min(collapsed.length, firstMatch + 360);
+  const prefix = start > 0 ? '...' : '';
+  const suffix = end < collapsed.length ? '...' : '';
+
+  // Neutralize prompt-injection vectors (zero-width unicode, dangerous URL schemes)
+  // before the excerpt flows into AI client context.
+  return sanitizeForReflection(`${prefix}${collapsed.slice(start, end)}${suffix}`);
+}
+
+export function matchesPathPrefix(url: string, pathPrefixes?: string[]): boolean {
+  if (!pathPrefixes || pathPrefixes.length === 0) return true;
+  return pathPrefixes.some((prefix) => url.startsWith(prefix));
+}

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -32,6 +32,10 @@ interface ServerConfig {
   description?: string;
 }
 
+// Cap how many JSON-RPC items a single batch can carry. The 60/min global rate limit only
+// charges per HTTP request, so without this cap a single batch could amplify a client's quota.
+export const MAX_BATCH_SIZE = 20;
+
 export class MCPServer {
   private readonly config: ServerConfig;
   private toolDomains: ToolDomain[] = [];
@@ -147,7 +151,9 @@ export class MCPServer {
           } catch (err) {
             toolError = sanitizeErrorMessage(err);
             toolResult = {
-              content: [{ type: 'text', text: err instanceof Error ? err.message : 'Tool error' }],
+              // Use sanitized message in the user-facing payload too — raw err.message can
+              // leak internal paths or library stack-trace fragments.
+              content: [{ type: 'text', text: toolError }],
               isError: true,
             };
           }
@@ -207,7 +213,7 @@ export class MCPServer {
         id,
         error: {
           code: -32603,
-          message: error instanceof Error ? error.message : 'Internal error',
+          message: sanitizeErrorMessage(error),
         },
       };
     }
@@ -227,6 +233,17 @@ export class MCPServer {
    */
   async handlePost(body: unknown): Promise<JsonRpcResponse | JsonRpcResponse[] | null> {
     if (Array.isArray(body)) {
+      if (body.length > MAX_BATCH_SIZE) {
+        return {
+          jsonrpc: '2.0',
+          id: null,
+          error: {
+            code: -32600,
+            message: `Batch size ${body.length} exceeds the maximum of ${MAX_BATCH_SIZE}`,
+          },
+        };
+      }
+
       const responses = await Promise.all(
         body.map(async (message) => {
           const parsed = jsonRpcMessageSchema.safeParse(message);

--- a/lib/mcp/tools/docs.ts
+++ b/lib/mcp/tools/docs.ts
@@ -237,19 +237,24 @@ const acpListTool: MCPTool = {
 };
 
 function validateFetchUrl(url: string): { valid: boolean; error?: string } {
-  // Must start with /
-  if (!url.startsWith('/')) {
+  if (typeof url !== 'string' || !url.startsWith('/')) {
     return { valid: false, error: 'URL must start with /' };
   }
 
-  // Reject external URLs, protocols, and path traversal
-  if (url.includes('://') || url.includes('..')) {
-    return { valid: false, error: 'URL must be an internal path without ".." or protocols' };
+  // Decode once so a percent-encoded `..` doesn't slip past the literal check.
+  let decoded = url;
+  try {
+    decoded = decodeURIComponent(url);
+  } catch {
+    return { valid: false, error: 'URL contains invalid percent-encoded characters' };
   }
 
-  // Only allow specific prefixes
+  if (decoded.includes('://') || decoded.includes('..') || decoded.includes('\\')) {
+    return { valid: false, error: 'URL must be an internal path without "..", "\\", or protocols' };
+  }
+
   const allowedPrefixes = ['/docs/', '/academy/', '/integrations/', '/blog/'];
-  if (!allowedPrefixes.some((prefix) => url.startsWith(prefix))) {
+  if (!allowedPrefixes.some((prefix) => decoded.startsWith(prefix))) {
     return {
       valid: false,
       error: `URL must start with one of: ${allowedPrefixes.join(', ')}`,
@@ -515,11 +520,16 @@ export const docsTools: ToolDomain = {
       }
 
       const sections: string[] = [];
+      let structuredEntry: AcpEntry | undefined;
 
       if (hasNumber) {
         try {
-          const entry = await findAcpByNumber(numericInput);
-          if (entry) sections.push(formatAcpEntry(entry));
+          structuredEntry = await findAcpByNumber(numericInput);
+          if (structuredEntry) {
+            sections.push(formatAcpEntry(structuredEntry));
+          } else {
+            sections.push(`No structured ACP-${numericInput} record found in the registry.`);
+          }
         } catch (error) {
           console.error('[acp_lookup] structured lookup failed', error);
         }
@@ -531,7 +541,13 @@ export const docsTools: ToolDomain = {
         pathPrefixes: ['/docs/acps'],
       });
 
-      sections.push(formatSearchResults(searchQuery, results, 'ACP results'));
+      const dedupedResults = structuredEntry
+        ? results.filter((result) => result.url !== structuredEntry!.url)
+        : results;
+
+      if (dedupedResults.length > 0 || !structuredEntry) {
+        sections.push(formatSearchResults(searchQuery, dedupedResults, 'ACP results'));
+      }
 
       return {
         content: [{ type: 'text', text: sections.join('\n\n') }],
@@ -541,10 +557,9 @@ export const docsTools: ToolDomain = {
     acp_list: async (args): Promise<ToolResult> => {
       const status = getStringArg(args, 'status') || undefined;
       const track = getStringArg(args, 'track') || undefined;
-      const limit =
-        typeof args.limit === 'number' && args.limit > 0
-          ? Math.min(Math.floor(args.limit), 100)
-          : 50;
+      // Use a 100-cap default of 50 — separate from the search-result getLimit (which caps at 50).
+      const rawLimit = typeof args.limit === 'number' ? args.limit : 50;
+      const limit = Math.min(Math.max(Math.floor(rawLimit), 1), 100);
 
       try {
         const entries = await listAcps({ status, track, limit });

--- a/lib/mcp/tools/docs.ts
+++ b/lib/mcp/tools/docs.ts
@@ -14,6 +14,10 @@ const CLI_VALUES = ['avalanche-cli', 'platform-cli', 'tmpnet', 'all'] as const;
 const RPC_CHAIN_VALUES = ['p-chain', 'c-chain', 'x-chain', 'subnet-evm', 'other', 'all'] as const;
 const ACP_TRACKS = ['Standards', 'Best Practices', 'Meta', 'Subnet'] as const;
 
+// Cap a single docs_fetch response so a long Academy page can't dump 100KB+ of markdown
+// into the AI client in one tool call. Matches github_get_file's MAX_FILE_CONTENT_CHARS.
+const MAX_FETCH_CONTENT_CHARS = 50_000;
+
 const CLI_PATH_PREFIXES: Record<(typeof CLI_VALUES)[number], string[]> = {
   'avalanche-cli': ['/docs/tooling/avalanche-cli'],
   'platform-cli': ['/docs/tooling/platform-cli'],
@@ -391,8 +395,13 @@ export const docsTools: ToolDomain = {
         };
       }
 
+      const truncated = content.length > MAX_FETCH_CONTENT_CHARS;
+      const responseText = truncated
+        ? `${content.slice(0, MAX_FETCH_CONTENT_CHARS)}\n\n... [truncated at ${MAX_FETCH_CONTENT_CHARS} characters; use docs_search for targeted excerpts] ...`
+        : content;
+
       return {
-        content: [{ type: 'text', text: content }],
+        content: [{ type: 'text', text: responseText }],
       };
     },
 

--- a/lib/mcp/tools/docs.ts
+++ b/lib/mcp/tools/docs.ts
@@ -1,7 +1,240 @@
 import { documentation, academy, integration, blog } from '@/lib/source';
 import { searchDocs, getPageContent } from '@/lib/mcp-server';
+import {
+  ACP_STATUSES,
+  findAcpByNumber,
+  listAcps,
+  type AcpEntry,
+} from '@/lib/mcp/acps';
 import { captureMCPEvent, truncateForTracking } from '../analytics';
-import type { ToolDomain, ToolResult } from '../types';
+import type { MCPTool, ToolDomain, ToolResult } from '../types';
+
+const SOURCE_VALUES = ['docs', 'academy', 'integrations', 'blog'] as const;
+const CLI_VALUES = ['avalanche-cli', 'platform-cli', 'tmpnet', 'all'] as const;
+const RPC_CHAIN_VALUES = ['p-chain', 'c-chain', 'x-chain', 'subnet-evm', 'other', 'all'] as const;
+const ACP_TRACKS = ['Standards', 'Best Practices', 'Meta', 'Subnet'] as const;
+
+const CLI_PATH_PREFIXES: Record<(typeof CLI_VALUES)[number], string[]> = {
+  'avalanche-cli': ['/docs/tooling/avalanche-cli'],
+  'platform-cli': ['/docs/tooling/platform-cli'],
+  tmpnet: ['/docs/tooling/tmpnet'],
+  all: ['/docs/tooling/avalanche-cli', '/docs/tooling/platform-cli', '/docs/tooling/tmpnet'],
+};
+
+const RPC_PATH_PREFIXES: Record<(typeof RPC_CHAIN_VALUES)[number], string[]> = {
+  'p-chain': ['/docs/rpcs/p-chain'],
+  'c-chain': ['/docs/rpcs/c-chain'],
+  'x-chain': ['/docs/rpcs/x-chain'],
+  'subnet-evm': ['/docs/rpcs/subnet-evm'],
+  other: ['/docs/rpcs/other'],
+  all: ['/docs/rpcs'],
+};
+
+function getStringArg(args: Record<string, unknown>, key: string): string {
+  const value = args[key];
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function getLimit(args: Record<string, unknown>, defaultLimit = 10): number {
+  const rawLimit = args.limit;
+  const limit = typeof rawLimit === 'number' ? rawLimit : defaultLimit;
+  return Math.min(Math.max(Math.floor(limit), 1), 50);
+}
+
+function formatSearchResults(
+  query: string,
+  results: Awaited<ReturnType<typeof searchDocs>>,
+  emptyLabel = 'results'
+): string {
+  if (results.length === 0) {
+    return `No ${emptyLabel} found for "${query}"`;
+  }
+
+  const formattedResults = results
+    .map((result, index) => {
+      const citation = `https://build.avax.network${result.url}`;
+      const chunk = result.chunkIndex !== undefined ? `, chunk ${result.chunkIndex + 1}` : '';
+      const description = result.description ? `\n   ${result.description}` : '';
+      const excerpt = result.excerpt ? `\n   Match: ${result.excerpt}` : '';
+
+      return `${index + 1}. [${result.title}](${citation}) (${result.source}${chunk})${description}${excerpt}`;
+    })
+    .join('\n\n');
+
+  return `Found ${results.length} source-grounded matches for "${query}":\n\n${formattedResults}`;
+}
+
+function prependAliasNotice(result: ToolResult, canonicalName: string): ToolResult {
+  const notice = `Note: this avalanche_* tool name is kept for compatibility. Prefer \`${canonicalName}\` for new clients.\n\n`;
+  return {
+    ...result,
+    content: result.content.map((item, index) =>
+      index === 0 && item.type === 'text'
+        ? { ...item, text: `${notice}${item.text}` }
+        : item
+    ),
+  };
+}
+
+const docsSearchTool: MCPTool = {
+  name: 'docs_search',
+  description:
+    'Search body-level chunks across Avalanche documentation, academy courses, integrations, and blog posts. Returns source citations and matching excerpts.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'The search query',
+      },
+      source: {
+        type: 'string',
+        enum: SOURCE_VALUES,
+        description: 'Filter by documentation source (optional)',
+      },
+      limit: {
+        type: 'number',
+        minimum: 1,
+        maximum: 50,
+        description: 'Maximum number of chunk results (default: 10)',
+      },
+    },
+    required: ['query'],
+  },
+};
+
+const docsFetchTool: MCPTool = {
+  name: 'docs_fetch',
+  description: 'Fetch a specific documentation page as markdown',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: {
+        type: 'string',
+        description: 'The page URL path (e.g., /docs/primary-network/overview)',
+      },
+    },
+    required: ['url'],
+  },
+};
+
+const docsListSectionsTool: MCPTool = {
+  name: 'docs_list_sections',
+  description: 'List available documentation sections and their page counts',
+  inputSchema: {
+    type: 'object',
+    properties: {},
+    required: [],
+  },
+};
+
+const cliLookupTool: MCPTool = {
+  name: 'cli_lookup_command',
+  description:
+    'Look up Avalanche CLI, Platform CLI, and tmpnet command guidance in the docs. Returns cited command references and task docs.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Command, flag, or task to look up',
+      },
+      cli: {
+        type: 'string',
+        enum: CLI_VALUES,
+        description: 'CLI surface to search. Defaults to all.',
+      },
+      limit: {
+        type: 'number',
+        minimum: 1,
+        maximum: 20,
+        description: 'Maximum number of results (default: 8)',
+      },
+    },
+    required: ['query'],
+  },
+};
+
+const rpcLookupTool: MCPTool = {
+  name: 'rpc_lookup_method',
+  description:
+    'Look up Avalanche RPC methods and API guides across C-Chain, P-Chain, X-Chain, Subnet-EVM, and node RPC docs.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'RPC method, namespace, or task to look up',
+      },
+      chain: {
+        type: 'string',
+        enum: RPC_CHAIN_VALUES,
+        description: 'RPC area to search. Defaults to all.',
+      },
+      limit: {
+        type: 'number',
+        minimum: 1,
+        maximum: 20,
+        description: 'Maximum number of results (default: 8)',
+      },
+    },
+    required: ['query'],
+  },
+};
+
+const acpLookupTool: MCPTool = {
+  name: 'acp_lookup',
+  description:
+    'Look up Avalanche Community Proposals (ACPs) by number, title, or topic. When a number is provided the structured ACP record is returned (title, status, track, authors, cross-references).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'ACP title, topic, or keyword',
+      },
+      number: {
+        type: 'number',
+        description: 'ACP number, if known',
+      },
+      limit: {
+        type: 'number',
+        minimum: 1,
+        maximum: 20,
+        description: 'Maximum number of results (default: 8)',
+      },
+    },
+    required: [],
+  },
+};
+
+const acpListTool: MCPTool = {
+  name: 'acp_list',
+  description:
+    'List Avalanche Community Proposals with structured fields, optionally filtered by status (Activated, Implementable, Proposed, Stale, Withdrawn) or track (Standards, Best Practices, Meta, Subnet).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      status: {
+        type: 'string',
+        enum: [...ACP_STATUSES, 'Unknown'],
+        description: 'Filter by ACP status (case-insensitive)',
+      },
+      track: {
+        type: 'string',
+        enum: ACP_TRACKS,
+        description: 'Filter by ACP track. Matches Standards, Best Practices, Meta, or Subnet.',
+      },
+      limit: {
+        type: 'number',
+        minimum: 1,
+        maximum: 100,
+        description: 'Maximum number of ACPs to return (default: 50)',
+      },
+    },
+    required: [],
+  },
+};
 
 function validateFetchUrl(url: string): { valid: boolean; error?: string } {
   // Must start with /
@@ -26,56 +259,56 @@ function validateFetchUrl(url: string): { valid: boolean; error?: string } {
   return { valid: true };
 }
 
+function formatAcpEntry(entry: AcpEntry): string {
+  const lines = [
+    `**ACP-${entry.number}: ${entry.title}**`,
+    `Status: ${entry.status}${entry.rawStatus && entry.rawStatus !== entry.status ? ` (${entry.rawStatus})` : ''}`,
+    `Track: ${entry.tracks.join(', ') || 'Unspecified'}`,
+  ];
+  if (entry.authors.length > 0) {
+    lines.push(`Authors: ${entry.authors.join(', ')}`);
+  }
+  if (entry.replaces && entry.replaces.length > 0) {
+    lines.push(`Replaces: ${entry.replaces.map((n) => `ACP-${n}`).join(', ')}`);
+  }
+  if (entry.supersededBy && entry.supersededBy.length > 0) {
+    lines.push(`Superseded by: ${entry.supersededBy.map((n) => `ACP-${n}`).join(', ')}`);
+  }
+  if (entry.updates && entry.updates.length > 0) {
+    lines.push(`Updates: ${entry.updates.map((n) => `ACP-${n}`).join(', ')}`);
+  }
+  if (entry.updatedBy && entry.updatedBy.length > 0) {
+    lines.push(`Updated by: ${entry.updatedBy.map((n) => `ACP-${n}`).join(', ')}`);
+  }
+  lines.push(`Source: https://build.avax.network${entry.url}`);
+  if (entry.discussionUrl) lines.push(`Discussion: ${entry.discussionUrl}`);
+  return lines.join('\n');
+}
+
 export const docsTools: ToolDomain = {
   tools: [
+    docsSearchTool,
+    docsFetchTool,
+    docsListSectionsTool,
+    cliLookupTool,
+    rpcLookupTool,
+    acpLookupTool,
+    acpListTool,
     {
-      name: 'docs_search',
+      ...docsSearchTool,
+      name: 'avalanche_docs_search',
+      description: 'Compatibility alias for docs_search. Prefer docs_search for new clients.',
+    },
+    {
+      ...docsFetchTool,
+      name: 'avalanche_docs_fetch',
+      description: 'Compatibility alias for docs_fetch. Prefer docs_fetch for new clients.',
+    },
+    {
+      ...docsListSectionsTool,
+      name: 'avalanche_docs_list_sections',
       description:
-        'Search across Avalanche documentation, academy courses, integrations, and blog posts',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          query: {
-            type: 'string',
-            description: 'The search query',
-          },
-          source: {
-            type: 'string',
-            enum: ['docs', 'academy', 'integrations', 'blog'],
-            description: 'Filter by documentation source (optional)',
-          },
-          limit: {
-            type: 'number',
-            minimum: 1,
-            maximum: 50,
-            description: 'Maximum number of results (default: 10)',
-          },
-        },
-        required: ['query'],
-      },
-    },
-    {
-      name: 'docs_fetch',
-      description: 'Fetch a specific documentation page as markdown',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          url: {
-            type: 'string',
-            description: 'The page URL path (e.g., /docs/primary-network/overview)',
-          },
-        },
-        required: ['url'],
-      },
-    },
-    {
-      name: 'docs_list_sections',
-      description: 'List available documentation sections and their page counts',
-      inputSchema: {
-        type: 'object',
-        properties: {},
-        required: [],
-      },
+        'Compatibility alias for docs_list_sections. Prefer docs_list_sections for new clients.',
     },
   ],
 
@@ -83,9 +316,11 @@ export const docsTools: ToolDomain = {
     docs_search: async (args): Promise<ToolResult> => {
       const startTime = Date.now();
 
-      const query = typeof args.query === 'string' ? args.query : '';
-      const source = typeof args.source === 'string' ? args.source : undefined;
-      const limit = typeof args.limit === 'number' ? args.limit : undefined;
+      const query = getStringArg(args, 'query');
+      const source = SOURCE_VALUES.includes(args.source as (typeof SOURCE_VALUES)[number])
+        ? (args.source as string)
+        : undefined;
+      const limit = getLimit(args);
 
       if (!query) {
         return {
@@ -94,7 +329,7 @@ export const docsTools: ToolDomain = {
         };
       }
 
-      const results = searchDocs(query, { source, limit });
+      const results = await searchDocs(query, { source, limit });
       const latencyMs = Date.now() - startTime;
 
       captureMCPEvent('mcp_search', {
@@ -104,24 +339,11 @@ export const docsTools: ToolDomain = {
         latency_ms: latencyMs,
       });
 
-      if (results.length === 0) {
-        return {
-          content: [{ type: 'text', text: `No results found for "${query}"` }],
-        };
-      }
-
-      const formattedResults = results
-        .map(
-          (r) =>
-            `- [${r.title}](https://build.avax.network${r.url}) (${r.source})${r.description ? `\n  ${r.description}` : ''}`
-        )
-        .join('\n');
-
       return {
         content: [
           {
             type: 'text',
-            text: `Found ${results.length} results for "${query}":\n\n${formattedResults}`,
+            text: formatSearchResults(query, results),
           },
         ],
       };
@@ -130,7 +352,14 @@ export const docsTools: ToolDomain = {
     docs_fetch: async (args): Promise<ToolResult> => {
       const startTime = Date.now();
 
-      const url = args.url as string;
+      const url = getStringArg(args, 'url');
+
+      if (!url) {
+        return {
+          content: [{ type: 'text', text: 'Error: url parameter is required' }],
+          isError: true,
+        };
+      }
 
       const validation = validateFetchUrl(url);
       if (!validation.valid) {
@@ -214,6 +443,159 @@ export const docsTools: ToolDomain = {
       return {
         content: [{ type: 'text', text }],
       };
+    },
+
+    cli_lookup_command: async (args): Promise<ToolResult> => {
+      const query = getStringArg(args, 'query');
+      const cli = CLI_VALUES.includes(args.cli as (typeof CLI_VALUES)[number])
+        ? (args.cli as (typeof CLI_VALUES)[number])
+        : 'all';
+
+      if (!query) {
+        return {
+          content: [{ type: 'text', text: 'Error: query parameter is required' }],
+          isError: true,
+        };
+      }
+
+      const results = await searchDocs(query, {
+        source: 'docs',
+        limit: getLimit(args, 8),
+        pathPrefixes: CLI_PATH_PREFIXES[cli],
+      });
+
+      return {
+        content: [{ type: 'text', text: formatSearchResults(query, results, 'CLI results') }],
+      };
+    },
+
+    rpc_lookup_method: async (args): Promise<ToolResult> => {
+      const query = getStringArg(args, 'query');
+      const chain = RPC_CHAIN_VALUES.includes(args.chain as (typeof RPC_CHAIN_VALUES)[number])
+        ? (args.chain as (typeof RPC_CHAIN_VALUES)[number])
+        : 'all';
+
+      if (!query) {
+        return {
+          content: [{ type: 'text', text: 'Error: query parameter is required' }],
+          isError: true,
+        };
+      }
+
+      const results = await searchDocs(query, {
+        source: 'docs',
+        limit: getLimit(args, 8),
+        pathPrefixes: RPC_PATH_PREFIXES[chain],
+      });
+
+      return {
+        content: [{ type: 'text', text: formatSearchResults(query, results, 'RPC results') }],
+      };
+    },
+
+    acp_lookup: async (args): Promise<ToolResult> => {
+      const query = getStringArg(args, 'query');
+      const numericInput =
+        typeof args.number === 'number'
+          ? Math.floor(args.number)
+          : Number.parseInt(getStringArg(args, 'number'), 10);
+
+      const hasNumber = Number.isFinite(numericInput) && numericInput > 0;
+      const numberLabel = hasNumber ? String(numericInput) : '';
+      const searchQuery = [numberLabel ? `ACP ${numberLabel}` : '', query]
+        .filter(Boolean)
+        .join(' ')
+        .trim();
+
+      if (!searchQuery) {
+        return {
+          content: [{ type: 'text', text: 'Error: query or number parameter is required' }],
+          isError: true,
+        };
+      }
+
+      const sections: string[] = [];
+
+      if (hasNumber) {
+        try {
+          const entry = await findAcpByNumber(numericInput);
+          if (entry) sections.push(formatAcpEntry(entry));
+        } catch (error) {
+          console.error('[acp_lookup] structured lookup failed', error);
+        }
+      }
+
+      const results = await searchDocs(searchQuery, {
+        source: 'docs',
+        limit: getLimit(args, 8),
+        pathPrefixes: ['/docs/acps'],
+      });
+
+      sections.push(formatSearchResults(searchQuery, results, 'ACP results'));
+
+      return {
+        content: [{ type: 'text', text: sections.join('\n\n') }],
+      };
+    },
+
+    acp_list: async (args): Promise<ToolResult> => {
+      const status = getStringArg(args, 'status') || undefined;
+      const track = getStringArg(args, 'track') || undefined;
+      const limit =
+        typeof args.limit === 'number' && args.limit > 0
+          ? Math.min(Math.floor(args.limit), 100)
+          : 50;
+
+      try {
+        const entries = await listAcps({ status, track, limit });
+        if (entries.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `No ACPs match the requested filters (status=${status || 'any'}, track=${track || 'any'}).`,
+              },
+            ],
+          };
+        }
+
+        const text = [
+          `Found ${entries.length} ACPs (status=${status || 'any'}, track=${track || 'any'}):`,
+          '',
+          ...entries.map(
+            (entry) =>
+              `- ACP-${entry.number} | ${entry.status} | ${entry.tracks.join('/') || 'No track'} - ${entry.title} (https://build.avax.network${entry.url})`
+          ),
+        ].join('\n');
+
+        return { content: [{ type: 'text', text }] };
+      } catch (error) {
+        console.error('[acp_list] registry load failed', error);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error: failed to load ACP registry - ${error instanceof Error ? error.message : 'unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+
+    avalanche_docs_search: async (args): Promise<ToolResult> => {
+      const result = await docsTools.handlers.docs_search(args);
+      return prependAliasNotice(result, 'docs_search');
+    },
+
+    avalanche_docs_fetch: async (args): Promise<ToolResult> => {
+      const result = await docsTools.handlers.docs_fetch(args);
+      return prependAliasNotice(result, 'docs_fetch');
+    },
+
+    avalanche_docs_list_sections: async (args): Promise<ToolResult> => {
+      const result = await docsTools.handlers.docs_list_sections(args);
+      return prependAliasNotice(result, 'docs_list_sections');
     },
   },
 };

--- a/lib/mcp/tools/github.ts
+++ b/lib/mcp/tools/github.ts
@@ -138,9 +138,14 @@ function buildSearchQuery(rawQuery: string): string {
   return sanitized.length > MAX_USER_QUERY_CHARS ? sanitized.slice(0, MAX_USER_QUERY_CHARS) : sanitized;
 }
 
-function buildGithubHeaders(): HeadersInit {
+function buildGithubHeaders(options: { textMatch?: boolean } = {}): HeadersInit {
+  // The text-match media type is only useful on /search/code — it tells GitHub to populate
+  // the `text_matches` array with code-context fragments. Without it, the fragments we map
+  // over in searchSingleRepo are always empty.
   const headers: HeadersInit = {
-    Accept: 'application/vnd.github.v3+json',
+    Accept: options.textMatch
+      ? 'application/vnd.github.v3.text-match+json'
+      : 'application/vnd.github.v3+json',
     'User-Agent': 'Avalanche-Builders-Hub',
   };
   const token = process.env.GITHUB_TOKEN;
@@ -194,7 +199,7 @@ async function searchSingleRepo(
   url.searchParams.set('q', searchQuery);
   url.searchParams.set('per_page', String(perPage));
 
-  const response = await fetch(url.toString(), { headers: buildGithubHeaders() });
+  const response = await fetch(url.toString(), { headers: buildGithubHeaders({ textMatch: true }) });
 
   if (!response.ok) {
     const details = await response.text().catch(() => '');

--- a/lib/mcp/tools/github.ts
+++ b/lib/mcp/tools/github.ts
@@ -1,36 +1,148 @@
 import type { ToolDomain, ToolResult } from '../types';
 
 const GITHUB_API = 'https://api.github.com';
-const ALLOWED_REPOS = ['ava-labs/avalanchego', 'ava-labs/icm-services', 'ava-labs/builders-hub'];
+const MAX_FILE_CONTENT_CHARS = 50_000;
+
+export const GITHUB_REPOSITORIES = [
+  {
+    name: 'avalanchego',
+    fullName: 'ava-labs/avalanchego',
+    description: 'AvalancheGo node, consensus, PlatformVM, AVM, networking, and core node APIs',
+  },
+  {
+    name: 'subnet-evm',
+    fullName: 'ava-labs/subnet-evm',
+    description: 'Subnet-EVM implementation, precompiles, EVM chain configuration, and VM plugin code',
+  },
+  {
+    name: 'coreth',
+    fullName: 'ava-labs/coreth',
+    description: 'C-Chain EVM implementation history and Coreth code',
+  },
+  {
+    name: 'avalanche-cli',
+    fullName: 'ava-labs/avalanche-cli',
+    description: 'Avalanche CLI commands for L1 creation, deployment, validation, and node workflows',
+  },
+  {
+    name: 'platform-cli',
+    fullName: 'ava-labs/platform-cli',
+    description: 'Platform CLI commands for P-Chain, staking, validators, keys, and transfers',
+  },
+  {
+    name: 'icm-services',
+    fullName: 'ava-labs/icm-services',
+    description: 'Interchain Messaging services, relayer code, and ICM contracts',
+  },
+  {
+    name: 'avalanche-network-runner',
+    fullName: 'ava-labs/avalanche-network-runner',
+    description: 'Local Avalanche network orchestration and test network tooling',
+  },
+  {
+    name: 'icm-contracts',
+    fullName: 'ava-labs/icm-contracts',
+    description: 'Interchain Messaging Solidity contracts (Teleporter, ICTT, registry)',
+  },
+  {
+    name: 'hypersdk',
+    fullName: 'ava-labs/hypersdk',
+    description: 'HyperSDK framework for high-performance Avalanche VMs',
+  },
+  {
+    name: 'libevm',
+    fullName: 'ava-labs/libevm',
+    description: 'libevm shared EVM library used by Avalanche VMs',
+  },
+  {
+    name: 'builders-hub',
+    fullName: 'ava-labs/builders-hub',
+    description: 'Builders Hub docs, examples, MCP server, and developer site code',
+  },
+] as const;
+
+export const GITHUB_REPO_NAMES = GITHUB_REPOSITORIES.map((repo) => repo.name);
+export const GITHUB_LANGUAGE_FILTERS = [
+  'go',
+  'solidity',
+  'typescript',
+  'javascript',
+  'python',
+  'rust',
+  'shell',
+  'markdown',
+  'yaml',
+  'json',
+  'any',
+] as const;
+
+type RepoName = (typeof GITHUB_REPO_NAMES)[number];
+type RepoSearchName = RepoName | 'all';
+type LanguageFilter = (typeof GITHUB_LANGUAGE_FILTERS)[number];
+
+const ALLOWED_REPOS = GITHUB_REPOSITORIES.map((repo) => repo.fullName);
 
 interface SearchCodeParams {
   query: string;
-  repo?: 'avalanchego' | 'icm-services' | 'builders-hub' | 'all';
-  language?: 'go' | 'solidity' | 'typescript' | 'any';
+  repo?: RepoSearchName;
+  language?: LanguageFilter;
   perPage?: number;
 }
 
 interface GetFileParams {
-  repo: 'avalanchego' | 'icm-services' | 'builders-hub';
+  repo: RepoName;
   path: string;
   ref?: string;
 }
 
+function isRepoName(repo: unknown): repo is RepoName {
+  return typeof repo === 'string' && GITHUB_REPO_NAMES.includes(repo as RepoName);
+}
+
+function getRepoFullName(repo: RepoName): string {
+  return `ava-labs/${repo}`;
+}
+
+function validateRepoPath(path: string): string | null {
+  if (!path) return 'File path is required';
+  if (path.startsWith('/')) return 'File path must be relative to the repository root';
+  if (path.includes('..')) return 'File path must not include path traversal';
+  if (path.includes('://')) return 'File path must not include a protocol';
+  return null;
+}
+
 async function searchCode(params: SearchCodeParams) {
   const { query, repo = 'all', language = 'any', perPage = 10 } = params;
+  const trimmedQuery = typeof query === 'string' ? query.trim() : '';
+
+  if (!trimmedQuery) {
+    return {
+      total_count: 0,
+      items: [],
+      error: 'Search query is required',
+    };
+  }
+
+  if (repo !== 'all' && !isRepoName(repo)) {
+    return {
+      total_count: 0,
+      items: [],
+      error: `Repository ${repo} is not in the allowed list`,
+      allowedRepos: [...GITHUB_REPO_NAMES, 'all'],
+    };
+  }
 
   // Simplify query for better GitHub API compatibility
   // Remove very long queries that cause timeouts
-  const simplifiedQuery = query.length > 100 ? query.slice(0, 100) : query;
+  const simplifiedQuery = trimmedQuery.length > 100 ? trimmedQuery.slice(0, 100) : trimmedQuery;
 
   // Build GitHub search query
   let searchQuery = simplifiedQuery;
 
   if (repo === 'all') {
-    // Search all repos
-    searchQuery = `${simplifiedQuery} repo:ava-labs/avalanchego repo:ava-labs/icm-services repo:ava-labs/builders-hub`;
+    searchQuery = `${simplifiedQuery} ${ALLOWED_REPOS.map((fullName) => `repo:${fullName}`).join(' ')}`;
   } else {
-    searchQuery = `${simplifiedQuery} repo:ava-labs/${repo}`;
+    searchQuery = `${simplifiedQuery} repo:${getRepoFullName(repo)}`;
   }
 
   if (language !== 'any') {
@@ -39,7 +151,7 @@ async function searchCode(params: SearchCodeParams) {
 
   const url = new URL(`${GITHUB_API}/search/code`);
   url.searchParams.set('q', searchQuery);
-  url.searchParams.set('per_page', String(Math.min(perPage, 5))); // Limit to 5 results to avoid timeouts
+  url.searchParams.set('per_page', String(Math.min(Math.max(perPage, 1), 10)));
 
   const headers: HeadersInit = {
     'Accept': 'application/vnd.github.v3+json',
@@ -105,17 +217,24 @@ async function searchCode(params: SearchCodeParams) {
 async function getFileContents(params: GetFileParams) {
   const { repo, path, ref = 'HEAD' } = params;
   const owner = 'ava-labs';
+  const requestedPath = typeof path === 'string' ? path : '';
 
-  // Validate repo is in allowed list
-  const fullRepo = `${owner}/${repo}`;
-  if (!ALLOWED_REPOS.includes(fullRepo)) {
+  if (!isRepoName(repo)) {
     return {
-      error: `Repository ${fullRepo} is not in the allowed list`,
-      allowedRepos: ALLOWED_REPOS
+      error: `Repository ${owner}/${String(repo)} is not in the allowed list`,
+      allowedRepos: GITHUB_REPO_NAMES
     };
   }
 
-  const url = `${GITHUB_API}/repos/${owner}/${repo}/contents/${path}?ref=${ref}`;
+  const pathError = validateRepoPath(requestedPath);
+  if (pathError) {
+    return {
+      error: pathError,
+      path: requestedPath,
+    };
+  }
+
+  const url = `${GITHUB_API}/repos/${owner}/${repo}/contents/${requestedPath}?ref=${ref}`;
 
   const headers: HeadersInit = {
     'Accept': 'application/vnd.github.v3+json',
@@ -139,7 +258,7 @@ async function getFileContents(params: GetFileParams) {
       return {
         error: 'Rate limit exceeded or file access restricted.',
         suggestion: 'Wait a moment and try again, or try a different file.',
-        path: path
+        path: requestedPath
       };
     }
     // Return error instead of throwing to avoid disrupting the AI stream
@@ -147,7 +266,7 @@ async function getFileContents(params: GetFileParams) {
     return {
       error: `GitHub API error: ${response.status}`,
       details: errorText.substring(0, 500),
-      path: path
+      path: requestedPath
     };
   }
 
@@ -155,15 +274,17 @@ async function getFileContents(params: GetFileParams) {
 
   // Decode base64 content
   if (data.content && data.encoding === 'base64') {
-    const content = atob(data.content.replace(/\n/g, ''));
+    const content = Buffer.from(data.content.replace(/\n/g, ''), 'base64').toString('utf-8');
+    const truncated = content.length > MAX_FILE_CONTENT_CHARS;
     return {
       name: data.name,
       path: data.path,
       size: data.size,
       html_url: data.html_url,
-      content: content,
-      // Truncate very large files
-      truncated: content.length > 50000,
+      content: truncated
+        ? `${content.slice(0, MAX_FILE_CONTENT_CHARS)}\n\n... [truncated at ${MAX_FILE_CONTENT_CHARS} characters]`
+        : content,
+      truncated,
     };
   }
 
@@ -174,7 +295,8 @@ export const githubTools: ToolDomain = {
   tools: [
     {
       name: 'github_search_code',
-      description: 'Search for code across Avalanche GitHub repositories (avalanchego, icm-services, builders-hub).',
+      description:
+        'Search for code across core Avalanche GitHub repositories including avalanchego, subnet-evm, coreth, libevm, avalanche-cli, platform-cli, icm-services, icm-contracts, avalanche-network-runner, hypersdk, and builders-hub.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -184,13 +306,19 @@ export const githubTools: ToolDomain = {
           },
           repo: {
             type: 'string',
-            enum: ['avalanchego', 'icm-services', 'builders-hub', 'all'],
+            enum: [...GITHUB_REPO_NAMES, 'all'],
             description: 'The repository to search in. Defaults to "all".',
           },
           language: {
             type: 'string',
-            enum: ['go', 'solidity', 'typescript', 'any'],
+            enum: GITHUB_LANGUAGE_FILTERS,
             description: 'Filter results by programming language. Defaults to "any".',
+          },
+          perPage: {
+            type: 'number',
+            minimum: 1,
+            maximum: 10,
+            description: 'Maximum number of GitHub results to return (default: 10).',
           },
         },
         required: ['query'],
@@ -204,7 +332,7 @@ export const githubTools: ToolDomain = {
         properties: {
           repo: {
             type: 'string',
-            enum: ['avalanchego', 'icm-services', 'builders-hub'],
+            enum: GITHUB_REPO_NAMES,
             description: 'The repository to fetch the file from (owner is always ava-labs).',
           },
           path: {
@@ -219,6 +347,15 @@ export const githubTools: ToolDomain = {
         required: ['repo', 'path'],
       },
     },
+    {
+      name: 'github_list_repositories',
+      description: 'List the Avalanche GitHub repositories covered by github_search_code and github_get_file.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
   ],
   handlers: {
     github_search_code: async (args): Promise<ToolResult> => {
@@ -227,6 +364,7 @@ export const githubTools: ToolDomain = {
           query: args.query as string,
           repo: args.repo as SearchCodeParams['repo'],
           language: args.language as SearchCodeParams['language'],
+          perPage: typeof args.perPage === 'number' ? args.perPage : undefined,
         });
         return {
           content: [{ type: 'text', text: JSON.stringify(result) }],
@@ -257,5 +395,8 @@ export const githubTools: ToolDomain = {
         };
       }
     },
+    github_list_repositories: async (_args): Promise<ToolResult> => ({
+      content: [{ type: 'text', text: JSON.stringify({ repositories: GITHUB_REPOSITORIES }) }],
+    }),
   },
 };

--- a/lib/mcp/tools/github.ts
+++ b/lib/mcp/tools/github.ts
@@ -2,6 +2,13 @@ import type { ToolDomain, ToolResult } from '../types';
 
 const GITHUB_API = 'https://api.github.com';
 const MAX_FILE_CONTENT_CHARS = 50_000;
+const MAX_USER_QUERY_CHARS = 100;
+const MAX_PATH_CHARS = 512;
+// Conservative subset of valid git refs: branches, tags, SHAs (e.g. "main", "v1.2.3", "feat/foo", "abc123def").
+// Disallows whitespace, ?, &, #, %, NUL, and anything else that could change request semantics.
+const REF_REGEX = /^[A-Za-z0-9._/\-]{1,200}$/;
+// Strip GitHub search qualifiers a user might inject (repo:, org:, user:, in:, path:, etc.) — we'll add our own.
+const QUALIFIER_REGEX = /\b(repo|org|user|in|path|filename|extension|language|fork|size|stars|forks|created|pushed|topic|topics|archived|mirror|is):\S*/gi;
 
 export const GITHUB_REPOSITORIES = [
   {
@@ -105,10 +112,112 @@ function getRepoFullName(repo: RepoName): string {
 
 function validateRepoPath(path: string): string | null {
   if (!path) return 'File path is required';
-  if (path.startsWith('/')) return 'File path must be relative to the repository root';
-  if (path.includes('..')) return 'File path must not include path traversal';
-  if (path.includes('://')) return 'File path must not include a protocol';
+  if (path.length > MAX_PATH_CHARS) return `File path exceeds ${MAX_PATH_CHARS} characters`;
+
+  // Decode once to catch percent-encoded traversal attempts.
+  let decoded = path;
+  try {
+    decoded = decodeURIComponent(path);
+  } catch {
+    return 'File path contains invalid percent-encoded characters';
+  }
+
+  if (decoded.startsWith('/')) return 'File path must be relative to the repository root';
+  if (decoded.includes('..')) return 'File path must not include path traversal';
+  if (decoded.includes('://')) return 'File path must not include a protocol';
+  if (decoded.includes('\\')) return 'File path must use forward slashes';
+  if (/^[A-Za-z]:/.test(decoded)) return 'File path must not be an absolute Windows path';
+  if (/[\x00-\x1f]/.test(decoded)) return 'File path must not contain control characters';
   return null;
+}
+
+function buildSearchQuery(rawQuery: string): string {
+  // Strip qualifier-style tokens to prevent users from broadening the search scope to repos
+  // outside the allowlist (the server-side GITHUB_TOKEN could otherwise expose private content).
+  const sanitized = rawQuery.replace(QUALIFIER_REGEX, ' ').replace(/\s+/g, ' ').trim();
+  return sanitized.length > MAX_USER_QUERY_CHARS ? sanitized.slice(0, MAX_USER_QUERY_CHARS) : sanitized;
+}
+
+function buildGithubHeaders(): HeadersInit {
+  const headers: HeadersInit = {
+    Accept: 'application/vnd.github.v3+json',
+    'User-Agent': 'Avalanche-Builders-Hub',
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+
+interface GithubSearchItem {
+  name: string;
+  path: string;
+  repository: { full_name: string };
+  html_url: string;
+  text_matches?: Array<{ fragment?: string }>;
+  score?: number;
+}
+
+interface GithubSearchResponse {
+  total_count?: number;
+  items?: GithubSearchItem[];
+}
+
+interface SingleRepoSearchOk {
+  ok: true;
+  total_count: number;
+  items: Array<{
+    name: string;
+    path: string;
+    repository: string;
+    html_url: string;
+    text_matches?: Array<{ fragment?: string }>;
+    score?: number;
+  }>;
+}
+
+interface SingleRepoSearchErr {
+  ok: false;
+  status: number;
+  details: string;
+}
+
+async function searchSingleRepo(
+  sanitizedQuery: string,
+  repoFullName: string,
+  language: LanguageFilter,
+  perPage: number
+): Promise<SingleRepoSearchOk | SingleRepoSearchErr> {
+  let searchQuery = `${sanitizedQuery} repo:${repoFullName}`;
+  if (language !== 'any') searchQuery += ` language:${language}`;
+
+  const url = new URL(`${GITHUB_API}/search/code`);
+  url.searchParams.set('q', searchQuery);
+  url.searchParams.set('per_page', String(perPage));
+
+  const response = await fetch(url.toString(), { headers: buildGithubHeaders() });
+
+  if (!response.ok) {
+    const details = await response.text().catch(() => '');
+    return { ok: false, status: response.status, details: details.slice(0, 500) };
+  }
+
+  const data = (await response.json()) as GithubSearchResponse;
+  const items = Array.isArray(data.items) ? data.items : [];
+
+  return {
+    ok: true,
+    total_count: typeof data.total_count === 'number' ? data.total_count : items.length,
+    items: items
+      .filter((item): item is GithubSearchItem => !!item && !!item.repository?.full_name)
+      .map((item) => ({
+        name: item.name,
+        path: item.path,
+        repository: item.repository.full_name,
+        html_url: item.html_url,
+        text_matches: item.text_matches?.map((m) => ({ fragment: m.fragment })),
+        score: typeof item.score === 'number' ? item.score : undefined,
+      })),
+  };
 }
 
 async function searchCode(params: SearchCodeParams) {
@@ -132,85 +241,83 @@ async function searchCode(params: SearchCodeParams) {
     };
   }
 
-  // Simplify query for better GitHub API compatibility
-  // Remove very long queries that cause timeouts
-  const simplifiedQuery = trimmedQuery.length > 100 ? trimmedQuery.slice(0, 100) : trimmedQuery;
-
-  // Build GitHub search query
-  let searchQuery = simplifiedQuery;
-
-  if (repo === 'all') {
-    searchQuery = `${simplifiedQuery} ${ALLOWED_REPOS.map((fullName) => `repo:${fullName}`).join(' ')}`;
-  } else {
-    searchQuery = `${simplifiedQuery} repo:${getRepoFullName(repo)}`;
-  }
-
-  if (language !== 'any') {
-    searchQuery += ` language:${language}`;
-  }
-
-  const url = new URL(`${GITHUB_API}/search/code`);
-  url.searchParams.set('q', searchQuery);
-  url.searchParams.set('per_page', String(Math.min(Math.max(perPage, 1), 10)));
-
-  const headers: HeadersInit = {
-    'Accept': 'application/vnd.github.v3+json',
-    'User-Agent': 'Avalanche-Builders-Hub',
-  };
-
-  // Add auth token if available for higher rate limits
-  const token = process.env.GITHUB_TOKEN;
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
-
-  const response = await fetch(url.toString(), { headers });
-
-  if (!response.ok) {
-    const error = await response.text();
-    console.error('GitHub search error:', response.status, error);
-
-    // Return helpful error info instead of throwing
-    if (response.status === 408) {
-      return {
-        total_count: 0,
-        items: [],
-        error: 'Search timed out. Try a simpler query with fewer keywords.',
-        suggestion: 'Use specific function or type names instead of long phrases.'
-      };
-    }
-    if (response.status === 403) {
-      return {
-        total_count: 0,
-        items: [],
-        error: 'Rate limit exceeded. Please wait a moment before searching again.',
-        suggestion: 'GitHub allows ~30 searches per minute for authenticated users.'
-      };
-    }
-    // Return error instead of throwing to avoid disrupting the AI stream
+  const sanitizedQuery = buildSearchQuery(trimmedQuery);
+  if (!sanitizedQuery) {
     return {
       total_count: 0,
       items: [],
-      error: `GitHub API error: ${response.status}`,
-      details: error.substring(0, 500)
+      error: 'Search query was empty after sanitization (qualifier tokens are stripped automatically)',
     };
   }
 
-  const data = await response.json();
+  const clampedPerPage = Math.min(Math.max(perPage, 1), 10);
 
-  // Format results for the chat
+  // Single-repo search: one round-trip.
+  if (repo !== 'all') {
+    const result = await searchSingleRepo(sanitizedQuery, getRepoFullName(repo), language, clampedPerPage);
+    if (!result.ok) {
+      console.error('GitHub search error:', result.status, result.details);
+      return mapGithubError(result.status, result.details);
+    }
+    return { total_count: result.total_count, items: result.items };
+  }
+
+  // Multi-repo "all": fan out in parallel, then merge.
+  // (Each `repo:` qualifier costs 14-38 chars; combining all 11 into one query exceeds GitHub's 256-char q limit.)
+  const results = await Promise.all(
+    ALLOWED_REPOS.map((fullName) => searchSingleRepo(sanitizedQuery, fullName, language, clampedPerPage))
+  );
+
+  const okResults = results.filter((r): r is SingleRepoSearchOk => r.ok);
+  if (okResults.length === 0) {
+    const firstErr = results.find((r): r is SingleRepoSearchErr => !r.ok);
+    if (firstErr) {
+      console.error('GitHub search error (all repos failed):', firstErr.status, firstErr.details);
+      return mapGithubError(firstErr.status, firstErr.details);
+    }
+    return { total_count: 0, items: [] };
+  }
+
+  // Merge: total_count is the sum, items sorted by score desc and capped to perPage.
+  const totalCount = okResults.reduce((sum, r) => sum + r.total_count, 0);
+  const merged = okResults.flatMap((r) => r.items);
+  merged.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+
   return {
-    total_count: data.total_count,
-    items: data.items.map((item: any) => ({
-      name: item.name,
-      path: item.path,
-      repository: item.repository.full_name,
-      html_url: item.html_url,
-      // Include a snippet of the match context if available
-      text_matches: item.text_matches?.map((match: any) => ({
-        fragment: match.fragment,
-      })),
-    })),
+    total_count: totalCount,
+    items: merged.slice(0, clampedPerPage),
+  };
+}
+
+function mapGithubError(status: number, details: string) {
+  if (status === 408) {
+    return {
+      total_count: 0,
+      items: [],
+      error: 'Search timed out. Try a simpler query with fewer keywords.',
+      suggestion: 'Use specific function or type names instead of long phrases.',
+    };
+  }
+  if (status === 403) {
+    return {
+      total_count: 0,
+      items: [],
+      error: 'Rate limit exceeded. Please wait a moment before searching again.',
+      suggestion: 'GitHub allows ~30 searches per minute for authenticated users.',
+    };
+  }
+  if (status === 422) {
+    return {
+      total_count: 0,
+      items: [],
+      error: 'Query was rejected by GitHub (likely too long or malformed).',
+      suggestion: 'Use a shorter query with specific symbol or function names.',
+    };
+  }
+  return {
+    total_count: 0,
+    items: [],
+    error: `GitHub API error: ${status}`,
   };
 }
 
@@ -218,6 +325,7 @@ async function getFileContents(params: GetFileParams) {
   const { repo, path, ref = 'HEAD' } = params;
   const owner = 'ava-labs';
   const requestedPath = typeof path === 'string' ? path : '';
+  const requestedRef = typeof ref === 'string' ? ref.trim() : 'HEAD';
 
   if (!isRepoName(repo)) {
     return {
@@ -234,18 +342,23 @@ async function getFileContents(params: GetFileParams) {
     };
   }
 
-  const url = `${GITHUB_API}/repos/${owner}/${repo}/contents/${requestedPath}?ref=${ref}`;
-
-  const headers: HeadersInit = {
-    'Accept': 'application/vnd.github.v3+json',
-    'User-Agent': 'Avalanche-Builders-Hub',
-  };
-
-  if (process.env.GITHUB_TOKEN) {
-    headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+  if (!REF_REGEX.test(requestedRef)) {
+    return {
+      error: 'Ref must be a valid git ref (alphanumerics, dot, underscore, slash, dash; max 200 chars)',
+      ref: requestedRef,
+    };
   }
 
-  const response = await fetch(url, { headers });
+  // Encode each path segment but preserve `/` as a separator (GitHub contents API expects path segments).
+  const encodedPath = requestedPath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+
+  const url = new URL(`${GITHUB_API}/repos/${owner}/${repo}/contents/${encodedPath}`);
+  url.searchParams.set('ref', requestedRef);
+
+  const response = await fetch(url.toString(), { headers: buildGithubHeaders() });
 
   if (!response.ok) {
     if (response.status === 404) {

--- a/public/mcp-manifest.json
+++ b/public/mcp-manifest.json
@@ -1,48 +1,213 @@
 {
-  "name": "avalanche-docs",
-  "version": "1.0.0",
-  "description": "MCP server for Avalanche documentation - search and retrieve docs, academy courses, integrations, and blog posts",
+  "name": "avalanche-mcp",
+  "version": "2.1.0",
+  "description": "Unified read-only MCP server for Avalanche docs, CLI/RPC/ACP lookup, code search, public blockchain lookups, P-Chain RPCs, and Info API calls.",
   "endpoint": "https://build.avax.network/api/mcp",
   "protocol": "mcp/http",
-  "categories": ["documentation", "blockchain", "developer-tools"],
+  "readOnly": true,
+  "categories": ["documentation", "blockchain", "developer-tools", "code-search"],
+  "capabilities": {
+    "tools": true,
+    "resources": true,
+    "streamableHttp": true
+  },
+  "canonicalTooling": {
+    "preferredDocsTools": ["docs_search", "docs_fetch", "docs_list_sections"],
+    "compatibilityAliases": [
+      "avalanche_docs_search",
+      "avalanche_docs_fetch",
+      "avalanche_docs_list_sections"
+    ]
+  },
+  "repositoryCoverage": [
+    "ava-labs/avalanchego",
+    "ava-labs/subnet-evm",
+    "ava-labs/coreth",
+    "ava-labs/avalanche-cli",
+    "ava-labs/platform-cli",
+    "ava-labs/icm-services",
+    "ava-labs/avalanche-network-runner",
+    "ava-labs/icm-contracts",
+    "ava-labs/hypersdk",
+    "ava-labs/libevm",
+    "ava-labs/builders-hub"
+  ],
   "tools": [
     {
+      "name": "docs_search",
+      "description": "Search body-level chunks across Avalanche docs, academy, integrations, and blog posts with citations and matching excerpts."
+    },
+    {
+      "name": "docs_fetch",
+      "description": "Fetch a specific documentation page as markdown by internal URL path."
+    },
+    {
+      "name": "docs_list_sections",
+      "description": "List available documentation sections and page counts."
+    },
+    {
+      "name": "cli_lookup_command",
+      "description": "Search Avalanche CLI, Platform CLI, and tmpnet docs for commands, flags, and task guidance."
+    },
+    {
+      "name": "rpc_lookup_method",
+      "description": "Search Avalanche RPC method docs across C-Chain, P-Chain, X-Chain, Subnet-EVM, and node APIs."
+    },
+    {
+      "name": "acp_lookup",
+      "description": "Search Avalanche Community Proposals by number, title, or topic."
+    },
+    {
+      "name": "acp_list",
+      "description": "List Avalanche Community Proposals with structured fields and optional status or track filters."
+    },
+    {
       "name": "avalanche_docs_search",
-      "description": "Search across Avalanche documentation, academy courses, integrations, and blog posts",
-      "parameters": {
-        "query": {
-          "type": "string",
-          "description": "The search query",
-          "required": true
-        },
-        "source": {
-          "type": "string",
-          "enum": ["docs", "academy", "integrations", "blog"],
-          "description": "Filter by documentation source (optional)"
-        },
-        "limit": {
-          "type": "number",
-          "minimum": 1,
-          "maximum": 50,
-          "description": "Maximum number of results (default: 10)"
-        }
-      }
+      "description": "Compatibility alias for docs_search."
     },
     {
       "name": "avalanche_docs_fetch",
-      "description": "Fetch a specific documentation page as markdown",
-      "parameters": {
-        "url": {
-          "type": "string",
-          "description": "The page URL path (e.g., /docs/primary-network/overview)",
-          "required": true
-        }
-      }
+      "description": "Compatibility alias for docs_fetch."
     },
     {
       "name": "avalanche_docs_list_sections",
-      "description": "List available documentation sections and their page counts",
-      "parameters": {}
+      "description": "Compatibility alias for docs_list_sections."
+    },
+    {
+      "name": "github_search_code",
+      "description": "Search code across core Avalanche repositories."
+    },
+    {
+      "name": "github_get_file",
+      "description": "Fetch a file from an allowed Avalanche GitHub repository."
+    },
+    {
+      "name": "github_list_repositories",
+      "description": "List GitHub repositories covered by the MCP GitHub tools."
+    },
+    {
+      "name": "blockchain_get_native_balance",
+      "description": "Get native AVAX balance for an EVM address."
+    },
+    {
+      "name": "blockchain_get_contract_info",
+      "description": "Inspect whether an EVM address is a contract and identify common token metadata."
+    },
+    {
+      "name": "blockchain_lookup_transaction",
+      "description": "Look up Avalanche transactions and parse common P-Chain/X-Chain transaction types."
+    },
+    {
+      "name": "blockchain_lookup_address",
+      "description": "Look up EVM or P-Chain address details."
+    },
+    {
+      "name": "blockchain_lookup_subnet",
+      "description": "Look up subnet details."
+    },
+    {
+      "name": "blockchain_lookup_chain",
+      "description": "Look up blockchain details."
+    },
+    {
+      "name": "blockchain_lookup_validator",
+      "description": "Look up validator details."
+    },
+    {
+      "name": "platform_get_height",
+      "description": "Get the current P-Chain block height."
+    },
+    {
+      "name": "platform_get_block",
+      "description": "Get a P-Chain block by block ID."
+    },
+    {
+      "name": "platform_get_block_by_height",
+      "description": "Get a P-Chain block by height."
+    },
+    {
+      "name": "platform_get_blockchains",
+      "description": "Get blockchains registered on the P-Chain."
+    },
+    {
+      "name": "platform_get_subnets",
+      "description": "Get subnet information."
+    },
+    {
+      "name": "platform_get_current_validators",
+      "description": "Get current validators for the Primary Network or a subnet."
+    },
+    {
+      "name": "platform_get_pending_validators",
+      "description": "Get pending validators for the Primary Network or a subnet."
+    },
+    {
+      "name": "platform_get_staking_asset_id",
+      "description": "Get the staking asset ID for a subnet."
+    },
+    {
+      "name": "platform_get_min_stake",
+      "description": "Get minimum validator and delegator stake amounts."
+    },
+    {
+      "name": "platform_get_total_stake",
+      "description": "Get total stake on a subnet."
+    },
+    {
+      "name": "platform_get_balance",
+      "description": "Get P-Chain address balances."
+    },
+    {
+      "name": "platform_get_utxos",
+      "description": "Get P-Chain UTXOs."
+    },
+    {
+      "name": "platform_get_tx",
+      "description": "Get a P-Chain transaction."
+    },
+    {
+      "name": "platform_get_tx_status",
+      "description": "Get P-Chain transaction status."
+    },
+    {
+      "name": "platform_get_current_supply",
+      "description": "Get current AVAX supply from the P-Chain."
+    },
+    {
+      "name": "platform_get_validators_at",
+      "description": "Get validators at a historical P-Chain height."
+    },
+    {
+      "name": "info_get_node_version",
+      "description": "Get Avalanche node version and compatibility information."
+    },
+    {
+      "name": "info_get_network_id",
+      "description": "Get the numeric Avalanche network ID."
+    },
+    {
+      "name": "info_get_network_name",
+      "description": "Get the Avalanche network name."
+    },
+    {
+      "name": "info_get_blockchain_id",
+      "description": "Resolve a blockchain alias to a blockchain ID."
+    },
+    {
+      "name": "info_is_bootstrapped",
+      "description": "Check whether a chain is bootstrapped."
+    },
+    {
+      "name": "info_get_tx_fee",
+      "description": "Get current Avalanche transaction fees."
+    },
+    {
+      "name": "info_peers",
+      "description": "List node peers."
+    },
+    {
+      "name": "info_acps",
+      "description": "Get live ACP voting/status information from the Info API."
     }
   ],
   "resources": [
@@ -63,8 +228,33 @@
       "name": "Integrations Index",
       "description": "Index of all Avalanche integrations",
       "mimeType": "text/markdown"
+    },
+    {
+      "uri": "blog://index",
+      "name": "Blog Index",
+      "description": "Index of all Avalanche Builders Hub blog posts",
+      "mimeType": "text/markdown"
+    },
+    {
+      "uri": "rpcs://index",
+      "name": "RPC Documentation Index",
+      "description": "Index of Avalanche RPC method and API documentation",
+      "mimeType": "text/markdown"
+    },
+    {
+      "uri": "cli://index",
+      "name": "CLI Documentation Index",
+      "description": "Index of Avalanche CLI, Platform CLI, and tmpnet documentation",
+      "mimeType": "text/markdown"
+    },
+    {
+      "uri": "acps://index",
+      "name": "ACP Index",
+      "description": "Index of Avalanche Community Proposal documentation",
+      "mimeType": "text/markdown"
     }
   ],
-  "homepage": "https://build.avax.network/docs/tooling/ai-llm",
-  "repository": "https://github.com/ava-labs/builders-hub"
+  "homepage": "https://build.avax.network/docs/tooling/ai-llm/mcp-server",
+  "repository": "https://github.com/ava-labs/builders-hub",
+  "roadmapIssue": "https://github.com/ava-labs/builders-hub/issues/4070"
 }

--- a/tests/unit/mcp/acps/parser.test.ts
+++ b/tests/unit/mcp/acps/parser.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseAcpDocument, normalizeStatus, normalizeTracks } from '@/lib/mcp/acps/parser';
+
+const acp103 = `---
+title: "ACP-103: Dynamic Fees"
+description: "Details for Avalanche Community Proposal 103: Dynamic Fees"
+edit_url: https://github.com/avalanche-foundation/ACPs/edit/main/ACPs/103-dynamic-fees/README.md
+---
+
+| ACP | 103 |
+| :--- | :--- |
+| **Title** | Add Dynamic Fees to the P-Chain |
+| **Author(s)** | Dhruba Basu ([@dhrubabasu](https://github.com/dhrubabasu)), Alberto Benegiamo ([@abi87](https://github.com/abi87)) |
+| **Status** | Activated ([Discussion](https://github.com/avalanche-foundation/ACPs/discussions/104)) |
+| **Track** | Standards |
+
+## Abstract
+
+Introduce a dynamic fee mechanism to the P-Chain.
+`;
+
+const acp13 = `---
+title: "ACP-13: Subnet Only Validators"
+---
+
+| ACP | 13 |
+| :--- | :--- |
+| **Title** | Subnet-Only Validators (SOVs) |
+| **Author(s)** | Patrick O'Grady |
+| **Status** | Stale |
+| **Track** | Standards |
+| **Superseded-By** | [ACP-77](https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/77-reinventing-subnets/README.md) |
+`;
+
+const acp131 = `---
+title: "ACP-131: Cancun Eips"
+---
+
+| ACP | 131 |
+| :--- | :--- |
+| **Title** | Activate Cancun EIPs on C-Chain and Subnet-EVM chains |
+| **Author(s)** | Darioush Jalali |
+| **Status** | Activated ([Discussion](https://github.com/avalanche-foundation/ACPs/discussions/139)) |
+| **Track** | Standards, Subnet |
+`;
+
+const acp77 = `---
+title: "ACP-77: Reinventing Subnets"
+---
+
+| ACP           | 77                                                                                        |
+| :------------ | :---------------------------------------------------------------------------------------- |
+| **Title**     | Reinventing Subnets                                                                       |
+| **Author(s)** | Dhruba Basu ([@dhrubabasu](https://github.com/dhrubabasu))                                |
+| **Status**    | Activated                                                                                 |
+| **Track**     | Standards                                                                                 |
+| **Replaces**  | [ACP-13](https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/13-subnet-only-validators/README.md)                                          |
+`;
+
+describe('parseAcpDocument', () => {
+  it('extracts number, title, status, track, and authors from ACP-103', () => {
+    const parsed = parseAcpDocument(acp103, '/docs/acps/103-dynamic-fees');
+
+    expect(parsed.number).toBe(103);
+    expect(parsed.title).toBe('Add Dynamic Fees to the P-Chain');
+    expect(parsed.status).toBe('Activated');
+    expect(parsed.tracks).toEqual(['Standards']);
+    expect(parsed.authors).toContain('Dhruba Basu');
+    expect(parsed.authors).toContain('Alberto Benegiamo');
+    expect(parsed.url).toBe('/docs/acps/103-dynamic-fees');
+  });
+
+  it('extracts the Superseded-By reference for ACP-13', () => {
+    const parsed = parseAcpDocument(acp13, '/docs/acps/13-subnet-only-validators');
+
+    expect(parsed.number).toBe(13);
+    expect(parsed.status).toBe('Stale');
+    expect(parsed.supersededBy).toEqual([77]);
+  });
+
+  it('extracts the Replaces reference for ACP-77', () => {
+    const parsed = parseAcpDocument(acp77, '/docs/acps/77-reinventing-subnets');
+
+    expect(parsed.number).toBe(77);
+    expect(parsed.replaces).toEqual([13]);
+    expect(parsed.tracks).toEqual(['Standards']);
+  });
+
+  it('splits comma-separated tracks for ACP-131', () => {
+    const parsed = parseAcpDocument(acp131, '/docs/acps/131-cancun-eips');
+
+    expect(parsed.tracks).toEqual(['Standards', 'Subnet']);
+  });
+
+  it('falls back to URL when number cannot be parsed from the table', () => {
+    const incomplete = `---\ntitle: "ACP-256: Hardware"\n---\n\nNo table here.`;
+    const parsed = parseAcpDocument(incomplete, '/docs/acps/256-hardware-recommendations');
+
+    expect(parsed.number).toBe(256);
+    expect(parsed.title).toBe('Hardware');
+    expect(parsed.status).toBe('Unknown');
+  });
+});
+
+describe('normalizeStatus', () => {
+  it('maps known status keywords case-insensitively', () => {
+    expect(normalizeStatus('Activated ([Discussion](url))')).toBe('Activated');
+    expect(normalizeStatus('proposed')).toBe('Proposed');
+    expect(normalizeStatus('IMPLEMENTABLE')).toBe('Implementable');
+    expect(normalizeStatus('  stale  ')).toBe('Stale');
+    expect(normalizeStatus('withdrawn')).toBe('Withdrawn');
+  });
+
+  it('returns Unknown for unrecognized values', () => {
+    expect(normalizeStatus('')).toBe('Unknown');
+    expect(normalizeStatus('something else')).toBe('Unknown');
+  });
+});
+
+describe('normalizeTracks', () => {
+  it('splits and trims comma-separated tracks', () => {
+    expect(normalizeTracks('Standards, Subnet')).toEqual(['Standards', 'Subnet']);
+    expect(normalizeTracks('Best Practices Track')).toEqual(['Best Practices']);
+    expect(normalizeTracks('Meta')).toEqual(['Meta']);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(normalizeTracks('')).toEqual([]);
+  });
+});

--- a/tests/unit/mcp/acps/parser.test.ts
+++ b/tests/unit/mcp/acps/parser.test.ts
@@ -58,9 +58,15 @@ title: "ACP-77: Reinventing Subnets"
 | **Replaces**  | [ACP-13](https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/13-subnet-only-validators/README.md)                                          |
 `;
 
+function expectParsed(content: string, url: string) {
+  const parsed = parseAcpDocument(content, url);
+  expect(parsed).not.toBeNull();
+  return parsed!;
+}
+
 describe('parseAcpDocument', () => {
   it('extracts number, title, status, track, and authors from ACP-103', () => {
-    const parsed = parseAcpDocument(acp103, '/docs/acps/103-dynamic-fees');
+    const parsed = expectParsed(acp103, '/docs/acps/103-dynamic-fees');
 
     expect(parsed.number).toBe(103);
     expect(parsed.title).toBe('Add Dynamic Fees to the P-Chain');
@@ -72,7 +78,7 @@ describe('parseAcpDocument', () => {
   });
 
   it('extracts the Superseded-By reference for ACP-13', () => {
-    const parsed = parseAcpDocument(acp13, '/docs/acps/13-subnet-only-validators');
+    const parsed = expectParsed(acp13, '/docs/acps/13-subnet-only-validators');
 
     expect(parsed.number).toBe(13);
     expect(parsed.status).toBe('Stale');
@@ -80,7 +86,7 @@ describe('parseAcpDocument', () => {
   });
 
   it('extracts the Replaces reference for ACP-77', () => {
-    const parsed = parseAcpDocument(acp77, '/docs/acps/77-reinventing-subnets');
+    const parsed = expectParsed(acp77, '/docs/acps/77-reinventing-subnets');
 
     expect(parsed.number).toBe(77);
     expect(parsed.replaces).toEqual([13]);
@@ -88,18 +94,23 @@ describe('parseAcpDocument', () => {
   });
 
   it('splits comma-separated tracks for ACP-131', () => {
-    const parsed = parseAcpDocument(acp131, '/docs/acps/131-cancun-eips');
+    const parsed = expectParsed(acp131, '/docs/acps/131-cancun-eips');
 
     expect(parsed.tracks).toEqual(['Standards', 'Subnet']);
   });
 
   it('falls back to URL when number cannot be parsed from the table', () => {
     const incomplete = `---\ntitle: "ACP-256: Hardware"\n---\n\nNo table here.`;
-    const parsed = parseAcpDocument(incomplete, '/docs/acps/256-hardware-recommendations');
+    const parsed = expectParsed(incomplete, '/docs/acps/256-hardware-recommendations');
 
     expect(parsed.number).toBe(256);
     expect(parsed.title).toBe('Hardware');
     expect(parsed.status).toBe('Unknown');
+  });
+
+  it('returns null when no ACP number can be derived from anywhere', () => {
+    const noNumber = `---\ntitle: "Just a doc"\n---\n\nNo table, no number.`;
+    expect(parseAcpDocument(noNumber, '/docs/acps/index')).toBeNull();
   });
 });
 

--- a/tests/unit/mcp/acps/registry.test.ts
+++ b/tests/unit/mcp/acps/registry.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterAcps } from '@/lib/mcp/acps/filter';
+import type { AcpEntry } from '@/lib/mcp/acps/parser';
+
+const fixtures: AcpEntry[] = [
+  {
+    number: 103,
+    title: 'Add Dynamic Fees to the P-Chain',
+    status: 'Activated',
+    rawStatus: 'Activated',
+    tracks: ['Standards'],
+    authors: ['Dhruba Basu'],
+    url: '/docs/acps/103-dynamic-fees',
+  },
+  {
+    number: 13,
+    title: 'Subnet-Only Validators',
+    status: 'Stale',
+    rawStatus: 'Stale',
+    tracks: ['Standards'],
+    authors: ['Patrick OGrady'],
+    supersededBy: [77],
+    url: '/docs/acps/13-subnet-only-validators',
+  },
+  {
+    number: 131,
+    title: 'Activate Cancun EIPs on C-Chain and Subnet-EVM',
+    status: 'Activated',
+    rawStatus: 'Activated',
+    tracks: ['Standards', 'Subnet'],
+    authors: ['Darioush Jalali'],
+    url: '/docs/acps/131-cancun-eips',
+  },
+  {
+    number: 108,
+    title: 'EVM Event Importing Standard',
+    status: 'Proposed',
+    rawStatus: 'Proposed',
+    tracks: ['Best Practices'],
+    authors: ['Michael Kaplan'],
+    url: '/docs/acps/108-evm-event-importing',
+  },
+];
+
+describe('filterAcps', () => {
+  it('returns all entries when no filters are provided', () => {
+    expect(filterAcps(fixtures)).toHaveLength(4);
+  });
+
+  it('filters by status case-insensitively', () => {
+    const result = filterAcps(fixtures, { status: 'activated' });
+    expect(result.map((e) => e.number).sort((a, b) => a - b)).toEqual([103, 131]);
+  });
+
+  it('filters by track using prefix match across combined tracks', () => {
+    const standards = filterAcps(fixtures, { track: 'standards' });
+    expect(standards.map((e) => e.number).sort((a, b) => a - b)).toEqual([13, 103, 131]);
+
+    const subnet = filterAcps(fixtures, { track: 'subnet' });
+    expect(subnet.map((e) => e.number)).toEqual([131]);
+
+    const bestPractices = filterAcps(fixtures, { track: 'Best Practices' });
+    expect(bestPractices.map((e) => e.number)).toEqual([108]);
+  });
+
+  it('combines status and track filters', () => {
+    const result = filterAcps(fixtures, { status: 'Activated', track: 'subnet' });
+    expect(result.map((e) => e.number)).toEqual([131]);
+  });
+
+  it('respects the limit parameter', () => {
+    const result = filterAcps(fixtures, { limit: 2 });
+    expect(result).toHaveLength(2);
+  });
+
+  it('ignores limit when it is zero or negative', () => {
+    expect(filterAcps(fixtures, { limit: 0 })).toHaveLength(4);
+    expect(filterAcps(fixtures, { limit: -3 })).toHaveLength(4);
+  });
+
+  it('returns an empty array for unknown status', () => {
+    expect(filterAcps(fixtures, { status: 'Withdrawn' })).toEqual([]);
+  });
+});

--- a/tests/unit/mcp/chunking.test.ts
+++ b/tests/unit/mcp/chunking.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CHUNK_WORDS,
+  countOccurrences,
+  makeExcerpt,
+  matchesPathPrefix,
+  normalizeForSearch,
+  sanitizeForReflection,
+  sanitizeUrl,
+  scoreChunk,
+  splitIntoChunks,
+  tokenizeQuery,
+} from '@/lib/mcp/search-utils';
+
+describe('splitIntoChunks', () => {
+  it('returns an empty array for empty content', () => {
+    expect(splitIntoChunks('')).toEqual([]);
+    expect(splitIntoChunks('   \n  ')).toEqual([]);
+  });
+
+  it('returns a single chunk when the content fits the chunk window', () => {
+    const words = Array.from({ length: 50 }, (_, i) => `word${i}`).join(' ');
+    const chunks = splitIntoChunks(words);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].split(' ')).toHaveLength(50);
+  });
+
+  it('splits long content into overlapping windows', () => {
+    const words = Array.from({ length: 600 }, (_, i) => `w${i}`).join(' ');
+    const chunks = splitIntoChunks(words);
+    // 600 words / step (180-35=145) ~= 5 windows; the loop guard caps before tail-only chunk.
+    expect(chunks.length).toBeGreaterThanOrEqual(3);
+    expect(chunks.length).toBeLessThanOrEqual(6);
+    // Each chunk except possibly the last should be at most CHUNK_WORDS=180 words.
+    for (const chunk of chunks) {
+      expect(chunk.split(/\s+/).length).toBeLessThanOrEqual(180);
+    }
+  });
+
+  it('does not produce a tail chunk that is fully covered by the previous window', () => {
+    // 200 words with step 145 + overlap 35: window 0..180, then start=145, 145..200 (55 words),
+    // but 145+180=325 >= 200 so we break. The tail-cover guard prevents an extra small chunk.
+    const words = Array.from({ length: 200 }, (_, i) => `w${i}`).join(' ');
+    const chunks = splitIntoChunks(words);
+    expect(chunks.length).toBeLessThanOrEqual(2);
+  });
+
+  it('normalizes \\r\\n to \\n before tokenizing', () => {
+    const content = 'foo\r\nbar\r\nbaz';
+    expect(splitIntoChunks(content)).toEqual(['foo bar baz']);
+  });
+
+  it('respects the CHUNK_WORDS constant', () => {
+    expect(CHUNK_WORDS).toBe(180);
+  });
+});
+
+describe('normalizeForSearch / tokenizeQuery', () => {
+  it('lowercases and collapses whitespace', () => {
+    expect(normalizeForSearch('  Foo   BAR\n\tbaz  ')).toBe('foo bar baz');
+  });
+
+  it('drops short tokens but preserves slashes and underscores in identifiers', () => {
+    expect(tokenizeQuery('How do I configure platform_get_block?')).toEqual([
+      'how',
+      'do',
+      'configure',
+      'platform_get_block',
+    ]);
+  });
+});
+
+describe('countOccurrences', () => {
+  it('counts non-overlapping occurrences', () => {
+    expect(countOccurrences('abcabcabc', 'abc')).toBe(3);
+  });
+
+  it('returns 0 for empty needle and avoids infinite loops', () => {
+    expect(countOccurrences('foo', '')).toBe(0);
+  });
+});
+
+describe('scoreChunk', () => {
+  const baseChunk = {
+    url: '/docs/primary-network/overview',
+    title: 'Primary Network Overview',
+    description: 'Avalanche primary network composed of P, X, C chains',
+    normalizedText: normalizeForSearch(
+      'the primary network includes the p-chain, x-chain, and c-chain validators stake avax to validate'
+    ),
+  };
+
+  it('rewards full-phrase matches more than per-term matches', () => {
+    const phrase = scoreChunk(baseChunk, 'primary network', ['primary', 'network']);
+    const terms = scoreChunk(baseChunk, 'primary unrelated', ['primary', 'unrelated']);
+    expect(phrase).toBeGreaterThan(terms);
+  });
+
+  it('returns 0 when nothing matches', () => {
+    expect(scoreChunk(baseChunk, 'nonsensequery', ['nonsensequery'])).toBe(0);
+  });
+});
+
+describe('makeExcerpt', () => {
+  it('returns a window around the first matching term', () => {
+    const text = 'a '.repeat(200) + 'TARGET ' + 'b '.repeat(200);
+    const excerpt = makeExcerpt(text, 'target', ['target']);
+    expect(excerpt.toLowerCase()).toContain('target');
+    expect(excerpt.startsWith('...')).toBe(true);
+    expect(excerpt.endsWith('...')).toBe(true);
+  });
+});
+
+describe('matchesPathPrefix', () => {
+  it('matches when no prefixes are provided', () => {
+    expect(matchesPathPrefix('/docs/foo', undefined)).toBe(true);
+    expect(matchesPathPrefix('/docs/foo', [])).toBe(true);
+  });
+
+  it('matches when at least one prefix matches', () => {
+    expect(matchesPathPrefix('/docs/acps/77', ['/docs/acps'])).toBe(true);
+    expect(matchesPathPrefix('/docs/other/foo', ['/docs/acps', '/docs/rpcs'])).toBe(false);
+  });
+});
+
+describe('sanitizeForReflection', () => {
+  it('strips zero-width / bidi unicode characters', () => {
+    const tricky = 'foo​bar‌baz‮qux﻿end';
+    expect(sanitizeForReflection(tricky)).toBe('foobarbazquxend');
+  });
+
+  it('strips ASCII control characters but keeps newlines and tabs', () => {
+    const text = 'line1\n\tline2\x07with\x1Fcontrol';
+    expect(sanitizeForReflection(text)).toBe('line1\n\tline2withcontrol');
+  });
+
+  it('strips dangerous URL schemes from markdown links, keeping link text', () => {
+    const md = 'See [click me](javascript:alert(1)) for more.';
+    expect(sanitizeForReflection(md)).toBe('See click me for more.');
+  });
+
+  it('handles data: and vbscript: schemes too', () => {
+    expect(sanitizeForReflection('[x](data:text/html,<script>)')).toBe('x');
+    expect(sanitizeForReflection('[y](vbscript:msgbox)')).toBe('y');
+    expect(sanitizeForReflection('[z](file:///etc/passwd)')).toBe('z');
+  });
+
+  it('preserves http(s) and internal markdown links', () => {
+    const md = 'See [docs](https://build.avax.network/docs) and [home](/docs).';
+    expect(sanitizeForReflection(md)).toBe(md);
+  });
+
+  it('neutralizes bare dangerous schemes that are not in markdown link syntax', () => {
+    expect(sanitizeForReflection('try javascript:alert(1) here')).toContain('[blocked-scheme]:');
+  });
+
+  it('handles empty / non-string inputs safely', () => {
+    expect(sanitizeForReflection('')).toBe('');
+    // @ts-expect-error verifying runtime safety
+    expect(sanitizeForReflection(null)).toBe('');
+  });
+});
+
+describe('sanitizeUrl', () => {
+  it('allows https and http URLs', () => {
+    expect(sanitizeUrl('https://example.com/path')).toBe('https://example.com/path');
+    expect(sanitizeUrl('http://localhost:3000')).toBe('http://localhost:3000');
+  });
+
+  it('allows internal absolute paths', () => {
+    expect(sanitizeUrl('/docs/foo')).toBe('/docs/foo');
+  });
+
+  it('rejects protocol-relative URLs', () => {
+    expect(sanitizeUrl('//evil.com/path')).toBeUndefined();
+  });
+
+  it('rejects dangerous schemes', () => {
+    expect(sanitizeUrl('javascript:alert(1)')).toBeUndefined();
+    expect(sanitizeUrl('data:text/html,xxx')).toBeUndefined();
+    expect(sanitizeUrl('file:///etc/passwd')).toBeUndefined();
+    expect(sanitizeUrl('mailto:a@b.com')).toBeUndefined();
+  });
+
+  it('rejects empty or non-string input', () => {
+    expect(sanitizeUrl(undefined)).toBeUndefined();
+    expect(sanitizeUrl('')).toBeUndefined();
+    expect(sanitizeUrl('   ')).toBeUndefined();
+  });
+});
+
+describe('makeExcerpt sanitization', () => {
+  it('removes zero-width unicode and dangerous links from excerpts', () => {
+    const text =
+      'Click here​ for a [malicious](javascript:steal()) link or [safe](/docs/foo) one.';
+    const out = makeExcerpt(text, 'click', ['click']);
+    expect(out).not.toContain('​');
+    expect(out).not.toContain('javascript:');
+    expect(out).toContain('malicious');
+    expect(out).toContain('[safe](/docs/foo)');
+  });
+});

--- a/tests/unit/mcp/handler-validation.test.ts
+++ b/tests/unit/mcp/handler-validation.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Stub fumadocs source loaders so importing the handler modules doesn't pull MDX
+// content through Vite's transform pipeline (which choked on academy/*.mdx in CI).
+vi.mock('@/lib/source', () => {
+  const empty = { getPages: () => [] };
+  return {
+    documentation: empty,
+    academy: empty,
+    integration: empty,
+    blog: empty,
+  };
+});
+
+vi.mock('@/lib/llm-utils', () => ({
+  getLLMText: vi.fn(async () => ''),
+}));
+
+vi.mock('@/lib/posthog-server', () => ({
+  captureServerEvent: vi.fn(),
+}));
+
+import { docsTools } from '@/lib/mcp/tools/docs';
+import { githubTools } from '@/lib/mcp/tools/github';
+
+function getText(result: { content: Array<{ type: 'text'; text: string }>; isError?: boolean }) {
+  return { text: result.content[0]?.text ?? '', isError: !!result.isError };
+}
+
+describe('docs_fetch URL validation', () => {
+  it('rejects URLs that do not start with /', async () => {
+    const result = getText(await docsTools.handlers.docs_fetch({ url: 'docs/foo' }));
+    expect(result.isError).toBe(true);
+    expect(result.text).toMatch(/must start with/);
+  });
+
+  it('rejects path traversal', async () => {
+    const result = getText(await docsTools.handlers.docs_fetch({ url: '/docs/../secrets' }));
+    expect(result.isError).toBe(true);
+    expect(result.text).toMatch(/Invalid URL/);
+  });
+
+  it('rejects percent-encoded path traversal', async () => {
+    const result = getText(await docsTools.handlers.docs_fetch({ url: '/docs/%2e%2e/secrets' }));
+    expect(result.isError).toBe(true);
+    expect(result.text).toMatch(/Invalid URL/);
+  });
+
+  it('rejects URLs with a protocol', async () => {
+    const result = getText(await docsTools.handlers.docs_fetch({ url: '/docs/https://evil.com' }));
+    expect(result.isError).toBe(true);
+    expect(result.text).toMatch(/Invalid URL/);
+  });
+
+  it('rejects URLs outside allowed prefixes', async () => {
+    const result = getText(await docsTools.handlers.docs_fetch({ url: '/api/secret' }));
+    expect(result.isError).toBe(true);
+    expect(result.text).toMatch(/must start with one of/);
+  });
+
+  it('rejects malformed percent-encoding', async () => {
+    const result = getText(await docsTools.handlers.docs_fetch({ url: '/docs/%E0%A4%A' }));
+    expect(result.isError).toBe(true);
+    expect(result.text).toMatch(/percent-encoded/);
+  });
+});
+
+describe('github_get_file path & ref validation', () => {
+  it('rejects absolute paths', async () => {
+    const result = getText(
+      await githubTools.handlers.github_get_file({ repo: 'avalanchego', path: '/etc/passwd' })
+    );
+    expect(result.text).toMatch(/relative to the repository root/);
+  });
+
+  it('rejects path traversal', async () => {
+    const result = getText(
+      await githubTools.handlers.github_get_file({ repo: 'avalanchego', path: '../foo' })
+    );
+    expect(result.text).toMatch(/path traversal/);
+  });
+
+  it('rejects percent-encoded path traversal', async () => {
+    const result = getText(
+      await githubTools.handlers.github_get_file({ repo: 'avalanchego', path: '%2e%2e/foo' })
+    );
+    expect(result.text).toMatch(/path traversal/);
+  });
+
+  it('rejects backslash separators', async () => {
+    const result = getText(
+      await githubTools.handlers.github_get_file({ repo: 'avalanchego', path: 'foo\\bar' })
+    );
+    expect(result.text).toMatch(/forward slashes/);
+  });
+
+  it('rejects Windows drive letters', async () => {
+    const result = getText(
+      await githubTools.handlers.github_get_file({ repo: 'avalanchego', path: 'C:/foo' })
+    );
+    expect(result.text).toMatch(/absolute Windows path/);
+  });
+
+  it('rejects unknown repo', async () => {
+    const result = getText(
+      await githubTools.handlers.github_get_file({ repo: 'evil/repo', path: 'README.md' })
+    );
+    expect(result.text).toMatch(/not in the allowed list/);
+  });
+
+  it('rejects refs with invalid characters', async () => {
+    const result = getText(
+      await githubTools.handlers.github_get_file({
+        repo: 'avalanchego',
+        path: 'README.md',
+        ref: 'main; echo pwn',
+      })
+    );
+    expect(result.text).toMatch(/valid git ref/);
+  });
+
+  it('rejects refs that are too long', async () => {
+    const result = getText(
+      await githubTools.handlers.github_get_file({
+        repo: 'avalanchego',
+        path: 'README.md',
+        ref: 'a'.repeat(201),
+      })
+    );
+    expect(result.text).toMatch(/valid git ref/);
+  });
+});
+
+describe('github_search_code qualifier stripping', () => {
+  it('rejects empty queries (and queries that become empty after stripping qualifiers)', async () => {
+    const result = getText(
+      await githubTools.handlers.github_search_code({ query: 'repo:attacker/private' })
+    );
+    expect(result.text).toMatch(/empty after sanitization|query is required/i);
+  });
+
+  it('rejects unknown repo', async () => {
+    const result = getText(
+      await githubTools.handlers.github_search_code({
+        query: 'foo',
+        repo: 'definitely-not-a-repo',
+      })
+    );
+    expect(result.text).toMatch(/not in the allowed list/);
+  });
+});

--- a/tests/unit/mcp/server.test.ts
+++ b/tests/unit/mcp/server.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { MCPServer } from '@/lib/mcp/server'
+import { MCPServer, MAX_BATCH_SIZE } from '@/lib/mcp/server'
 import { jsonRpcMessageSchema } from '@/lib/mcp/types'
 import { GITHUB_REPOSITORIES, githubTools } from '@/lib/mcp/tools/github'
 
@@ -81,6 +81,24 @@ describe('MCPServer.handlePost', () => {
         result: {},
       },
     ])
+  })
+
+  it('rejects batches that exceed the maximum batch size', async () => {
+    const server = createServer()
+    const batch = Array.from({ length: MAX_BATCH_SIZE + 1 }, (_, i) => ({
+      jsonrpc: '2.0' as const,
+      id: i,
+      method: 'ping' as const,
+    }))
+
+    await expect(server.handlePost(batch)).resolves.toEqual({
+      jsonrpc: '2.0',
+      id: null,
+      error: {
+        code: -32600,
+        message: expect.stringContaining(`exceeds the maximum of ${MAX_BATCH_SIZE}`),
+      },
+    })
   })
 })
 

--- a/tests/unit/mcp/server.test.ts
+++ b/tests/unit/mcp/server.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { MCPServer } from '@/lib/mcp/server'
 import { jsonRpcMessageSchema } from '@/lib/mcp/types'
+import { GITHUB_REPOSITORIES, githubTools } from '@/lib/mcp/tools/github'
 
 vi.mock('@/lib/posthog-server', () => ({
   captureServerEvent: vi.fn(),
@@ -80,5 +81,34 @@ describe('MCPServer.handlePost', () => {
         result: {},
       },
     ])
+  })
+})
+
+describe('githubTools', () => {
+  it('covers the core Avalanche repositories from the MCP roadmap', () => {
+    expect(GITHUB_REPOSITORIES.map((repo) => repo.fullName)).toEqual([
+      'ava-labs/avalanchego',
+      'ava-labs/subnet-evm',
+      'ava-labs/coreth',
+      'ava-labs/avalanche-cli',
+      'ava-labs/platform-cli',
+      'ava-labs/icm-services',
+      'ava-labs/avalanche-network-runner',
+      'ava-labs/icm-contracts',
+      'ava-labs/hypersdk',
+      'ava-labs/libevm',
+      'ava-labs/builders-hub',
+    ])
+  })
+
+  it('exposes repository coverage through an MCP tool', async () => {
+    const result = await githubTools.handlers.github_list_repositories({})
+    const payload = JSON.parse(result.content[0].text)
+
+    expect(payload.repositories).toHaveLength(11)
+    expect(payload.repositories[0]).toMatchObject({
+      name: 'avalanchego',
+      fullName: 'ava-labs/avalanchego',
+    })
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary                                                                                                                                                                         
                                                                                                                                                                                     
  Turns the public MCP from a thin docs-search layer into a first-class Avalanche knowledge surface: chunked full-text retrieval, structured ACP records, task-shaped lookups,       
  expanded GitHub coverage, and a hardened JSON-RPC transport.                                                                                                                       
                                                                                                                                                                                     
  ### Knowledge plane                                                                                                                                                              
  - `docs_search` now returns body-level chunks (180-word windows, 35-word overlap) with source URLs, chunk indices, and matching excerpts — replaces the old metadata-only search.
  - New task-shaped tools: `cli_lookup_command` (avalanche-cli / platform-cli / tmpnet, path-prefix scoped), `rpc_lookup_method` (C/P/X-Chain, Subnet-EVM, other).                   
  - New ACP surface backed by a parsed registry under `lib/mcp/acps/`:                                                                                                               
    - `acp_lookup` — by number returns structured record (status, track, authors, replaces / superseded-by / updates cross-refs); by query returns docs excerpts.                    
    - `acp_list` — filterable by `status` (Activated, Implementable, Proposed, Stale, Withdrawn) and `track` (Standards, Best Practices, Meta, Subnet).                              
  - New resources: `rpcs://index`, `cli://index`, `acps://index` (alongside existing docs / academy / integrations / blog indexes).                                                  
                                                                                                                                                                                     
  ### GitHub coverage                                                                                                                                                                
  - Tools now cover 11 repos: `avalanchego`, `subnet-evm`, `coreth`, `avalanche-cli`, `platform-cli`, `icm-services`, `avalanche-network-runner`, `icm-contracts`, `hypersdk`,       
  `libevm`, `builders-hub`.                                                                                                                                                          
  - `github_search_code` requests the `text-match` media type so result fragments are populated.                                                                                   
  - New `github_list_repositories` for discoverability.                                                                                                                              
                                                                                                                                                                                     
  ### Chat integration                                                                                                                                                               
  - Exposes `cli_lookup_command`, `rpc_lookup_method`, `acp_lookup`, `acp_list` to the chat AI alongside existing GitHub / blockchain tools.                                         
  - Fixes the search-result parser to dedup per-URL on the chat side.                                                                                                                
                                                                                                                                                                                     
  ### Hardening                                                                                                                                                                      
  - JSON-RPC batch cap (`MAX_BATCH_SIZE = 20`), 256 KB request body cap, bounded concurrency (8) on cold-start index build, failure-rate logging when >5 % of pages fail to index.   
  - `docs_fetch` capped at 50 KB (matches `github_get_file`).                                                                                                                        
  - URL / path validators with percent-decode pass to catch encoded traversal.
  - GitHub query qualifier stripping (`repo:`, `org:`, `in:`, …) so a user query can't escape the allowlist and reach private content via the server-side `GITHUB_TOKEN`.            
  - Git ref regex on `github_get_file`.                                                                                                                                              
  - Prompt-injection sanitizer for reflected text: zero-width / bidi unicode strip, `javascript:` / `data:` / `vbscript:` / `file:` neutralized in markdown links and bare URLs.     
  - ACP parser drops phantom ACP-0 entries and only allows `https?:` discussion URLs.                                                                                                
  - Compatibility aliases `avalanche_docs_search` / `_fetch` / `_list_sections` kept and emit a one-line deprecation notice pointing at the new canonical names.                     
                                                                                                                                                                                     
  ### Docs + manifest                                                                                                                                                                
  - `content/docs/tooling/ai-llm/mcp-server.mdx` rewritten to reflect the full surface and the new tools.                                                                            
  - `public/mcp-manifest.json` lists every tool, every resource, repository coverage, canonical vs. compat aliases, and links to the roadmap issue.                                  
                                                                                                                                                                                     
  ### Tests
  - New unit tests: chunking + scoring + sanitizers (28), handler input validation (16), server batch / id handling (7), ACP parser (10), ACP filter / registry (7). 68 passing.     
                                                                                                                                                                                     
  ## Phase-2 follow-ups (deliberately out of scope)                                                                                                                                  
                                                                                                                                                                                     
  Tracked separately under #4070:                                                                                                                                                    
  - Release / upgrade lookup tool (joining `info_acps` voting state, avalanchego releases, upgrade docs).                                                                          
  - Semantic / hybrid search (wire existing `lib/embeddings.ts` infra into `docs_search`).                                                                                           
  - Code symbol / snippet lookup on top of `github_search_code`.                                                                                                                     
  - Node / validator / subnet troubleshooting helpers.                                                                                                                               
  - Per-page resources (`acp://77`, `rpc://platform.getCurrentValidators`).                                                                                                          
                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                       
                                                                                                                                                                                     
  - [ ] `curl -X POST $MCP -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'` lists every new tool.                                                                                
  - [ ] `docs_search` returns body-level chunks with citations + excerpts.                                                                                                         
  - [ ] `cli_lookup_command({ query: "add validator", cli: "avalanche-cli" })` returns scoped CLI results.                                                                           
  - [ ] `rpc_lookup_method({ query: "platform.getCurrentValidators", chain: "p-chain" })` returns scoped RPC results.                                                                
  - [ ] `acp_lookup({ number: 77 })` returns the structured ACP-77 record.                                                                                                           
  - [ ] `acp_list({ status: "Activated", track: "Standards" })` filters correctly.                                                                                                   
  - [ ] `github_search_code` results include populated `text_matches` fragments.                                                                                                     
  - [ ] `docs_fetch` on a long page returns truncated body with the size notice.                                                                                                     
  - [ ] `docs_fetch` rejects path traversal, percent-encoded traversal, protocol injection, paths outside `/docs/`, `/academy/`, `/integrations/`, `/blog/`.                         
  - [ ] `github_get_file` rejects absolute paths, `..`, `\\`, Windows drive letters, refs failing the regex.                                                                         
  - [ ] `github_search_code` strips qualifiers (`repo:attacker/private` → empty after sanitization).                                                                                 
  - [ ] JSON-RPC batch with 21 messages → `-32600 Batch size exceeds the maximum`.                                                                                                   
  - [ ] Request body > 256 KB → 413.                                                                                                                                                 
  - [ ] `npm run test -- tests/unit/mcp` → 68/68 pass.                                                                    