### PR TITLE
fix(console): scope live chain reads to active wallet

### DIFF
--- a/components/toolbox/components/ChainGate.tsx
+++ b/components/toolbox/components/ChainGate.tsx
@@ -8,7 +8,11 @@ import { getL1ListStore, type L1ListItem } from '@/components/toolbox/stores/l1L
 import { useWallet } from '@/components/toolbox/hooks/useWallet';
 import { Button } from '@/components/toolbox/components/Button';
 import type { RequiredChain } from '@/components/console/step-flow';
-import { readLiveWalletChainId, useLiveWalletChainId } from '@/components/toolbox/hooks/useLiveWalletChainId';
+import {
+  readLiveWalletChainId,
+  useActiveWalletProvider,
+  useLiveWalletChainId,
+} from '@/components/toolbox/hooks/useLiveWalletChainId';
 import { resolveCreateL1RequiredChain } from '@/lib/console/create-l1-chain';
 
 interface ChainGateProps {
@@ -34,7 +38,15 @@ export function ChainGate({ requiredChain, children }: ChainGateProps) {
   const mainnetL1s = getL1ListStore(false)((state: { l1List: L1ListItem[] }) => state.l1List);
   const walletL1s = useMemo(() => [...testnetL1s, ...mainnetL1s], [testnetL1s, mainnetL1s]);
   const { addChain, switchChain } = useWallet();
-  const liveChainId = useLiveWalletChainId(walletChainId);
+  const activeProvider = useActiveWalletProvider({
+    enabled: Boolean(walletEVMAddress),
+    refreshKey: walletChainId,
+  });
+  const liveChainId = useLiveWalletChainId({
+    provider: activeProvider,
+    enabled: Boolean(walletEVMAddress),
+    refreshKey: walletChainId,
+  });
   const [isSwitching, setIsSwitching] = useState(false);
 
   // No requirement or P-Chain (no EVM switch needed) — pass through
@@ -123,7 +135,7 @@ export function ChainGate({ requiredChain, children }: ChainGateProps) {
     setIsSwitching(true);
     try {
       await switchChain(expectedChainId, isTestnet ?? false);
-      const live = await readLiveWalletChainId();
+      const live = await readLiveWalletChainId(activeProvider);
       if (live === expectedChainId) {
         if (walletChainId !== expectedChainId) setWalletChainId(expectedChainId);
         return;

--- a/components/toolbox/components/ChainGate.tsx
+++ b/components/toolbox/components/ChainGate.tsx
@@ -135,11 +135,26 @@ export function ChainGate({ requiredChain, children }: ChainGateProps) {
     setIsSwitching(true);
     try {
       await switchChain(expectedChainId, isTestnet ?? false);
-      const live = await readLiveWalletChainId(activeProvider);
-      if (live === expectedChainId) {
-        if (walletChainId !== expectedChainId) setWalletChainId(expectedChainId);
+
+      // useWalletSwitch writes walletChainId after a confirmed switch. Check
+      // the store before reading the async provider hook so a fast click while
+      // activeProvider is still resolving does not fall through to Add Chain.
+      if (useWalletStore.getState().walletChainId === expectedChainId) {
         return;
       }
+
+      const live = await readLiveWalletChainId(activeProvider);
+      if (live === expectedChainId) {
+        if (useWalletStore.getState().walletChainId !== expectedChainId) {
+          setWalletChainId(expectedChainId);
+        }
+        return;
+      }
+
+      if (useWalletStore.getState().walletChainId === expectedChainId) {
+        return;
+      }
+
       // Switch didn't move the chain — chain probably isn't in the wallet
       // at all. Open the add-chain modal so the user can register it.
       await handleAddToWallet();

--- a/components/toolbox/components/console-header/WalletSync.tsx
+++ b/components/toolbox/components/console-header/WalletSync.tsx
@@ -1,13 +1,21 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { useAccount, useAccountEffect, useChainId, useSwitchChain } from 'wagmi';
 import { avalancheFuji } from 'wagmi/chains';
 import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import { getL1ListStore, type L1ListItem } from '@/components/toolbox/stores/l1ListStore';
 import { createCoreWalletClient } from '@/components/toolbox/coreViem';
 import { networkIDs } from '@avalabs/avalanchejs';
 import posthog from 'posthog-js';
+import {
+  parseProviderChainId,
+  readWalletProviderChainId,
+  resolveActiveWalletProvider,
+  type Eip1193Provider,
+} from '@/components/toolbox/lib/walletProvider';
+import { C_CHAIN_FUJI, C_CHAIN_MAINNET, findL1ByEvmChainId } from '@/lib/console/l1-dashboard';
 
 /**
  * Invisible component that bridges wagmi/RainbowKit state into the
@@ -62,10 +70,49 @@ export function WalletSync() {
   const updateAllBalances = useWalletStore((s) => s.updateAllBalances);
   const setBootstrapped = useWalletStore((s) => s.setBootstrapped);
   const setWalletType = useWalletStore((s) => s.setWalletType);
+  const testnetL1List = getL1ListStore(true)((state: { l1List: L1ListItem[] }) => state.l1List);
+  const mainnetL1List = getL1ListStore(false)((state: { l1List: L1ListItem[] }) => state.l1List);
 
   // Track previous address to detect actual changes
   const prevAddressRef = useRef<string | undefined>(undefined);
   const prevChainIdRef = useRef<number | undefined>(undefined);
+
+  const getKnownL1 = useCallback(
+    (nextChainId: number) => {
+      const activeFirstLists = useWalletStore.getState().isTestnet
+        ? [testnetL1List, mainnetL1List]
+        : [mainnetL1List, testnetL1List];
+      return findL1ByEvmChainId(nextChainId, activeFirstLists);
+    },
+    [mainnetL1List, testnetL1List],
+  );
+
+  const resolveTestnetForChainId = useCallback(
+    (nextChainId: number): boolean => {
+      if (nextChainId === C_CHAIN_FUJI) return true;
+      if (nextChainId === C_CHAIN_MAINNET) return false;
+      return getKnownL1(nextChainId)?.isTestnet ?? useWalletStore.getState().isTestnet;
+    },
+    [getKnownL1],
+  );
+
+  const applyWalletChainId = useCallback(
+    (nextChainId: number) => {
+      if (!Number.isFinite(nextChainId) || nextChainId <= 0) return;
+
+      const current = useWalletStore.getState();
+      if (nextChainId !== current.walletChainId) {
+        setWalletChainId(nextChainId);
+      }
+
+      const nextIsTestnet = resolveTestnetForChainId(nextChainId);
+      if (nextIsTestnet !== current.isTestnet) {
+        setIsTestnet(nextIsTestnet);
+        setAvalancheNetworkID(nextIsTestnet ? networkIDs.FujiID : networkIDs.MainnetID);
+      }
+    },
+    [resolveTestnetForChainId, setAvalancheNetworkID, setIsTestnet, setWalletChainId],
+  );
 
   /**
    * Determine if the connected wallet is Core.
@@ -216,13 +263,18 @@ export function WalletSync() {
 
             if (pAddr) setPChainAddress(pAddr);
             if (cAddr) setCoreEthAddress(cAddr);
+            let resolvedCoreChainId = 0;
             if (coreChainId) {
-              const numId = typeof coreChainId === 'string' ? parseInt(coreChainId as any, 16) : coreChainId;
-              setWalletChainId(numId);
+              resolvedCoreChainId = typeof coreChainId === 'string' ? parseInt(coreChainId as any, 16) : coreChainId;
+              applyWalletChainId(resolvedCoreChainId);
             }
             if (typeof chainInfo?.isTestnet === 'boolean') {
-              setIsTestnet(chainInfo.isTestnet);
-              setAvalancheNetworkID(chainInfo.isTestnet ? networkIDs.FujiID : networkIDs.MainnetID);
+              const knownL1 = resolvedCoreChainId > 0 ? getKnownL1(resolvedCoreChainId) : null;
+              const chainInfoIsAuthoritative =
+                resolvedCoreChainId === C_CHAIN_FUJI || resolvedCoreChainId === C_CHAIN_MAINNET || !knownL1;
+              const nextIsTestnet = chainInfoIsAuthoritative ? chainInfo.isTestnet : knownL1.isTestnet;
+              setIsTestnet(nextIsTestnet);
+              setAvalancheNetworkID(nextIsTestnet ? networkIDs.FujiID : networkIDs.MainnetID);
               setEvmChainName(chainInfo.chainName);
             }
           } catch {
@@ -247,7 +299,26 @@ export function WalletSync() {
         } catch {}
       }
     }
-  }, [isConnected, address, isCoreConnector]);
+  }, [
+    address,
+    applyWalletChainId,
+    chainId,
+    connector,
+    getKnownL1,
+    isConnected,
+    isCoreConnector,
+    setAvalancheNetworkID,
+    setBootstrapped,
+    setCoreEthAddress,
+    setCoreWalletClient,
+    setEvmChainName,
+    setIsTestnet,
+    setPChainAddress,
+    setWalletChainId,
+    setWalletEVMAddress,
+    setWalletType,
+    updateAllBalances,
+  ]);
 
   // Sync chain changes → Zustand store
   //
@@ -262,16 +333,8 @@ export function WalletSync() {
     if (chainId === prevChainIdRef.current) return;
     prevChainIdRef.current = chainId;
 
-    setWalletChainId(chainId);
-
-    // Determine testnet status from chain ID, preserving current state for L1s
-    const resolveTestnet = (): boolean => {
-      if (chainId === 43113) return true; // Fuji C-Chain
-      if (chainId === 43114) return false; // Mainnet C-Chain
-      // Custom L1 — preserve the current testnet state from the store
-      return useWalletStore.getState().isTestnet;
-    };
-    const testnet = resolveTestnet();
+    applyWalletChainId(chainId);
+    const testnet = resolveTestnetForChainId(chainId);
 
     if (isCoreConnector) {
       // Re-create Core client for the new chain and update store.
@@ -312,7 +375,7 @@ export function WalletSync() {
         updateAllBalances();
       } catch {}
     }
-  }, [chainId, isConnected, isCoreConnector]);
+  }, [applyWalletChainId, chainId, isConnected, isCoreConnector, resolveTestnetForChainId]);
 
   // Bridge raw EIP-1193 `chainChanged` events into the store.
   //
@@ -322,27 +385,35 @@ export function WalletSync() {
   // `walletChainId` stale in the store and breaks ChainGate for L1 steps.
   // A native listener catches every switch regardless of registration.
   useEffect(() => {
-    if (typeof window === 'undefined') return;
+    if (isCoreConnector === null) return;
+    if (!isConnected) return;
 
-    const handler = (chainIdHex: string | number) => {
-      const next = typeof chainIdHex === 'string' ? Number.parseInt(chainIdHex, 16) : Number(chainIdHex);
-      if (!Number.isFinite(next) || next <= 0) return;
-      if (next === useWalletStore.getState().walletChainId) return;
-      setWalletChainId(next);
+    const handler = (chainIdHex: unknown) => {
+      const next = parseProviderChainId(chainIdHex);
+      if (next !== null) applyWalletChainId(next);
     };
 
-    const providers: Array<{
-      on?: (event: string, listener: (...args: any[]) => void) => void;
-      removeListener?: (event: string, listener: (...args: any[]) => void) => void;
-    }> = [];
-    if (window.avalanche) providers.push(window.avalanche as any);
-    if (window.ethereum && window.ethereum !== window.avalanche) providers.push(window.ethereum as any);
+    let cancelled = false;
+    let activeProvider: Eip1193Provider | null = null;
+    const walletType = isCoreConnector ? 'core' : 'generic-evm';
 
-    providers.forEach((p) => p.on?.('chainChanged', handler));
+    resolveActiveWalletProvider({ connector, walletType }).then(async (provider) => {
+      if (cancelled || !provider) return;
+
+      activeProvider = provider;
+      provider.on?.('chainChanged', handler);
+
+      const liveChainId = await readWalletProviderChainId(provider);
+      if (!cancelled && liveChainId !== null) {
+        applyWalletChainId(liveChainId);
+      }
+    });
+
     return () => {
-      providers.forEach((p) => p.removeListener?.('chainChanged', handler));
+      cancelled = true;
+      activeProvider?.removeListener?.('chainChanged', handler);
     };
-  }, [setWalletChainId]);
+  }, [applyWalletChainId, connector, isConnected, isCoreConnector]);
 
   return null;
 }

--- a/components/toolbox/contexts/ConnectedWalletContext.tsx
+++ b/components/toolbox/contexts/ConnectedWalletContext.tsx
@@ -5,6 +5,7 @@ import { useViemChainStore } from '../stores/toolboxStore';
 import { createWalletClient, custom } from 'viem';
 import type { CoreWalletClientType } from '../coreViem';
 import type { WalletClient } from 'viem';
+import { useActiveWalletProvider } from '../hooks/useLiveWalletChainId';
 
 interface ConnectedWalletContextValue {
   /** Wagmi wallet client — works for ALL connected EVM wallets (Core, MetaMask, Rabby, etc.) */
@@ -22,6 +23,10 @@ export function ConnectedWalletProvider({ children }: { children: React.ReactNod
   const { data: connectorClient } = useConnectorClient();
   const { address } = useAccount();
   const viemChain = useViemChainStore();
+  const activeProvider = useActiveWalletProvider({
+    enabled: Boolean(address || walletEVMAddress),
+    refreshKey: address || walletEVMAddress,
+  });
 
   // Fallback: create a wallet client manually when wagmi can't provide one.
   // This happens when:
@@ -33,16 +38,14 @@ export function ConnectedWalletProvider({ children }: { children: React.ReactNod
     // Use wagmi's address if connected, otherwise our bootstrap's address
     const effectiveAddress = address || walletEVMAddress;
     if (!effectiveAddress || !viemChain) return null;
-
-    const provider = typeof window !== 'undefined' ? window.avalanche || (window as any).ethereum : null;
-    if (!provider) return null;
+    if (!activeProvider) return null;
 
     return createWalletClient({
       chain: viemChain,
-      transport: custom(provider),
+      transport: custom(activeProvider),
       account: effectiveAddress as `0x${string}`,
     });
-  }, [wagmiWalletClient, connectorClient, address, walletEVMAddress, viemChain]);
+  }, [activeProvider, wagmiWalletClient, connectorClient, address, walletEVMAddress, viemChain]);
 
   const resolvedClient = wagmiWalletClient ?? (connectorClient as WalletClient | undefined) ?? fallbackWalletClient;
 

--- a/components/toolbox/hooks/useLiveWalletChainId.ts
+++ b/components/toolbox/hooks/useLiveWalletChainId.ts
@@ -1,64 +1,95 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useAccount } from 'wagmi';
+import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import {
+  type Eip1193Provider,
+  parseProviderChainId,
+  readWalletProviderChainId,
+  resolveActiveWalletProvider,
+} from '@/components/toolbox/lib/walletProvider';
 
-type Eip1193Provider = {
-  request?: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
-  on?: (event: string, listener: (...args: unknown[]) => void) => void;
-  removeListener?: (event: string, listener: (...args: unknown[]) => void) => void;
+export type { Eip1193Provider };
+
+type UseActiveWalletProviderOptions = {
+  enabled?: boolean;
+  refreshKey?: unknown;
 };
 
-function parseChainId(value: unknown): number | null {
-  const parsed = typeof value === 'string' ? Number.parseInt(value, 16) : Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+type UseLiveWalletChainIdOptions = {
+  provider?: Eip1193Provider | null;
+  enabled?: boolean;
+  refreshKey?: unknown;
+};
+
+export function useActiveWalletProvider({
+  enabled = true,
+  refreshKey,
+}: UseActiveWalletProviderOptions = {}): Eip1193Provider | null {
+  const { connector, isConnected } = useAccount();
+  const walletType = useWalletStore((s) => s.walletType);
+  const [provider, setProvider] = useState<Eip1193Provider | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!enabled || !isConnected) {
+      setProvider(null);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    resolveActiveWalletProvider({ connector, walletType }).then((resolvedProvider) => {
+      if (!cancelled) setProvider(resolvedProvider);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [connector, enabled, isConnected, walletType, refreshKey]);
+
+  return provider;
 }
 
-function getWalletProviders(): Eip1193Provider[] {
-  if (typeof window === 'undefined') return [];
+export const readLiveWalletChainId = readWalletProviderChainId;
 
-  const providers: Eip1193Provider[] = [];
-  const avalanche = (window as any).avalanche as Eip1193Provider | undefined;
-  const ethereum = (window as any).ethereum as Eip1193Provider | undefined;
-
-  if (avalanche) providers.push(avalanche);
-  if (ethereum && ethereum !== avalanche) providers.push(ethereum);
-
-  return providers;
-}
-
-export async function readLiveWalletChainId(): Promise<number | null> {
-  const provider = getWalletProviders().find((p) => typeof p.request === 'function');
-  if (!provider?.request) return null;
-
-  try {
-    return parseChainId(await provider.request({ method: 'eth_chainId' }));
-  } catch {
-    return null;
-  }
-}
-
-export function useLiveWalletChainId(refreshKey?: unknown): number | null {
+export function useLiveWalletChainId({ provider, enabled = true, refreshKey }: UseLiveWalletChainIdOptions = {}):
+  | number
+  | null {
   const [liveChainId, setLiveChainId] = useState<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
 
+    if (!enabled || !provider?.request) {
+      setLiveChainId(null);
+      return () => {
+        cancelled = true;
+      };
+    }
+
     const refresh = () => {
-      readLiveWalletChainId().then((chainId) => {
+      readLiveWalletChainId(provider).then((chainId) => {
         if (!cancelled) setLiveChainId(chainId);
       });
     };
 
+    const handleChainChanged = (chainId: unknown) => {
+      const parsed = parseProviderChainId(chainId);
+      if (!cancelled) setLiveChainId(parsed);
+    };
+
     refresh();
 
-    const providers = getWalletProviders();
-    providers.forEach((provider) => provider.on?.('chainChanged', refresh));
+    provider.on?.('chainChanged', handleChainChanged);
 
     return () => {
       cancelled = true;
-      providers.forEach((provider) => provider.removeListener?.('chainChanged', refresh));
+      provider.removeListener?.('chainChanged', handleChainChanged);
     };
-  }, [refreshKey]);
+  }, [provider, enabled, refreshKey]);
 
   return liveChainId;
 }

--- a/components/toolbox/hooks/useResolvedWalletClient.ts
+++ b/components/toolbox/hooks/useResolvedWalletClient.ts
@@ -4,6 +4,7 @@ import { createWalletClient, custom } from 'viem';
 import type { WalletClient } from 'viem';
 import { useWalletStore } from '../stores/walletStore';
 import { useViemChainStore } from '../stores/toolboxStore';
+import { useActiveWalletProvider } from './useLiveWalletChainId';
 
 /**
  * Returns a wallet client that works on custom L1 chains.
@@ -17,19 +18,21 @@ export function useResolvedWalletClient(): WalletClient | undefined {
   const { data: wagmiWalletClient } = useWalletClient();
   const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
   const viemChain = useViemChainStore();
+  const activeProvider = useActiveWalletProvider({
+    enabled: Boolean(walletEVMAddress),
+    refreshKey: walletEVMAddress,
+  });
 
   return useMemo(() => {
     if (wagmiWalletClient) return wagmiWalletClient;
 
     if (!walletEVMAddress || !viemChain) return undefined;
-
-    const provider = typeof window !== 'undefined' ? window.avalanche || (window as any).ethereum : null;
-    if (!provider) return undefined;
+    if (!activeProvider) return undefined;
 
     return createWalletClient({
       chain: viemChain,
-      transport: custom(provider),
+      transport: custom(activeProvider),
       account: walletEVMAddress as `0x${string}`,
     });
-  }, [wagmiWalletClient, walletEVMAddress, viemChain]);
+  }, [activeProvider, wagmiWalletClient, walletEVMAddress, viemChain]);
 }

--- a/components/toolbox/lib/walletProvider.ts
+++ b/components/toolbox/lib/walletProvider.ts
@@ -1,0 +1,78 @@
+export type Eip1193Provider = {
+  request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
+  on?: (event: string, listener: (...args: unknown[]) => void) => void;
+  removeListener?: (event: string, listener: (...args: unknown[]) => void) => void;
+  isAvalanche?: boolean;
+  providers?: Eip1193Provider[];
+  selectedProvider?: Eip1193Provider;
+};
+
+export type WalletConnectorLike = {
+  getProvider?: () => unknown | Promise<unknown>;
+};
+
+export type WalletTypeLike = 'core' | 'generic-evm' | null | undefined;
+
+function hasRequest(value: unknown): value is Eip1193Provider {
+  return !!value && typeof value === 'object' && typeof (value as Eip1193Provider).request === 'function';
+}
+
+function normalizeProvider(value: unknown): Eip1193Provider | null {
+  if (hasRequest(value)) return value;
+
+  const maybeProvider = value as Eip1193Provider | null | undefined;
+  if (hasRequest(maybeProvider?.selectedProvider)) return maybeProvider.selectedProvider;
+
+  const providerFromList = maybeProvider?.providers?.find(hasRequest);
+  return providerFromList ?? null;
+}
+
+export function getWindowWalletProviders(): {
+  avalanche: Eip1193Provider | null;
+  ethereum: Eip1193Provider | null;
+} {
+  if (typeof window === 'undefined') {
+    return { avalanche: null, ethereum: null };
+  }
+
+  return {
+    avalanche: normalizeProvider((window as any).avalanche),
+    ethereum: normalizeProvider((window as any).ethereum),
+  };
+}
+
+export async function resolveActiveWalletProvider({
+  connector,
+  walletType,
+}: {
+  connector?: WalletConnectorLike | null;
+  walletType?: WalletTypeLike;
+}): Promise<Eip1193Provider | null> {
+  try {
+    const connectorProvider = normalizeProvider(await connector?.getProvider?.());
+    if (connectorProvider) return connectorProvider;
+  } catch {
+    // Fall back to the wallet type hint below.
+  }
+
+  const { avalanche, ethereum } = getWindowWalletProviders();
+  if (walletType === 'core') return avalanche;
+  if (walletType === 'generic-evm') return ethereum;
+
+  return ethereum ?? avalanche;
+}
+
+export function parseProviderChainId(value: unknown): number | null {
+  const parsed = typeof value === 'string' ? Number.parseInt(value, 16) : Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export async function readWalletProviderChainId(provider: Eip1193Provider | null | undefined): Promise<number | null> {
+  if (!provider?.request) return null;
+
+  try {
+    return parseProviderChainId(await provider.request({ method: 'eth_chainId' }));
+  } catch {
+    return null;
+  }
+}

--- a/components/toolbox/stores/l1ListStore.ts
+++ b/components/toolbox/stores/l1ListStore.ts
@@ -3,6 +3,7 @@ import { persist, createJSONStorage, combine } from 'zustand/middleware';
 import { useWalletStore } from './walletStore';
 import { localStorageComp, STORE_VERSION } from './utils';
 import { useMemo } from 'react';
+import { findL1ByEvmChainId } from '@/lib/console/l1-dashboard';
 
 export type FaucetThresholds = {
   threshold: number; // min balance threshold to trigger drip
@@ -263,13 +264,23 @@ export const useL1ListStore = () => {
 
 export const useSelectedL1 = (): L1ListItem | undefined => {
   const walletChainId = useWalletStore((s) => s.walletChainId);
-  const l1List = useL1ListStore()((state: { l1List: L1ListItem[] }) => state.l1List);
-  return useMemo(() => l1List.find((l1: L1ListItem) => l1.evmChainId === walletChainId), [l1List, walletChainId]);
+  const isTestnet = useWalletStore((s) => s.isTestnet);
+  const testnetL1List = getL1ListStore(true)((state: { l1List: L1ListItem[] }) => state.l1List);
+  const mainnetL1List = getL1ListStore(false)((state: { l1List: L1ListItem[] }) => state.l1List);
+  return useMemo(() => {
+    const activeFirstLists = isTestnet ? [testnetL1List, mainnetL1List] : [mainnetL1List, testnetL1List];
+    return findL1ByEvmChainId(walletChainId, activeFirstLists) ?? undefined;
+  }, [isTestnet, mainnetL1List, testnetL1List, walletChainId]);
 };
 
 export const useL1ByChainId = (chainId: string): L1ListItem | undefined => {
-  const l1List = useL1ListStore()((state: { l1List: L1ListItem[] }) => state.l1List);
-  return useMemo(() => l1List.find((l1: L1ListItem) => l1.id === chainId), [l1List, chainId]);
+  const isTestnet = useWalletStore((s) => s.isTestnet);
+  const testnetL1List = getL1ListStore(true)((state: { l1List: L1ListItem[] }) => state.l1List);
+  const mainnetL1List = getL1ListStore(false)((state: { l1List: L1ListItem[] }) => state.l1List);
+  return useMemo(() => {
+    const activeFirstLists = isTestnet ? [testnetL1List, mainnetL1List] : [mainnetL1List, testnetL1List];
+    return activeFirstLists.flat().find((l1: L1ListItem) => l1.id === chainId);
+  }, [chainId, isTestnet, mainnetL1List, testnetL1List]);
 };
 
 // Native currency hooks for L1 store

--- a/components/toolbox/stores/toolboxStore.ts
+++ b/components/toolbox/stores/toolboxStore.ts
@@ -4,7 +4,8 @@ import { useMemo } from 'react';
 import { useWalletStore } from './walletStore';
 import { L1ListItem, useSelectedL1 } from './l1ListStore';
 import { localStorageComp, STORE_VERSION } from './utils';
-import { useL1ListStore } from './l1ListStore';
+import { getL1ListStore } from './l1ListStore';
+import { findL1ByEvmChainId } from '@/lib/console/l1-dashboard';
 
 const toolboxInitialState = {
   validatorMessagesLibAddress: '',
@@ -84,12 +85,13 @@ export const useToolboxStore = () => {
 };
 
 export function useViemChainStore() {
-  const { walletChainId } = useWalletStore();
-  const l1List = useL1ListStore()(({ l1List }: { l1List: L1ListItem[] }) => l1List);
-  const selectedL1 = useMemo(
-    () => l1List.find((l1: L1ListItem) => l1.evmChainId === walletChainId),
-    [l1List, walletChainId],
-  );
+  const { walletChainId, isTestnet } = useWalletStore();
+  const testnetL1List = getL1ListStore(true)(({ l1List }: { l1List: L1ListItem[] }) => l1List);
+  const mainnetL1List = getL1ListStore(false)(({ l1List }: { l1List: L1ListItem[] }) => l1List);
+  const selectedL1 = useMemo(() => {
+    const activeFirstLists = isTestnet ? [testnetL1List, mainnetL1List] : [mainnetL1List, testnetL1List];
+    return findL1ByEvmChainId(walletChainId, activeFirstLists);
+  }, [isTestnet, mainnetL1List, testnetL1List, walletChainId]);
 
   const viemChain = useMemo(() => {
     if (!selectedL1) {

--- a/hooks/useL1Dashboard.ts
+++ b/hooks/useL1Dashboard.ts
@@ -5,7 +5,7 @@ import { useWalletStore, useNetworkInfo } from "@/components/toolbox/stores/wall
 import { getL1ListStore, useL1List, type L1ListItem } from "@/components/toolbox/stores/l1ListStore";
 import { createPublicClient, http, formatEther } from "viem";
 import { networkIDs } from "@avalabs/avalanchejs";
-import { useLiveWalletChainId } from "@/components/toolbox/hooks/useLiveWalletChainId";
+import { useActiveWalletProvider, useLiveWalletChainId } from "@/components/toolbox/hooks/useLiveWalletChainId";
 import { resolveL1DashboardConnection } from "@/lib/console/l1-dashboard";
 const GLACIER_API = "https://glacier-api.avax.network";
 
@@ -55,7 +55,18 @@ export function useL1Dashboard(): L1DashboardData {
   const l1List = useL1List();
   const testnetL1List = getL1ListStore(true)((state: { l1List: L1ListItem[] }) => state.l1List);
   const mainnetL1List = getL1ListStore(false)((state: { l1List: L1ListItem[] }) => state.l1List);
-  const liveChainId = useLiveWalletChainId(walletChainId);
+
+  // Determine if connected
+  const isConnected = Boolean(walletEVMAddress);
+  const activeProvider = useActiveWalletProvider({
+    enabled: isConnected,
+    refreshKey: walletChainId,
+  });
+  const liveChainId = useLiveWalletChainId({
+    provider: activeProvider,
+    enabled: isConnected,
+    refreshKey: walletChainId,
+  });
 
   const [healthStatus, setHealthStatus] = useState<L1HealthStatus>("unknown");
   const [blockTime, setBlockTime] = useState<number | null>(null);
@@ -63,17 +74,15 @@ export function useL1Dashboard(): L1DashboardData {
   const [validatorCount, setValidatorCount] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
 
-  // Determine if connected
-  const isConnected = Boolean(walletEVMAddress);
-
   const { effectiveChainId, isConnectedToCChain, currentL1 } = useMemo(
     () =>
       resolveL1DashboardConnection({
+        isConnected,
         walletChainId,
         liveChainId,
         l1Lists: [l1List, testnetL1List, mainnetL1List],
       }),
-    [walletChainId, liveChainId, l1List, testnetL1List, mainnetL1List],
+    [isConnected, walletChainId, liveChainId, l1List, testnetL1List, mainnetL1List],
   );
 
   useEffect(() => {

--- a/lib/console/l1-dashboard.ts
+++ b/lib/console/l1-dashboard.ts
@@ -20,22 +20,24 @@ export function findL1ByEvmChainId(chainId: number, l1Lists: L1ListItem[][]): L1
 }
 
 export function resolveL1DashboardConnection({
+  isConnected,
   walletChainId,
   liveChainId,
   l1Lists,
 }: {
+  isConnected: boolean;
   walletChainId: number;
   liveChainId?: number | null;
   l1Lists: L1ListItem[][];
 }): L1DashboardConnection {
   const effectiveChainId = liveChainId && liveChainId > 0 ? liveChainId : walletChainId;
-  const isConnectedToCChain = C_CHAIN_IDS.has(effectiveChainId);
+  const isConnectedToCChain = isConnected && C_CHAIN_IDS.has(effectiveChainId);
 
   return {
     effectiveChainId,
     isConnectedToCChain,
     currentL1:
-      effectiveChainId > 0 && !isConnectedToCChain
+      isConnected && effectiveChainId > 0 && !isConnectedToCChain
         ? findL1ByEvmChainId(effectiveChainId, l1Lists)
         : null,
   };

--- a/tests/unit/console/l1-dashboard.test.ts
+++ b/tests/unit/console/l1-dashboard.test.ts
@@ -26,6 +26,7 @@ describe('resolveL1DashboardConnection', () => {
   it('uses the live provider chain over a stale wallet-store chain', () => {
     const l1 = makeL1();
     const resolved = resolveL1DashboardConnection({
+      isConnected: true,
       walletChainId: C_CHAIN_FUJI,
       liveChainId: l1.evmChainId,
       l1Lists: [[l1]],
@@ -39,6 +40,7 @@ describe('resolveL1DashboardConnection', () => {
   it('searches all supplied L1 stores, not only the active network store', () => {
     const testnetL1 = makeL1({ evmChainId: 555_777 });
     const resolved = resolveL1DashboardConnection({
+      isConnected: true,
       walletChainId: testnetL1.evmChainId,
       liveChainId: null,
       l1Lists: [[], [testnetL1], []],
@@ -49,6 +51,7 @@ describe('resolveL1DashboardConnection', () => {
 
   it('keeps C-Chain classified as C-Chain even when L1 lists are populated', () => {
     const resolved = resolveL1DashboardConnection({
+      isConnected: true,
       walletChainId: C_CHAIN_FUJI,
       liveChainId: null,
       l1Lists: [[makeL1()]],
@@ -60,11 +63,26 @@ describe('resolveL1DashboardConnection', () => {
 
   it('returns no L1 for an unregistered custom chain', () => {
     const resolved = resolveL1DashboardConnection({
+      isConnected: true,
       walletChainId: 999_000,
       liveChainId: null,
       l1Lists: [[makeL1()]],
     });
 
+    expect(resolved.isConnectedToCChain).toBe(false);
+    expect(resolved.currentL1).toBeNull();
+  });
+
+  it('ignores live provider chain state while the wallet is disconnected', () => {
+    const l1 = makeL1();
+    const resolved = resolveL1DashboardConnection({
+      isConnected: false,
+      walletChainId: 0,
+      liveChainId: l1.evmChainId,
+      l1Lists: [[l1]],
+    });
+
+    expect(resolved.effectiveChainId).toBe(l1.evmChainId);
     expect(resolved.isConnectedToCChain).toBe(false);
     expect(resolved.currentL1).toBeNull();
   });

--- a/tests/unit/console/wallet-provider.test.ts
+++ b/tests/unit/console/wallet-provider.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  readWalletProviderChainId,
+  resolveActiveWalletProvider,
+  type Eip1193Provider,
+} from '@/components/toolbox/lib/walletProvider';
+
+function makeProvider(chainId: number): Eip1193Provider {
+  return {
+    request: vi.fn(async ({ method }) => {
+      if (method !== 'eth_chainId') throw new Error(`unexpected method ${method}`);
+      return `0x${chainId.toString(16)}`;
+    }),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  };
+}
+
+describe('wallet provider resolution', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the connected connector provider instead of the first injected provider', async () => {
+    const coreProvider = makeProvider(43_113);
+    const genericProvider = makeProvider(123_456);
+    vi.stubGlobal('window', {
+      avalanche: coreProvider,
+      ethereum: genericProvider,
+    });
+
+    const provider = await resolveActiveWalletProvider({
+      connector: { getProvider: vi.fn(async () => genericProvider) },
+      walletType: 'generic-evm',
+    });
+
+    expect(provider).toBe(genericProvider);
+    expect(await readWalletProviderChainId(provider)).toBe(123_456);
+    expect(coreProvider.request).not.toHaveBeenCalled();
+  });
+
+  it('uses Core provider when Core is the connected connector', async () => {
+    const coreProvider = makeProvider(555_777);
+    const genericProvider = makeProvider(43_114);
+    vi.stubGlobal('window', {
+      avalanche: coreProvider,
+      ethereum: genericProvider,
+    });
+
+    const provider = await resolveActiveWalletProvider({
+      connector: { getProvider: vi.fn(async () => coreProvider) },
+      walletType: 'core',
+    });
+
+    expect(provider).toBe(coreProvider);
+    expect(await readWalletProviderChainId(provider)).toBe(555_777);
+    expect(genericProvider.request).not.toHaveBeenCalled();
+  });
+
+  it('returns null chain state when no connected provider is supplied', async () => {
+    expect(await readWalletProviderChainId(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
  - Follow up on #4153 by scoping live wallet chain reads to the active connected provider instead of the first injected provider on `window`.
  - Update `WalletSync`, `ChainGate`, dashboard connection resolution, and fallback wallet clients to use the active connector provider.
  - Prevent disconnected browser extensions from producing a dashboard `currentL1` or triggering L1 polling.
  - Make custom L1 lookup resilient when the wallet network flag is stale by searching the active L1 store first, then the other store.

  ## Test plan
  - [x] `yarn -s vitest run tests/unit/console/l1-dashboard.test.ts tests/unit/console/create-l1-chain.test.ts tests/unit/console/wallet-provider.test.ts`
  - [x] `yarn -s tsc --noEmit`
  - [x] `git diff --check`
  - [x] Focused ESLint on changed files; no errors, only existing config ignore warnings for root/test paths.