### PR TITLE
feat(stats): updated validator section on all-chains and primary netw…

### DIFF
--- a/app/(home)/stats/validators/c-chain/page.tsx
+++ b/app/(home)/stats/validators/c-chain/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState, useEffect, useMemo, useTransition, useRef } from "react";
-import { Area, AreaChart, Bar, BarChart, CartesianGrid, XAxis, YAxis, Pie, PieChart, Line, LineChart, Brush, ResponsiveContainer, Tooltip, ComposedChart, Cell } from "recharts";
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, XAxis, YAxis, Pie, PieChart, Line, LineChart, Brush, ResponsiveContainer, Tooltip, ComposedChart, Cell, ReferenceLine, Label } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -17,13 +17,14 @@ import { SortIcon } from "@/components/stats/SortIcon";
 import { useSectionNavigation } from "@/hooks/use-section-navigation";
 import { LinkableHeading } from "@/components/stats/LinkableHeading";
 import { ChartSkeletonLoader } from "@/components/ui/chart-skeleton";
-import { TimeSeriesDataPoint, ChartDataPoint, PrimaryNetworkMetrics, VersionCount, L1Chain } from "@/types/stats";
+import { TimeSeriesDataPoint, TimeSeriesMetric, ChartDataPoint, PrimaryNetworkMetrics, VersionCount, L1Chain } from "@/types/stats";
 import { AvalancheLogo } from "@/components/navigation/avalanche-logo";
 import { ChartWatermark } from "@/components/stats/ChartWatermark";
 import { StatsBreadcrumb } from "@/components/navigation/StatsBreadcrumb";
 import { ChainIdChips } from "@/components/ui/copyable-id-chip";
 import { AddToWalletButton } from "@/components/ui/add-to-wallet-button";
 import { VersionBreakdownCard, calculateVersionStats, type VersionBreakdownData } from "@/components/stats/VersionBreakdown";
+import { ValidatorChartCard, timeSeriesToChartData } from "@/components/stats/ValidatorChartCard";
 import l1ChainsData from "@/constants/l1-chains.json";
 import { getMAConfig } from "@/utils/chart-utils";
 import { calculateDateRangeDays, formatXAxisLabel, generateXAxisTicks } from "@/components/stats/chart-axis-utils";
@@ -87,6 +88,7 @@ export default function CChainValidatorMetrics() {
     current: { supply: number; totalBurned: number; maxAPY: number; minAPY: number };
   } | null>(null);
   const [stakingAPYLoading, setStakingAPYLoading] = useState(true);
+  const [totalValidatorSeats, setTotalValidatorSeats] = useState<TimeSeriesMetric | null>(null);
 
   const fetchData = async () => {
     try {
@@ -208,6 +210,7 @@ export default function CChainValidatorMetrics() {
           console.error('Error parsing P2P validators data:', err);
         }
       }
+
     } catch (err) {
       setError(`An error occurred while fetching data`);
     } finally {
@@ -216,8 +219,22 @@ export default function CChainValidatorMetrics() {
     }
   };
 
+  const fetchTotalEcosystemValidators = async () => {
+    try {
+      const response = await fetch('/api/total-ecosystem-validators?timeRange=all');
+      if (!response.ok) return;
+      const data = await response.json();
+      if (data?.total_validator_seats) {
+        setTotalValidatorSeats(data.total_validator_seats);
+      }
+    } catch (err) {
+      console.error('Error parsing total validator seats data:', err);
+    }
+  };
+
   useEffect(() => {
     fetchData();
+    fetchTotalEcosystemValidators();
   }, []);
 
   const formatNumber = (num: number | string): string => {
@@ -440,21 +457,8 @@ export default function CChainValidatorMetrics() {
       | "delegator_weight"
     >
   ): ChartDataPoint[] => {
-    if (!metrics || !metrics[metricKey]?.data) return [];
-    const today = new Date().toISOString().split("T")[0];
-    const finalizedData = metrics[metricKey].data.filter(
-      (point) => point.date !== today
-    );
-
-    return finalizedData
-      .map((point: TimeSeriesDataPoint) => ({
-        day: point.date,
-        value:
-          typeof point.value === "string"
-            ? parseFloat(point.value)
-            : point.value,
-      }))
-      .reverse();
+    if (!metrics) return [];
+    return timeSeriesToChartData(metrics[metricKey]);
   };
 
   const formatTooltipValue = (value: number, metricKey: string): string => {
@@ -1108,6 +1112,11 @@ export default function CChainValidatorMetrics() {
               const period = chartPeriods[config.metricKey];
               const currentValue = getCurrentValue(config.metricKey);
 
+              const isValidatorCount = config.metricKey === "validator_count";
+              const overlayData: ChartDataPoint[] | undefined = isValidatorCount
+                ? timeSeriesToChartData(totalValidatorSeats)
+                : undefined;
+
               return (
                 <ValidatorChartCard
                   key={config.metricKey}
@@ -1128,6 +1137,19 @@ export default function CChainValidatorMetrics() {
                     config.metricKey.includes("weight")
                       ? formatWeightForAxis
                       : formatNumber
+                  }
+                  overlayData={overlayData}
+                  overlayLabel={
+                    isValidatorCount ? "Total Validator Seats (Primary + L1s)" : undefined
+                  }
+                  overlayColor={isValidatorCount ? "#3B82F6" : undefined}
+                  overlayStartDate={isValidatorCount ? "2024-12-16" : undefined}
+                  referenceLineDate={isValidatorCount ? "2024-12-16" : undefined}
+                  referenceLineLabel={isValidatorCount ? "ACP-77 (Etna)" : undefined}
+                  descriptionNote={
+                    isValidatorCount
+                      ? "After the Etna upgrade, validators of subnets that converted into sovereign L1s no longer needed to also stake on the Primary Network."
+                      : undefined
                   }
                 />
               );
@@ -2256,477 +2278,6 @@ export default function CChainValidatorMetrics() {
   );
 }
 
-function ValidatorChartCard({
-  config,
-  rawData,
-  period,
-  currentValue,
-  onPeriodChange,
-  formatTooltipValue,
-  formatYAxisValue,
-}: {
-  config: any;
-  rawData: any[];
-  period: "D" | "W" | "M" | "Q" | "Y";
-  currentValue: number | string;
-  onPeriodChange: (period: "D" | "W" | "M" | "Q" | "Y") => void;
-  formatTooltipValue: (value: number) => string;
-  formatYAxisValue: (value: number) => string;
-}) {
-  const [brushIndexes, setBrushIndexes] = useState<{
-    startIndex: number;
-    endIndex: number;
-  } | null>(null);
-  const chartContainerRef = useRef<HTMLDivElement>(null);
-  const { resolvedTheme } = useTheme();
-  const handleScreenshot = async () => {
-    if (!chartContainerRef.current) return;
-
-    try {
-      const element = chartContainerRef.current;
-      const bgColor = resolvedTheme === "dark" ? "#0a0a0a" : "#ffffff";
-
-      const dataUrl = await toPng(element, {
-        quality: 1,
-        pixelRatio: 2,
-        backgroundColor: bgColor,
-        cacheBust: true,
-      });
-
-      const link = document.createElement("a");
-      link.download = `${config.title.replace(/\s+/g, "_")}_${period}_${new Date().toISOString().split("T")[0]}.png`;
-      link.href = dataUrl;
-      link.click();
-    } catch (error) {
-      console.error("Failed to capture screenshot:", error);
-    }
-  };
-
-  const aggregatedData = useMemo(() => {
-    if (period === "D") return rawData;
-
-    const grouped = new Map<
-      string,
-      { sum: number; count: number; date: string }
-    >();
-
-    rawData.forEach((point) => {
-      const date = new Date(point.day);
-      let key: string;
-
-      if (period === "W") {
-        const weekStart = new Date(date);
-        weekStart.setDate(date.getDate() - date.getDay());
-        key = weekStart.toISOString().split("T")[0];
-      } else if (period === "M") {
-        key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
-          2,
-          "0"
-        )}`;
-      } else if (period === "Q") {
-        const quarter = Math.floor(date.getMonth() / 3) + 1;
-        key = `${date.getFullYear()}-Q${quarter}`;
-      } else {
-        key = String(date.getFullYear());
-      }
-
-      if (!grouped.has(key)) {
-        grouped.set(key, { sum: 0, count: 0, date: key });
-      }
-
-      const group = grouped.get(key)!;
-      group.sum += point.value;
-      group.count += 1;
-    });
-
-    return Array.from(grouped.values())
-      .map((group) => ({
-        day: group.date,
-        value: group.sum / group.count,
-      }))
-      .sort((a, b) => a.day.localeCompare(b.day));
-  }, [rawData, period]);
-
-  useEffect(() => {
-    if (aggregatedData.length === 0) return;
-
-    if (period === "D") {
-      const daysToShow = 90;
-      setBrushIndexes({
-        startIndex: Math.max(0, aggregatedData.length - daysToShow),
-        endIndex: aggregatedData.length - 1,
-      });
-    } else {
-      setBrushIndexes({
-        startIndex: 0,
-        endIndex: aggregatedData.length - 1,
-      });
-    }
-  }, [period, aggregatedData.length]);
-
-  const displayData = brushIndexes
-    ? aggregatedData.slice(brushIndexes.startIndex, brushIndexes.endIndex + 1)
-    : aggregatedData;
-
-  const brushRangeDays = useMemo(() => {
-    return calculateDateRangeDays(displayData, "day");
-  }, [displayData]);
-
-  const totalDataDays = useMemo(() => {
-    return calculateDateRangeDays(aggregatedData, "day");
-  }, [aggregatedData]);
-
-  const formatXAxis = (value: string) => formatXAxisLabel(value, brushRangeDays);
-  const formatBrushXAxis = (value: string) => formatXAxisLabel(value, totalDataDays);
-
-  const xAxisTicks = useMemo(() => {
-    return generateXAxisTicks(displayData, brushRangeDays, "day");
-  }, [displayData, brushRangeDays]);
-
-  const dynamicChange = useMemo(() => {
-    if (!displayData || displayData.length < 2) {
-      return { change: 0, isPositive: true };
-    }
-    const firstValue = displayData[0].value;
-    const lastValue = displayData[displayData.length - 1].value;
-    if (lastValue === 0) {
-      return { change: 0, isPositive: true };
-    }
-    const changePercentage = ((lastValue - firstValue) / firstValue) * 100;
-    return {
-      change: Math.abs(changePercentage),
-      isPositive: changePercentage >= 0,
-    };
-  }, [displayData]);
-
-  // CSV download function
-  const downloadCSV = () => {
-    if (!displayData || displayData.length === 0) return;
-
-    const headers = ["Date", config.title];
-    const rows = displayData.map((point: any) => [point.day, point.value].join(","));
-
-    const csvContent = [headers.join(","), ...rows].join("\n");
-    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = `${config.title.replace(/\s+/g, "_")}_${period}_${new Date().toISOString().split("T")[0]}.csv`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  };
-
-  const formatTooltipDate = (value: string) => {
-    if (period === "Y") {
-      return value;
-    }
-
-    if (period === "Q") {
-      const parts = value.split("-");
-      if (parts.length === 2) {
-        return `${parts[1]} ${parts[0]}`;
-      }
-      return value;
-    }
-
-    const date = new Date(value);
-
-    if (period === "M") {
-      return date.toLocaleDateString("en-US", {
-        month: "long",
-        year: "numeric",
-      });
-    }
-
-    if (period === "W") {
-      const endDate = new Date(date);
-      endDate.setDate(date.getDate() + 6);
-      const startMonth = date.toLocaleDateString("en-US", { month: "long" });
-      const endMonth = endDate.toLocaleDateString("en-US", { month: "long" });
-      const startDay = date.getDate();
-      const endDay = endDate.getDate();
-      const year = endDate.getFullYear();
-
-      if (startMonth === endMonth) {
-        return `${startMonth} ${startDay}-${endDay}, ${year}`;
-      } else {
-        return `${startMonth} ${startDay} - ${endMonth} ${endDay}, ${year}`;
-      }
-    }
-
-    return date.toLocaleDateString("en-US", {
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-    });
-  };
-
-  const Icon = config.icon;
-
-  return (
-    <Card className="py-0 border-gray-200 rounded-md dark:border-gray-700" ref={chartContainerRef}>
-      <CardContent className="p-0">
-        <div className="flex items-center justify-between px-4 sm:px-5 py-3 sm:py-4 border-b border-gray-200 dark:border-gray-700">
-          <div className="flex items-center gap-2 sm:gap-3">
-            <div
-              className="rounded-full p-2 sm:p-3 flex items-center justify-center"
-              style={{ backgroundColor: `${config.color}20` }}
-            >
-              <Icon
-                className="h-5 w-5 sm:h-6 sm:w-6"
-                style={{ color: config.color }}
-              />
-            </div>
-            <div>
-              <h3 className="text-base sm:text-lg font-normal">
-                {config.title}
-              </h3>
-              <p className="text-xs sm:text-sm text-muted-foreground hidden sm:block">
-                {config.description}
-              </p>
-            </div>
-          </div>
-          <div className="flex items-center gap-1">
-            <Select
-              value={period}
-              onValueChange={(value) =>
-                onPeriodChange(value as "D" | "W" | "M" | "Q" | "Y")
-              }
-            >
-              <SelectTrigger className="h-7 w-auto px-2 gap-1 text-xs sm:text-sm border-0 bg-transparent hover:bg-muted focus:ring-0 shadow-none">
-                <SelectValue>
-                  {period === "D" ? "Daily" : period === "W" ? "Weekly" : period === "M" ? "Monthly" : period === "Q" ? "Quarterly" : "Yearly"}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {(["D", "W", "M", "Q", "Y"] as const).map((p) => (
-                  <SelectItem key={p} value={p}>
-                    {p === "D" ? "Daily" : p === "W" ? "Weekly" : p === "M" ? "Monthly" : p === "Q" ? "Quarterly" : "Yearly"}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <button
-              onClick={handleScreenshot}
-              className="p-1.5 sm:p-2 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors cursor-pointer"
-              title="Download chart as image"
-            >
-              <Camera className="h-4 w-4" />
-            </button>
-            <button
-              onClick={downloadCSV}
-              className="p-1.5 sm:p-2 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors cursor-pointer"
-              title="Download CSV"
-            >
-              <Download className="h-4 w-4" />
-            </button>
-          </div>
-        </div>
-
-        <div className="px-5 pt-6 pb-6">
-          {/* Current Value and Change */}
-          <div className="flex items-center gap-2 sm:gap-4 mb-3 sm:mb-4 pl-2 sm:pl-4">
-            <div className="text-md sm:text-xl font-mono break-all">
-              {formatTooltipValue(
-                typeof currentValue === "string"
-                  ? parseFloat(currentValue)
-                  : currentValue
-              )}
-            </div>
-            {dynamicChange.change > 0 && (
-              <div
-                className={`flex items-center gap-1 text-xs sm:text-sm ${
-                  dynamicChange.isPositive ? "text-green-600" : "text-red-600"
-                }`}
-                title={`Change over selected time range`}
-              >
-                <TrendingUp
-                  className={`h-3 w-3 sm:h-4 sm:w-4 ${
-                    dynamicChange.isPositive ? "" : "rotate-180"
-                  }`}
-                />
-                {dynamicChange.change.toFixed(1)}%
-              </div>
-            )}
-          </div>
-
-          <ChartWatermark className="mb-6">
-            <ResponsiveContainer width="100%" height={350}>
-              {config.chartType === "bar" ? (
-                <BarChart
-                  data={displayData}
-                  margin={{ top: 10, right: 30, left: 0, bottom: 0 }}
-                >
-                  <CartesianGrid
-                    strokeDasharray="3 3"
-                    className="stroke-gray-200 dark:stroke-gray-700"
-                    vertical={false}
-                  />
-                  <XAxis
-                    dataKey="day"
-                    tickFormatter={formatXAxis}
-                    className="text-xs text-gray-600 dark:text-gray-400"
-                    tick={{ className: "fill-gray-600 dark:fill-gray-400" }}
-                    ticks={xAxisTicks}
-                    interval={0}
-                  />
-                  <YAxis
-                    tickFormatter={formatYAxisValue}
-                    className="text-xs text-gray-600 dark:text-gray-400"
-                    tick={{ className: "fill-gray-600 dark:fill-gray-400" }}
-                  />
-                  <Tooltip
-                    cursor={{ fill: `${config.color}20` }}
-                    content={({ active, payload }) => {
-                      if (!active || !payload?.[0]) return null;
-                      const formattedDate = formatTooltipDate(
-                        payload[0].payload.day
-                      );
-                      return (
-                        <div className="rounded-lg border bg-background p-2 shadow-sm font-mono">
-                          <div className="grid gap-2">
-                            <div className="font-medium text-sm">
-                              {formattedDate}
-                            </div>
-                            <div className="text-sm">
-                              {formatTooltipValue(payload[0].value as number)}
-                            </div>
-                          </div>
-                        </div>
-                      );
-                    }}
-                  />
-                  <Bar
-                    dataKey="value"
-                    fill={config.color}
-                    radius={[4, 4, 0, 0]}
-                  />
-                </BarChart>
-              ) : (
-                <AreaChart
-                  data={displayData}
-                  margin={{ top: 10, right: 30, left: 0, bottom: 0 }}
-                >
-                  <defs>
-                    <linearGradient
-                      id={`gradient-${config.metricKey}`}
-                      x1="0"
-                      y1="0"
-                      x2="0"
-                      y2="1"
-                    >
-                      <stop
-                        offset="5%"
-                        stopColor={config.color}
-                        stopOpacity={0.3}
-                      />
-                      <stop
-                        offset="95%"
-                        stopColor={config.color}
-                        stopOpacity={0}
-                      />
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid
-                    strokeDasharray="3 3"
-                    className="stroke-gray-200 dark:stroke-gray-700"
-                    vertical={false}
-                  />
-                  <XAxis
-                    dataKey="day"
-                    tickFormatter={formatXAxis}
-                    className="text-xs text-gray-600 dark:text-gray-400"
-                    tick={{ className: "fill-gray-600 dark:fill-gray-400" }}
-                    ticks={xAxisTicks}
-                    interval={0}
-                  />
-                  <YAxis
-                    tickFormatter={formatYAxisValue}
-                    className="text-xs text-gray-600 dark:text-gray-400"
-                    tick={{ className: "fill-gray-600 dark:fill-gray-400" }}
-                  />
-                  <Tooltip
-                    cursor={{ fill: `${config.color}20` }}
-                    content={({ active, payload }) => {
-                      if (!active || !payload?.[0]) return null;
-                      const formattedDate = formatTooltipDate(
-                        payload[0].payload.day
-                      );
-                      return (
-                        <div className="rounded-lg border bg-background p-2 shadow-sm font-mono">
-                          <div className="grid gap-2">
-                            <div className="font-medium text-sm">
-                              {formattedDate}
-                            </div>
-                            <div className="text-sm">
-                              {formatTooltipValue(payload[0].value as number)}
-                            </div>
-                          </div>
-                        </div>
-                      );
-                    }}
-                  />
-                  <Area
-                    type="monotone"
-                    dataKey="value"
-                    stroke={config.color}
-                    fill={`url(#gradient-${config.metricKey})`}
-                    strokeWidth={2}
-                  />
-                </AreaChart>
-              )}
-            </ResponsiveContainer>
-          </ChartWatermark>
-
-          {/* Brush Slider */}
-          <div className="mt-4 bg-white dark:bg-black pl-[60px]">
-            <ResponsiveContainer width="100%" height={80}>
-              <LineChart
-                data={aggregatedData}
-                margin={{ top: 0, right: 30, left: 0, bottom: 5 }}
-              >
-                <Brush
-                  dataKey="day"
-                  height={80}
-                  stroke={config.color}
-                  fill={`${config.color}20`}
-                  alwaysShowText={false}
-                  startIndex={brushIndexes?.startIndex ?? 0}
-                  endIndex={brushIndexes?.endIndex ?? aggregatedData.length - 1}
-                  onChange={(e: any) => {
-                    if (
-                      e.startIndex !== undefined &&
-                      e.endIndex !== undefined
-                    ) {
-                      setBrushIndexes({
-                        startIndex: e.startIndex,
-                        endIndex: e.endIndex,
-                      });
-                    }
-                  }}
-                  travellerWidth={8}
-                  tickFormatter={formatBrushXAxis}
-                >
-                  <LineChart>
-                    <Line
-                      type="monotone"
-                      dataKey="value"
-                      stroke={config.color}
-                      strokeWidth={1}
-                      dot={false}
-                    />
-                  </LineChart>
-                </Brush>
-              </LineChart>
-            </ResponsiveContainer>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
 
 // Daily Rewards Chart Card with 30-day moving average and total
 function DailyRewardsChartCard({

--- a/app/(home)/stats/validators/c-chain/page.tsx
+++ b/app/(home)/stats/validators/c-chain/page.tsx
@@ -24,9 +24,9 @@ import { StatsBreadcrumb } from "@/components/navigation/StatsBreadcrumb";
 import { ChainIdChips } from "@/components/ui/copyable-id-chip";
 import { AddToWalletButton } from "@/components/ui/add-to-wallet-button";
 import { VersionBreakdownCard, calculateVersionStats, type VersionBreakdownData } from "@/components/stats/VersionBreakdown";
-import { ValidatorChartCard, timeSeriesToChartData } from "@/components/stats/ValidatorChartCard";
+import { ValidatorChartCard } from "@/components/stats/ValidatorChartCard";
 import l1ChainsData from "@/constants/l1-chains.json";
-import { getMAConfig } from "@/utils/chart-utils";
+import { getMAConfig, timeSeriesMetricToChartData } from "@/utils/chart-utils";
 import { calculateDateRangeDays, formatXAxisLabel, generateXAxisTicks } from "@/components/stats/chart-axis-utils";
 import { useTheme } from "next-themes";
 import { toPng } from "html-to-image";
@@ -458,7 +458,7 @@ export default function CChainValidatorMetrics() {
     >
   ): ChartDataPoint[] => {
     if (!metrics) return [];
-    return timeSeriesToChartData(metrics[metricKey]);
+    return timeSeriesMetricToChartData(metrics[metricKey], { excludeToday: true });
   };
 
   const formatTooltipValue = (value: number, metricKey: string): string => {
@@ -1114,7 +1114,7 @@ export default function CChainValidatorMetrics() {
 
               const isValidatorCount = config.metricKey === "validator_count";
               const overlayData: ChartDataPoint[] | undefined = isValidatorCount
-                ? timeSeriesToChartData(totalValidatorSeats)
+                ? timeSeriesMetricToChartData(totalValidatorSeats, { excludeToday: true })
                 : undefined;
 
               return (

--- a/app/api/total-ecosystem-validators/route.ts
+++ b/app/api/total-ecosystem-validators/route.ts
@@ -1,0 +1,318 @@
+import { NextResponse } from 'next/server';
+import l1ChainsData from "@/constants/l1-chains.json";
+import {
+  TimeSeriesDataPoint,
+  TimeSeriesMetric,
+  STATS_CONFIG,
+  getTimestampsFromTimeRange,
+  createTimeSeriesMetric,
+} from "@/types/stats";
+
+export const dynamic = 'force-dynamic';
+
+const CACHE_CONTROL_HEADER = 'public, max-age=14400, s-maxage=14400, stale-while-revalidate=86400';
+const MAX_CONCURRENT_REQUESTS = 10;
+const REQUEST_TIMEOUT_MS = 15000;
+const METRICS_API_BASE_URL = process.env.METRICS_API_URL || 'https://metrics.avax.network';
+
+const PRIMARY_NETWORK_SUBNET_ID = '11111111111111111111111111111111LpoYY';
+
+const getRlToken = () => process.env.METRICS_BYPASS_TOKEN || '';
+
+interface L1ChainRecord {
+  subnetId?: string;
+  isTestnet?: boolean;
+  isActive?: boolean;
+}
+
+interface MetricsValidatorCountPoint {
+  timestamp: number;
+  value: number | string;
+}
+
+interface MetricsValidatorCountResponse {
+  results?: MetricsValidatorCountPoint[];
+  nextPageToken?: string;
+}
+
+interface TotalEcosystemValidatorsResponse {
+  total_validator_seats: TimeSeriesMetric;
+  l1_validator_seats: TimeSeriesMetric;
+  primary_network_validator_count: TimeSeriesMetric;
+  subnets_included: number;
+  last_updated: number;
+}
+
+const cachedData = new Map<string, { data: TotalEcosystemValidatorsResponse; timestamp: number }>();
+const revalidatingKeys = new Set<string>();
+const pendingRequests = new Map<string, Promise<TotalEcosystemValidatorsResponse | null>>();
+
+function getActiveMainnetSubnetIds(): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const chain of l1ChainsData as L1ChainRecord[]) {
+    if (chain.isTestnet === true) continue;
+    if (chain.isActive === false) continue;
+    if (!chain.subnetId || chain.subnetId === 'N/A') continue;
+    if (chain.subnetId === PRIMARY_NETWORK_SUBNET_ID) continue;
+    if (seen.has(chain.subnetId)) continue;
+    seen.add(chain.subnetId);
+    ids.push(chain.subnetId);
+  }
+  return ids;
+}
+
+async function fetchWithTimeout(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    return await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+      next: { revalidate: 0 },
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function fetchValidatorCountSeries(
+  subnetId: string | undefined,
+  startTimestamp: number,
+  endTimestamp: number,
+  pageSize: number,
+  fetchAllPages: boolean,
+): Promise<TimeSeriesDataPoint[] | null> {
+  try {
+    const rlToken = getRlToken();
+    const all: MetricsValidatorCountPoint[] = [];
+    let nextPageToken: string | undefined;
+
+    do {
+      const url = new URL('/v2/networks/mainnet/metrics/validatorCount', METRICS_API_BASE_URL);
+      url.searchParams.set('startTimestamp', String(startTimestamp));
+      url.searchParams.set('endTimestamp', String(endTimestamp));
+      url.searchParams.set('pageSize', String(pageSize));
+      if (subnetId) url.searchParams.set('subnetId', subnetId);
+      if (nextPageToken) url.searchParams.set('pageToken', nextPageToken);
+      if (rlToken) url.searchParams.set('rltoken', rlToken);
+
+      const response = await fetchWithTimeout(url.toString());
+      if (!response.ok) {
+        console.warn(
+          `[total-ecosystem-validators] Metrics API returned ${response.status} for subnet ${subnetId ?? 'primary'}.`,
+        );
+        return null;
+      }
+
+      const page = (await response.json()) as MetricsValidatorCountResponse;
+      if (Array.isArray(page.results)) {
+        all.push(...page.results);
+      }
+
+      nextPageToken = fetchAllPages ? page.nextPageToken : undefined;
+      if (!fetchAllPages) break;
+    } while (nextPageToken);
+
+    return all
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .map((r) => ({
+        timestamp: r.timestamp,
+        value: r.value || 0,
+        date: new Date(r.timestamp * 1000).toISOString().split('T')[0],
+      }));
+  } catch (error) {
+    console.warn(`[total-ecosystem-validators] Failed for subnet ${subnetId ?? 'primary'}:`, error);
+    return null;
+  }
+}
+
+async function processInBatches<T, R>(
+  items: T[],
+  processor: (item: T) => Promise<R>,
+  batchSize: number,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    const batchResults = await Promise.all(batch.map(processor));
+    results.push(...batchResults);
+  }
+  return results;
+}
+
+function sumSeriesByDate(seriesList: TimeSeriesDataPoint[][]): TimeSeriesDataPoint[] {
+  const totals = new Map<string, { timestamp: number; value: number }>();
+  for (const series of seriesList) {
+    for (const point of series) {
+      const numeric = typeof point.value === 'string' ? parseFloat(point.value) : point.value;
+      if (!Number.isFinite(numeric)) continue;
+      const existing = totals.get(point.date);
+      if (existing) {
+        existing.value += numeric;
+      } else {
+        totals.set(point.date, { timestamp: point.timestamp, value: numeric });
+      }
+    }
+  }
+  return Array.from(totals.entries())
+    .map(([date, { timestamp, value }]) => ({ date, timestamp, value }))
+    .sort((a, b) => b.timestamp - a.timestamp);
+}
+
+async function fetchFreshDataInternal(timeRange: string): Promise<TotalEcosystemValidatorsResponse | null> {
+  try {
+    const config = STATS_CONFIG.TIME_RANGES[timeRange as keyof typeof STATS_CONFIG.TIME_RANGES]
+      || STATS_CONFIG.TIME_RANGES['30d'];
+    const { pageSize, fetchAllPages } = config;
+    const { startTimestamp, endTimestamp } = getTimestampsFromTimeRange(timeRange);
+
+    const subnetIds = getActiveMainnetSubnetIds();
+
+    const [primarySeries, l1SeriesList] = await Promise.all([
+      fetchValidatorCountSeries(undefined, startTimestamp, endTimestamp, pageSize, fetchAllPages),
+      processInBatches(
+        subnetIds,
+        (subnetId) =>
+          fetchValidatorCountSeries(subnetId, startTimestamp, endTimestamp, pageSize, fetchAllPages),
+        MAX_CONCURRENT_REQUESTS,
+      ),
+    ]);
+
+    if (primarySeries === null) {
+      console.warn('[total-ecosystem-validators] Primary Network fetch failed; falling back to cache.');
+      return null;
+    }
+    const failedL1Index = l1SeriesList.findIndex((s) => s === null);
+    if (failedL1Index !== -1) {
+      console.warn(
+        `[total-ecosystem-validators] L1 fetch failed for subnet ${subnetIds[failedL1Index]}; falling back to cache.`,
+      );
+      return null;
+    }
+
+    const l1Totals = sumSeriesByDate(l1SeriesList as TimeSeriesDataPoint[][]);
+    const grandTotals = sumSeriesByDate([primarySeries, l1Totals]);
+
+    return {
+      total_validator_seats: createTimeSeriesMetric(grandTotals),
+      l1_validator_seats: createTimeSeriesMetric(l1Totals),
+      primary_network_validator_count: createTimeSeriesMetric(primarySeries),
+      subnets_included: subnetIds.length,
+      last_updated: Date.now(),
+    };
+  } catch (error) {
+    console.error('[total-ecosystem-validators] fetchFreshData failed:', error);
+    return null;
+  }
+}
+
+function createResponse(
+  data: TotalEcosystemValidatorsResponse | { error: string },
+  meta: { source: string; timeRange?: string; cacheAge?: number; fetchTime?: number },
+  status = 200,
+) {
+  const headers: Record<string, string> = {
+    'Cache-Control': CACHE_CONTROL_HEADER,
+    'X-Data-Source': meta.source,
+  };
+  if (meta.timeRange) headers['X-Time-Range'] = meta.timeRange;
+  if (meta.cacheAge !== undefined) headers['X-Cache-Age'] = `${Math.round(meta.cacheAge / 1000)}s`;
+  if (meta.fetchTime !== undefined) headers['X-Fetch-Time'] = `${meta.fetchTime}ms`;
+  return NextResponse.json(data, { status, headers });
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const timeRange = searchParams.get('timeRange') || 'all';
+
+    if (searchParams.get('clearCache') === 'true') {
+      cachedData.clear();
+      revalidatingKeys.clear();
+    }
+
+    const cached = cachedData.get(timeRange);
+    const cacheAge = cached ? Date.now() - cached.timestamp : Infinity;
+    const isCacheValid = cacheAge < STATS_CONFIG.CACHE.LONG_DURATION;
+    const isCacheStale = cached && !isCacheValid;
+
+    if (isCacheStale && cached) {
+      if (!revalidatingKeys.has(timeRange)) {
+        revalidatingKeys.add(timeRange);
+        (async () => {
+          try {
+            const freshData = await fetchFreshDataInternal(timeRange);
+            if (freshData) {
+              cachedData.set(timeRange, { data: freshData, timestamp: Date.now() });
+            }
+          } finally {
+            revalidatingKeys.delete(timeRange);
+          }
+        })();
+      }
+      return createResponse(cached.data, { source: 'stale-while-revalidate', timeRange, cacheAge });
+    }
+
+    if (isCacheValid && cached) {
+      return createResponse(cached.data, { source: 'cache', timeRange, cacheAge });
+    }
+
+    const pendingKey = `total-${timeRange}`;
+    let pendingPromise = pendingRequests.get(pendingKey);
+    if (!pendingPromise) {
+      pendingPromise = fetchFreshDataInternal(timeRange);
+      pendingRequests.set(pendingKey, pendingPromise);
+      pendingPromise.finally(() => pendingRequests.delete(pendingKey));
+    }
+
+    const startTime = Date.now();
+    const freshData = await pendingPromise;
+
+    if (!freshData) {
+      const fallbackCached = cached ?? cachedData.get(timeRange);
+      if (fallbackCached) {
+        return createResponse(
+          fallbackCached.data,
+          {
+            source: 'error-fallback-cache',
+            timeRange,
+            cacheAge: Date.now() - fallbackCached.timestamp,
+          },
+          206,
+        );
+      }
+      return createResponse(
+        { error: 'Failed to fetch total ecosystem validator stats' },
+        { source: 'error' },
+        500,
+      );
+    }
+
+    cachedData.set(timeRange, { data: freshData, timestamp: Date.now() });
+    const fetchTime = Date.now() - startTime;
+    return createResponse(freshData, { source: 'fresh', timeRange, fetchTime });
+  } catch (error) {
+    console.error('[GET /api/total-ecosystem-validators] Unhandled error:', error);
+    const { searchParams } = new URL(request.url);
+    const timeRange = searchParams.get('timeRange') || 'all';
+    const cached = cachedData.get(timeRange);
+    if (cached) {
+      return createResponse(
+        cached.data,
+        {
+          source: 'error-fallback-cache',
+          timeRange,
+          cacheAge: Date.now() - cached.timestamp,
+        },
+        206,
+      );
+    }
+    return createResponse(
+      { error: 'Failed to fetch total ecosystem validator stats' },
+      { source: 'error' },
+      500,
+    );
+  }
+}

--- a/components/stats/ChainMetricsPage.tsx
+++ b/components/stats/ChainMetricsPage.tsx
@@ -11,7 +11,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { getMAConfig, calculateMovingAverage } from "@/utils/chart-utils";
+import {
+  calculateMovingAverage,
+  getMAConfig,
+  timeSeriesMetricToChartData,
+} from "@/utils/chart-utils";
 import { Users, Activity, FileText, MessageCircleMore, TrendingUp, UserPlus, Hash, Code2, Gauge, DollarSign, Clock, Fuel, ArrowUpRight, Twitter, Linkedin, Download, Camera, Sparkles, Monitor } from "lucide-react";
 import { ImageExportStudio } from "@/components/stats/image-export";
 import { ChainIdChips } from "@/components/ui/copyable-id-chip";
@@ -30,7 +34,7 @@ import { StatsBreadcrumb } from "@/components/navigation/StatsBreadcrumb";
 import { ChainCategoryFilter, allChains } from "@/components/stats/ChainCategoryFilter";
 import { BaasProviderList } from "@/components/stats/BaasProviderBadge";
 import { useSectionNavigation } from "@/hooks/use-section-navigation";
-import { ValidatorChartCard, timeSeriesToChartData } from "@/components/stats/ValidatorChartCard";
+import { ValidatorChartCard } from "@/components/stats/ValidatorChartCard";
 import { ValidatorPieCard } from "@/components/stats/ValidatorPieCard";
 import { useTheme } from "next-themes";
 import { toPng } from "html-to-image";
@@ -2161,7 +2165,9 @@ export default function ChainMetricsPage({
                         chartType: "bar",
                         icon: Monitor,
                       }}
-                      rawData={timeSeriesToChartData(primaryValidatorMetric)}
+                      rawData={timeSeriesMetricToChartData(primaryValidatorMetric, {
+                        excludeToday: true,
+                      })}
                       period={validatorChartPeriod}
                       currentValue={totalValidatorSeats.current_value}
                       onPeriodChange={setValidatorChartPeriod}
@@ -2169,7 +2175,9 @@ export default function ChainMetricsPage({
                         `${formatNumber(Math.round(value))} Validator Seats`
                       }
                       formatYAxisValue={formatNumber}
-                      overlayData={timeSeriesToChartData(totalValidatorSeats)}
+                      overlayData={timeSeriesMetricToChartData(totalValidatorSeats, {
+                        excludeToday: true,
+                      })}
                       overlayLabel="Total Validator Seats (Primary + L1s)"
                       overlayColor="#3B82F6"
                       overlayStartDate="2024-12-16"

--- a/components/stats/ChainMetricsPage.tsx
+++ b/components/stats/ChainMetricsPage.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { getMAConfig, calculateMovingAverage } from "@/utils/chart-utils";
-import { Users, Activity, FileText, MessageCircleMore, TrendingUp, UserPlus, Hash, Code2, Gauge, DollarSign, Clock, Fuel, ArrowUpRight, Twitter, Linkedin, Download, Camera, Sparkles } from "lucide-react";
+import { Users, Activity, FileText, MessageCircleMore, TrendingUp, UserPlus, Hash, Code2, Gauge, DollarSign, Clock, Fuel, ArrowUpRight, Twitter, Linkedin, Download, Camera, Sparkles, Monitor } from "lucide-react";
 import { ImageExportStudio } from "@/components/stats/image-export";
 import { ChainIdChips } from "@/components/ui/copyable-id-chip";
 import { AddToWalletButton } from "@/components/ui/add-to-wallet-button";
@@ -30,6 +30,8 @@ import { StatsBreadcrumb } from "@/components/navigation/StatsBreadcrumb";
 import { ChainCategoryFilter, allChains } from "@/components/stats/ChainCategoryFilter";
 import { BaasProviderList } from "@/components/stats/BaasProviderBadge";
 import { useSectionNavigation } from "@/hooks/use-section-navigation";
+import { ValidatorChartCard, timeSeriesToChartData } from "@/components/stats/ValidatorChartCard";
+import { ValidatorPieCard } from "@/components/stats/ValidatorPieCard";
 import { useTheme } from "next-themes";
 import { toPng } from "html-to-image";
 import l1ChainsData from "@/constants/l1-chains.json";
@@ -130,6 +132,17 @@ export default function ChainMetricsPage({
   const [loading, setLoading] = useState(true);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const [primaryValidatorMetric, setPrimaryValidatorMetric] = useState<any>(null);
+  const [totalValidatorSeats, setTotalValidatorSeats] = useState<any>(null);
+  const [subnetValidatorStats, setSubnetValidatorStats] = useState<
+    { id: string; name: string; nodes: number; isL1: boolean }[] | null
+  >(null);
+  const [validatorsLoading, setValidatorsLoading] = useState(false);
+  const [totalSeatsLoading, setTotalSeatsLoading] = useState(false);
+  const [validatorChartPeriod, setValidatorChartPeriod] = useState<
+    "D" | "W" | "M" | "Q" | "Y"
+  >("D");
 
   // Cache for "all chains" data - fetched once and reused for filtering
   const [cachedAllData, setCachedAllData] = useState<CChainMetrics | null>(
@@ -449,6 +462,63 @@ export default function ChainMetricsPage({
     selectedChainIds.size,
     excludedChainIds.join(","),
   ]);
+
+  useEffect(() => {
+    if (!isAllChainsView) return;
+    let cancelled = false;
+    setValidatorsLoading(true);
+
+    Promise.allSettled([
+      fetch("/api/primary-network-stats?timeRange=all").then((r) =>
+        r.ok ? r.json() : null,
+      ),
+      fetch("/api/validator-stats?network=mainnet").then((r) =>
+        r.ok ? r.json() : null,
+      ),
+    ])
+      .then(([primaryResult, subnetsResult]) => {
+        if (cancelled) return;
+        if (primaryResult.status === "fulfilled" && primaryResult.value?.validator_count) {
+          setPrimaryValidatorMetric(primaryResult.value.validator_count);
+        }
+        if (subnetsResult.status === "fulfilled" && Array.isArray(subnetsResult.value)) {
+          setSubnetValidatorStats(
+            subnetsResult.value.map((s: any) => ({
+              id: s.id,
+              name: s.name,
+              nodes: Object.values(s.byClientVersion ?? {}).reduce(
+                (sum: number, v: any) => sum + (v?.nodes ?? 0),
+                0,
+              ),
+              isL1: Boolean(s.isL1),
+            })),
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setValidatorsLoading(false);
+      });
+
+    setTotalSeatsLoading(true);
+    fetch("/api/total-ecosystem-validators?timeRange=all")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled) return;
+        if (data?.total_validator_seats) {
+          setTotalValidatorSeats(data.total_validator_seats);
+        }
+      })
+      .catch((err) =>
+        console.error("Error fetching total ecosystem validators:", err),
+      )
+      .finally(() => {
+        if (!cancelled) setTotalSeatsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAllChainsView]);
 
   const formatNumber = (num: number | string): string => {
     if (num === "N/A" || num === "") return "N/A";
@@ -925,6 +995,9 @@ export default function ChainMetricsPage({
     },
     { id: "fees", label: "Fees", metricKeys: ["feesPaid", "avgGasPrice", "maxGasPrice"] },
     { id: "interchain", label: "Interchain", metricKeys: ["icmMessages"] },
+    ...(isAllChainsView
+      ? [{ id: "validators", label: "Validators", metricKeys: [] as string[] }]
+      : []),
   ];
 
   // export all metrics as csv
@@ -2060,6 +2133,73 @@ export default function ChainMetricsPage({
                 })}
               </div>
             </section>
+
+            {isAllChainsView && (
+              <section className="space-y-4 sm:space-y-6">
+                <div className="space-y-2">
+                  <LinkableHeading
+                    as="h2"
+                    id="validators"
+                    className="text-lg sm:text-2xl font-medium text-left"
+                  >
+                    Validators
+                  </LinkableHeading>
+                  <p className="text-zinc-500 dark:text-zinc-400 text-sm">
+                    Validator distribution across the Avalanche ecosystem
+                  </p>
+                </div>
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
+                  {primaryValidatorMetric?.data?.length &&
+                  totalValidatorSeats?.data?.length ? (
+                    <ValidatorChartCard
+                      config={{
+                        title: "Avalanche Ecosystem Validator Count",
+                        description:
+                          "Validator seats across the Primary Network and sovereign L1s",
+                        metricKey: "validator_count",
+                        color: themeColor,
+                        chartType: "bar",
+                        icon: Monitor,
+                      }}
+                      rawData={timeSeriesToChartData(primaryValidatorMetric)}
+                      period={validatorChartPeriod}
+                      currentValue={totalValidatorSeats.current_value}
+                      onPeriodChange={setValidatorChartPeriod}
+                      formatTooltipValue={(value) =>
+                        `${formatNumber(Math.round(value))} Validator Seats`
+                      }
+                      formatYAxisValue={formatNumber}
+                      overlayData={timeSeriesToChartData(totalValidatorSeats)}
+                      overlayLabel="Total Validator Seats (Primary + L1s)"
+                      overlayColor="#3B82F6"
+                      overlayStartDate="2024-12-16"
+                      referenceLineDate="2024-12-16"
+                      referenceLineLabel="ACP-77 (Etna)"
+                      descriptionNote="Before the Etna upgrade every L1 validator was also a Primary Network validator, so total ecosystem seats only diverge from the Primary Network count after this point."
+                      primaryAsLine
+                    />
+                  ) : (
+                    <ValidatorChartPlaceholder
+                      title="Avalanche Ecosystem Validator Count"
+                      description="Validator seats across the Primary Network and sovereign L1s"
+                      color={themeColor}
+                      loading={validatorsLoading || totalSeatsLoading}
+                    />
+                  )}
+                  <ValidatorPieCard
+                    primaryNetworkCount={
+                      primaryValidatorMetric?.current_value != null
+                        ? typeof primaryValidatorMetric.current_value === "string"
+                          ? parseFloat(primaryValidatorMetric.current_value)
+                          : primaryValidatorMetric.current_value
+                        : null
+                    }
+                    subnetStats={subnetValidatorStats}
+                    loading={validatorsLoading}
+                  />
+                </div>
+              </section>
+            )}
           </>
         )}
       </div>
@@ -2076,6 +2216,42 @@ export default function ChainMetricsPage({
         <StatsBubbleNav />
       )}
     </div>
+  );
+}
+
+function ValidatorChartPlaceholder({
+  title,
+  description,
+  color,
+  loading,
+}: {
+  title: string;
+  description: string;
+  color: string;
+  loading: boolean;
+}) {
+  return (
+    <Card className="py-0 border-gray-200 rounded-md dark:border-gray-700">
+      <CardContent className="p-0">
+        <div className="flex items-center gap-2 sm:gap-3 px-4 sm:px-5 py-3 sm:py-4 border-b border-gray-200 dark:border-gray-700">
+          <div
+            className="rounded-full p-2 sm:p-3 flex items-center justify-center"
+            style={{ backgroundColor: `${color}20` }}
+          >
+            <Monitor className="h-5 w-5 sm:h-6 sm:w-6" style={{ color }} />
+          </div>
+          <div>
+            <h3 className="text-base sm:text-lg font-normal">{title}</h3>
+            <p className="text-xs sm:text-sm text-muted-foreground hidden sm:block">
+              {description}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center justify-center h-[440px] text-sm text-muted-foreground">
+          {loading ? "Loading…" : "Validator data unavailable."}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/components/stats/ValidatorChartCard.tsx
+++ b/components/stats/ValidatorChartCard.tsx
@@ -1,0 +1,642 @@
+"use client";
+import { useState, useEffect, useMemo, useRef } from "react";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  Brush,
+  CartesianGrid,
+  ComposedChart,
+  Label,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { TrendingUp, Camera, Download } from "lucide-react";
+import { ChartWatermark } from "@/components/stats/ChartWatermark";
+import {
+  calculateDateRangeDays,
+  formatXAxisLabel,
+  generateXAxisTicks,
+} from "@/components/stats/chart-axis-utils";
+import { useTheme } from "next-themes";
+import { toPng } from "html-to-image";
+import { TimeSeriesMetric, TimeSeriesDataPoint, ChartDataPoint } from "@/types/stats";
+
+export function timeSeriesToChartData(
+  metric: TimeSeriesMetric | null | undefined,
+): ChartDataPoint[] {
+  if (!metric?.data) return [];
+  const today = new Date().toISOString().split("T")[0];
+  return metric.data
+    .filter((point) => point.date !== today)
+    .map((point: TimeSeriesDataPoint) => ({
+      day: point.date,
+      value:
+        typeof point.value === "string"
+          ? parseFloat(point.value)
+          : point.value,
+    }))
+    .reverse();
+}
+
+export interface ValidatorChartCardProps {
+  config: {
+    title: string;
+    description: string;
+    metricKey: string;
+    color: string;
+    chartType: "bar" | "area";
+    icon: React.ComponentType<{ className?: string; style?: React.CSSProperties }>;
+  };
+  rawData: ChartDataPoint[];
+  period: "D" | "W" | "M" | "Q" | "Y";
+  currentValue: number | string;
+  onPeriodChange: (period: "D" | "W" | "M" | "Q" | "Y") => void;
+  formatTooltipValue: (value: number) => string;
+  formatYAxisValue: (value: number) => string;
+  overlayData?: ChartDataPoint[];
+  overlayLabel?: string;
+  overlayColor?: string;
+  overlayStartDate?: string;
+  referenceLineDate?: string;
+  referenceLineLabel?: string;
+  descriptionNote?: string;
+  primaryAsLine?: boolean;
+  primarySeriesLabel?: string;
+}
+
+export function ValidatorChartCard({
+  config,
+  rawData,
+  period,
+  currentValue,
+  onPeriodChange,
+  formatTooltipValue,
+  formatYAxisValue,
+  overlayData,
+  overlayLabel,
+  overlayColor,
+  overlayStartDate,
+  referenceLineDate,
+  referenceLineLabel,
+  descriptionNote,
+  primaryAsLine = false,
+  primarySeriesLabel = "Primary Network",
+}: ValidatorChartCardProps) {
+  const filteredOverlayData = useMemo(() => {
+    if (!overlayData) return undefined;
+    if (!overlayStartDate) return overlayData;
+    return overlayData.filter((p) => p.day >= overlayStartDate);
+  }, [overlayData, overlayStartDate]);
+  const hasOverlay = Array.isArray(filteredOverlayData) && filteredOverlayData.length > 0;
+  const [brushIndexes, setBrushIndexes] = useState<{
+    startIndex: number;
+    endIndex: number;
+  } | null>(null);
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const { resolvedTheme } = useTheme();
+
+  const handleScreenshot = async () => {
+    if (!chartContainerRef.current) return;
+    try {
+      const element = chartContainerRef.current;
+      const bgColor = resolvedTheme === "dark" ? "#0a0a0a" : "#ffffff";
+      const dataUrl = await toPng(element, {
+        quality: 1,
+        pixelRatio: 2,
+        backgroundColor: bgColor,
+        cacheBust: true,
+      });
+      const link = document.createElement("a");
+      link.download = `${config.title.replace(/\s+/g, "_")}_${period}_${new Date().toISOString().split("T")[0]}.png`;
+      link.href = dataUrl;
+      link.click();
+    } catch (error) {
+      console.error("Failed to capture screenshot:", error);
+    }
+  };
+
+  const aggregatedData = useMemo(() => {
+    if (period === "D") return rawData;
+    const grouped = new Map<string, { sum: number; count: number; date: string }>();
+    rawData.forEach((point) => {
+      const date = new Date(point.day);
+      let key: string;
+      if (period === "W") {
+        const weekStart = new Date(date);
+        weekStart.setDate(date.getDate() - date.getDay());
+        key = weekStart.toISOString().split("T")[0];
+      } else if (period === "M") {
+        key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+      } else if (period === "Q") {
+        const quarter = Math.floor(date.getMonth() / 3) + 1;
+        key = `${date.getFullYear()}-Q${quarter}`;
+      } else {
+        key = String(date.getFullYear());
+      }
+      if (!grouped.has(key)) grouped.set(key, { sum: 0, count: 0, date: key });
+      const group = grouped.get(key)!;
+      group.sum += point.value;
+      group.count += 1;
+    });
+    return Array.from(grouped.values())
+      .map((group) => ({ day: group.date, value: group.sum / group.count }))
+      .sort((a, b) => a.day.localeCompare(b.day));
+  }, [rawData, period]);
+
+  const aggregatedOverlay = useMemo(() => {
+    if (!hasOverlay) return null;
+    if (period === "D") return filteredOverlayData!;
+    const grouped = new Map<string, { sum: number; count: number; date: string }>();
+    filteredOverlayData!.forEach((point) => {
+      const date = new Date(point.day);
+      let key: string;
+      if (period === "W") {
+        const weekStart = new Date(date);
+        weekStart.setDate(date.getDate() - date.getDay());
+        key = weekStart.toISOString().split("T")[0];
+      } else if (period === "M") {
+        key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+      } else if (period === "Q") {
+        const quarter = Math.floor(date.getMonth() / 3) + 1;
+        key = `${date.getFullYear()}-Q${quarter}`;
+      } else {
+        key = String(date.getFullYear());
+      }
+      if (!grouped.has(key)) grouped.set(key, { sum: 0, count: 0, date: key });
+      const group = grouped.get(key)!;
+      group.sum += point.value;
+      group.count += 1;
+    });
+    return Array.from(grouped.values())
+      .map((group) => ({ day: group.date, value: group.sum / group.count }))
+      .sort((a, b) => a.day.localeCompare(b.day));
+  }, [filteredOverlayData, period, hasOverlay]);
+
+  const mergedAggregated = useMemo(() => {
+    if (!hasOverlay || !aggregatedOverlay) return aggregatedData;
+    const overlayMap = new Map(aggregatedOverlay.map((p) => [p.day, p.value]));
+    return aggregatedData.map((point) => ({
+      ...point,
+      overlayValue: overlayMap.get(point.day) ?? null,
+    }));
+  }, [aggregatedData, aggregatedOverlay, hasOverlay]);
+
+  const referenceLineBucket = useMemo(() => {
+    if (!referenceLineDate) return null;
+    const date = new Date(referenceLineDate);
+    if (period === "D") return referenceLineDate;
+    if (period === "W") {
+      const weekStart = new Date(date);
+      weekStart.setDate(date.getDate() - date.getDay());
+      return weekStart.toISOString().split("T")[0];
+    }
+    if (period === "M") {
+      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+    }
+    if (period === "Q") {
+      const q = Math.floor(date.getMonth() / 3) + 1;
+      return `${date.getFullYear()}-Q${q}`;
+    }
+    return String(date.getFullYear());
+  }, [referenceLineDate, period]);
+
+  useEffect(() => {
+    if (aggregatedData.length === 0) return;
+    if (period === "D") {
+      const daysToShow = 90;
+      let startIndex = Math.max(0, aggregatedData.length - daysToShow);
+      if (referenceLineBucket) {
+        const refIdx = aggregatedData.findIndex((p) => p.day === referenceLineBucket);
+        if (refIdx >= 0 && refIdx < startIndex) {
+          startIndex = Math.max(0, refIdx - 30);
+        }
+      }
+      setBrushIndexes({ startIndex, endIndex: aggregatedData.length - 1 });
+    } else {
+      setBrushIndexes({ startIndex: 0, endIndex: aggregatedData.length - 1 });
+    }
+  }, [period, aggregatedData.length, referenceLineBucket]);
+
+  const displayData = brushIndexes
+    ? mergedAggregated.slice(brushIndexes.startIndex, brushIndexes.endIndex + 1)
+    : mergedAggregated;
+
+  const isReferenceInRange = useMemo(() => {
+    if (!referenceLineBucket || displayData.length === 0) return false;
+    const first = displayData[0].day;
+    const last = displayData[displayData.length - 1].day;
+    return referenceLineBucket >= first && referenceLineBucket <= last;
+  }, [referenceLineBucket, displayData]);
+
+  const brushRangeDays = useMemo(
+    () => calculateDateRangeDays(displayData as any, "day"),
+    [displayData],
+  );
+  const totalDataDays = useMemo(
+    () => calculateDateRangeDays(aggregatedData as any, "day"),
+    [aggregatedData],
+  );
+
+  const formatXAxis = (value: string) => formatXAxisLabel(value, brushRangeDays);
+  const formatBrushXAxis = (value: string) => formatXAxisLabel(value, totalDataDays);
+
+  const xAxisTicks = useMemo(
+    () => generateXAxisTicks(displayData as any, brushRangeDays, "day"),
+    [displayData, brushRangeDays],
+  );
+
+  const headlineKey: "value" | "overlayValue" =
+    primaryAsLine && hasOverlay ? "overlayValue" : "value";
+
+  const dynamicChange = useMemo(() => {
+    if (!displayData || displayData.length < 2) return { change: 0, isPositive: true };
+    const firstValue = (displayData[0] as any)[headlineKey];
+    const lastValue = (displayData[displayData.length - 1] as any)[headlineKey];
+    if (typeof firstValue !== "number" || typeof lastValue !== "number") {
+      return { change: 0, isPositive: true };
+    }
+    if (firstValue === 0) return { change: 0, isPositive: true };
+    const changePercentage = ((lastValue - firstValue) / firstValue) * 100;
+    return {
+      change: Math.abs(changePercentage),
+      isPositive: changePercentage >= 0,
+    };
+  }, [displayData, headlineKey]);
+
+  const downloadCSV = () => {
+    if (!displayData || displayData.length === 0) return;
+    const headers = ["Date", primarySeriesLabel];
+    if (hasOverlay) headers.push(overlayLabel ?? "Total Validator Seats");
+    const rows = displayData.map((point: any) => {
+      const cells = [point.day, point.value];
+      if (hasOverlay) cells.push(point.overlayValue ?? "");
+      return cells.join(",");
+    });
+    const csvContent = [headers.join(","), ...rows].join("\n");
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${config.title.replace(/\s+/g, "_")}_${period}_${new Date().toISOString().split("T")[0]}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const formatTooltipDate = (value: string) => {
+    if (period === "Y") return value;
+    if (period === "Q") {
+      const parts = value.split("-");
+      if (parts.length === 2) return `${parts[1]} ${parts[0]}`;
+      return value;
+    }
+    const date = new Date(value);
+    if (period === "M") {
+      return date.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+    }
+    if (period === "W") {
+      const endDate = new Date(date);
+      endDate.setDate(date.getDate() + 6);
+      const startMonth = date.toLocaleDateString("en-US", { month: "long" });
+      const endMonth = endDate.toLocaleDateString("en-US", { month: "long" });
+      const startDay = date.getDate();
+      const endDay = endDate.getDate();
+      const year = endDate.getFullYear();
+      if (startMonth === endMonth) return `${startMonth} ${startDay}-${endDay}, ${year}`;
+      return `${startMonth} ${startDay} - ${endMonth} ${endDay}, ${year}`;
+    }
+    return date.toLocaleDateString("en-US", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
+  };
+
+  const Icon = config.icon;
+
+  return (
+    <Card className="py-0 border-gray-200 rounded-md dark:border-gray-700" ref={chartContainerRef}>
+      <CardContent className="p-0">
+        <div className="flex items-center justify-between px-4 sm:px-5 py-3 sm:py-4 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center gap-2 sm:gap-3">
+            <div
+              className="rounded-full p-2 sm:p-3 flex items-center justify-center"
+              style={{ backgroundColor: `${config.color}20` }}
+            >
+              <Icon className="h-5 w-5 sm:h-6 sm:w-6" style={{ color: config.color }} />
+            </div>
+            <div>
+              <h3 className="text-base sm:text-lg font-normal">{config.title}</h3>
+              <p className="text-xs sm:text-sm text-muted-foreground hidden sm:block">
+                {config.description}
+              </p>
+              {descriptionNote && isReferenceInRange && (
+                <p className="mt-1 text-xs text-muted-foreground/80 italic hidden sm:block max-w-2xl">
+                  {descriptionNote}
+                </p>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-1">
+            <Select
+              value={period}
+              onValueChange={(value) => onPeriodChange(value as "D" | "W" | "M" | "Q" | "Y")}
+            >
+              <SelectTrigger className="h-7 w-auto px-2 gap-1 text-xs sm:text-sm border-0 bg-transparent hover:bg-muted focus:ring-0 shadow-none">
+                <SelectValue>
+                  {period === "D" ? "Daily" : period === "W" ? "Weekly" : period === "M" ? "Monthly" : period === "Q" ? "Quarterly" : "Yearly"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {(["D", "W", "M", "Q", "Y"] as const).map((p) => (
+                  <SelectItem key={p} value={p}>
+                    {p === "D" ? "Daily" : p === "W" ? "Weekly" : p === "M" ? "Monthly" : p === "Q" ? "Quarterly" : "Yearly"}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <button
+              onClick={handleScreenshot}
+              className="p-1.5 sm:p-2 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors cursor-pointer"
+              title="Download chart as image"
+            >
+              <Camera className="h-4 w-4" />
+            </button>
+            <button
+              onClick={downloadCSV}
+              className="p-1.5 sm:p-2 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors cursor-pointer"
+              title="Download CSV"
+            >
+              <Download className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        <div className="px-5 pt-6 pb-6">
+          <div className="flex items-center gap-2 sm:gap-4 mb-3 sm:mb-4 pl-2 sm:pl-4">
+            <div className="text-md sm:text-xl font-mono break-all">
+              {formatTooltipValue(
+                typeof currentValue === "string" ? parseFloat(currentValue) : currentValue,
+              )}
+            </div>
+            {dynamicChange.change > 0 && (
+              <div
+                className={`flex items-center gap-1 text-xs sm:text-sm ${
+                  dynamicChange.isPositive ? "text-green-600" : "text-red-600"
+                }`}
+                title="Change over selected time range"
+              >
+                <TrendingUp
+                  className={`h-3 w-3 sm:h-4 sm:w-4 ${
+                    dynamicChange.isPositive ? "" : "rotate-180"
+                  }`}
+                />
+                {dynamicChange.change.toFixed(1)}%
+              </div>
+            )}
+          </div>
+
+          {hasOverlay && (
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mb-3 pl-2 sm:pl-4 text-xs text-muted-foreground">
+              <div className="flex items-center gap-1.5">
+                <span
+                  className={
+                    primaryAsLine ? "inline-block h-0.5 w-3" : "inline-block h-2.5 w-2.5 rounded-sm"
+                  }
+                  style={{ backgroundColor: config.color }}
+                />
+                <span>{primarySeriesLabel}</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span
+                  className="inline-block h-0.5 w-3"
+                  style={{ backgroundColor: overlayColor ?? "#3B82F6" }}
+                />
+                <span>{overlayLabel ?? "Total Validator Seats"}</span>
+              </div>
+            </div>
+          )}
+
+          <ChartWatermark className="mb-6">
+            <ResponsiveContainer width="100%" height={350}>
+              {config.chartType === "bar" ? (
+                <ComposedChart data={displayData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    className="stroke-gray-200 dark:stroke-gray-700"
+                    vertical={false}
+                  />
+                  <XAxis
+                    dataKey="day"
+                    tickFormatter={formatXAxis}
+                    className="text-xs text-gray-600 dark:text-gray-400"
+                    tick={{ className: "fill-gray-600 dark:fill-gray-400" }}
+                    ticks={xAxisTicks}
+                    interval={0}
+                  />
+                  <YAxis
+                    tickFormatter={formatYAxisValue}
+                    className="text-xs text-gray-600 dark:text-gray-400"
+                    tick={{ className: "fill-gray-600 dark:fill-gray-400" }}
+                  />
+                  <Tooltip
+                    cursor={{ fill: `${config.color}20` }}
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.length) return null;
+                      const barPoint =
+                        payload.find((p: any) => p.dataKey === "value") ?? payload[0];
+                      const overlayPoint = payload.find(
+                        (p: any) => p.dataKey === "overlayValue",
+                      );
+                      const formattedDate = formatTooltipDate(barPoint.payload.day);
+                      return (
+                        <div className="rounded-lg border bg-background p-2 shadow-sm font-mono">
+                          <div className="grid gap-1.5">
+                            <div className="font-medium text-sm">{formattedDate}</div>
+                            {hasOverlay ? (
+                              <div className="text-sm flex items-center gap-2">
+                                <span
+                                  className="inline-block h-2 w-2 rounded-sm"
+                                  style={{ backgroundColor: config.color }}
+                                />
+                                <span>
+                                  {primarySeriesLabel}:{" "}
+                                  {formatTooltipValue(barPoint.value as number)}
+                                </span>
+                              </div>
+                            ) : (
+                              <div className="text-sm">
+                                {formatTooltipValue(barPoint.value as number)}
+                              </div>
+                            )}
+                            {hasOverlay && overlayPoint && overlayPoint.value != null && (
+                              <div className="text-sm flex items-center gap-2">
+                                <span
+                                  className="inline-block h-2 w-2 rounded-sm"
+                                  style={{ backgroundColor: overlayColor }}
+                                />
+                                <span>
+                                  {overlayLabel ?? "Total Validator Seats"}:{" "}
+                                  {formatTooltipValue(overlayPoint.value as number)}
+                                </span>
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    }}
+                  />
+                  {primaryAsLine ? (
+                    <Line
+                      type="monotone"
+                      dataKey="value"
+                      stroke={config.color}
+                      strokeWidth={2}
+                      dot={false}
+                      isAnimationActive={false}
+                    />
+                  ) : (
+                    <Bar dataKey="value" fill={config.color} radius={[4, 4, 0, 0]} />
+                  )}
+                  {hasOverlay && (
+                    <Line
+                      type="monotone"
+                      dataKey="overlayValue"
+                      stroke={overlayColor ?? "#3B82F6"}
+                      strokeWidth={2}
+                      dot={false}
+                      connectNulls
+                      isAnimationActive={false}
+                    />
+                  )}
+                  {referenceLineBucket && isReferenceInRange && (
+                    <ReferenceLine
+                      x={referenceLineBucket}
+                      stroke="#E84142"
+                      strokeDasharray="4 4"
+                      strokeWidth={2}
+                    >
+                      <Label
+                        value={referenceLineLabel ?? "ACP-77"}
+                        position="insideTopRight"
+                        fill="#E84142"
+                        fontSize={11}
+                        offset={8}
+                      />
+                    </ReferenceLine>
+                  )}
+                </ComposedChart>
+              ) : (
+                <AreaChart data={displayData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+                  <defs>
+                    <linearGradient
+                      id={`gradient-${config.metricKey}`}
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="1"
+                    >
+                      <stop offset="5%" stopColor={config.color} stopOpacity={0.3} />
+                      <stop offset="95%" stopColor={config.color} stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    className="stroke-gray-200 dark:stroke-gray-700"
+                    vertical={false}
+                  />
+                  <XAxis
+                    dataKey="day"
+                    tickFormatter={formatXAxis}
+                    className="text-xs text-gray-600 dark:text-gray-400"
+                    tick={{ className: "fill-gray-600 dark:fill-gray-400" }}
+                    ticks={xAxisTicks}
+                    interval={0}
+                  />
+                  <YAxis
+                    tickFormatter={formatYAxisValue}
+                    className="text-xs text-gray-600 dark:text-gray-400"
+                    tick={{ className: "fill-gray-600 dark:fill-gray-400" }}
+                  />
+                  <Tooltip
+                    cursor={{ fill: `${config.color}20` }}
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.[0]) return null;
+                      const formattedDate = formatTooltipDate(payload[0].payload.day);
+                      return (
+                        <div className="rounded-lg border bg-background p-2 shadow-sm font-mono">
+                          <div className="grid gap-2">
+                            <div className="font-medium text-sm">{formattedDate}</div>
+                            <div className="text-sm">
+                              {formatTooltipValue(payload[0].value as number)}
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    }}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="value"
+                    stroke={config.color}
+                    fill={`url(#gradient-${config.metricKey})`}
+                    strokeWidth={2}
+                  />
+                </AreaChart>
+              )}
+            </ResponsiveContainer>
+          </ChartWatermark>
+
+          <div className="mt-4 bg-white dark:bg-black pl-[60px]">
+            <ResponsiveContainer width="100%" height={80}>
+              <LineChart data={mergedAggregated} margin={{ top: 0, right: 30, left: 0, bottom: 5 }}>
+                <Brush
+                  dataKey="day"
+                  height={80}
+                  stroke={config.color}
+                  fill={`${config.color}20`}
+                  alwaysShowText={false}
+                  startIndex={brushIndexes?.startIndex ?? 0}
+                  endIndex={brushIndexes?.endIndex ?? aggregatedData.length - 1}
+                  onChange={(e: any) => {
+                    if (e.startIndex !== undefined && e.endIndex !== undefined) {
+                      setBrushIndexes({ startIndex: e.startIndex, endIndex: e.endIndex });
+                    }
+                  }}
+                  travellerWidth={8}
+                  tickFormatter={formatBrushXAxis}
+                >
+                  <LineChart>
+                    <Line
+                      type="monotone"
+                      dataKey={headlineKey}
+                      stroke={config.color}
+                      strokeWidth={1}
+                      dot={false}
+                      connectNulls
+                    />
+                  </LineChart>
+                </Brush>
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/stats/ValidatorChartCard.tsx
+++ b/components/stats/ValidatorChartCard.tsx
@@ -33,24 +33,7 @@ import {
 } from "@/components/stats/chart-axis-utils";
 import { useTheme } from "next-themes";
 import { toPng } from "html-to-image";
-import { TimeSeriesMetric, TimeSeriesDataPoint, ChartDataPoint } from "@/types/stats";
-
-export function timeSeriesToChartData(
-  metric: TimeSeriesMetric | null | undefined,
-): ChartDataPoint[] {
-  if (!metric?.data) return [];
-  const today = new Date().toISOString().split("T")[0];
-  return metric.data
-    .filter((point) => point.date !== today)
-    .map((point: TimeSeriesDataPoint) => ({
-      day: point.date,
-      value:
-        typeof point.value === "string"
-          ? parseFloat(point.value)
-          : point.value,
-    }))
-    .reverse();
-}
+import type { ChartDataPoint } from "@/types/stats";
 
 export interface ValidatorChartCardProps {
   config: {

--- a/components/stats/ValidatorPieCard.tsx
+++ b/components/stats/ValidatorPieCard.tsx
@@ -1,0 +1,226 @@
+"use client";
+import { useMemo } from "react";
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import { Card, CardContent } from "@/components/ui/card";
+import { Users } from "lucide-react";
+
+export const POS_L1_SUBNET_IDS: Record<string, string> = {
+  "21uUaTxVdR3Sp6SJhpcSrdH1g66aFoE8mPQDvwKJCjXNexo5y6": "Kite",
+  eYwmVU67LmSfZb1RwqCMhBYkFyG8ftxn6jAwqzFmxC9STBWLC: "Beam",
+  WChFQ1twkXBLxZGo4qojC9AgizFrRdMRnPCK9FZmisY7z6pUs: "CX",
+  wenKDikJWAYQs3f2v9JhV86fC6kHZwkFZsuUBftnmgZ4QXPnu: "Dexalot",
+};
+
+const PRIMARY_NETWORK_COLOR = "#E84142";
+const POS_L1_COLOR = "#3B82F6";
+const POA_L1_COLOR = "#A78BFA";
+
+interface SubnetStat {
+  id: string;
+  name: string;
+  nodes: number;
+  isL1: boolean;
+}
+
+export interface ValidatorPieCardProps {
+  primaryNetworkCount: number | null;
+  subnetStats: SubnetStat[] | null;
+  loading?: boolean;
+}
+
+interface Slice {
+  category: "primary" | "pos" | "poa";
+  label: string;
+  count: number;
+  color: string;
+  members: { name: string; count: number }[];
+}
+
+export function ValidatorPieCard({
+  primaryNetworkCount,
+  subnetStats,
+  loading,
+}: ValidatorPieCardProps) {
+  const slices = useMemo<Slice[]>(() => {
+    const result: Slice[] = [];
+
+    if (typeof primaryNetworkCount === "number" && primaryNetworkCount > 0) {
+      result.push({
+        category: "primary",
+        label: "Primary Network",
+        count: primaryNetworkCount,
+        color: PRIMARY_NETWORK_COLOR,
+        members: [{ name: "Primary Network", count: primaryNetworkCount }],
+      });
+    }
+
+    if (subnetStats?.length) {
+      const posMembers: { name: string; count: number }[] = [];
+      const poaMembers: { name: string; count: number }[] = [];
+      let posTotal = 0;
+      let poaTotal = 0;
+
+      for (const subnet of subnetStats) {
+        if (!subnet.isL1) continue;
+        if (subnet.nodes <= 0) continue;
+        if (POS_L1_SUBNET_IDS[subnet.id]) {
+          posMembers.push({ name: subnet.name, count: subnet.nodes });
+          posTotal += subnet.nodes;
+        } else {
+          poaMembers.push({ name: subnet.name, count: subnet.nodes });
+          poaTotal += subnet.nodes;
+        }
+      }
+
+      if (posTotal > 0) {
+        posMembers.sort((a, b) => b.count - a.count);
+        result.push({
+          category: "pos",
+          label: "Proof-of-Stake L1s",
+          count: posTotal,
+          color: POS_L1_COLOR,
+          members: posMembers,
+        });
+      }
+
+      if (poaTotal > 0) {
+        poaMembers.sort((a, b) => b.count - a.count);
+        result.push({
+          category: "poa",
+          label: "Proof-of-Authority L1s",
+          count: poaTotal,
+          color: POA_L1_COLOR,
+          members: poaMembers,
+        });
+      }
+    }
+
+    return result;
+  }, [primaryNetworkCount, subnetStats]);
+
+  const total = slices.reduce((sum, s) => sum + s.count, 0);
+  const subnetDataMissing = subnetStats === null;
+
+  return (
+    <Card className="py-0 border-gray-200 rounded-md dark:border-gray-700">
+      <CardContent className="p-0">
+        <div className="flex items-center justify-between px-4 sm:px-5 py-3 sm:py-4 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center gap-2 sm:gap-3">
+            <div
+              className="rounded-full p-2 sm:p-3 flex items-center justify-center"
+              style={{ backgroundColor: `${PRIMARY_NETWORK_COLOR}20` }}
+            >
+              <Users className="h-5 w-5 sm:h-6 sm:w-6" style={{ color: PRIMARY_NETWORK_COLOR }} />
+            </div>
+            <div>
+              <h3 className="text-base sm:text-lg font-normal">
+                Validator Distribution
+              </h3>
+              <p className="text-xs sm:text-sm text-muted-foreground hidden sm:block">
+                Primary Network vs Proof-of-Stake and Proof-of-Authority L1s
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="px-5 pt-6 pb-6">
+          {loading || subnetDataMissing ? (
+            <div className="flex items-center justify-center h-[350px] text-sm text-muted-foreground">
+              {loading ? "Loading…" : "Validator distribution unavailable."}
+            </div>
+          ) : total === 0 ? (
+            <div className="flex items-center justify-center h-[350px] text-sm text-muted-foreground">
+              No validator data available.
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
+                <ResponsiveContainer width="100%" height={280}>
+                  <PieChart>
+                    <Tooltip
+                      content={({ active, payload }) => {
+                        if (!active || !payload?.[0]) return null;
+                        const slice = payload[0].payload as Slice;
+                        const pct = total > 0 ? (slice.count / total) * 100 : 0;
+                        return (
+                          <div className="rounded-lg border bg-background p-2 shadow-sm font-mono text-xs">
+                            <div className="font-medium mb-1">{slice.label}</div>
+                            <div>
+                              {slice.count.toLocaleString()} ({pct.toFixed(1)}%)
+                            </div>
+                            {slice.category !== "primary" && slice.members.length > 0 && (
+                              <div className="mt-1 pt-1 border-t border-gray-200 dark:border-gray-700">
+                                {slice.members.slice(0, 6).map((m) => (
+                                  <div key={m.name} className="flex justify-between gap-3">
+                                    <span className="text-muted-foreground">{m.name}</span>
+                                    <span>{m.count.toLocaleString()}</span>
+                                  </div>
+                                ))}
+                                {slice.members.length > 6 && (
+                                  <div className="text-muted-foreground">
+                                    +{slice.members.length - 6} more
+                                  </div>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        );
+                      }}
+                    />
+                    <Pie
+                      data={slices}
+                      dataKey="count"
+                      nameKey="label"
+                      innerRadius={60}
+                      outerRadius={110}
+                      paddingAngle={2}
+                      stroke="none"
+                    >
+                      {slices.map((slice) => (
+                        <Cell key={slice.category} fill={slice.color} />
+                      ))}
+                    </Pie>
+                  </PieChart>
+                </ResponsiveContainer>
+
+                <div className="flex flex-col gap-3">
+                  {slices.map((slice) => {
+                    const pct = total > 0 ? (slice.count / total) * 100 : 0;
+                    return (
+                      <div key={slice.category} className="space-y-1">
+                        <div className="flex items-center justify-between gap-2 text-sm">
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="inline-block h-3 w-3 rounded-sm"
+                              style={{ backgroundColor: slice.color }}
+                            />
+                            <span>{slice.label}</span>
+                          </div>
+                          <div className="font-mono">
+                            {slice.count.toLocaleString()}{" "}
+                            <span className="text-muted-foreground">
+                              ({pct.toFixed(1)}%)
+                            </span>
+                          </div>
+                        </div>
+                        {slice.category !== "primary" && slice.members.length > 0 && (
+                          <div className="pl-5 text-xs text-muted-foreground">
+                            {slice.members
+                              .slice(0, 3)
+                              .map((m) => m.name)
+                              .join(", ")}
+                            {slice.members.length > 3 && ` +${slice.members.length - 3} more`}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/utils/chart-utils.ts
+++ b/utils/chart-utils.ts
@@ -1,4 +1,5 @@
 // Chart utility functions for moving averages and data transformations
+import type { ChartDataPoint, TimeSeriesMetric } from "@/types/stats";
 
 export type Period = "D" | "W" | "M" | "Q" | "Y";
 
@@ -31,6 +32,28 @@ export interface DataPointWithMA {
   value: number;
   ma: number;
   [key: string]: any;
+}
+
+export function timeSeriesMetricToChartData(
+  metric: TimeSeriesMetric | null | undefined,
+  options: { excludeToday?: boolean } = {},
+): ChartDataPoint[] {
+  if (!metric?.data) return [];
+
+  const today = options.excludeToday
+    ? new Date().toISOString().split("T")[0]
+    : null;
+
+  return metric.data
+    .filter((point) => !today || point.date !== today)
+    .map((point) => ({
+      day: point.date,
+      value:
+        typeof point.value === "string"
+          ? Number.parseFloat(point.value)
+          : point.value,
+    }))
+    .reverse();
 }
 
 /**
@@ -120,4 +143,3 @@ export function processDataWithMA<T extends { day: string; value: number }>(
   const maConfig = getMAConfig(period);
   return calculateMovingAverage(aggregated, maConfig.window);
 }
-


### PR DESCRIPTION
## Summary

### `/stats/validators/c-chain` — Primary Network Validator Count chart
- add a Total Validator Seats overlay using the Primary Network plus indexed mainnet L1 `validatorCount` series, exposed via a new `/api/total-ecosystem-validators` endpoint
- add a red ACP-77 (Etna) reference marker and widen the default daily window when needed so the marker is visible on first load
- the blue Total Validator Seats line only starts drawing at the Etna marker — pre-Etna the metric is just Primary count plus subnet-membership overhead, which is more confusing than informative
- show a short note under the chart subtitle (only when the ACP-77 marker is inside the visible window) explaining that, after Etna, validators of subnets that converted into sovereign L1s no longer needed to also stake on the Primary Network
- exclude the Primary Network from the L1 aggregation to avoid double-counting and label the overlay as *validator seats* to reflect that this is a per-network seat count, not a distinct node count
- always-visible legend distinguishing the Primary Network bars from the Total Validator Seats line

<img width="1150" height="1082" alt="image" src="https://github.com/user-attachments/assets/ff13fedf-d5ea-420f-9b7f-2167d2dd95db" />

### `/stats/network-metrics` — new **Validators** section (all-chains view only)
- new section below Interchain on the all-chains view, with a matching nav entry
- left card is an **Avalanche Ecosystem Validator Count** chart: the headline number is the total ecosystem validator seats, the Primary Network is rendered as a comparison line (not bars), the Total Validator Seats line begins at the ACP-77 marker, and the percentage change / brush thumbnail / CSV all follow the headline (overlay) metric
- right card is a new pie chart breaking validator seats down by **Primary Network**, **Proof-of-Stake L1s** (Beam, CX, Dexalot, Kite — Dexalot via the Suzaku BalancerValidatorManager), and **Proof-of-Authority L1s** (every other sovereign L1). Per-subnet counts come from `/api/validator-stats`; Primary Network count comes from `/api/primary-network-stats`. The PoS L1 list is hardcoded since the existing API surface does not expose validator-manager consensus type

<img width="1186" height="638" alt="image" src="https://github.com/user-attachments/assets/1cdd32ca-4d03-4e1c-bbdb-9bca31f35044" />
