### PR TITLE
fix(managed-nodes): pass blockchainId/chainName to addNode

### DIFF
--- a/app/api/managed-testnet-nodes/constants.ts
+++ b/app/api/managed-testnet-nodes/constants.ts
@@ -10,8 +10,17 @@ if (MANAGED_TESTNET_NODES_SERVICE_URL.endsWith('/')) {
 
 // Managed Testnet Nodes service endpoints
 export const ManagedTestnetNodesServiceURLs = {
-  addNode: (subnetId: string, password: string) =>
-    `${MANAGED_TESTNET_NODES_SERVICE_URL}/node_admin/subnets/add/${subnetId}?password=${password}`,
+  // blockchainId/chainName are persisted on the slot's assignment so the
+  // firn-explorer tenant directory (`/explorer/tenants`) can resolve
+  // `<slug>.firn.gg` immediately, instead of waiting for a lazy back-fill on
+  // the first /firn/* proxy hit. Without these, the wildcard host falls
+  // through to the apex network switcher and the user sees the default
+  // chains rather than their L1's explorer.
+  addNode: (subnetId: string, password: string, blockchainId: string, chainName: string | null) => {
+    const params = new URLSearchParams({ password, blockchainId });
+    if (chainName) params.set('chainName', chainName);
+    return `${MANAGED_TESTNET_NODES_SERVICE_URL}/node_admin/subnets/add/${subnetId}?${params.toString()}`;
+  },
 
   deleteNode: (subnetId: string, nodeIndex: number, password: string) =>
     `${MANAGED_TESTNET_NODES_SERVICE_URL}/node_admin/subnets/delete/${subnetId}/${nodeIndex}?password=${password}`,

--- a/app/api/managed-testnet-nodes/route.ts
+++ b/app/api/managed-testnet-nodes/route.ts
@@ -73,8 +73,12 @@ async function handleCreateNode(request: NextRequest): Promise<NextResponse> {
       return jsonError(400, `Unsupported VM for this service. Expected Subnet EVM (vmID ${SUBNET_EVM_VM_ID}), got ${blockchainInfo.vmId}.`);
     }
 
-    // Make the request to Builder Hub API to add node
-    const data: SubnetStatusResponse = await builderHubAddNode(subnetId);
+    // Make the request to Builder Hub API to add node. Pass blockchainId
+    // and chainName so the slot's assignment is registered with both up
+    // front — otherwise the firn-explorer tenant directory omits this
+    // L1 until the first /firn/* proxy hit lazily back-fills it, and
+    // `<slug>.firn.gg` silently falls through to the apex view.
+    const data: SubnetStatusResponse = await builderHubAddNode(subnetId, blockchainId, chainName);
 
     // Store the new node in database
     if (data.nodes && data.nodes.length > 0) {

--- a/app/api/managed-testnet-nodes/service.ts
+++ b/app/api/managed-testnet-nodes/service.ts
@@ -3,11 +3,15 @@ import { ManagedTestnetNodesServiceURLs } from './constants';
 import { SubnetStatusResponse, NodeInfo, SubnetStatusResponseSchema, ServiceErrorSchema } from './types';
 import { toDateFromEpoch, NODE_TTL_MS } from './utils';
 
-export async function builderHubAddNode(subnetId: string): Promise<SubnetStatusResponse> {
+export async function builderHubAddNode(
+  subnetId: string,
+  blockchainId: string,
+  chainName: string | null,
+): Promise<SubnetStatusResponse> {
   const password = process.env.MANAGED_TESTNET_NODE_SERVICE_PASSWORD;
   if (!password) throw new Error('MANAGED_TESTNET_NODE_SERVICE_PASSWORD not configured');
 
-  const url = ManagedTestnetNodesServiceURLs.addNode(subnetId, password);
+  const url = ManagedTestnetNodesServiceURLs.addNode(subnetId, password, blockchainId, chainName);
   const response = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },


### PR DESCRIPTION
## Summary
- Builder Hub's `POST /api/managed-testnet-nodes` (and the proxied call to managed-nodes' `/node_admin/subnets/add/:subnetId`) wasn't forwarding `blockchainId` or `chainName` query params.
- Without `blockchainId` on the slot's assignment, `database.getActiveTenants()` on managed-nodes silently drops it from `GET /explorer/tenants` — so `<slug>.firn.gg` falls through to the apex network switcher and the user sees the default chains instead of their L1's explorer.
- Verified on prod `chains.json`: 9 / 18 active assignments are missing `blockchainId` and absent from the tenants directory.

## Changes
- `constants.ts`: `addNode` URL builder now appends `&blockchainId=...&chainName=...` (URLSearchParams handles encoding).
- `service.ts`: `builderHubAddNode` accepts and forwards `blockchainId` + `chainName`.
- `route.ts`: passes the already-fetched `blockchainId` (request body) and `chainName` (`getBlockchainInfo`) through.

## Test plan
- [ ] Create a node from `/console/testnet-infra/nodes`, then within ~30s `curl -s https://nodes-prod.18.182.4.86.sslip.io/explorer/tenants | jq '.tenants | keys'` — slug appears.
- [ ] Click the "Explorer" URL on the node card — renders the L1's data, not Benchmark/echo defaults.