### PR TITLE
feat(docs): add halted L1 recovery guide and animated diagram

### DIFF
--- a/app/docs/[...slug]/page.tsx
+++ b/app/docs/[...slug]/page.tsx
@@ -1,5 +1,6 @@
 import { TransactionLifecycle } from "@/components/sae/TransactionLifecycle";
 import { FirewoodPage } from "@/components/firewood/FirewoodPage";
+import { HaltedBlockProductionDiagram } from "@/components/l1-recovery/HaltedBlockProductionDiagram";
 import StateGrowthChart from "@/components/content-design/state-growth-chart";
 import { BackToTop } from "@/components/ui/back-to-top";
 import { Feedback } from "@/components/ui/feedback";
@@ -101,6 +102,7 @@ export default async function Page(props: {
             StateGrowthChart,
             TransactionLifecycle,
             FirewoodPage,
+            HaltedBlockProductionDiagram,
             AddNetworkButtonInline,
             File,
             Folder,

--- a/components/l1-recovery/HaltedBlockProductionDiagram.tsx
+++ b/components/l1-recovery/HaltedBlockProductionDiagram.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { LayoutGroup, motion } from "framer-motion";
+import { faLinkSlash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+const steps = [
+  {
+    eyebrow: "Last accepted L1 block",
+    title: "L1 is pinned to P-Chain height X",
+    body: "The last accepted L1 block references height X. ProposerVM will use that parent context to choose who may build next.",
+    markerIndex: 0,
+  },
+  {
+    eyebrow: "P-Chain advances",
+    title: "The P-Chain moves to X+1",
+    body: "The Primary Network keeps accepting P-Chain blocks even while the L1 is halted. The L1 parent still points at X.",
+    markerIndex: 1,
+  },
+  {
+    eyebrow: "P-Chain advances",
+    title: "The P-Chain moves to X+2",
+    body: "More P-Chain height passes, but no L1 block has been accepted to update the L1's referenced height.",
+    markerIndex: 2,
+  },
+  {
+    eyebrow: "Balance top-up",
+    title: "The balance top-up lands at X+N",
+    body: "Registered validators are reactivated at the current P-Chain height, not retroactively at X.",
+    markerIndex: 3,
+  },
+  {
+    eyebrow: "Next block attempt",
+    title: "ProposerVM still checks height X",
+    body: "The next L1 block must be built from the last accepted parent, so proposer selection still uses X.",
+    markerIndex: 3,
+  },
+  {
+    eyebrow: "Result",
+    title: "ProposerVM still sees all registered validators inactive at block height X",
+    body: "At X, every registered validator is still inactive. The top-up exists at X+N, but the L1 cannot reference X+N until a new block is accepted.",
+    markerIndex: 3,
+  },
+];
+
+const pchainHeights = ["X", "X+1", "X+2", "X+N"];
+const STEP_DURATION_MS = 5200;
+
+function ArrowSegment({ active }: { active: boolean }) {
+  return (
+    <svg className="h-6 w-full" viewBox="0 0 80 24" fill="none" aria-hidden="true">
+      <motion.path
+        d="M4 12H70"
+        strokeLinecap="round"
+        initial={false}
+        animate={{
+          stroke: active ? "rgb(16 185 129)" : "rgb(161 161 170)",
+          opacity: active ? 0.9 : 0.45,
+        }}
+        strokeWidth="2"
+      />
+      <motion.path
+        d="M62 5L72 12L62 19"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        initial={false}
+        animate={{
+          stroke: active ? "rgb(16 185 129)" : "rgb(161 161 170)",
+          opacity: active ? 0.9 : 0.45,
+        }}
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
+function StatusPill({
+  label,
+  active,
+  tone,
+}: {
+  label: string;
+  active: boolean;
+  tone: "red" | "amber" | "emerald" | "sky";
+}) {
+  const tones = {
+    red: "border-red-500/50 bg-red-500/10 text-red-600 dark:text-red-300",
+    amber: "border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    emerald: "border-emerald-500/50 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+    sky: "border-sky-500/50 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  };
+
+  return (
+    <motion.div
+      animate={{ opacity: active ? 1 : 0.45, scale: active ? 1 : 0.98 }}
+      className={`rounded-md border px-2 py-1 text-[11px] font-medium ${tones[tone]}`}
+    >
+      {label}
+    </motion.div>
+  );
+}
+
+function HaltBadge({ active }: { active: boolean }) {
+  return (
+    <motion.div
+      animate={{ opacity: active ? 1 : 0.45, scale: active ? 1 : 0.98 }}
+      className="flex min-h-20 min-w-28 items-center justify-center rounded-md border border-red-300 bg-red-50 px-4 py-3 text-red-700 dark:border-red-500/35 dark:bg-red-500/10 dark:text-red-300"
+      aria-label="L1 block production halted"
+    >
+      <FontAwesomeIcon icon={faLinkSlash} className="h-10 w-10" />
+    </motion.div>
+  );
+}
+
+export function HaltedBlockProductionDiagram() {
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setStep((current) => (current + 1) % steps.length);
+    }, STEP_DURATION_MS);
+
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const markerIndex = steps[step].markerIndex;
+  const pChainAdvanced = step >= 1;
+  const topUpVisible = step >= 3;
+  const proposerCheckVisible = step >= 4;
+  const haltVisible = step >= 5;
+
+  return (
+    <div className="my-8 overflow-hidden rounded-md border border-zinc-200 bg-white text-zinc-950 shadow-sm dark:border-white/10 dark:bg-zinc-950 dark:text-white">
+      <div className="border-b border-zinc-200 px-4 py-3 dark:border-white/10">
+        <div className="text-xs font-mono uppercase tracking-[0.18em] text-zinc-500 dark:text-zinc-400">
+          Balance top-up vs proposer selection
+        </div>
+        <div className="mt-1 text-lg font-semibold">
+          The top-up lands at X+N, but the L1 is still trying to build from X
+        </div>
+      </div>
+
+      <div className="grid gap-5 p-4 lg:grid-cols-[1fr_280px]">
+        <div className="min-w-0 space-y-6">
+          <div>
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <span className="text-xs font-mono uppercase tracking-[0.16em] text-zinc-500 dark:text-zinc-400">
+                P-Chain time
+              </span>
+              <StatusPill
+                label={topUpVisible ? "Top-up accepted at current height" : "P-Chain height is advancing"}
+                active={pChainAdvanced || topUpVisible}
+                tone={topUpVisible ? "emerald" : "sky"}
+              />
+            </div>
+
+            <div className="relative rounded-md border border-zinc-200 bg-zinc-50 px-4 py-5 dark:border-white/10 dark:bg-white/[0.03]">
+              <LayoutGroup>
+                <div className="grid grid-cols-[56px_minmax(28px,1fr)_56px_minmax(28px,1fr)_56px_minmax(28px,1fr)_56px] items-start gap-2">
+                  {pchainHeights.map((height, index) => {
+                    const isPinned = index === 0;
+                    const isTopUp = index === pchainHeights.length - 1;
+                    const markerHere = markerIndex === index;
+                    const active = isPinned || (pChainAdvanced && index > 0 && markerIndex >= index);
+
+                    return (
+                      <div key={height} className="contents">
+                        <div className="flex flex-col items-center gap-2">
+                          <motion.div
+                            animate={{
+                              borderColor: active
+                                ? isPinned
+                                  ? "rgb(244 63 94)"
+                                  : "rgb(16 185 129)"
+                                : "rgba(113,113,122,0.35)",
+                              backgroundColor: active
+                                ? isPinned
+                                  ? "rgba(244,63,94,0.12)"
+                                  : "rgba(16,185,129,0.12)"
+                                : "rgba(113,113,122,0.08)",
+                            }}
+                            className="relative flex h-12 w-12 items-center justify-center rounded-md border text-sm font-bold"
+                          >
+                            {height}
+                            {markerHere && (
+                              <motion.div
+                                layoutId="l1-top-up-marker"
+                                className="absolute -bottom-1.5 -right-1.5 h-3 w-3 rounded-full bg-emerald-500 shadow-[0_0_18px_rgba(16,185,129,0.8)]"
+                                transition={{ duration: 1.8, ease: "easeInOut" }}
+                              />
+                            )}
+                          </motion.div>
+                          <span className="max-w-[72px] text-center text-[10px] leading-tight text-zinc-500 dark:text-zinc-400">
+                            {isPinned ? "last block produced" : isTopUp ? "balance top-up" : "passes"}
+                          </span>
+                        </div>
+                        {index < pchainHeights.length - 1 && (
+                          <div className="pt-3">
+                            <ArrowSegment active={pChainAdvanced && markerIndex > index} />
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </LayoutGroup>
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-[1fr_80px_1fr]">
+            <div className="rounded-md border border-red-200 bg-red-50 p-4 dark:border-red-500/30 dark:bg-red-500/10">
+              <div className="text-xs font-mono uppercase tracking-[0.16em] text-red-700 dark:text-red-300">
+                L1 parent
+              </div>
+              <div className="mt-2 text-sm font-semibold">Last accepted block</div>
+              <div className="mt-3 rounded-md border border-red-300 bg-white p-3 font-mono text-xs dark:border-red-500/40 dark:bg-zinc-950">
+                pChainHeight: X
+              </div>
+            </div>
+
+            <div className="flex items-center justify-center">
+              <motion.div
+                animate={{
+                  opacity: proposerCheckVisible ? 1 : 0.35,
+                  x: proposerCheckVisible ? [0, 8, 0] : 0,
+                }}
+                transition={{ duration: 1.2, repeat: proposerCheckVisible ? Infinity : 0 }}
+                className="hidden h-px w-full bg-red-400 md:block"
+              />
+              <div className="h-8 w-px bg-red-400 md:hidden" />
+            </div>
+
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-4 dark:border-amber-500/30 dark:bg-amber-500/10">
+              <div className="text-xs font-mono uppercase tracking-[0.16em] text-amber-700 dark:text-amber-300">
+                ProposerVM check
+              </div>
+              <div className="mt-2 text-sm font-semibold">Select proposer from height X</div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <StatusPill label="all registered inactive at X" active={proposerCheckVisible} tone="red" />
+                <StatusPill label="top-up only at X+N" active={topUpVisible} tone="emerald" />
+              </div>
+            </div>
+          </div>
+
+          <motion.div
+            animate={{
+              opacity: haltVisible ? 1 : 0.45,
+              borderColor: haltVisible ? "rgba(244,63,94,0.55)" : "rgba(113,113,122,0.25)",
+            }}
+            className="rounded-md border bg-zinc-50 p-4 dark:bg-white/[0.03]"
+          >
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <div className="text-xs font-mono uppercase tracking-[0.16em] text-zinc-500 dark:text-zinc-400">
+                  Result
+                </div>
+                <div className="mt-1 text-sm font-semibold">
+                  ProposerVM still sees all registered validators inactive at block height X - L1 can't produce a new block
+                </div>
+              </div>
+              <HaltBadge active={haltVisible} />
+            </div>
+          </motion.div>
+        </div>
+
+        <div className="rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-white/10 dark:bg-white/[0.03]">
+          <motion.div
+            key={step}
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.25 }}
+          >
+            <div className="text-xs font-mono uppercase tracking-[0.16em] text-zinc-500 dark:text-zinc-400">
+              {steps[step].eyebrow}
+            </div>
+            <div className="mt-2 text-base font-semibold">{steps[step].title}</div>
+            <p className="mt-3 text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
+              {steps[step].body}
+            </p>
+          </motion.div>
+
+          <div className="mt-5 grid grid-cols-6 gap-2">
+            {steps.map((item, index) => (
+              <button
+                key={item.eyebrow}
+                type="button"
+                aria-label={`Show step ${index + 1}`}
+                onClick={() => setStep(index)}
+                className="h-1.5 rounded-full bg-zinc-200 dark:bg-white/15"
+              >
+                <motion.div
+                  animate={{ width: index === step ? "100%" : "0%" }}
+                  transition={{ duration: index === step ? STEP_DURATION_MS / 1000 - 0.1 : 0.15, ease: "linear" }}
+                  className="h-full rounded-full bg-sky-500"
+                />
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/content/docs/avalanche-l1s/maintain/halted-block-production.mdx
+++ b/content/docs/avalanche-l1s/maintain/halted-block-production.mdx
@@ -1,0 +1,185 @@
+---
+title: Recovering a Halted L1 After Validator Inactivity
+description: Diagnose and plan recovery when an Avalanche L1 stops producing blocks after all registered validator balances are exhausted.
+---
+
+An Avalanche L1 can stop producing blocks when all registered validators become
+inactive after their P-Chain balances are exhausted. The L1 RPC can remain
+responsive and transactions can sit in the mempool, but no registered validator
+is eligible to propose the next block at the P-Chain height referenced by the
+last accepted L1 block.
+
+<Callout type="warn" title="Recovery Patch Not Merged">
+The fallback proposer path described below is based on an unmerged AvalancheGo
+pull request. Treat it as a recovery approach under testing, not as a standard
+AvalancheGo release feature.
+</Callout>
+
+## Prevention
+
+Treat validator P-Chain balances as a production SLO:
+
+1. Monitor each validator's remaining continuous-fee balance.
+2. Set L1 balance runway alerts in [Validator Alerts](/validator-alerts) so
+   operators are notified well before a validator can reach zero balance.
+3. Top up balances before exhaustion with `IncreaseL1ValidatorBalanceTx`.
+4. Keep at least one registered validator active and funded at all times, and
+   maintain enough funded validator redundancy that missed top-ups cannot
+   cascade into the entire registered validator set reaching zero balance.
+5. Keep direct contact information for every validator operator.
+
+For the fee model and top-up transaction, see
+[How Do L1 Validator Fees Work](/blog/l1-validator-fee) and
+[ACP-77](/docs/acps/77-reinventing-subnets#increasel1validatorbalancetx).
+
+## Symptoms
+
+This failure mode usually looks like:
+
+- RPC endpoints still answer requests.
+- New transactions are accepted into the mempool.
+- `eth_blockNumber` stops increasing.
+- Validators repeatedly log a ProposerVM wait near the one-hour fallback window:
+
+```text
+Waiting until we should build a block duration=59m59s
+```
+
+Check the current height from any L1 RPC endpoint:
+
+```bash
+curl -s http://127.0.0.1:9650/ext/bc/<blockchainID>/rpc \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
+```
+
+If the value does not change while transactions are pending, review the
+validator set and P-Chain balances before restarting nodes. This recovery path
+applies to the all-validators-inactive case; if any registered validator is
+still eligible at the stuck P-Chain height, investigate connectivity,
+subnet-tracking, or other consensus issues first.
+
+## Why the Halt Occurs
+
+Avalanche L1 validators pay a continuous P-Chain fee. When a validator's balance
+reaches zero, the validator becomes inactive until its balance is increased with
+`IncreaseL1ValidatorBalanceTx`.
+
+The halt happens when the last accepted L1 block references a P-Chain height
+where every registered validator for the L1 is inactive. A
+top-up applies at the current P-Chain height, but the L1 cannot move to that
+newer reference until it accepts another block.
+
+<HaltedBlockProductionDiagram />
+
+This creates a chicken-and-egg problem:
+
+- The L1 needs a new block to advance its P-Chain reference.
+- The new block needs an eligible proposer from the validator set at the stuck
+  P-Chain reference.
+- Reactivated or newly registered validators only become visible at a newer
+  P-Chain height that the halted L1 has not referenced yet.
+
+ACP-151 explains that ProposerVM still uses the parent block's P-Chain height to
+verify proposers, even though newer P-Chain heights can be used for ICM message
+verification. See
+[ACP-151](/docs/acps/151-use-current-block-pchain-height-as-context) and the
+[Warp Messenger P-Chain height notes](/docs/avalanche-l1s/precompiles/warp-messenger#p-chain-height-considerations).
+
+## Pre-Recovery Checklist
+
+Before attempting any recovery, confirm all of the following:
+
+- All registered validators for the L1 were inactive at the P-Chain height
+  referenced by the last accepted L1 block. If only some validators ran out of
+  balance, this specific recovery path is likely not the right diagnosis.
+- Every validator that should participate after recovery has a P-Chain balance
+  greater than zero.
+- Do not rely on restarts alone; restarting validators does not change the
+  P-Chain height referenced by the last accepted L1 block.
+- Do not rely on top-ups alone; top-ups reactivate validators at the current
+  P-Chain height, not retroactively at the stuck height.
+- Do not rely on new validator registration alone. On-chain registration, or an
+  off-chain signed and aggregated `RegisterL1ValidatorMessage`, makes a
+  validator visible at a newer P-Chain height. ProposerVM still selects the next
+  proposer from the stuck height referenced by the last accepted L1 block.
+- The L1's last accepted block height and timestamp are known.
+- If recovery depends on Warp already being active, the effective
+  `warpConfig.blockTimestamp` is less than or equal to the last accepted L1 block
+  timestamp. A future activation timestamp cannot be reached while the chain is
+  halted.
+- AvalancheGo is explicitly configured to track the L1 subnet ID with
+  `--track-subnets` or equivalent node configuration.
+- The recovery node will run the exact AvalancheGo build from PR #4955 that was
+  reviewed for this attempt. Upgrading to the latest released AvalancheGo is not
+  a substitute for this experimental recovery path unless that release includes
+  the fallback proposer change.
+- Any ProposerVM recovery flags are set explicitly in node config and recorded
+  for removal after recovery.
+- Every validator operator has taken a full backup of its `~/.avalanchego`
+  directory.
+
+## Experimental Recovery Only
+
+<Callout type="error" title="Mainnet Danger">
+Do not attempt this on a mainnet L1 unless you have contacted the Avalanche team,
+coordinated all validator operators and external integrators, paused bridge
+contracts and integrations that read L1 state, taken full backups of every
+validator's `~/.avalanchego` directory, and tested on a mirrored environment if
+feasible.
+</Callout>
+
+AvalancheGo PR
+[#4955](https://github.com/ava-labs/avalanchego/pull/4955) proposes an
+emergency ProposerVM fallback that lets a non-validator propose after a maximum
+wait time. The PR is open, unmerged, and unsupported. It is not part of a
+standard AvalancheGo release.
+
+The patch introduces two node-level flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--proposervm-fallback-nonvalidator-can-propose` | Enables the emergency non-validator proposer fallback. |
+| `--proposervm-fallback-nonvalidator-max-wait-time` | Sets the maximum wait time before the fallback can propose. The patch requires a value between 1 second and 1 hour. |
+
+At a high level, the recovery procedure is:
+
+1. Build AvalancheGo from the exact PR #4955 code under engineering review.
+2. Select a node that has the L1 state, tracks the L1, and is coordinated with
+   the validator operators.
+3. Start only that custom-build node with the emergency flags enabled and an
+   agreed `--proposervm-fallback-nonvalidator-max-wait-time`.
+4. Wait for it to propose one block that advances the L1's P-Chain reference to
+   a height where the validator set is active again.
+5. Verify normal validators resume block production.
+6. Shut down the custom-build node.
+7. Restart with a standard AvalancheGo build and remove the emergency flags from
+   all node configuration.
+
+## Risks
+
+This recovery path changes proposer behavior in a custom AvalancheGo build. The
+main risks are:
+
+- The custom node could build malformed or otherwise unexpected blocks.
+- The patch has not been audited or released.
+- A failed attempt can deepen the halt or complicate later recovery.
+- Operators can diverge if they run different binaries or leave emergency flags
+  enabled after recovery.
+
+Do not run the custom build longer than needed to advance the chain past the
+stuck P-Chain reference.
+
+## Verification
+
+Confirm recovery from at least two independent nodes:
+
+1. Poll `eth_blockNumber` and verify it increases.
+2. Check validator logs for normal block proposal and acceptance.
+3. Confirm the emergency custom-build node is stopped.
+4. Confirm standard AvalancheGo binaries and normal node configs are restored.
+5. Confirm external integrations and bridges are only resumed after the chain is
+   producing blocks normally.
+
+If block production does not resume, stop the custom-build node and preserve
+logs, configs, and backups before attempting further changes.

--- a/content/docs/avalanche-l1s/maintain/halted-block-production.mdx
+++ b/content/docs/avalanche-l1s/maintain/halted-block-production.mdx
@@ -58,10 +58,11 @@ whether this is the all-registered-validators-inactive case. Do not treat node
 restarts as a recovery step: restarting validators does not change the P-Chain
 height referenced by the last accepted L1 block.
 
-If enough active validator weight is still online, blocks should continue to be
-built as long as there is traffic. In that case, investigate connectivity,
-subnet tracking, mempool, or other consensus issues instead of using the
-recovery path below.
+If any active L1 validator weight is still present at the stuck P-Chain height,
+this is not the all-registered-validators-balance-exhausted recovery case. At
+least one registered validator is still eligible to propose, so investigate
+connectivity, subnet tracking, mempool, or other consensus issues instead of
+using the recovery path below.
 
 ## Why the Halt Occurs
 
@@ -109,9 +110,9 @@ block.
      }'
    ```
 
-   If this returns active validator weight for the L1, this guide is probably
-   not the right diagnosis. With enough active validator weight online, block
-   production should continue when there is traffic.
+   If this returns any active validator weight for the L1, this guide is not the
+   right diagnosis. At least one registered validator is still eligible at the
+   stuck P-Chain height, so the halt has a different cause.
 
 2. Check the current registered L1 validators and their balances:
 
@@ -126,7 +127,8 @@ block.
      }'
    ```
 
-   For each `validationID`, confirm the current remaining balance:
+   Confirm the current remaining balance for the validators you plan to bring
+   back online:
 
    ```bash
    avalanche validator getBalance \
@@ -135,7 +137,9 @@ block.
    ```
 
    You can also query `platform.getL1Validator` for each `validationID` and
-   inspect the `balance` field.
+   inspect the `balance` field. Before attempting recovery, top up validators
+   representing at least 80% of the L1's stake weight so the validator set can
+   resume block production once the stuck P-Chain reference advances.
 
 ## Pre-Recovery Checklist
 
@@ -143,8 +147,8 @@ Before attempting any recovery, confirm all of the following:
 
 - `platform.getValidatorsAt` returns no active L1 validator weight at the
   P-Chain height referenced by the last accepted L1 block.
-- Every registered `validationID` that should participate after recovery has a
-  current P-Chain balance greater than zero.
+- Validators representing at least 80% of the L1's stake weight have been
+  topped up and have current P-Chain balance greater than zero.
 - Do not rely on restarts alone; restarting validators does not change the
   P-Chain height referenced by the last accepted L1 block.
 - Do not rely on top-ups alone; top-ups reactivate validators at the current
@@ -177,6 +181,13 @@ coordinated all validator operators and external integrators, paused bridge
 contracts and integrations that read L1 state, taken full backups of every
 validator's `~/.avalanchego` directory, and tested on a mirrored environment if
 feasible.
+</Callout>
+
+<Callout type="info" title="Testnet Recovery Choice">
+For a halted testnet or development L1, recreating the L1 is usually the more
+straightforward path if the existing chain state can be discarded. Use this
+recovery path for testnet only when the current state must be preserved to
+continue testing.
 </Callout>
 
 AvalancheGo PR

--- a/content/docs/avalanche-l1s/maintain/halted-block-production.mdx
+++ b/content/docs/avalanche-l1s/maintain/halted-block-production.mdx
@@ -53,17 +53,22 @@ curl -s http://127.0.0.1:9650/ext/bc/<blockchainID>/rpc \
   -d '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
 ```
 
-If the value does not change while transactions are pending, review the
-validator set and P-Chain balances before restarting nodes. This recovery path
-applies to the all-validators-inactive case; if any registered validator is
-still eligible at the stuck P-Chain height, investigate connectivity,
-subnet-tracking, or other consensus issues first.
+If the value does not change while transactions are pending, first confirm
+whether this is the all-registered-validators-inactive case. Do not treat node
+restarts as a recovery step: restarting validators does not change the P-Chain
+height referenced by the last accepted L1 block.
+
+If enough active validator weight is still online, blocks should continue to be
+built as long as there is traffic. In that case, investigate connectivity,
+subnet tracking, mempool, or other consensus issues instead of using the
+recovery path below.
 
 ## Why the Halt Occurs
 
-Avalanche L1 validators pay a continuous P-Chain fee. When a validator's balance
-reaches zero, the validator becomes inactive until its balance is increased with
-`IncreaseL1ValidatorBalanceTx`.
+Avalanche L1 validators pay a continuous P-Chain fee for their validator state
+to be maintained and for ICM messages from the L1 to be verifiable by P-Chain
+validators. When a validator's balance reaches zero, the validator becomes
+inactive until its balance is increased with `IncreaseL1ValidatorBalanceTx`.
 
 The halt happens when the last accepted L1 block references a P-Chain height
 where every registered validator for the L1 is inactive. A
@@ -86,15 +91,60 @@ verification. See
 [ACP-151](/docs/acps/151-use-current-block-pchain-height-as-context) and the
 [Warp Messenger P-Chain height notes](/docs/avalanche-l1s/precompiles/warp-messenger#p-chain-height-considerations).
 
+## Confirm the Diagnosis
+
+Use the L1's Subnet ID and the P-Chain height referenced by the last accepted L1
+block.
+
+1. Query the validator set at the stuck P-Chain height:
+
+   ```bash
+   curl -s http://127.0.0.1:9650/ext/bc/P \
+     -H 'content-type: application/json' \
+     -d '{
+       "jsonrpc":"2.0",
+       "id":1,
+       "method":"platform.getValidatorsAt",
+       "params":{"subnetID":"<subnetID>","height":<pChainHeight>}
+     }'
+   ```
+
+   If this returns active validator weight for the L1, this guide is probably
+   not the right diagnosis. With enough active validator weight online, block
+   production should continue when there is traffic.
+
+2. Check the current registered L1 validators and their balances:
+
+   ```bash
+   curl -s http://127.0.0.1:9650/ext/bc/P \
+     -H 'content-type: application/json' \
+     -d '{
+       "jsonrpc":"2.0",
+       "id":1,
+       "method":"platform.getCurrentValidators",
+       "params":{"subnetID":"<subnetID>"}
+     }'
+   ```
+
+   For each `validationID`, confirm the current remaining balance:
+
+   ```bash
+   avalanche validator getBalance \
+     --validation-id <validationID> \
+     --mainnet
+   ```
+
+   You can also query `platform.getL1Validator` for each `validationID` and
+   inspect the `balance` field.
+
 ## Pre-Recovery Checklist
 
 Before attempting any recovery, confirm all of the following:
 
-- All registered validators for the L1 were inactive at the P-Chain height
-  referenced by the last accepted L1 block. If only some validators ran out of
-  balance, this specific recovery path is likely not the right diagnosis.
-- Every validator that should participate after recovery has a P-Chain balance
-  greater than zero.
+- `platform.getValidatorsAt` returns no active L1 validator weight at the
+  P-Chain height referenced by the last accepted L1 block.
+- Every registered `validationID` that should participate after recovery has a
+  current P-Chain balance greater than zero.
 - Do not rely on restarts alone; restarting validators does not change the
   P-Chain height referenced by the last accepted L1 block.
 - Do not rely on top-ups alone; top-ups reactivate validators at the current
@@ -104,18 +154,18 @@ Before attempting any recovery, confirm all of the following:
   validator visible at a newer P-Chain height. ProposerVM still selects the next
   proposer from the stuck height referenced by the last accepted L1 block.
 - The L1's last accepted block height and timestamp are known.
-- If recovery depends on Warp already being active, the effective
-  `warpConfig.blockTimestamp` is less than or equal to the last accepted L1 block
-  timestamp. A future activation timestamp cannot be reached while the chain is
-  halted.
+- If recovery depends on Warp, Warp was already active at the last accepted L1
+  block. A halted L1 can still serve RPC and produce signatures from its
+  existing state, but it cannot accept a new block to cross a future Warp
+  activation timestamp.
 - AvalancheGo is explicitly configured to track the L1 subnet ID with
   `--track-subnets` or equivalent node configuration.
-- The recovery node will run the exact AvalancheGo build from PR #4955 that was
-  reviewed for this attempt. Upgrading to the latest released AvalancheGo is not
-  a substitute for this experimental recovery path unless that release includes
-  the fallback proposer change.
-- Any ProposerVM recovery flags are set explicitly in node config and recorded
-  for removal after recovery.
+- The recovery build has been reviewed for this attempt and is based on the
+  AvalancheGo version currently running the L1, with the recovery patch
+  cherry-picked on top.
+- The emergency ProposerVM flags and config that will be used during recovery
+  are recorded before startup, and operators have a rollback plan that removes
+  them after recovery.
 - Every validator operator has taken a full backup of its `~/.avalanchego`
   directory.
 
@@ -133,7 +183,9 @@ AvalancheGo PR
 [#4955](https://github.com/ava-labs/avalanchego/pull/4955) proposes an
 emergency ProposerVM fallback that lets a non-validator propose after a maximum
 wait time. The PR is open, unmerged, and unsupported. It is not part of a
-standard AvalancheGo release.
+standard AvalancheGo release. Do not run that branch directly without review;
+for a live recovery attempt, the fallback change should be reviewed and
+cherry-picked onto the AvalancheGo version the L1 is already running.
 
 The patch introduces two node-level flags:
 
@@ -144,16 +196,23 @@ The patch introduces two node-level flags:
 
 At a high level, the recovery procedure is:
 
-1. Build AvalancheGo from the exact PR #4955 code under engineering review.
-2. Select a node that has the L1 state, tracks the L1, and is coordinated with
-   the validator operators.
-3. Start only that custom-build node with the emergency flags enabled and an
-   agreed `--proposervm-fallback-nonvalidator-max-wait-time`.
-4. Wait for it to propose one block that advances the L1's P-Chain reference to
-   a height where the validator set is active again.
-5. Verify normal validators resume block production.
-6. Shut down the custom-build node.
-7. Restart with a standard AvalancheGo build and remove the emergency flags from
+1. Coordinate the recovery plan with Avalanche engineering, DevRel, and all
+   online L1 node operators.
+2. Build a recovery AvalancheGo binary by cherry-picking the reviewed fallback
+   change onto the AvalancheGo version currently running the L1.
+3. Roll that recovery-capable binary to every online L1 node. Nodes without the
+   verification change can reject the fallback-produced block and fail to advance
+   the L1's P-Chain height reference.
+4. Agree which node will attempt the fallback proposal and the
+   `--proposervm-fallback-nonvalidator-max-wait-time` value.
+5. Start the online L1 nodes with the recovery-capable binary and agreed
+   emergency configuration.
+6. Wait for the fallback proposer to build one block that advances the L1's
+   P-Chain reference to a height where the validator set is active again.
+7. Verify every online L1 node accepts that block and advances to the same L1
+   height.
+8. Verify normal validators resume block production.
+9. Restart with a standard AvalancheGo build and remove the emergency flags from
    all node configuration.
 
 ## Risks
@@ -161,25 +220,26 @@ At a high level, the recovery procedure is:
 This recovery path changes proposer behavior in a custom AvalancheGo build. The
 main risks are:
 
-- The custom node could build malformed or otherwise unexpected blocks.
+- The recovery build could build malformed or otherwise unexpected blocks.
 - The patch has not been audited or released.
 - A failed attempt can deepen the halt or complicate later recovery.
-- Operators can diverge if they run different binaries or leave emergency flags
-  enabled after recovery.
+- Operators can diverge if online nodes run different binaries, reject the
+  fallback-produced block, or leave emergency flags enabled after recovery.
 
-Do not run the custom build longer than needed to advance the chain past the
-stuck P-Chain reference.
+Do not run the recovery build or emergency flags longer than needed to advance
+the chain past the stuck P-Chain reference.
 
 ## Verification
 
-Confirm recovery from at least two independent nodes:
+Confirm recovery from every online L1 node:
 
-1. Poll `eth_blockNumber` and verify it increases.
-2. Check validator logs for normal block proposal and acceptance.
-3. Confirm the emergency custom-build node is stopped.
+1. Poll `eth_blockNumber` and verify each node advances to the same height.
+2. Confirm each online L1 node accepted the fallback-produced block.
+3. Check validator logs for normal block proposal and acceptance after the
+   recovery block.
 4. Confirm standard AvalancheGo binaries and normal node configs are restored.
 5. Confirm external integrations and bridges are only resumed after the chain is
    producing blocks normally.
 
-If block production does not resume, stop the custom-build node and preserve
-logs, configs, and backups before attempting further changes.
+If block production does not resume, stop the recovery attempt and preserve logs,
+configs, and backups before attempting further changes.

--- a/content/docs/avalanche-l1s/meta.json
+++ b/content/docs/avalanche-l1s/meta.json
@@ -11,7 +11,7 @@
     "---Overview---",
     "index",
     "validator-manager/contract",
-     "---Network Upgrades---",
+    "---Network Upgrades---",
     "...upgrade",
     "---EVM Configuration---",
     "...evm-configuration/evm-l1-customization",
@@ -24,6 +24,8 @@
     "manage-vm-binaries",
     "golang-vms",
     "rust-vms",
-    "timestamp-vm"
+    "timestamp-vm",
+    "---Maintenance---",
+    "...maintain"
   ]
 }

--- a/content/docs/avalanche-l1s/upgrade/precompile-upgrades.mdx
+++ b/content/docs/avalanche-l1s/upgrade/precompile-upgrades.mdx
@@ -36,6 +36,15 @@ The content of the `upgrade.json` should be formatted according to the following
 An invalid `blockTimestamp` in an upgrade file results the update failing. The `blockTimestamp` value should be set to a valid Unix timestamp value which is in the _future_ relative to the _head of the chain_. If the node encounters a `blockTimestamp` which is in the past, it will fail on startup.
 </Callout>
 
+<Callout type="warn" title="Halted L1 Recovery">
+If an L1 is already halted because all registered validators ran out of balance,
+new future `blockTimestamp` values cannot activate until another block is
+accepted. For recovery procedures that depend on Warp already being active,
+confirm the effective `warpConfig.blockTimestamp` is less than or equal to the
+last accepted L1 block timestamp. See
+[Recovering a Halted L1 After Validator Inactivity](/docs/avalanche-l1s/maintain/halted-block-production).
+</Callout>
+
 ## Disabling Precompiles
 
 To disable a precompile, use the following format:

--- a/content/docs/nodes/run-a-node/common-errors.mdx
+++ b/content/docs/nodes/run-a-node/common-errors.mdx
@@ -57,6 +57,7 @@ If you experience any issues running your node, here are common errors and their
 |-------|-------|----------|
 | `not a validator` (Code: -3) | • Validator-only operation on non-validator<br/>• Stake expired or not active<br/>• Not registered as validator | • Verify registration status<br/>• Check stake is active<br/>• Wait for validation period<br/>• Use correct API for node type |
 | `unknown validator` | • Not in current validator set<br/>• NodeID mismatch<br/>• Validator expired/removed | • Verify validator is active<br/>• Check end time hasn't passed<br/>• Confirm correct NodeID<br/>• Query validator set |
+| `Waiting until we should build a block duration=59m59s` on an L1 | • ProposerVM is waiting for an eligible proposer<br/>• All registered L1 validator balances may have reached zero<br/>• The last accepted L1 block may reference a P-Chain height where every registered validator is inactive | • Check whether `eth_blockNumber` is advancing<br/>• Check P-Chain balances for all registered L1 validators<br/>• Do not rely on restarts or top-ups alone if every registered validator was inactive at the stuck height<br/>• See [Recovering a Halted L1 After Validator Inactivity](/docs/avalanche-l1s/maintain/halted-block-production) |
 
 ## Version and Upgrade Errors
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@fireworks-js/react": "^2.10.8",
+    "@fortawesome/fontawesome-svg-core": "^7.2.0",
+    "@fortawesome/free-solid-svg-icons": "^7.2.0",
+    "@fortawesome/react-fontawesome": "^3.3.1",
     "@fumadocs/cli": "^0.2.1",
     "@fumadocs/mdx-remote": "^1.4.0",
     "@hookform/resolvers": "^4.1.3",
@@ -201,6 +204,5 @@
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.58.1"
   },
-
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/utils/remote-content/avalanche-l1s.mts
+++ b/utils/remote-content/avalanche-l1s.mts
@@ -26,6 +26,16 @@ export function getAvalancheL1sConfigs(): FileConfig[] {
       title: "Validator Manager Contracts",
       description: "This page lists all available contracts for the Validator Manager.",
       contentUrl: "https://github.com/ava-labs/icm-services/blob/main/icm-contracts/avalanche/validator-manager/",
+      postProcess: (content) => content.replace(
+        "Disabled L1 validators can re-activate at any time by increasing their balance with an `IncreaseBalanceTx`. Anyone can call `IncreaseBalanceTx` for any validator on the P-Chain. A disabled validator can only be completely and permanently removed from the validator set by a call to `initiateValidatorRemoval`.",
+        `Disabled L1 validators can re-activate at any time by increasing their balance with an \`IncreaseBalanceTx\`. Anyone can call \`IncreaseBalanceTx\` for any validator on the P-Chain. A disabled validator can only be completely and permanently removed from the validator set by a call to \`initiateValidatorRemoval\`.
+
+<Callout type="warn">
+If all registered validators become inactive and the L1 stops producing blocks,
+a later \`IncreaseBalanceTx\` may not recover block production by itself. See
+[Recovering a Halted L1 After Validator Inactivity](/docs/avalanche-l1s/maintain/halted-block-production).
+</Callout>`
+      ),
     },
     {
       sourceUrl: "https://raw.githubusercontent.com/ava-labs/avalanchego/master/graft/subnet-evm/precompile/contracts/warp/README.md",
@@ -36,4 +46,3 @@ export function getAvalancheL1sConfigs(): FileConfig[] {
     },
   ];
 }
-

--- a/utils/remote-content/shared.mts
+++ b/utils/remote-content/shared.mts
@@ -10,6 +10,7 @@ export interface FileConfig {
   description: string;
   contentUrl: string;
   content?: string; // Optional: directly provide content instead of fetching from sourceUrl
+  postProcess?: (content: string) => string;
 }
 
 export type SectionParser = (content: string, meta: {
@@ -190,20 +191,24 @@ export async function processFile(fileConfig: FileConfig, parser?: SectionParser
     } else if (parser && fileConfig.contentUrl) {
       const contentBaseUrl = new URL('.', fileConfig.contentUrl).href;
       const editUrl = fileConfig.sourceUrl ? deriveEditUrlFromSourceUrl(fileConfig.sourceUrl) : undefined;
-      transformedContent = parser(content, { 
-        title: fileConfig.title, 
-        description: fileConfig.description, 
-        sourceBaseUrl: contentBaseUrl, 
-        editUrl 
+      transformedContent = parser(content, {
+        title: fileConfig.title,
+        description: fileConfig.description,
+        sourceBaseUrl: contentBaseUrl,
+        editUrl
       });
     } else {
       transformedContent = content;
     }
-    
+
+    if (fileConfig.postProcess) {
+      transformedContent = fileConfig.postProcess(transformedContent);
+    }
+
     const outputDir = path.dirname(fileConfig.outputPath);
     fs.mkdirSync(outputDir, { recursive: true });
 
     fs.writeFileSync(fileConfig.outputPath, transformedContent);
     console.log(`Processed and saved: ${fileConfig.outputPath}`);
   }
-} 
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,6 +1255,30 @@
   dependencies:
     tslib "^2.8.0"
 
+"@fortawesome/fontawesome-common-types@7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.2.0.tgz#ae54831ab5974bc1a64e8b07410f2da2b4abf87f"
+  integrity sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==
+
+"@fortawesome/fontawesome-svg-core@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.2.0.tgz#813550a5e8946a798e170d3f7331a685f8f8a550"
+  integrity sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "7.2.0"
+
+"@fortawesome/free-solid-svg-icons@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.2.0.tgz#9c761f7ab393e281f750c54d9ed1ebbcd4d581fa"
+  integrity sha512-YTVITFGN0/24PxzXrwqCgnyd7njDuzp5ZvaCx5nq/jg55kUYd94Nj8UTchBdBofi/L0nwRfjGOg0E41d2u9T1w==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "7.2.0"
+
+"@fortawesome/react-fontawesome@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz#7fb1d1f4b48a15b9c6c4d88d579dacc478ebf3ef"
+  integrity sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w==
+
 "@fumadocs/cli@^0.2.1":
   version "0.2.1"
   resolved "https://registry.npmjs.org/@fumadocs/cli/-/cli-0.2.1.tgz"


### PR DESCRIPTION
## Summary

Closes #4132.

- Adds a Maintenance docs page for recovering an Avalanche L1 that halts after all registered validators run out of P-Chain balance.
- Adds an animated React diagram showing why a balance top-up at `X+N` does not make ProposerVM see validators as active at the last produced block's P-Chain height `X`.
- Adds related links/callouts from common node errors, precompile upgrades, and generated Validator Manager docs.
- Moves the Maintain section lower in the Avalanche L1 sidebar and links the Validator Alerts flow from prevention guidance.
- Calls out that the recovery patch is experimental and not yet merged into AvalancheGo.

## Testing

- `yarn install`
- `yarn fumadocs-mdx`
- `yarn tsc --noEmit`
- `git diff --check`
- `yarn dev` and verified the page at `/docs/avalanche-l1s/maintain/halted-block-production`
