### PR TITLE
fix(eerc): validate balance witnesses

### DIFF
--- a/components/toolbox/console/encrypted-erc/BalanceHistory.tsx
+++ b/components/toolbox/console/encrypted-erc/BalanceHistory.tsx
@@ -167,6 +167,15 @@ function BalanceHistory() {
       {balance.error && (
         <div className="rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/10 p-3 text-xs text-red-700 dark:text-red-400">
           {balance.error}
+          {balance.validationError && (
+            <>
+              {' '}
+              <Link href="/console/encrypted-erc/register" className="underline font-medium">
+                Open Register
+              </Link>
+              .
+            </>
+          )}
         </div>
       )}
 

--- a/components/toolbox/console/encrypted-erc/PrivateTransfer.tsx
+++ b/components/toolbox/console/encrypted-erc/PrivateTransfer.tsx
@@ -17,7 +17,11 @@ import { useEERCAuditorAndTokenId } from '@/hooks/eerc/useEERCAuditorAndTokenId'
 import { useEERCTransfer } from '@/hooks/eerc/useEERCTransfer';
 import { Scalar } from '@/lib/eerc/crypto/scalar';
 import { parseEERCAmount } from '@/lib/eerc/parseAmount';
-import { EERC_BALANCE_PROOF_MISMATCH_MESSAGE } from '@/lib/eerc/balanceValidation';
+import {
+  EERC_BALANCE_PROOF_MISMATCH_MESSAGE,
+  EERC_BALANCE_UNINITIALIZED_MESSAGE,
+  EERC_PRIVATE_KEY_INVALID_MESSAGE,
+} from '@/lib/eerc/balanceValidation';
 import { EERCToolShell } from './shared/EERCToolShell';
 import { EERCTxLink } from './shared/EERCTxLink';
 import { ENCRYPTED_ERC_SOURCES, EERC_COMMIT } from '@/lib/eerc/contractSources';
@@ -244,11 +248,20 @@ function PrivateTransfer() {
         {tr.error && (
           <div className="text-[11px] text-red-600 dark:text-red-400">
             {tr.error}
-            {tr.error === EERC_BALANCE_PROOF_MISMATCH_MESSAGE && (
+            {(tr.error === EERC_BALANCE_PROOF_MISMATCH_MESSAGE || tr.error === EERC_PRIVATE_KEY_INVALID_MESSAGE) && (
               <>
                 {' '}
                 <Link href="/console/encrypted-erc/register" className="underline font-medium">
                   Open Register
+                </Link>
+                .
+              </>
+            )}
+            {tr.error === EERC_BALANCE_UNINITIALIZED_MESSAGE && (
+              <>
+                {' '}
+                <Link href="/console/encrypted-erc/deposit" className="underline font-medium">
+                  Open Deposit
                 </Link>
                 .
               </>

--- a/components/toolbox/console/encrypted-erc/PrivateTransfer.tsx
+++ b/components/toolbox/console/encrypted-erc/PrivateTransfer.tsx
@@ -17,6 +17,7 @@ import { useEERCAuditorAndTokenId } from '@/hooks/eerc/useEERCAuditorAndTokenId'
 import { useEERCTransfer } from '@/hooks/eerc/useEERCTransfer';
 import { Scalar } from '@/lib/eerc/crypto/scalar';
 import { parseEERCAmount } from '@/lib/eerc/parseAmount';
+import { EERC_BALANCE_PROOF_MISMATCH_MESSAGE } from '@/lib/eerc/balanceValidation';
 import { EERCToolShell } from './shared/EERCToolShell';
 import { EERCTxLink } from './shared/EERCTxLink';
 import { ENCRYPTED_ERC_SOURCES, EERC_COMMIT } from '@/lib/eerc/contractSources';
@@ -240,7 +241,20 @@ function PrivateTransfer() {
           </div>
         )}
 
-        {tr.error && <div className="text-[11px] text-red-600 dark:text-red-400">{tr.error}</div>}
+        {tr.error && (
+          <div className="text-[11px] text-red-600 dark:text-red-400">
+            {tr.error}
+            {tr.error === EERC_BALANCE_PROOF_MISMATCH_MESSAGE && (
+              <>
+                {' '}
+                <Link href="/console/encrypted-erc/register" className="underline font-medium">
+                  Open Register
+                </Link>
+                .
+              </>
+            )}
+          </div>
+        )}
         {tr.status === 'success' && tr.txHash && (
           <div className="text-[11px]">
             <EERCTxLink chainId={activeChainId} txHash={tr.txHash}>

--- a/components/toolbox/console/encrypted-erc/PrivateTransfer.tsx
+++ b/components/toolbox/console/encrypted-erc/PrivateTransfer.tsx
@@ -194,6 +194,21 @@ function PrivateTransfer() {
         </div>
       </div>
 
+      {balance.error && (
+        <div className="rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/10 p-3 text-xs text-red-700 dark:text-red-400">
+          {balance.error}
+          {balance.validationError && (
+            <>
+              {' '}
+              <Link href="/console/encrypted-erc/register" className="underline font-medium">
+                Open Register
+              </Link>
+              .
+            </>
+          )}
+        </div>
+      )}
+
       {!aud.isAuditorSet && !aud.isLoading && (
         <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/10 p-3 text-xs text-amber-700 dark:text-amber-300">
           Auditor public key not set — transfers will revert. Visit{' '}

--- a/components/toolbox/console/encrypted-erc/Register.tsx
+++ b/components/toolbox/console/encrypted-erc/Register.tsx
@@ -14,6 +14,7 @@ import { useEERCDeployment } from '@/hooks/eerc/useEERCDeployment';
 import { useEERCRegistration } from '@/hooks/eerc/useEERCRegistration';
 import { EERCToolShell } from './shared/EERCToolShell';
 import { REGISTRAR_SOURCES, EERC_COMMIT } from '@/lib/eerc/contractSources';
+import { localIdentityMatchesRegistrar } from '@/lib/eerc/identityValidation';
 
 const metadata: ConsoleToolMetadata = {
   title: 'Register Encrypted ERC Keys',
@@ -40,6 +41,7 @@ export function Register() {
   const deployment = standalone.deployment ?? converter.deployment;
 
   const reg = useEERCRegistration(deployment);
+  const localKeyMatchesOnChain = localIdentityMatchesRegistrar(reg.identity, reg.onChainPublicKey);
 
   if (!deployment) {
     return <NoDeployment />;
@@ -63,6 +65,7 @@ export function Register() {
           registrar={deployment.registrar}
           onChainKey={reg.onChainPublicKey}
           hasLocalKey={reg.identity !== null}
+          localKeyMatchesOnChain={localKeyMatchesOnChain}
           onResetLocal={reg.resetIdentity}
           onDeriveLocal={reg.deriveIdentity}
         />
@@ -208,6 +211,7 @@ function RegisteredPanel({
   registrar,
   onChainKey,
   hasLocalKey,
+  localKeyMatchesOnChain,
   onResetLocal,
   onDeriveLocal,
 }: {
@@ -215,6 +219,7 @@ function RegisteredPanel({
   registrar: string;
   onChainKey: [bigint, bigint] | null;
   hasLocalKey: boolean;
+  localKeyMatchesOnChain: boolean | null;
   onResetLocal: () => void;
   onDeriveLocal: () => Promise<void>;
 }) {
@@ -231,10 +236,17 @@ function RegisteredPanel({
       setIsReDeriving(false);
     }
   };
+  const hasLocalKeyMismatch = hasLocalKey && localKeyMatchesOnChain === false;
 
   return (
     <div className="space-y-4">
-      <div className="rounded-xl border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/10 p-5 space-y-4">
+      <div
+        className={
+          hasLocalKeyMismatch
+            ? 'rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/10 p-5 space-y-4'
+            : 'rounded-xl border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/10 p-5 space-y-4'
+        }
+      >
         <div className="flex items-center gap-2.5">
           <div className="shrink-0 w-8 h-8 rounded-full bg-green-500 text-white flex items-center justify-center">
             <Check className="w-4 h-4" />
@@ -253,7 +265,26 @@ function RegisteredPanel({
           <Field label="Public key y" value={onChainKey?.[1].toString() ?? '—'} mono />
         </div>
         <div className="rounded-md border border-green-200/50 dark:border-green-800/50 bg-white/50 dark:bg-zinc-900/30 p-3 text-xs text-zinc-600 dark:text-zinc-400 leading-relaxed">
-          {hasLocalKey ? (
+          {hasLocalKeyMismatch ? (
+            <div className="space-y-2">
+              <p className="text-amber-800 dark:text-amber-300">
+                The local BabyJubJub key cached in this browser does not match the public key registered on-chain.
+                Deposit, transfer, and withdraw are blocked until they match.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <button className="underline text-zinc-700 dark:text-zinc-300" onClick={onResetLocal}>
+                  Clear local key
+                </button>
+                <button
+                  className="underline text-zinc-700 dark:text-zinc-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={handleReDerive}
+                  disabled={isReDeriving}
+                >
+                  {isReDeriving ? 'Deriving…' : 'Re-derive from wallet'}
+                </button>
+              </div>
+            </div>
+          ) : hasLocalKey ? (
             <>
               Your BabyJubJub private key is cached locally so decrypt and transfer tools won&apos;t re-prompt for a
               signature.{' '}

--- a/components/toolbox/console/encrypted-erc/WithdrawBurn.tsx
+++ b/components/toolbox/console/encrypted-erc/WithdrawBurn.tsx
@@ -122,6 +122,21 @@ function WithdrawBurn() {
         </div>
       </div>
 
+      {balance.error && (
+        <div className="rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/10 p-3 text-xs text-red-700 dark:text-red-400">
+          {balance.error}
+          {balance.validationError && (
+            <>
+              {' '}
+              <Link href="/console/encrypted-erc/register" className="underline font-medium">
+                Open Register
+              </Link>
+              .
+            </>
+          )}
+        </div>
+      )}
+
       {!aud.isAuditorSet && !aud.isLoading && (
         <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/10 p-3 text-xs text-amber-700 dark:text-amber-300">
           Auditor public key not set — withdrawals will revert. Visit{' '}

--- a/components/toolbox/console/encrypted-erc/WithdrawBurn.tsx
+++ b/components/toolbox/console/encrypted-erc/WithdrawBurn.tsx
@@ -16,6 +16,7 @@ import { useEERCAuditorAndTokenId } from '@/hooks/eerc/useEERCAuditorAndTokenId'
 import { useEERCWithdraw } from '@/hooks/eerc/useEERCWithdraw';
 import { Scalar } from '@/lib/eerc/crypto/scalar';
 import { parseEERCAmount } from '@/lib/eerc/parseAmount';
+import { EERC_BALANCE_PROOF_MISMATCH_MESSAGE } from '@/lib/eerc/balanceValidation';
 import { EERCToolShell } from './shared/EERCToolShell';
 import { EERCTxLink } from './shared/EERCTxLink';
 import { ENCRYPTED_ERC_SOURCES, EERC_COMMIT } from '@/lib/eerc/contractSources';
@@ -162,7 +163,20 @@ function WithdrawBurn() {
             Exceeds balance ({Scalar.parseEERCBalance(balance.decryptedCents)}).
           </div>
         )}
-        {wd.error && <div className="text-[11px] text-red-600 dark:text-red-400">{wd.error}</div>}
+        {wd.error && (
+          <div className="text-[11px] text-red-600 dark:text-red-400">
+            {wd.error}
+            {wd.error === EERC_BALANCE_PROOF_MISMATCH_MESSAGE && (
+              <>
+                {' '}
+                <Link href="/console/encrypted-erc/register" className="underline font-medium">
+                  Open Register
+                </Link>
+                .
+              </>
+            )}
+          </div>
+        )}
         {wd.status === 'success' && wd.txHash && (
           <div className="text-[11px]">
             <EERCTxLink chainId={converter.chainId} txHash={wd.txHash}>

--- a/components/toolbox/console/encrypted-erc/WithdrawBurn.tsx
+++ b/components/toolbox/console/encrypted-erc/WithdrawBurn.tsx
@@ -16,7 +16,11 @@ import { useEERCAuditorAndTokenId } from '@/hooks/eerc/useEERCAuditorAndTokenId'
 import { useEERCWithdraw } from '@/hooks/eerc/useEERCWithdraw';
 import { Scalar } from '@/lib/eerc/crypto/scalar';
 import { parseEERCAmount } from '@/lib/eerc/parseAmount';
-import { EERC_BALANCE_PROOF_MISMATCH_MESSAGE } from '@/lib/eerc/balanceValidation';
+import {
+  EERC_BALANCE_PROOF_MISMATCH_MESSAGE,
+  EERC_BALANCE_UNINITIALIZED_MESSAGE,
+  EERC_PRIVATE_KEY_INVALID_MESSAGE,
+} from '@/lib/eerc/balanceValidation';
 import { EERCToolShell } from './shared/EERCToolShell';
 import { EERCTxLink } from './shared/EERCTxLink';
 import { ENCRYPTED_ERC_SOURCES, EERC_COMMIT } from '@/lib/eerc/contractSources';
@@ -166,11 +170,20 @@ function WithdrawBurn() {
         {wd.error && (
           <div className="text-[11px] text-red-600 dark:text-red-400">
             {wd.error}
-            {wd.error === EERC_BALANCE_PROOF_MISMATCH_MESSAGE && (
+            {(wd.error === EERC_BALANCE_PROOF_MISMATCH_MESSAGE || wd.error === EERC_PRIVATE_KEY_INVALID_MESSAGE) && (
               <>
                 {' '}
                 <Link href="/console/encrypted-erc/register" className="underline font-medium">
                   Open Register
+                </Link>
+                .
+              </>
+            )}
+            {wd.error === EERC_BALANCE_UNINITIALIZED_MESSAGE && (
+              <>
+                {' '}
+                <Link href="/console/encrypted-erc/deposit" className="underline font-medium">
+                  Open Deposit
                 </Link>
                 .
               </>

--- a/hooks/eerc/useEERCBalance.ts
+++ b/hooks/eerc/useEERCBalance.ts
@@ -3,41 +3,26 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useAccount, usePublicClient } from 'wagmi';
 import EncryptedERCArtifact from '@/contracts/encrypted-erc/compiled/EncryptedERC.json';
-import { Poseidon } from '@/lib/eerc/crypto';
 import { Scalar } from '@/lib/eerc/crypto/scalar';
 import { loadIdentity, type EERCIdentitySecret } from '@/lib/eerc/identity';
-import type { EERCDeployment, ERC20Meta, Hex } from '@/lib/eerc/types';
-
-type RawEGCT = readonly [readonly [bigint, bigint], readonly [bigint, bigint]]; // (c1, c2)
-
-/**
- * Each amountPCT entry is the Solidity struct `{ pct: uint256[7], index: uint256 }`.
- * viem returns named-field structs as objects (with the named keys) rather
- * than tuples, so we type accordingly. Destructuring as a tuple
- * (`for (const [pct] of …)`) throws `is not iterable` at runtime.
- */
-interface RawAmountPCT {
-  pct: readonly [bigint, bigint, bigint, bigint, bigint, bigint, bigint];
-  index: bigint;
-}
-
-/** Raw shape returned by the contract's `balanceOfStandalone` / `getBalanceFromTokenAddress`. */
-interface RawBalance {
-  eGCT: { c1: readonly [bigint, bigint]; c2: readonly [bigint, bigint] };
-  nonce: bigint;
-  amountPCTs: readonly RawAmountPCT[];
-  balancePCT: readonly [bigint, bigint, bigint, bigint, bigint, bigint, bigint];
-  transactionIndex: bigint;
-}
+import {
+  validateEERCBalance,
+  type EERCPCT,
+  type RawEERCAmountPCT,
+  type RawEERCBalance,
+} from '@/lib/eerc/balanceValidation';
+import type { EERCDeployment, ERC20Meta } from '@/lib/eerc/types';
 
 export interface EERCBalanceState {
   /** Decrypted balance in eERC units (2 decimals). Null when we can't decrypt. */
   decryptedCents: bigint | null;
   /** Human-readable balance string ("12.34") when decrypted, else null. */
   formatted: string | null;
-  raw: RawBalance | null;
+  raw: RawEERCBalance | null;
   isLoading: boolean;
   error: string | null;
+  /** Set when the balance ciphertext is readable but unsafe to spend. */
+  validationError: string | null;
   /** True when a BJJ identity is cached but hasn't been registered on-chain. */
   hasIdentity: boolean;
   /** Reload from the chain. */
@@ -56,12 +41,15 @@ export function useEERCBalance(
 ): EERCBalanceState {
   const { address } = useAccount();
   const publicClient = usePublicClient();
-  const [state, setState] = useState<Pick<EERCBalanceState, 'decryptedCents' | 'formatted' | 'raw' | 'isLoading' | 'error'>>({
+  const [state, setState] = useState<
+    Pick<EERCBalanceState, 'decryptedCents' | 'formatted' | 'raw' | 'isLoading' | 'error' | 'validationError'>
+  >({
     decryptedCents: null,
     formatted: null,
     raw: null,
     isLoading: false,
     error: null,
+    validationError: null,
   });
   const [identity, setIdentity] = useState<EERCIdentitySecret | null>(null);
 
@@ -74,6 +62,7 @@ export function useEERCBalance(
         raw: null,
         isLoading: false,
         error: null,
+        validationError: null,
       });
       return;
     }
@@ -83,13 +72,13 @@ export function useEERCBalance(
   const refresh = useCallback(async () => {
     if (!address || !deployment || !publicClient) return;
     if (mode === 'converter' && !token) {
-      setState((s) => ({ ...s, error: 'No token selected for converter mode' }));
+      setState((s) => ({ ...s, error: 'No token selected for converter mode', validationError: null }));
       return;
     }
 
     const currentIdentity = loadIdentity(address, deployment.registrar);
     setIdentity(currentIdentity);
-    setState((s) => ({ ...s, isLoading: true, error: null }));
+    setState((s) => ({ ...s, isLoading: true, error: null, validationError: null }));
 
     try {
       const raw = (await publicClient.readContract({
@@ -100,8 +89,8 @@ export function useEERCBalance(
       })) as readonly [
         { c1: { x: bigint; y: bigint } | readonly [bigint, bigint]; c2: { x: bigint; y: bigint } | readonly [bigint, bigint] },
         bigint,
-        readonly RawAmountPCT[],
-        readonly [bigint, bigint, bigint, bigint, bigint, bigint, bigint],
+        readonly RawEERCAmountPCT[],
+        EERCPCT,
         bigint,
       ];
 
@@ -117,7 +106,7 @@ export function useEERCBalance(
         return [obj.x, obj.y];
       };
 
-      const asStruct: RawBalance = {
+      const asStruct: RawEERCBalance = {
         eGCT: {
           c1: normalizePoint(raw[0].c1),
           c2: normalizePoint(raw[0].c2),
@@ -128,66 +117,15 @@ export function useEERCBalance(
         transactionIndex: raw[4],
       };
 
-      // True balance in eERC = decrypt(balancePCT) + sum(decrypt(amountPCT)).
-      //
-      //   - balancePCT is the snapshot the user proved against at their last
-      //     outgoing op (transfer/withdraw). All-zero on a fresh account.
-      //   - amountPCTs[] accumulates incoming deposits and transfers since
-      //     then; the contract clears it whenever the user submits a fresh
-      //     balancePCT (i.e., on transfer/withdraw).
-      //
-      // Earlier versions only decrypted balancePCT, so a user who had only
-      // deposited (balancePCT still all-zero) saw 0. We now sum both
-      // components so the deposit-only path reports correctly.
-      const allZeroBalancePct = asStruct.balancePCT.every((x) => x === 0n);
-
       let decryptedCents: bigint | null = null;
+      let validationError: string | null = null;
       if (currentIdentity) {
-        let total = 0n;
-        let anyDecryptSucceeded = false;
-
-        // Component 1: balancePCT (the running-balance snapshot). Skip the
-        // decrypt call entirely on all-zero — Poseidon's integrity check
-        // throws on a zeroed ciphertext.
-        if (!allZeroBalancePct) {
-          try {
-            total += Poseidon.decryptAmountPCT(
-              currentIdentity.decryptionKey,
-              asStruct.balancePCT.map((x) => x.toString()),
-            );
-            anyDecryptSucceeded = true;
-          } catch {
-            // balancePCT didn't decrypt to our key — leave total alone and
-            // hope the amountPCTs path picks up the real balance. Common
-            // failure mode: stale identity from a previous registration.
-          }
+        const validation = validateEERCBalance(asStruct, currentIdentity);
+        if (validation.ok) {
+          decryptedCents = validation.decryptedCents;
         } else {
-          // All-zero balancePCT is the legitimate fresh-account state, not
-          // a decrypt failure. Treat it as a successful zero contribution.
-          anyDecryptSucceeded = true;
+          validationError = validation.message;
         }
-
-        // Component 2: amountPCTs[] — incoming deposits/transfers since the
-        // last outgoing op. Each entry is the struct `{ pct: uint256[7],
-        // index: uint256 }`; viem returns it as a named-field object, not
-        // a tuple, so access via `.pct` (a tuple-style destructure throws
-        // "is not iterable" at runtime). We only need the pct portion;
-        // sum every entry that successfully decrypts.
-        for (const entry of asStruct.amountPCTs) {
-          try {
-            total += Poseidon.decryptAmountPCT(
-              currentIdentity.decryptionKey,
-              entry.pct.map((x) => x.toString()),
-            );
-            anyDecryptSucceeded = true;
-          } catch {
-            // Skip entries that aren't encrypted to our key. Shouldn't
-            // happen in practice (the contract gates by msg.sender), but
-            // a stray entry shouldn't blank the whole balance.
-          }
-        }
-
-        decryptedCents = anyDecryptSucceeded ? total : null;
       }
 
       setState({
@@ -195,14 +133,18 @@ export function useEERCBalance(
         formatted: decryptedCents === null ? null : Scalar.parseEERCBalance(decryptedCents),
         raw: asStruct,
         isLoading: false,
-        error: null,
+        error: validationError,
+        validationError,
       });
     } catch (err) {
-      setState((s) => ({
-        ...s,
+      setState({
+        decryptedCents: null,
+        formatted: null,
+        raw: null,
         isLoading: false,
         error: err instanceof Error ? err.message : 'Failed to read balance',
-      }));
+        validationError: null,
+      });
     }
   }, [address, deployment, publicClient, mode, token]);
 

--- a/hooks/eerc/useEERCDeposit.ts
+++ b/hooks/eerc/useEERCDeposit.ts
@@ -6,7 +6,7 @@ import { formatUnits } from 'viem';
 import { useResolvedWalletClient } from '@/components/toolbox/hooks/useResolvedWalletClient';
 import { useEERCNotifiedWrite } from './useEERCNotifiedWrite';
 import { depositToEERC, ERC20_MINIMAL_ABI, computeDepositCents } from '@/lib/eerc/operations/deposit';
-import { loadIdentity } from '@/lib/eerc/identity';
+import { loadVerifiedEERCIdentity } from '@/lib/eerc/identityValidation';
 import type { EERCDeployment, ERC20Meta, Hex } from '@/lib/eerc/types';
 
 export type DepositStatus = 'idle' | 'checking-allowance' | 'approving' | 'depositing' | 'confirming' | 'success' | 'error';
@@ -68,6 +68,8 @@ export function useEERCDeposit(deployment: EERCDeployment | undefined, token: ER
       setTxHash(null);
 
       try {
+        setStatus('checking-allowance');
+        await loadVerifiedEERCIdentity({ address, registrar: deployment.registrar, publicClient });
         setStatus('approving');
         // Routes the ERC20 approval through the notified-write helper so
         // the console toast + tx-history row fire alongside every other
@@ -101,14 +103,13 @@ export function useEERCDeposit(deployment: EERCDeployment | undefined, token: ER
       if (!address || !deployment || !token || !walletClient || !publicClient) {
         throw new Error('Wallet not connected or deployment/token not resolved');
       }
-      const identity = loadIdentity(address, deployment.registrar);
-      if (!identity) throw new Error('Register your BabyJubJub identity first');
 
       setError(null);
       setTxHash(null);
 
       try {
         setStatus('checking-allowance');
+        const identity = await loadVerifiedEERCIdentity({ address, registrar: deployment.registrar, publicClient });
         const allowance = await refreshAllowance();
         if (allowance !== null && allowance < amountWei) {
           throw new Error('Approve WAVAX before depositing.');

--- a/hooks/eerc/useEERCTransfer.ts
+++ b/hooks/eerc/useEERCTransfer.ts
@@ -7,9 +7,9 @@ import { useEERCNotifiedWrite } from './useEERCNotifiedWrite';
 import RegistrarArtifact from '@/contracts/encrypted-erc/compiled/Registrar.json';
 import { transferPrivate, type FlatEncryptedBalance } from '@/lib/eerc/operations/transfer';
 import { Scalar } from '@/lib/eerc/crypto/scalar';
-import { loadIdentity } from '@/lib/eerc/identity';
+import { loadVerifiedEERCIdentity } from '@/lib/eerc/identityValidation';
 import type { BJPoint } from '@/lib/eerc/crypto/babyjub';
-import type { EERCDeployment, ERC20Meta, Hex } from '@/lib/eerc/types';
+import type { EERCDeployment, Hex } from '@/lib/eerc/types';
 
 export type TransferStatus = 'idle' | 'lookup' | 'proving' | 'submitting' | 'confirming' | 'success' | 'error';
 
@@ -60,14 +60,13 @@ export function useEERCTransfer(
       if (!address || !deployment || !walletClient || !publicClient) {
         throw new Error('Wallet not connected or deployment not resolved');
       }
-      const identity = loadIdentity(address, deployment.registrar);
-      if (!identity) throw new Error('Register your BabyJubJub identity first');
 
       setError(null);
       setTxHash(null);
 
       try {
         setStatus('lookup');
+        const identity = await loadVerifiedEERCIdentity({ address, registrar: deployment.registrar, publicClient });
         // Recipient must be registered — fetch their pubkey from Registrar.
         const recipientPkArr = (await publicClient.readContract({
           address: deployment.registrar,

--- a/hooks/eerc/useEERCWithdraw.ts
+++ b/hooks/eerc/useEERCWithdraw.ts
@@ -6,7 +6,7 @@ import { useResolvedWalletClient } from '@/components/toolbox/hooks/useResolvedW
 import { useEERCNotifiedWrite } from './useEERCNotifiedWrite';
 import { withdrawFromEERC } from '@/lib/eerc/operations/withdraw';
 import { Scalar } from '@/lib/eerc/crypto/scalar';
-import { loadIdentity } from '@/lib/eerc/identity';
+import { loadVerifiedEERCIdentity } from '@/lib/eerc/identityValidation';
 import type { BJPoint } from '@/lib/eerc/crypto/babyjub';
 import type { FlatEncryptedBalance } from '@/lib/eerc/operations/transfer';
 import type { EERCDeployment, Hex } from '@/lib/eerc/types';
@@ -54,8 +54,6 @@ export function useEERCWithdraw(
       if (!address || !deployment || !walletClient || !publicClient) {
         throw new Error('Wallet not connected or deployment not resolved');
       }
-      const identity = loadIdentity(address, deployment.registrar);
-      if (!identity) throw new Error('Register your BabyJubJub identity first');
 
       setError(null);
       setTxHash(null);
@@ -63,6 +61,7 @@ export function useEERCWithdraw(
       const human = Scalar.parseEERCBalance(amountCents);
       try {
         setStatus('proving');
+        const identity = await loadVerifiedEERCIdentity({ address, registrar: deployment.registrar, publicClient });
         const result = await withdrawFromEERC({
           deployment,
           senderAddress: address as Hex,

--- a/lib/eerc/balanceValidation.ts
+++ b/lib/eerc/balanceValidation.ts
@@ -1,0 +1,128 @@
+import { BabyJub, type BJPoint } from './crypto/babyjub';
+import { FF } from './crypto/ff';
+import { Poseidon } from './crypto';
+import { Scalar } from './crypto/scalar';
+import { SNARK_FIELD_SIZE } from './crypto/constants';
+import type { EERCIdentitySecret } from './identity';
+
+export type EERCPCT = readonly [bigint, bigint, bigint, bigint, bigint, bigint, bigint];
+export type RawEERCPoint = readonly [bigint, bigint];
+
+export interface RawEERCAmountPCT {
+  pct: EERCPCT;
+  index: bigint;
+}
+
+export interface RawEERCBalance {
+  eGCT: {
+    c1: RawEERCPoint;
+    c2: RawEERCPoint;
+  };
+  nonce: bigint;
+  amountPCTs: readonly RawEERCAmountPCT[];
+  balancePCT: EERCPCT;
+  transactionIndex: bigint;
+}
+
+export const EERC_BALANCE_PCT_DECRYPTION_MESSAGE =
+  'Your cached BabyJubJub key cannot decrypt the encrypted balance history. Open Register, clear the local key, and re-derive it before depositing, transferring, or withdrawing.';
+
+export const EERC_BALANCE_EGCT_MISMATCH_MESSAGE =
+  'Encrypted balance verification failed: the decrypted history does not match the on-chain EGCT for your local BabyJubJub key. Open Register, clear/re-derive the local key, then refresh. If this balance was created with a different key, you need that key to spend it.';
+
+export type EERCBalanceValidationResult =
+  | {
+      ok: true;
+      decryptedCents: bigint;
+    }
+  | {
+      ok: false;
+      decryptedCents: bigint | null;
+      reason: 'pct-decryption-failed' | 'egct-mismatch';
+      message: string;
+    };
+
+export function validateEERCBalance(
+  raw: Pick<RawEERCBalance, 'eGCT' | 'amountPCTs' | 'balancePCT'>,
+  identity: EERCIdentitySecret,
+): EERCBalanceValidationResult {
+  let total = 0n;
+
+  if (!isZeroPCT(raw.balancePCT)) {
+    const decrypted = decryptPCT(identity, raw.balancePCT);
+    if (decrypted === null) {
+      return {
+        ok: false,
+        decryptedCents: null,
+        reason: 'pct-decryption-failed',
+        message: EERC_BALANCE_PCT_DECRYPTION_MESSAGE,
+      };
+    }
+    total += decrypted;
+  }
+
+  for (const amountPCT of raw.amountPCTs) {
+    const decrypted = decryptPCT(identity, amountPCT.pct);
+    if (decrypted === null) {
+      return {
+        ok: false,
+        decryptedCents: null,
+        reason: 'pct-decryption-failed',
+        message: EERC_BALANCE_PCT_DECRYPTION_MESSAGE,
+      };
+    }
+    total += decrypted;
+  }
+
+  if (!egctMatchesTotal(raw.eGCT, identity.formattedKey, total)) {
+    const formatted = Scalar.parseEERCBalance(total);
+    return {
+      ok: false,
+      decryptedCents: total,
+      reason: 'egct-mismatch',
+      message: `${EERC_BALANCE_EGCT_MISMATCH_MESSAGE} Local history decrypted to ${formatted} eERC, but the prover would reject the raw EGCT.`,
+    };
+  }
+
+  return { ok: true, decryptedCents: total };
+}
+
+function decryptPCT(identity: EERCIdentitySecret, pct: EERCPCT): bigint | null {
+  try {
+    return Poseidon.decryptAmountPCT(identity.decryptionKey, pct.map((x) => x.toString()));
+  } catch {
+    return null;
+  }
+}
+
+function egctMatchesTotal(
+  eGCT: RawEERCBalance['eGCT'],
+  privateKey: bigint,
+  totalBalance: bigint,
+): boolean {
+  if (totalBalance === 0n && isZeroEGCT(eGCT)) return true;
+
+  const field = new FF(SNARK_FIELD_SIZE);
+  const curve = new BabyJub(field);
+
+  let decryptedEGCT: BJPoint;
+  try {
+    decryptedEGCT = curve.elGamalDecryption(privateKey, {
+      c1: [eGCT.c1[0], eGCT.c1[1]],
+      c2: [eGCT.c2[0], eGCT.c2[1]],
+    });
+  } catch {
+    return false;
+  }
+
+  const expectedPoint = curve.mulWithScalar(curve.Base8, totalBalance);
+  return decryptedEGCT[0] === expectedPoint[0] && decryptedEGCT[1] === expectedPoint[1];
+}
+
+function isZeroPCT(pct: EERCPCT): boolean {
+  return pct.every((x) => x === 0n);
+}
+
+function isZeroEGCT(eGCT: RawEERCBalance['eGCT']): boolean {
+  return eGCT.c1[0] === 0n && eGCT.c1[1] === 0n && eGCT.c2[0] === 0n && eGCT.c2[1] === 0n;
+}

--- a/lib/eerc/balanceValidation.ts
+++ b/lib/eerc/balanceValidation.ts
@@ -7,6 +7,7 @@ import type { EERCIdentitySecret } from './identity';
 
 export type EERCPCT = readonly [bigint, bigint, bigint, bigint, bigint, bigint, bigint];
 export type RawEERCPoint = readonly [bigint, bigint];
+export type FlatEERCEncryptedBalance = readonly [bigint, bigint, bigint, bigint];
 
 export interface RawEERCAmountPCT {
   pct: EERCPCT;
@@ -29,6 +30,9 @@ export const EERC_BALANCE_PCT_DECRYPTION_MESSAGE =
 
 export const EERC_BALANCE_EGCT_MISMATCH_MESSAGE =
   'Encrypted balance verification failed: the decrypted history does not match the on-chain EGCT for your local BabyJubJub key. Open Register, clear/re-derive the local key, then refresh. If this balance was created with a different key, you need that key to spend it.';
+
+export const EERC_BALANCE_PROOF_MISMATCH_MESSAGE =
+  'Encrypted balance proof blocked: the local BabyJubJub key cannot prove the on-chain encrypted balance. Refresh Balance, then open Register to clear/re-derive the local key. If this balance was created with a different key, that key is required to withdraw or transfer.';
 
 export type EERCBalanceValidationResult =
   | {
@@ -85,6 +89,47 @@ export function validateEERCBalance(
   }
 
   return { ok: true, decryptedCents: total };
+}
+
+export function encryptedBalanceMatchesPlaintext({
+  encryptedBalance,
+  privateKey,
+  plaintextBalance,
+}: {
+  encryptedBalance: FlatEERCEncryptedBalance;
+  privateKey: bigint;
+  plaintextBalance: bigint;
+}): boolean {
+  return egctMatchesTotal(
+    {
+      c1: [encryptedBalance[0], encryptedBalance[1]],
+      c2: [encryptedBalance[2], encryptedBalance[3]],
+    },
+    privateKey,
+    plaintextBalance,
+  );
+}
+
+export function assertEERCBalanceWitnessMatchesPlaintext(args: {
+  encryptedBalance: FlatEERCEncryptedBalance;
+  privateKey: bigint;
+  plaintextBalance: bigint;
+}): void {
+  if (!encryptedBalanceMatchesPlaintext(args)) {
+    throw new Error(EERC_BALANCE_PROOF_MISMATCH_MESSAGE);
+  }
+}
+
+export function normalizeEERCBalanceProofError(err: unknown): Error {
+  if (isEERCBalanceProofAssertion(err)) {
+    return new Error(EERC_BALANCE_PROOF_MISMATCH_MESSAGE);
+  }
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+export function isEERCBalanceProofAssertion(err: unknown): boolean {
+  const message = err instanceof Error ? `${err.message}\n${err.stack ?? ''}` : String(err);
+  return /Assert Failed/i.test(message) && /CheckValue/i.test(message) && /(WithdrawCircuit|TransferCircuit)/i.test(message);
 }
 
 function decryptPCT(identity: EERCIdentitySecret, pct: EERCPCT): bigint | null {

--- a/lib/eerc/balanceValidation.ts
+++ b/lib/eerc/balanceValidation.ts
@@ -2,7 +2,7 @@ import { BabyJub, type BJPoint } from './crypto/babyjub';
 import { FF } from './crypto/ff';
 import { Poseidon } from './crypto';
 import { Scalar } from './crypto/scalar';
-import { SNARK_FIELD_SIZE } from './crypto/constants';
+import { SNARK_FIELD_SIZE, SUB_GROUP_ORDER } from './crypto/constants';
 import type { EERCIdentitySecret } from './identity';
 
 export type EERCPCT = readonly [bigint, bigint, bigint, bigint, bigint, bigint, bigint];
@@ -33,6 +33,15 @@ export const EERC_BALANCE_EGCT_MISMATCH_MESSAGE =
 
 export const EERC_BALANCE_PROOF_MISMATCH_MESSAGE =
   'Encrypted balance proof blocked: the local BabyJubJub key cannot prove the on-chain encrypted balance. Refresh Balance, then open Register to clear/re-derive the local key. If this balance was created with a different key, that key is required to withdraw or transfer.';
+
+export const EERC_BALANCE_UNINITIALIZED_MESSAGE =
+  'Encrypted balance is uninitialized on-chain — Deposit at least once before withdrawing or transferring.';
+
+export const EERC_AMOUNT_OUT_OF_RANGE_MESSAGE =
+  'Amount is outside the BabyJubJub subgroup order. Use a smaller amount.';
+
+export const EERC_PRIVATE_KEY_INVALID_MESSAGE =
+  'Local BabyJubJub private key is invalid (zero or out of subgroup range). Open Register and re-derive the local key.';
 
 export type EERCBalanceValidationResult =
   | {
@@ -110,12 +119,60 @@ export function encryptedBalanceMatchesPlaintext({
   );
 }
 
+/**
+ * Run every TS-side check the withdraw/transfer circuit will run on the
+ * sender's encrypted balance witness.
+ *
+ * The circuit verifies (in order):
+ *   1. CheckPublicKey: privKey != 0, privKey < subgroup order, and privKey * Base8 == pubKey.
+ *   2. CheckValue: c1 and c2 are on the BabyJubJub curve (BabyCheck).
+ *   3. CheckValue: value < subgroup order (and value < 2^252 via Num2Bits(252)).
+ *   4. CheckValue: ElGamalDecrypt(c1, c2, privKey) == BabyPbk(value).
+ *
+ * Throwing here gives the user a friendly, actionable message **before** we
+ * spin up the multi-second snarkjs proof and expose the raw circom assert.
+ */
 export function assertEERCBalanceWitnessMatchesPlaintext(args: {
   encryptedBalance: FlatEERCEncryptedBalance;
   privateKey: bigint;
   plaintextBalance: bigint;
+  publicKey?: RawEERCPoint;
 }): void {
-  if (!encryptedBalanceMatchesPlaintext(args)) {
+  const { encryptedBalance, privateKey, plaintextBalance, publicKey } = args;
+
+  if (privateKey <= 0n || privateKey >= SUB_GROUP_ORDER) {
+    throw new Error(EERC_PRIVATE_KEY_INVALID_MESSAGE);
+  }
+
+  if (plaintextBalance < 0n || plaintextBalance >= SUB_GROUP_ORDER) {
+    throw new Error(EERC_AMOUNT_OUT_OF_RANGE_MESSAGE);
+  }
+
+  const c1: RawEERCPoint = [encryptedBalance[0], encryptedBalance[1]];
+  const c2: RawEERCPoint = [encryptedBalance[2], encryptedBalance[3]];
+
+  if (isZeroSentinelPoint(c1) || isZeroSentinelPoint(c2)) {
+    throw new Error(EERC_BALANCE_UNINITIALIZED_MESSAGE);
+  }
+
+  const field = new FF(SNARK_FIELD_SIZE);
+  const curve = new BabyJub(field);
+
+  if (!curve.inCurve([c1[0], c1[1]]) || !curve.inCurve([c2[0], c2[1]])) {
+    throw new Error(EERC_BALANCE_PROOF_MISMATCH_MESSAGE);
+  }
+
+  if (publicKey) {
+    if (!curve.inCurve([publicKey[0], publicKey[1]])) {
+      throw new Error(EERC_PRIVATE_KEY_INVALID_MESSAGE);
+    }
+    const derived = curve.generatePublicKey(privateKey);
+    if (derived[0] !== publicKey[0] || derived[1] !== publicKey[1]) {
+      throw new Error(EERC_PRIVATE_KEY_INVALID_MESSAGE);
+    }
+  }
+
+  if (!encryptedBalanceMatchesPlaintext({ encryptedBalance, privateKey, plaintextBalance })) {
     throw new Error(EERC_BALANCE_PROOF_MISMATCH_MESSAGE);
   }
 }
@@ -127,9 +184,21 @@ export function normalizeEERCBalanceProofError(err: unknown): Error {
   return err instanceof Error ? err : new Error(String(err));
 }
 
+/**
+ * Match the noisy "Assert Failed. Error in template ..." that
+ * snarkjs/circom_runtime throws when ANY witness constraint trips inside the
+ * eERC circuits. We deliberately accept all four spending circuits
+ * (Withdraw/Transfer/Burn/Mint) and the curve/value/PCT/auditor sub-templates
+ * so we don't leak `CheckValue_23 line: 258` to end users — the user-facing
+ * message is the same root-cause story regardless of which sub-assertion
+ * tripped (their local key cannot prove the on-chain balance).
+ */
 export function isEERCBalanceProofAssertion(err: unknown): boolean {
   const message = err instanceof Error ? `${err.message}\n${err.stack ?? ''}` : String(err);
-  return /Assert Failed/i.test(message) && /CheckValue/i.test(message) && /(WithdrawCircuit|TransferCircuit)/i.test(message);
+  if (!/Assert Failed/i.test(message)) return false;
+  const subAssert = /(CheckValue|CheckPublicKey|CheckPCT|CheckReceiverValue|CheckAuditorValue|BabyCheck)/i.test(message);
+  const circuit = /(WithdrawCircuit|TransferCircuit|BurnCircuit|MintCircuit)/i.test(message);
+  return subAssert && circuit;
 }
 
 function decryptPCT(identity: EERCIdentitySecret, pct: EERCPCT): bigint | null {
@@ -170,4 +239,14 @@ function isZeroPCT(pct: EERCPCT): boolean {
 
 function isZeroEGCT(eGCT: RawEERCBalance['eGCT']): boolean {
   return eGCT.c1[0] === 0n && eGCT.c1[1] === 0n && eGCT.c2[0] === 0n && eGCT.c2[1] === 0n;
+}
+
+/**
+ * The contract uses `(0, 0)` as a sentinel for an uninitialized balance —
+ * that point is **off the BabyJubJub curve**, so the circuit's `BabyCheck`
+ * will refuse it. Spending a fresh-state balance with no deposits is the
+ * canonical way users hit the raw `Error in template BabyCheck` assertion.
+ */
+function isZeroSentinelPoint(p: RawEERCPoint): boolean {
+  return p[0] === 0n && p[1] === 0n;
 }

--- a/lib/eerc/identityValidation.ts
+++ b/lib/eerc/identityValidation.ts
@@ -1,0 +1,72 @@
+import RegistrarArtifact from '@/contracts/encrypted-erc/compiled/Registrar.json';
+import { loadIdentity, type EERCIdentitySecret } from './identity';
+import type { Hex } from './types';
+import type { Abi } from 'viem';
+
+export const EERC_IDENTITY_MISMATCH_MESSAGE =
+  'Your cached BabyJubJub key does not match the public key registered on-chain. Open Register, clear the local key, and re-derive it from the wallet that created the registration before depositing, transferring, or withdrawing.';
+
+export const EERC_IDENTITY_NOT_REGISTERED_MESSAGE = 'Register your BabyJubJub identity before using encrypted-ERC.';
+
+export function eercPublicKeysEqual(
+  localKey: readonly [bigint, bigint] | null | undefined,
+  onChainKey: readonly [bigint, bigint] | null | undefined,
+): boolean {
+  return Boolean(localKey && onChainKey && localKey[0] === onChainKey[0] && localKey[1] === onChainKey[1]);
+}
+
+export function isZeroEERCPublicKey(key: readonly [bigint, bigint] | null | undefined): boolean {
+  return !key || (key[0] === 0n && key[1] === 0n);
+}
+
+export function assertEERCIdentityMatchesOnChain(
+  identity: EERCIdentitySecret,
+  onChainPublicKey: readonly [bigint, bigint],
+): void {
+  if (isZeroEERCPublicKey(onChainPublicKey)) {
+    throw new Error(EERC_IDENTITY_NOT_REGISTERED_MESSAGE);
+  }
+  if (!eercPublicKeysEqual(identity.publicKey, onChainPublicKey)) {
+    throw new Error(EERC_IDENTITY_MISMATCH_MESSAGE);
+  }
+}
+
+interface RegistrarReader {
+  readContract(args: {
+    address: Hex;
+    abi: Abi | readonly unknown[];
+    functionName: 'getUserPublicKey';
+    args: readonly [string];
+  }): Promise<unknown>;
+}
+
+export async function loadVerifiedEERCIdentity({
+  address,
+  registrar,
+  publicClient,
+}: {
+  address: string;
+  registrar: Hex;
+  publicClient: RegistrarReader;
+}): Promise<EERCIdentitySecret> {
+  const identity = loadIdentity(address, registrar);
+  if (!identity) throw new Error(EERC_IDENTITY_NOT_REGISTERED_MESSAGE);
+
+  const key = (await publicClient.readContract({
+    address: registrar,
+    abi: RegistrarArtifact.abi,
+    functionName: 'getUserPublicKey',
+    args: [address],
+  })) as readonly [bigint, bigint];
+
+  assertEERCIdentityMatchesOnChain(identity, key);
+  return identity;
+}
+
+export function localIdentityMatchesRegistrar(
+  identity: EERCIdentitySecret | null,
+  onChainPublicKey: readonly [bigint, bigint] | null,
+): boolean | null {
+  if (!identity || !onChainPublicKey || isZeroEERCPublicKey(onChainPublicKey)) return null;
+  return eercPublicKeysEqual(identity.publicKey, onChainPublicKey);
+}

--- a/lib/eerc/operations/transfer.ts
+++ b/lib/eerc/operations/transfer.ts
@@ -9,6 +9,10 @@
 import EncryptedERCArtifact from '@/contracts/encrypted-erc/compiled/EncryptedERC.json';
 import { BabyJub, FF, Poseidon, SNARK_FIELD_SIZE } from '../crypto';
 import type { BJPoint } from '../crypto/babyjub';
+import {
+  assertEERCBalanceWitnessMatchesPlaintext,
+  normalizeEERCBalanceProofError,
+} from '../balanceValidation';
 import { generateProof } from '../proof';
 import type { EERCDeployment, Hex } from '../types';
 
@@ -56,6 +60,11 @@ export async function transferPrivate(inputs: TransferInputs): Promise<{ txHash:
 
   if (amount <= 0n) throw new Error('Amount must be positive');
   if (amount > decryptedBalance) throw new Error('Insufficient encrypted balance');
+  assertEERCBalanceWitnessMatchesPlaintext({
+    encryptedBalance,
+    privateKey: senderPrivateKey,
+    plaintextBalance: decryptedBalance,
+  });
   if (recipientPublicKey[0] === 0n && recipientPublicKey[1] === 0n) {
     throw new Error('Recipient is not registered on this eERC Registrar');
   }
@@ -113,7 +122,13 @@ export async function transferPrivate(inputs: TransferInputs): Promise<{ txHash:
     AuditorPCTRandom: aPCT.encryptionRandom,
   };
 
-  const { points, publicSignals } = await generateProof('transfer', circuitInput);
+  let generatedProof: Awaited<ReturnType<typeof generateProof>>;
+  try {
+    generatedProof = await generateProof('transfer', circuitInput);
+  } catch (err) {
+    throw normalizeEERCBalanceProofError(err);
+  }
+  const { points, publicSignals } = generatedProof;
   if (publicSignals.length !== 32) {
     throw new Error(`Expected 32 public signals for transfer, got ${publicSignals.length}`);
   }

--- a/lib/eerc/operations/transfer.ts
+++ b/lib/eerc/operations/transfer.ts
@@ -64,6 +64,7 @@ export async function transferPrivate(inputs: TransferInputs): Promise<{ txHash:
     encryptedBalance,
     privateKey: senderPrivateKey,
     plaintextBalance: decryptedBalance,
+    publicKey: [senderPublicKey[0], senderPublicKey[1]],
   });
   if (recipientPublicKey[0] === 0n && recipientPublicKey[1] === 0n) {
     throw new Error('Recipient is not registered on this eERC Registrar');

--- a/lib/eerc/operations/withdraw.ts
+++ b/lib/eerc/operations/withdraw.ts
@@ -8,6 +8,10 @@
 import EncryptedERCArtifact from '@/contracts/encrypted-erc/compiled/EncryptedERC.json';
 import { BabyJub, FF, Poseidon, SNARK_FIELD_SIZE } from '../crypto';
 import type { BJPoint } from '../crypto/babyjub';
+import {
+  assertEERCBalanceWitnessMatchesPlaintext,
+  normalizeEERCBalanceProofError,
+} from '../balanceValidation';
 import { generateProof } from '../proof';
 import type { EERCDeployment, Hex } from '../types';
 import type { FlatEncryptedBalance } from './transfer';
@@ -45,6 +49,11 @@ export async function withdrawFromEERC(inputs: WithdrawInputs): Promise<{ txHash
 
   if (amount <= 0n) throw new Error('Amount must be positive');
   if (amount > decryptedBalance) throw new Error('Insufficient encrypted balance');
+  assertEERCBalanceWitnessMatchesPlaintext({
+    encryptedBalance,
+    privateKey: senderPrivateKey,
+    plaintextBalance: decryptedBalance,
+  });
 
   const newBalance = decryptedBalance - amount;
 
@@ -75,7 +84,13 @@ export async function withdrawFromEERC(inputs: WithdrawInputs): Promise<{ txHash
     AuditorPCTRandom: auditorPCT.encryptionRandom,
   };
 
-  const { points, publicSignals } = await generateProof('withdraw', circuitInput);
+  let generatedProof: Awaited<ReturnType<typeof generateProof>>;
+  try {
+    generatedProof = await generateProof('withdraw', circuitInput);
+  } catch (err) {
+    throw normalizeEERCBalanceProofError(err);
+  }
+  const { points, publicSignals } = generatedProof;
   if (publicSignals.length !== 16) {
     throw new Error(`Expected 16 public signals for withdraw, got ${publicSignals.length}`);
   }

--- a/lib/eerc/operations/withdraw.ts
+++ b/lib/eerc/operations/withdraw.ts
@@ -53,6 +53,7 @@ export async function withdrawFromEERC(inputs: WithdrawInputs): Promise<{ txHash
     encryptedBalance,
     privateKey: senderPrivateKey,
     plaintextBalance: decryptedBalance,
+    publicKey: [senderPublicKey[0], senderPublicKey[1]],
   });
 
   const newBalance = decryptedBalance - amount;

--- a/tests/unit/console/eerc-balance.test.ts
+++ b/tests/unit/console/eerc-balance.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  validateEERCBalance,
+  type EERCPCT,
+  type RawEERCBalance,
+  type RawEERCAmountPCT,
+} from '@/lib/eerc/balanceValidation';
+import { BabyJub, type BJPoint } from '@/lib/eerc/crypto/babyjub';
+import { FF } from '@/lib/eerc/crypto/ff';
+import { Poseidon } from '@/lib/eerc/crypto';
+import { SNARK_FIELD_SIZE } from '@/lib/eerc/crypto/constants';
+import { expandIdentity, type EERCIdentitySecret } from '@/lib/eerc/identity';
+import { EERC_IDENTITY_MISMATCH_MESSAGE, assertEERCIdentityMatchesOnChain } from '@/lib/eerc/identityValidation';
+
+const ZERO_PCT: EERCPCT = [0n, 0n, 0n, 0n, 0n, 0n, 0n];
+const ZERO_EGCT: RawEERCBalance['eGCT'] = {
+  c1: [0n, 0n],
+  c2: [0n, 0n],
+};
+
+function makeIdentity(seed: string): EERCIdentitySecret {
+  return expandIdentity(seed.padStart(64, '0'));
+}
+
+function cryptoSuite() {
+  const field = new FF(SNARK_FIELD_SIZE);
+  const curve = new BabyJub(field);
+  return { curve, poseidon: new Poseidon(field, curve) };
+}
+
+async function encryptPCT(identity: EERCIdentitySecret, amount: bigint): Promise<EERCPCT> {
+  const { poseidon } = cryptoSuite();
+  const encrypted = await poseidon.processPoseidonEncryption({
+    inputs: [amount],
+    publicKey: identity.publicKey,
+  });
+  return [
+    encrypted.cipher[0]!,
+    encrypted.cipher[1]!,
+    encrypted.cipher[2]!,
+    encrypted.cipher[3]!,
+    encrypted.authKey[0],
+    encrypted.authKey[1],
+    encrypted.nonce,
+  ];
+}
+
+async function encryptEGCT(publicKey: BJPoint, amount: bigint): Promise<RawEERCBalance['eGCT']> {
+  const { curve } = cryptoSuite();
+  const { cipher } = await curve.encryptMessage(publicKey, amount);
+  return {
+    c1: cipher.c1,
+    c2: cipher.c2,
+  };
+}
+
+function makeBalance({
+  eGCT,
+  balancePCT = ZERO_PCT,
+  amountPCTs = [],
+}: {
+  eGCT: RawEERCBalance['eGCT'];
+  balancePCT?: EERCPCT;
+  amountPCTs?: readonly RawEERCAmountPCT[];
+}): RawEERCBalance {
+  return {
+    eGCT,
+    nonce: 0n,
+    amountPCTs,
+    balancePCT,
+    transactionIndex: 0n,
+  };
+}
+
+describe('validateEERCBalance', () => {
+  beforeEach(() => {
+    let nextRandom = 1000n;
+    vi.spyOn(BabyJub, 'generateRandomValue').mockImplementation(async () => nextRandom++);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('accepts a valid deposit-only balance where amountPCTs match EGCT', async () => {
+    const identity = makeIdentity('1');
+    const raw = makeBalance({
+      eGCT: await encryptEGCT(identity.publicKey, 200n),
+      amountPCTs: [{ pct: await encryptPCT(identity, 200n), index: 0n }],
+    });
+
+    expect(validateEERCBalance(raw, identity)).toEqual({ ok: true, decryptedCents: 200n });
+  });
+
+  it('accepts balancePCT plus current amountPCTs after an outgoing operation', async () => {
+    const identity = makeIdentity('2');
+    const raw = makeBalance({
+      eGCT: await encryptEGCT(identity.publicKey, 200n),
+      balancePCT: await encryptPCT(identity, 125n),
+      amountPCTs: [{ pct: await encryptPCT(identity, 75n), index: 1n }],
+    });
+
+    expect(validateEERCBalance(raw, identity)).toEqual({ ok: true, decryptedCents: 200n });
+  });
+
+  it('rejects PCT history that decrypts to 2.00 when EGCT belongs to another key', async () => {
+    const identity = makeIdentity('3');
+    const wrongIdentity = makeIdentity('4');
+    const result = validateEERCBalance(
+      makeBalance({
+        eGCT: await encryptEGCT(wrongIdentity.publicKey, 200n),
+        amountPCTs: [{ pct: await encryptPCT(identity, 200n), index: 0n }],
+      }),
+      identity,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('egct-mismatch');
+      expect(result.decryptedCents).toBe(200n);
+    }
+  });
+
+  it('accepts a fresh zero balance with an all-zero EGCT', () => {
+    const identity = makeIdentity('5');
+
+    expect(validateEERCBalance(makeBalance({ eGCT: ZERO_EGCT }), identity)).toEqual({
+      ok: true,
+      decryptedCents: 0n,
+    });
+  });
+});
+
+describe('assertEERCIdentityMatchesOnChain', () => {
+  it('rejects a cached identity whose public key differs from Registrar', () => {
+    const identity = makeIdentity('6');
+    const otherIdentity = makeIdentity('7');
+
+    expect(() => assertEERCIdentityMatchesOnChain(identity, otherIdentity.publicKey)).toThrow(
+      EERC_IDENTITY_MISMATCH_MESSAGE,
+    );
+  });
+});

--- a/tests/unit/console/eerc-balance.test.ts
+++ b/tests/unit/console/eerc-balance.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  EERC_BALANCE_PROOF_MISMATCH_MESSAGE,
+  assertEERCBalanceWitnessMatchesPlaintext,
+  normalizeEERCBalanceProofError,
   validateEERCBalance,
   type EERCPCT,
   type RawEERCBalance,
@@ -129,6 +132,51 @@ describe('validateEERCBalance', () => {
       ok: true,
       decryptedCents: 0n,
     });
+  });
+});
+
+describe('assertEERCBalanceWitnessMatchesPlaintext', () => {
+  beforeEach(() => {
+    let nextRandom = 2000n;
+    vi.spyOn(BabyJub, 'generateRandomValue').mockImplementation(async () => nextRandom++);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('accepts the exact encrypted balance and plaintext used by the proof input', async () => {
+    const identity = makeIdentity('8');
+    const eGCT = await encryptEGCT(identity.publicKey, 100n);
+
+    expect(() =>
+      assertEERCBalanceWitnessMatchesPlaintext({
+        encryptedBalance: [eGCT.c1[0], eGCT.c1[1], eGCT.c2[0], eGCT.c2[1]],
+        privateKey: identity.formattedKey,
+        plaintextBalance: 100n,
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects the exact proof input when the plaintext does not match the EGCT', async () => {
+    const identity = makeIdentity('9');
+    const eGCT = await encryptEGCT(identity.publicKey, 100n);
+
+    expect(() =>
+      assertEERCBalanceWitnessMatchesPlaintext({
+        encryptedBalance: [eGCT.c1[0], eGCT.c1[1], eGCT.c2[0], eGCT.c2[1]],
+        privateKey: identity.formattedKey,
+        plaintextBalance: 200n,
+      }),
+    ).toThrow(EERC_BALANCE_PROOF_MISMATCH_MESSAGE);
+  });
+
+  it('normalizes withdraw CheckValue assertion errors into the balance recovery message', () => {
+    const err = new Error(
+      'Error: Assert Failed. Error in template CheckValue_23 line: 258 Error in template WithdrawCircuit_99 line: 55',
+    );
+
+    expect(normalizeEERCBalanceProofError(err).message).toBe(EERC_BALANCE_PROOF_MISMATCH_MESSAGE);
   });
 });
 

--- a/tests/unit/console/eerc-balance.test.ts
+++ b/tests/unit/console/eerc-balance.test.ts
@@ -2,13 +2,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   EERC_BALANCE_PROOF_MISMATCH_MESSAGE,
+  EERC_BALANCE_UNINITIALIZED_MESSAGE,
+  EERC_AMOUNT_OUT_OF_RANGE_MESSAGE,
+  EERC_PRIVATE_KEY_INVALID_MESSAGE,
   assertEERCBalanceWitnessMatchesPlaintext,
+  isEERCBalanceProofAssertion,
   normalizeEERCBalanceProofError,
   validateEERCBalance,
   type EERCPCT,
   type RawEERCBalance,
   type RawEERCAmountPCT,
 } from '@/lib/eerc/balanceValidation';
+import { SUB_GROUP_ORDER } from '@/lib/eerc/crypto/constants';
 import { BabyJub, type BJPoint } from '@/lib/eerc/crypto/babyjub';
 import { FF } from '@/lib/eerc/crypto/ff';
 import { Poseidon } from '@/lib/eerc/crypto';
@@ -177,6 +182,92 @@ describe('assertEERCBalanceWitnessMatchesPlaintext', () => {
     );
 
     expect(normalizeEERCBalanceProofError(err).message).toBe(EERC_BALANCE_PROOF_MISMATCH_MESSAGE);
+  });
+
+  it('rejects (0,0) sentinel c1 (uninitialized contract balance)', async () => {
+    const identity = makeIdentity('a');
+
+    expect(() =>
+      assertEERCBalanceWitnessMatchesPlaintext({
+        encryptedBalance: [0n, 0n, 0n, 0n],
+        privateKey: identity.formattedKey,
+        plaintextBalance: 0n,
+      }),
+    ).toThrow(EERC_BALANCE_UNINITIALIZED_MESSAGE);
+  });
+
+  it('rejects off-curve c1 / c2 with the proof-mismatch message', async () => {
+    const identity = makeIdentity('b');
+    const eGCT = await encryptEGCT(identity.publicKey, 100n);
+
+    expect(() =>
+      assertEERCBalanceWitnessMatchesPlaintext({
+        encryptedBalance: [123n, 456n, eGCT.c2[0], eGCT.c2[1]],
+        privateKey: identity.formattedKey,
+        plaintextBalance: 100n,
+      }),
+    ).toThrow(EERC_BALANCE_PROOF_MISMATCH_MESSAGE);
+  });
+
+  it('rejects values >= subgroup order before invoking the prover', async () => {
+    const identity = makeIdentity('c');
+    const eGCT = await encryptEGCT(identity.publicKey, 100n);
+
+    expect(() =>
+      assertEERCBalanceWitnessMatchesPlaintext({
+        encryptedBalance: [eGCT.c1[0], eGCT.c1[1], eGCT.c2[0], eGCT.c2[1]],
+        privateKey: identity.formattedKey,
+        plaintextBalance: SUB_GROUP_ORDER,
+      }),
+    ).toThrow(EERC_AMOUNT_OUT_OF_RANGE_MESSAGE);
+  });
+
+  it('rejects a public key that does not pair with the private key', async () => {
+    const identity = makeIdentity('d');
+    const wrong = makeIdentity('e');
+    const eGCT = await encryptEGCT(identity.publicKey, 100n);
+
+    expect(() =>
+      assertEERCBalanceWitnessMatchesPlaintext({
+        encryptedBalance: [eGCT.c1[0], eGCT.c1[1], eGCT.c2[0], eGCT.c2[1]],
+        privateKey: identity.formattedKey,
+        plaintextBalance: 100n,
+        publicKey: [wrong.publicKey[0], wrong.publicKey[1]],
+      }),
+    ).toThrow(EERC_PRIVATE_KEY_INVALID_MESSAGE);
+  });
+
+  it('rejects a zero private key', async () => {
+    const identity = makeIdentity('f');
+    const eGCT = await encryptEGCT(identity.publicKey, 100n);
+
+    expect(() =>
+      assertEERCBalanceWitnessMatchesPlaintext({
+        encryptedBalance: [eGCT.c1[0], eGCT.c1[1], eGCT.c2[0], eGCT.c2[1]],
+        privateKey: 0n,
+        plaintextBalance: 100n,
+      }),
+    ).toThrow(EERC_PRIVATE_KEY_INVALID_MESSAGE);
+  });
+});
+
+describe('isEERCBalanceProofAssertion', () => {
+  it('matches every spending circuit + sub-template combination', () => {
+    const cases = [
+      'Assert Failed. Error in template CheckValue_23 line: 258\nError in template WithdrawCircuit_99 line: 55',
+      'Assert Failed. Error in template CheckValue_77 line: 258\nError in template TransferCircuit_120 line: 99',
+      'Assert Failed. Error in template CheckPCT_98 line: 356\nError in template WithdrawCircuit_99 line: 66',
+      'Assert Failed. Error in template BabyCheck_4 line: 82\nError in template CheckValue_23 line: 228\nError in template WithdrawCircuit_99 line: 55',
+      'Assert Failed. Error in template CheckPublicKey_5 line: 217\nError in template BurnCircuit_50 line: 30',
+    ];
+    for (const msg of cases) {
+      expect(isEERCBalanceProofAssertion(new Error(msg))).toBe(true);
+    }
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isEERCBalanceProofAssertion(new Error('Network error: fetch failed'))).toBe(false);
+    expect(isEERCBalanceProofAssertion(new Error('Assert Failed. Some random circuit'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
# Summary                                                                                                                                                                           
                                                                                                                                                                                       
  Eliminates the raw circom assertion (`Error: Assert Failed. Error in template CheckValue_23 line: 258 Error in template WithdrawCircuit_99 line: 55`) that surfaced from snarkjs     
  during withdraw/transfer when the local BabyJubJub identity could not prove the on-chain encrypted balance. Replaces it with a deterministic, actionable pre-check + recovery UI.    
                                                                                                                                                                                       
  ### Validation pipeline (`lib/eerc/balanceValidation.ts`)                                                                                                                            
                                                                                                                                                                                       
  - **`validateEERCBalance`** — runs at every balance refresh:                                                                                                                         
    1. Decrypts `balancePCT` + every `amountPCT` and sums them.                                                                                                                      
    2. Confirms `decrypt(privKey, eGCT) == total · Base8`.                                                                                                                             
    3. Returns a typed `pct-decryption-failed` / `egct-mismatch` reason that the UI surfaces verbatim.                                                                                 
  - **`assertEERCBalanceWitnessMatchesPlaintext`** — runs in `withdraw` / `transfer` immediately before `generateProof`, mirroring **every** assertion the circuit will run:           
    1. `privKey ∈ (0, SUB_GROUP_ORDER)` → `EERC_PRIVATE_KEY_INVALID_MESSAGE`                                                                                                           
    2. `plaintextBalance < SUB_GROUP_ORDER` → `EERC_AMOUNT_OUT_OF_RANGE_MESSAGE`                                                                                                       
    3. `c1, c2 ≠ (0, 0)` (off-curve sentinel) → `EERC_BALANCE_UNINITIALIZED_MESSAGE`                                                                                                   
    4. `c1, c2` on the BabyJubJub curve → `EERC_BALANCE_PROOF_MISMATCH_MESSAGE`                                                                                                        
    5. `pubKey` on curve and `privKey · Base8 == pubKey`                                                                                                                               
    6. `decrypt(privKey, eGCT) == plaintextBalance · Base8`                                                                                                                            
                                                                                                                                                                                       
  ### Identity verification (`lib/eerc/identityValidation.ts`)                                                                                                                         
                                                                                                                                                                                       
  - `loadVerifiedEERCIdentity` resolves the cached BJJ key, reads the on-chain `Registrar.getUserPublicKey`, and refuses to spend if they diverge. Wired into `useEERCDeposit`,        
  `useEERCTransfer`, and `useEERCWithdraw`.                                                                                                                                          
                                                                                                                                                                                       
  ### Error normalization                                                                                                                                                            

  - `isEERCBalanceProofAssertion` now matches all four spending circuits (`Withdraw` / `Transfer` / `Burn` / `Mint`) and every sub-template (`CheckValue`, `CheckPublicKey`,           
  `CheckPCT`, `CheckReceiverValue`, `CheckAuditorValue`, `BabyCheck`). Any stray assert is rewritten to a single user-facing recovery message instead of leaking `_23 line: 258` to the
   UI.                                                                                                                                                                                 
                                                                                                                                                                                     
  ### UI

  - `WithdrawBurn` / `PrivateTransfer` / `BalanceHistory` show the validation reason inline.                                                                                           
  - Recovery hints route based on failure mode: **Open Register** for key/proof mismatches, **Open Deposit** for an uninitialized balance.
                                                                                                                                                                                       
  ### Tests (`tests/unit/console/eerc-balance.test.ts`)                                                                                                                                
                                                                                                                                                                                       
  15 unit tests covering: deposit-only / post-withdraw / wrong-key / fresh-zero balance validation, every new pre-check rejection path (sentinel c1, off-curve c1, value ≥ subgroup    
  order, mismatched pubKey, zero privKey), and every regex branch of the proof-error normalizer.                                                                                     
                                                                                                                                                                                       
  ## Test plan                                                                                                                                                                         
   
  - [ ] `yarn vitest run tests/unit/console/eerc-balance.test.ts` — 15 tests pass                                                                                                      
  - [ ] `yarn tsc --noEmit -p .` — clean                                                                                                                                             
  - [ ] **Register flow**: derive key → publish → confirm Registrar shows the new pubkey                                                                                               
  - [ ] **Deposit (Fuji WAVAX)**: 1 WAVAX → balance shows `1.00 eWAVAX`                                                                                                                
  - [ ] **Withdraw 1.00 eWAVAX**: friendly progress messages, no raw `CheckValue` text, tx confirms                                                                                    
  - [ ] **Private transfer**: send 0.50 eWAVAX to another registered Fuji address; both balances update                                                                                
  - [ ] **Recovery: stale local key**: clear `localStorage["eerc:identity:..."]` mid-session, hit Withdraw → see `EERC_IDENTITY_MISMATCH_MESSAGE` with **Open Register** link (not the 
  circom assert)                                                                                                                                                                       
  - [ ] **Recovery: wrong key for existing balance**: register fresh key over an existing deposit → balance read shows `EERC_BALANCE_PCT_DECRYPTION_MESSAGE`, withdraw button disabled 
  - [ ] **Recovery: pre-deposit withdraw attempt**: try Withdraw before any Deposit → see `EERC_BALANCE_UNINITIALIZED_MESSAGE` with **Open Deposit** link  