### PR TITLE
fix(landing): only show curated L1s on homepage globe

### DIFF
--- a/components/landing/globe.tsx
+++ b/components/landing/globe.tsx
@@ -132,9 +132,10 @@ export const Sponsors = ({ globeData }: SponsorsProps) => {
 			validatorCount: typeof avalancheChain?.validatorCount === 'number' ? avalancheChain.validatorCount : undefined,
 		}];
 
-		// Add every active L1 from the API. Chains without logos (e.g. P-Chain
-		// stub entries seeded from platform.getBlockchains) still render — the
-		// diagram falls back to a colored circle with the chain's initial.
+		// Homepage is a marketing surface — only render chains with curated
+		// logos so it feels polished. P-Chain stub entries (no Glacier
+		// metadata, no logo) are intentionally hidden here; they still appear
+		// on /stats/overview where comprehensiveness matters more than polish.
 		l1Chains.forEach(chain => {
 			const l1Chain = l1ChainsData.find(
 				(c: any) => c.chainId === chain.chainId ||
@@ -143,7 +144,9 @@ export const Sponsors = ({ globeData }: SponsorsProps) => {
 
 			const category = l1Chain?.category || 'General';
 			const slug = l1Chain?.slug;
-			const logo = chain.chainLogoURI || l1Chain?.chainLogoURI || undefined;
+			const logo = chain.chainLogoURI || l1Chain?.chainLogoURI;
+
+			if (!logo) return;
 
 			result.push({
 				id: chain.chainId,


### PR DESCRIPTION
## Summary

PR #4123 unified the homepage globe with `/stats/overview` to render every active L1, including P-Chain stubs without Glacier metadata. After looking at the result, the homepage as a marketing surface should stay polished — stubs without logos make it feel uneven mixing crisp brand artwork with first-letter placeholders.

This restores the homepage's pre-#4123 logo filter without touching `/stats/overview`. The two surfaces now have intentionally different contracts:

- **Homepage globe** (marketing): only chains with curated `chainLogoURI`. Every node renders with brand artwork; every click leads to a populated `/stats/l1/<slug>` page.
- **`/stats/overview` globe** (data): every P-Chain active L1, logos and stubs alike. Comprehensiveness > polish.

## Change

`components/landing/globe.tsx`: re-add `if (!logo) return;` guard on the L1 forEach loop. One file, +7/−4.

## Test plan

- [ ] Homepage `build.avax.network` shows only logo-bearing chains in the globe
- [ ] `/stats/overview` still shows all ~67 active L1s including stubs (Datagram Chain, kite, etc. with first-letter fallback)
- [ ] Clicking any chain on the homepage leads to a populated detail page