### PR TITLE
ICTT Bridge Console redesign

### DIFF
--- a/app/console/ictt/_components/activity-feed.tsx
+++ b/app/console/ictt/_components/activity-feed.tsx
@@ -41,13 +41,13 @@ export function ActivityFeed({
   }, []);
 
   return (
-    <div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 overflow-hidden flex flex-col min-h-0">
-      <div className="px-4 py-3 border-b border-zinc-100 dark:border-zinc-800/60 flex items-center justify-between flex-shrink-0">
+    <div className="rounded-2xl border border-border bg-card overflow-hidden flex flex-col min-h-0">
+      <div className="px-4 py-3 border-b border-border/60 flex items-center justify-between flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
-          <span className="text-xs font-semibold text-zinc-900 dark:text-zinc-100">Bridge activity</span>
+          <span className="text-xs font-semibold text-foreground">Bridge activity</span>
         </div>
-        <span className="text-[10px] text-zinc-400 dark:text-zinc-500">live</span>
+        <span className="text-[10px] text-muted-foreground">live</span>
       </div>
 
       {events.length === 0 ? (
@@ -59,7 +59,7 @@ export function ActivityFeed({
             >
               <Sparkles className="w-5 h-5" />
             </div>
-            <p className="text-xs text-zinc-500 dark:text-zinc-400 leading-relaxed">{emptyHint}</p>
+            <p className="text-xs text-muted-foreground leading-relaxed">{emptyHint}</p>
             {onStart && (
               <button
                 type="button"
@@ -73,28 +73,28 @@ export function ActivityFeed({
           </div>
         </div>
       ) : (
-        <div className="overflow-y-auto divide-y divide-zinc-100 dark:divide-zinc-800/60 flex-1">
+        <div className="overflow-y-auto divide-y divide-border/60 flex-1">
           {events.map((event) => {
             const explorerUrl = getExplorerUrl?.(event);
             return (
               <div key={event.id} className="px-4 py-2.5 flex items-center gap-3 text-xs">
                 <span className={cn('w-1.5 h-1.5 rounded-full flex-shrink-0', KIND_COLOR[event.kind])} />
-                <span className="text-zinc-600 dark:text-zinc-400 font-medium flex-1 truncate">{event.label}</span>
+                <span className="text-foreground/80 font-medium flex-1 truncate">{event.label}</span>
                 {event.amount && (
-                  <span className="font-mono text-[10px] text-zinc-400 dark:text-zinc-500">{event.amount}</span>
+                  <span className="font-mono text-[10px] text-muted-foreground">{event.amount}</span>
                 )}
                 {explorerUrl ? (
                   <a
                     href={explorerUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-[10px] text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-200 w-12 text-right flex items-center justify-end gap-0.5"
+                    className="text-[10px] text-muted-foreground hover:text-foreground w-12 text-right flex items-center justify-end gap-0.5"
                   >
                     {relativeTime(event.timestamp, now)}
                     <ExternalLink className="w-2.5 h-2.5" />
                   </a>
                 ) : (
-                  <span className="text-[10px] text-zinc-400 dark:text-zinc-500 w-12 text-right">
+                  <span className="text-[10px] text-muted-foreground w-12 text-right">
                     {relativeTime(event.timestamp, now)}
                   </span>
                 )}

--- a/app/console/ictt/_components/activity-feed.tsx
+++ b/app/console/ictt/_components/activity-feed.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ExternalLink } from 'lucide-react';
+import { cn } from '@/components/toolbox/lib/utils';
+import { relativeTime } from './relative-time';
+import type { ActivityEvent } from './types';
+
+interface ActivityFeedProps {
+  events: ActivityEvent[];
+  emptyHint?: string;
+  getExplorerUrl?: (event: ActivityEvent) => string | null;
+}
+
+const KIND_COLOR: Record<ActivityEvent['kind'], string> = {
+  deploy: 'bg-emerald-500',
+  register: 'bg-amber-500',
+  send: 'bg-blue-500',
+  collateral: 'bg-violet-500',
+  error: 'bg-red-500',
+};
+
+export function ActivityFeed({
+  events,
+  emptyHint = 'No bridge activity yet. Deploy a contract or send tokens to see events here.',
+  getExplorerUrl,
+}: ActivityFeedProps) {
+  // Tick once a second so relative-time labels stay fresh without React
+  // having to re-render the entire bridge console on each event.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  return (
+    <div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 overflow-hidden flex flex-col min-h-0">
+      <div className="px-4 py-3 border-b border-zinc-100 dark:border-zinc-800/60 flex items-center justify-between flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
+          <span className="text-xs font-semibold text-zinc-900 dark:text-zinc-100">Bridge activity</span>
+        </div>
+        <span className="text-[10px] text-zinc-400 dark:text-zinc-500">live</span>
+      </div>
+
+      {events.length === 0 ? (
+        <div className="flex-1 grid place-items-center px-6 py-8">
+          <p className="text-xs text-zinc-400 dark:text-zinc-500 text-center max-w-[20rem] leading-relaxed">
+            {emptyHint}
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-y-auto divide-y divide-zinc-100 dark:divide-zinc-800/60 flex-1">
+          {events.map((event) => {
+            const explorerUrl = getExplorerUrl?.(event);
+            return (
+              <div key={event.id} className="px-4 py-2.5 flex items-center gap-3 text-xs">
+                <span className={cn('w-1.5 h-1.5 rounded-full flex-shrink-0', KIND_COLOR[event.kind])} />
+                <span className="text-zinc-600 dark:text-zinc-400 font-medium flex-1 truncate">{event.label}</span>
+                {event.amount && (
+                  <span className="font-mono text-[10px] text-zinc-400 dark:text-zinc-500">{event.amount}</span>
+                )}
+                {explorerUrl ? (
+                  <a
+                    href={explorerUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[10px] text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-200 w-12 text-right flex items-center justify-end gap-0.5"
+                  >
+                    {relativeTime(event.timestamp, now)}
+                    <ExternalLink className="w-2.5 h-2.5" />
+                  </a>
+                ) : (
+                  <span className="text-[10px] text-zinc-400 dark:text-zinc-500 w-12 text-right">
+                    {relativeTime(event.timestamp, now)}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/console/ictt/_components/activity-feed.tsx
+++ b/app/console/ictt/_components/activity-feed.tsx
@@ -30,7 +30,7 @@ export function ActivityFeed({
   emptyHint = 'No bridge activity yet. Deploy a contract or send tokens to see events here.',
   getExplorerUrl,
   onStart,
-  accent = '#3B82F6',
+  accent = '#e84142',
 }: ActivityFeedProps) {
   // Tick once a second so relative-time labels stay fresh without React
   // having to re-render the entire bridge console on each event.

--- a/app/console/ictt/_components/activity-feed.tsx
+++ b/app/console/ictt/_components/activity-feed.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, Sparkles } from 'lucide-react';
 import { cn } from '@/components/toolbox/lib/utils';
 import { relativeTime } from './relative-time';
 import type { ActivityEvent } from './types';
@@ -10,6 +10,11 @@ interface ActivityFeedProps {
   events: ActivityEvent[];
   emptyHint?: string;
   getExplorerUrl?: (event: ActivityEvent) => string | null;
+  /** Called when user clicks the empty-state CTA. When provided, the
+   *  empty state becomes an actionable "Start with the Token phase"
+   *  card; without it, the empty state is just informational text. */
+  onStart?: () => void;
+  accent?: string;
 }
 
 const KIND_COLOR: Record<ActivityEvent['kind'], string> = {
@@ -24,6 +29,8 @@ export function ActivityFeed({
   events,
   emptyHint = 'No bridge activity yet. Deploy a contract or send tokens to see events here.',
   getExplorerUrl,
+  onStart,
+  accent = '#3B82F6',
 }: ActivityFeedProps) {
   // Tick once a second so relative-time labels stay fresh without React
   // having to re-render the entire bridge console on each event.
@@ -45,9 +52,25 @@ export function ActivityFeed({
 
       {events.length === 0 ? (
         <div className="flex-1 grid place-items-center px-6 py-8">
-          <p className="text-xs text-zinc-400 dark:text-zinc-500 text-center max-w-[20rem] leading-relaxed">
-            {emptyHint}
-          </p>
+          <div className="text-center max-w-[20rem]">
+            <div
+              className="w-10 h-10 rounded-xl mx-auto mb-3 grid place-items-center"
+              style={{ background: `${accent}20`, color: accent }}
+            >
+              <Sparkles className="w-5 h-5" />
+            </div>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400 leading-relaxed">{emptyHint}</p>
+            {onStart && (
+              <button
+                type="button"
+                onClick={onStart}
+                style={{ color: accent }}
+                className="mt-3 text-xs font-medium hover:underline cursor-pointer"
+              >
+                Start with the Token phase →
+              </button>
+            )}
+          </div>
         </div>
       ) : (
         <div className="overflow-y-auto divide-y divide-zinc-100 dark:divide-zinc-800/60 flex-1">

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -6,6 +6,7 @@ import { ArrowLeftRight } from 'lucide-react';
 import { useWalletStore } from '@/components/toolbox/stores/walletStore';
 import { useWalletSwitch } from '@/components/toolbox/hooks/useWalletSwitch';
 import { useL1List } from '@/components/toolbox/stores/l1ListStore';
+import { ConnectedWalletProvider } from '@/components/toolbox/contexts/ConnectedWalletContext';
 import { Note } from '@/components/toolbox/components/Note';
 import { useBridgeState } from './use-bridge-state';
 import { useBridgeActivity } from './use-bridge-activity';
@@ -364,7 +365,7 @@ export function BridgeConsole({
       )}
 
       {isWalletConnected && (
-        <>
+        <ConnectedWalletProvider>
           {/* Main two-pane layout: stacks vertically below `lg` (≥1024px). */}
           <div className="grid grid-cols-1 lg:grid-cols-[1fr_8rem_1fr] gap-3 px-4 md:px-5 pt-4 pb-2 flex-shrink-0">
             <ChainPanel
@@ -454,7 +455,7 @@ export function BridgeConsole({
               <Note variant="default">Switching wallet network…</Note>
             </div>
           )}
-        </>
+        </ConnectedWalletProvider>
       )}
     </div>
   );

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -12,6 +12,7 @@ import { useBridgeActivity } from './use-bridge-activity';
 import { useHomeTokenSnapshot, useRemoteTokenSnapshot } from './use-token-snapshot';
 import { TokenSnapshotPanel } from './token-snapshot';
 import { PhaseStrip } from './phase-strip';
+import { RemotePicker } from './remote-picker';
 import { ChainPanel } from './chain-panel';
 import { ICMConnection } from './icm-connection';
 import { ActivityFeed } from './activity-feed';
@@ -48,7 +49,8 @@ const PHASE_TO_NEXT: Record<PhaseId, PhaseId | null> = {
  * from the old `/setup/[step]` and `/token-transfer/[step]` routes.
  */
 export function BridgeConsole({ initialPhase }: { initialPhase?: PhaseId }) {
-  const bridge = useBridgeState();
+  const [preferredRemoteChainId, setPreferredRemoteChainId] = useState<string | undefined>(undefined);
+  const bridge = useBridgeState({ preferredRemoteChainId });
   const { events, append, messageCount } = useBridgeActivity();
   const homeSnapshot = useHomeTokenSnapshot({
     homeChain: bridge.homeChain,
@@ -276,6 +278,15 @@ export function BridgeConsole({ initialPhase }: { initialPhase?: PhaseId }) {
               contracts={bridge.remoteContracts}
               dim={dimRight}
               walletConnected={remoteWalletConnected}
+              headerExtra={
+                bridge.allRemotes.length > 1 && bridge.remoteChain ? (
+                  <RemotePicker
+                    remotes={bridge.allRemotes}
+                    selected={bridge.remoteChain}
+                    onChange={setPreferredRemoteChainId}
+                  />
+                ) : null
+              }
               expandedDetails={
                 <>
                   {bridge.remoteAddress && (

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -89,14 +89,27 @@ export function BridgeConsole({ initialPhase }: { initialPhase?: PhaseId }) {
   const [activePhase, setActivePhase] = useState<PhaseId>(computedActive);
   const [switching, setSwitching] = useState(false);
 
-  // If the computed phase changes (e.g., because the user just deployed
-  // something), nudge the active phase forward when it's currently
-  // pointing at a blocked / done phase the user hasn't manually picked.
+  // If the active phase becomes blocked (shouldn't happen normally, but
+  // can happen if state is rebuilt after a chain switch), fall back to
+  // the computed default phase.
   useEffect(() => {
     if (bridge.phaseStatus[activePhase] === 'blocked') {
       setActivePhase(computedActive);
     }
   }, [activePhase, bridge.phaseStatus, computedActive]);
+
+  // Smart auto-advance: when the active phase flips to `done` via
+  // background polling (e.g., the register phase confirms registration
+  // ~30s after the ICM message lands), auto-advance the user to the
+  // next non-blocked phase. Without this, users would stare at a "done"
+  // inspector and have to click "Continue" to move forward.
+  useEffect(() => {
+    if (bridge.phaseStatus[activePhase] !== 'done') return;
+    const next = PHASE_TO_NEXT[activePhase];
+    if (next && bridge.phaseStatus[next] !== 'blocked' && bridge.phaseStatus[next] !== 'done') {
+      setActivePhase(next);
+    }
+  }, [activePhase, bridge.phaseStatus]);
 
   const handleSwitchChain = async (chainId: number, isTestnet: boolean) => {
     setSwitching(true);
@@ -121,7 +134,6 @@ export function BridgeConsole({ initialPhase }: { initialPhase?: PhaseId }) {
     const common = {
       bridge,
       accent: ACCENT,
-      onClose: () => setActivePhase(computedActive),
       onAdvance: handleAdvance,
       appendActivity,
       switchChain: handleSwitchChain,

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -208,42 +208,48 @@ export function BridgeConsole({
 
   return (
     <div className="w-full h-full flex flex-col font-sans bg-zinc-50 dark:bg-zinc-950">
-      {/* Top bar */}
-      <div className="border-b border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 px-4 md:px-6 py-3 flex items-center justify-between flex-shrink-0 gap-3">
-        <div className="flex items-center gap-3 min-w-0">
-          <div className="w-7 h-7 rounded-lg grid place-items-center flex-shrink-0" style={{ background: ACCENT }}>
-            <ArrowLeftRight className="w-4 h-4 text-white" strokeWidth={2.5} />
+      {/* Sticky header group: top bar + phase strip stick together so the
+          phase navigation stays reachable when the user scrolls long
+          inspector content (especially on tablet). The `top-12` offset
+          clears the console layout's 3rem-tall header. */}
+      <div className="sticky top-12 z-20 flex-shrink-0">
+        {/* Top bar */}
+        <div className="border-b border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 px-4 md:px-6 py-3 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="w-7 h-7 rounded-lg grid place-items-center flex-shrink-0" style={{ background: ACCENT }}>
+              <ArrowLeftRight className="w-4 h-4 text-white" strokeWidth={2.5} />
+            </div>
+            <div className="min-w-0">
+              <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">ICTT Bridge Console</div>
+              <div className="text-[10px] text-zinc-500 dark:text-zinc-400 truncate">{subtitle}</div>
+            </div>
           </div>
-          <div className="min-w-0">
-            <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">ICTT Bridge Console</div>
-            <div className="text-[10px] text-zinc-500 dark:text-zinc-400 truncate">{subtitle}</div>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <Link
+              href="/console/history"
+              className="hidden md:inline-flex items-center px-3 py-1.5 text-xs font-medium text-zinc-600 dark:text-zinc-300 border border-zinc-200 dark:border-zinc-700 rounded-lg hover:bg-zinc-50 dark:hover:bg-zinc-900"
+            >
+              History
+            </Link>
+            <WalletPill
+              walletAddress={walletEVMAddress}
+              walletChainId={walletChainId}
+              expectedChain={expectedChain}
+              onSwitchChain={
+                expectedChain ? () => handleSwitchChain(expectedChain.evmChainId, !!expectedChain.isTestnet) : undefined
+              }
+            />
           </div>
         </div>
-        <div className="flex items-center gap-2 flex-shrink-0">
-          <Link
-            href="/console/history"
-            className="hidden md:inline-flex items-center px-3 py-1.5 text-xs font-medium text-zinc-600 dark:text-zinc-300 border border-zinc-200 dark:border-zinc-700 rounded-lg hover:bg-zinc-50 dark:hover:bg-zinc-900"
-          >
-            History
-          </Link>
-          <WalletPill
-            walletAddress={walletEVMAddress}
-            walletChainId={walletChainId}
-            expectedChain={expectedChain}
-            onSwitchChain={
-              expectedChain ? () => handleSwitchChain(expectedChain.evmChainId, !!expectedChain.isTestnet) : undefined
-            }
-          />
-        </div>
-      </div>
 
-      {/* Phase strip */}
-      <PhaseStrip
-        activePhase={activePhase}
-        phaseStatus={bridge.phaseStatus}
-        onPhaseClick={(p) => setActivePhase(p)}
-        accent={ACCENT}
-      />
+        {/* Phase strip */}
+        <PhaseStrip
+          activePhase={activePhase}
+          phaseStatus={bridge.phaseStatus}
+          onPhaseClick={(p) => setActivePhase(p)}
+          accent={ACCENT}
+        />
+      </div>
 
       {/* Empty state when wallet is disconnected */}
       {!isWalletConnected && (

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -267,7 +267,14 @@ export function BridgeConsole({
   const subtitle = (() => {
     const homeName = bridge.homeChain?.name ?? '—';
     const remoteName = bridge.remoteChain?.name ?? '—';
-    const tokenLabel = bridge.tokenAddress ? 'TOKEN' : '—';
+    // Prefer the home-side token snapshot's symbol once it's been read;
+    // fall back to a truncated address; finally to the em-dash placeholder
+    // before any token is set.
+    const tokenLabel = (() => {
+      if (homeSnapshot.symbol && homeSnapshot.symbol !== '—') return homeSnapshot.symbol;
+      if (bridge.tokenAddress) return `${bridge.tokenAddress.slice(0, 6)}…${bridge.tokenAddress.slice(-4)}`;
+      return '—';
+    })();
     return `${tokenLabel} · ${homeName} ↔ ${remoteName} · setup ${bridge.progress}% complete`;
   })();
 

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { ArrowLeftRight } from 'lucide-react';
 import { useWalletStore } from '@/components/toolbox/stores/walletStore';
 import { useWalletSwitch } from '@/components/toolbox/hooks/useWalletSwitch';
+import { useL1List } from '@/components/toolbox/stores/l1ListStore';
 import { Note } from '@/components/toolbox/components/Note';
 import { useBridgeState } from './use-bridge-state';
 import { useBridgeActivity } from './use-bridge-activity';
@@ -62,6 +63,17 @@ export function BridgeConsole({ initialPhase }: { initialPhase?: PhaseId }) {
   const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
   const walletChainId = useWalletStore((s) => s.walletChainId);
   const { safelySwitch } = useWalletSwitch();
+  const l1List = useL1List();
+
+  // Resolves an explorer transaction URL from an event's chainId by
+  // matching against `L1ListItem.evmChainId`. Returns null when the chain
+  // isn't recognized or doesn't have an explorerUrl configured.
+  const getEventExplorerUrl = (event: ActivityEvent) => {
+    if (!event.txHash) return null;
+    const chain = l1List.find((l1: { evmChainId: number; explorerUrl?: string }) => l1.evmChainId === event.chainId);
+    if (!chain?.explorerUrl) return null;
+    return `${chain.explorerUrl.replace(/\/+$/, '')}/tx/${event.txHash}`;
+  };
 
   // Compute the first non-blocked, non-done phase as the default. Falls
   // back to `transfer` (the live phase) when the bridge is fully set up.
@@ -275,7 +287,7 @@ export function BridgeConsole({ initialPhase }: { initialPhase?: PhaseId }) {
             </div>
             <div className="min-h-[16rem] flex">
               <div className="flex-1 flex">
-                <ActivityFeed events={events} />
+                <ActivityFeed events={events} getExplorerUrl={getEventExplorerUrl} />
               </div>
             </div>
           </div>

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -8,6 +8,8 @@ import { useWalletSwitch } from '@/components/toolbox/hooks/useWalletSwitch';
 import { Note } from '@/components/toolbox/components/Note';
 import { useBridgeState } from './use-bridge-state';
 import { useBridgeActivity } from './use-bridge-activity';
+import { useHomeTokenSnapshot, useRemoteTokenSnapshot } from './use-token-snapshot';
+import { TokenSnapshotPanel } from './token-snapshot';
 import { PhaseStrip } from './phase-strip';
 import { ChainPanel } from './chain-panel';
 import { ICMConnection } from './icm-connection';
@@ -47,6 +49,16 @@ const PHASE_TO_NEXT: Record<PhaseId, PhaseId | null> = {
 export function BridgeConsole({ initialPhase }: { initialPhase?: PhaseId }) {
   const bridge = useBridgeState();
   const { events, append, messageCount } = useBridgeActivity();
+  const homeSnapshot = useHomeTokenSnapshot({
+    homeChain: bridge.homeChain,
+    homeAddress: bridge.homeAddress,
+    homeKind: bridge.homeKind,
+    remoteChainId: bridge.remoteChain?.id,
+  });
+  const remoteSnapshot = useRemoteTokenSnapshot({
+    remoteChain: bridge.remoteChain,
+    remoteAddress: bridge.remoteAddress,
+  });
   const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
   const walletChainId = useWalletStore((s) => s.walletChainId);
   const { safelySwitch } = useWalletSwitch();
@@ -212,11 +224,16 @@ export function BridgeConsole({ initialPhase }: { initialPhase?: PhaseId }) {
               dim={dimLeft}
               walletConnected={homeWalletConnected}
               expandedDetails={
-                <CollateralProgressDetail
-                  registered={bridge.registered}
-                  collateralNeeded={bridge.collateralNeeded.toString()}
-                  accent={ACCENT}
-                />
+                <>
+                  {bridge.homeAddress && (
+                    <TokenSnapshotPanel title="Token snapshot" snapshot={homeSnapshot} />
+                  )}
+                  <CollateralProgressDetail
+                    registered={bridge.registered}
+                    collateralNeeded={bridge.collateralNeeded.toString()}
+                    accent={ACCENT}
+                  />
+                </>
               }
               initiallyExpanded={activePhase === 'transfer'}
             />
@@ -236,10 +253,16 @@ export function BridgeConsole({ initialPhase }: { initialPhase?: PhaseId }) {
               dim={dimRight}
               walletConnected={remoteWalletConnected}
               expandedDetails={
-                <PairingStatusDetail
-                  registered={bridge.registered}
-                  lastChecked={bridge.lastChecked}
-                />
+                <>
+                  {bridge.remoteAddress && (
+                    <TokenSnapshotPanel
+                      title="Wrapped supply"
+                      snapshot={remoteSnapshot}
+                      showBridged={false}
+                    />
+                  )}
+                  <PairingStatusDetail registered={bridge.registered} lastChecked={bridge.lastChecked} />
+                </>
               }
               initiallyExpanded={activePhase === 'transfer'}
             />

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -192,6 +192,33 @@ export function BridgeConsole({
     }
   }, [activePhase, bridge.phaseStatus]);
 
+  // Arrow-key phase navigation. Skips blocked phases so users can
+  // hold ← / → to scrub through what's actually reachable. Ignored when
+  // the focus is in an editable field so typed text isn't hijacked.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+        return;
+      }
+      const direction = e.key === 'ArrowLeft' ? -1 : 1;
+      const currentIndex = PHASES.findIndex((p) => p.id === activePhase);
+      if (currentIndex === -1) return;
+      // Walk in the chosen direction skipping blocked phases.
+      for (let i = currentIndex + direction; i >= 0 && i < PHASES.length; i += direction) {
+        const next = PHASES[i];
+        if (bridge.phaseStatus[next.id] !== 'blocked') {
+          e.preventDefault();
+          setActivePhase(next.id);
+          return;
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [activePhase, bridge.phaseStatus]);
+
   const handleSwitchChain = async (chainId: number, isTestnet: boolean) => {
     setSwitching(true);
     try {

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -310,7 +310,16 @@ export function BridgeConsole({ initialPhase }: { initialPhase?: PhaseId }) {
             </div>
             <div className="min-h-[16rem] flex">
               <div className="flex-1 flex">
-                <ActivityFeed events={events} getExplorerUrl={getEventExplorerUrl} />
+                <ActivityFeed
+                  events={events}
+                  getExplorerUrl={getEventExplorerUrl}
+                  accent={ACCENT}
+                  onStart={
+                    bridge.tokenAddress
+                      ? undefined
+                      : () => setActivePhase('token')
+                  }
+                />
               </div>
             </div>
           </div>

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -29,7 +29,8 @@ import { TransferInspector } from './inspectors/transfer-inspector';
 import { PHASES, type PhaseId } from './types';
 import type { ActivityEvent } from './types';
 
-const ACCENT = '#3B82F6';
+// Avalanche red — matches `.bg-avax-red` brand utility in app/global.css.
+const ACCENT = '#e84142';
 
 const PHASE_TO_NEXT: Record<PhaseId, PhaseId | null> = {
   token: 'home',

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -48,8 +48,14 @@ const PHASE_TO_NEXT: Record<PhaseId, PhaseId | null> = {
  * search-param deep-link is supported for the redirect targets coming
  * from the old `/setup/[step]` and `/token-transfer/[step]` routes.
  */
-export function BridgeConsole({ initialPhase }: { initialPhase?: PhaseId }) {
-  const [preferredRemoteChainId, setPreferredRemoteChainId] = useState<string | undefined>(undefined);
+export function BridgeConsole({
+  initialPhase,
+  initialRemoteChainId,
+}: {
+  initialPhase?: PhaseId;
+  initialRemoteChainId?: string;
+}) {
+  const [preferredRemoteChainId, setPreferredRemoteChainId] = useState<string | undefined>(initialRemoteChainId);
   const bridge = useBridgeState({ preferredRemoteChainId });
   const { events, append, messageCount } = useBridgeActivity();
   const homeSnapshot = useHomeTokenSnapshot({
@@ -90,6 +96,24 @@ export function BridgeConsole({ initialPhase }: { initialPhase?: PhaseId }) {
 
   const [activePhase, setActivePhase] = useState<PhaseId>(computedActive);
   const [switching, setSwitching] = useState(false);
+
+  // Keep the address bar in sync with active phase + selected remote so
+  // the URL is always shareable. Uses `history.replaceState` rather than
+  // Next.js `router.replace` to avoid a server round-trip on every click.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const url = new URL(window.location.href);
+    url.searchParams.set('phase', activePhase);
+    if (preferredRemoteChainId) {
+      url.searchParams.set('remote', preferredRemoteChainId);
+    } else {
+      url.searchParams.delete('remote');
+    }
+    const next = `${url.pathname}?${url.searchParams.toString()}`;
+    if (next !== `${window.location.pathname}${window.location.search}`) {
+      window.history.replaceState({}, '', next);
+    }
+  }, [activePhase, preferredRemoteChainId]);
 
   // If the active phase becomes blocked (shouldn't happen normally, but
   // can happen if state is rebuilt after a chain switch), fall back to

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -13,6 +13,7 @@ import { useHomeTokenSnapshot, useRemoteTokenSnapshot } from './use-token-snapsh
 import { TokenSnapshotPanel } from './token-snapshot';
 import { PhaseStrip } from './phase-strip';
 import { RemotePicker } from './remote-picker';
+import { ResetBridgeButton } from './reset-bridge-button';
 import { ChainPanel } from './chain-panel';
 import { ICMConnection } from './icm-connection';
 import { ActivityFeed } from './activity-feed';
@@ -57,7 +58,7 @@ export function BridgeConsole({
 }) {
   const [preferredRemoteChainId, setPreferredRemoteChainId] = useState<string | undefined>(initialRemoteChainId);
   const bridge = useBridgeState({ preferredRemoteChainId });
-  const { events, append, messageCount } = useBridgeActivity();
+  const { events, append, clear: clearActivity, messageCount } = useBridgeActivity();
   const homeSnapshot = useHomeTokenSnapshot({
     homeChain: bridge.homeChain,
     homeAddress: bridge.homeAddress,
@@ -231,6 +232,16 @@ export function BridgeConsole({
             >
               History
             </Link>
+            <ResetBridgeButton
+              homeChainId={bridge.homeChain?.id}
+              remoteChainIds={bridge.allRemotes.map((r) => r.chain.id)}
+              hasAnythingToReset={!!(bridge.tokenAddress || bridge.homeAddress || bridge.allRemotes.length > 0)}
+              onAfterReset={() => {
+                clearActivity();
+                setPreferredRemoteChainId(undefined);
+                setActivePhase('token');
+              }}
+            />
             <WalletPill
               walletAddress={walletEVMAddress}
               walletChainId={walletChainId}

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -291,27 +291,27 @@ export function BridgeConsole({
   const dimRight = activePhase === 'token' || activePhase === 'home' || activePhase === 'collateral';
 
   return (
-    <div className="w-full h-full flex flex-col font-sans bg-zinc-50 dark:bg-zinc-950">
+    <div className="w-full h-full flex flex-col font-sans bg-background">
       {/* Sticky header group: top bar + phase strip stick together so the
           phase navigation stays reachable when the user scrolls long
           inspector content (especially on tablet). The `top-12` offset
           clears the console layout's 3rem-tall header. */}
       <div className="sticky top-12 z-20 flex-shrink-0">
         {/* Top bar */}
-        <div className="border-b border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 px-4 md:px-6 py-3 flex items-center justify-between gap-3">
+        <div className="border-b border-border bg-card px-4 md:px-6 py-3 flex items-center justify-between gap-3">
           <div className="flex items-center gap-3 min-w-0">
             <div className="w-7 h-7 rounded-lg grid place-items-center flex-shrink-0" style={{ background: ACCENT }}>
               <ArrowLeftRight className="w-4 h-4 text-white" strokeWidth={2.5} />
             </div>
             <div className="min-w-0">
-              <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">ICTT Bridge Console</div>
-              <div className="text-[10px] text-zinc-500 dark:text-zinc-400 truncate">{subtitle}</div>
+              <div className="text-sm font-semibold text-foreground">ICTT Bridge Console</div>
+              <div className="text-[10px] text-muted-foreground truncate">{subtitle}</div>
             </div>
           </div>
           <div className="flex items-center gap-2 flex-shrink-0">
             <Link
               href="/console/history"
-              className="hidden md:inline-flex items-center px-3 py-1.5 text-xs font-medium text-zinc-600 dark:text-zinc-300 border border-zinc-200 dark:border-zinc-700 rounded-lg hover:bg-zinc-50 dark:hover:bg-zinc-900"
+              className="hidden md:inline-flex items-center px-3 py-1.5 text-xs font-medium text-foreground/80 border border-border rounded-lg hover:bg-muted"
             >
               History
             </Link>
@@ -353,10 +353,10 @@ export function BridgeConsole({
             <div className="w-12 h-12 rounded-2xl mx-auto mb-4 grid place-items-center" style={{ background: ACCENT }}>
               <ArrowLeftRight className="w-6 h-6 text-white" strokeWidth={2.5} />
             </div>
-            <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-2">
+            <h2 className="text-lg font-semibold text-foreground mb-2">
               Connect a wallet to start a bridge
             </h2>
-            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+            <p className="text-sm text-muted-foreground">
               The bridge console deploys TokenHome on a source chain, TokenRemote on a destination chain, and pairs
               them via ICM so tokens can move both ways.
             </p>
@@ -472,19 +472,19 @@ function CollateralProgressDetail({
 }) {
   return (
     <div>
-      <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 font-semibold mb-2">
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold mb-2">
         Collateral
       </div>
-      <div className="rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700 p-3 bg-zinc-50/50 dark:bg-zinc-900/30">
+      <div className="rounded-xl border border-dashed border-border p-3 bg-muted/30">
         <div className="flex items-center justify-between mb-2">
-          <span className="text-xs text-zinc-600 dark:text-zinc-400">
+          <span className="text-xs text-foreground/80">
             {registered ? 'Status' : 'Awaiting registration'}
           </span>
-          <span className="text-xs font-mono text-zinc-900 dark:text-zinc-100">
+          <span className="text-xs font-mono text-foreground">
             {registered ? `${collateralNeeded === '0' ? '✓ funded' : `needs ${collateralNeeded}`}` : '—'}
           </span>
         </div>
-        <div className="h-1.5 bg-zinc-200 dark:bg-zinc-800 rounded-full overflow-hidden">
+        <div className="h-1.5 bg-muted rounded-full overflow-hidden">
           <div
             className="h-full rounded-full transition-all"
             style={{ width: registered && collateralNeeded === '0' ? '100%' : '0%', background: accent }}
@@ -498,7 +498,7 @@ function CollateralProgressDetail({
 function PairingStatusDetail({ registered, lastChecked }: { registered: boolean; lastChecked: number | null }) {
   return (
     <div>
-      <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 font-semibold mb-2">
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold mb-2">
         Pairing status
       </div>
       <div

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -14,6 +14,7 @@ import { TokenSnapshotPanel } from './token-snapshot';
 import { PhaseStrip } from './phase-strip';
 import { RemotePicker } from './remote-picker';
 import { ResetBridgeButton } from './reset-bridge-button';
+import { ShortcutsOverlay } from './shortcuts-overlay';
 import { ChainPanel } from './chain-panel';
 import { ICMConnection } from './icm-connection';
 import { ActivityFeed } from './activity-feed';
@@ -323,6 +324,7 @@ export function BridgeConsole({
                 setActivePhase('token');
               }}
             />
+            <ShortcutsOverlay />
             <WalletPill
               walletAddress={walletEVMAddress}
               walletChainId={walletChainId}

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -337,12 +337,12 @@ export function BridgeConsole({
           </div>
         </div>
 
-        {/* Phase strip */}
+        {/* Phase strip — uses the same visual language as the shared
+            step-flow stepper across the rest of the console. */}
         <PhaseStrip
           activePhase={activePhase}
           phaseStatus={bridge.phaseStatus}
           onPhaseClick={(p) => setActivePhase(p)}
-          accent={ACCENT}
         />
       </div>
 

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -49,6 +49,40 @@ const PHASE_TO_NEXT: Record<PhaseId, PhaseId | null> = {
  * search-param deep-link is supported for the redirect targets coming
  * from the old `/setup/[step]` and `/token-transfer/[step]` routes.
  */
+const PREFERRED_REMOTE_STORAGE_KEY = 'ictt-bridge-preferred-remote-v1';
+
+/** Persist the preferred remote per home chain in localStorage so the
+ *  user's last selection survives a reload even without a URL param.
+ *  Keyed by home chain ID since the same wallet might run bridges from
+ *  multiple home chains. */
+function loadPreferredRemote(homeChainId: string | undefined): string | undefined {
+  if (!homeChainId || typeof window === 'undefined') return undefined;
+  try {
+    const raw = window.localStorage.getItem(PREFERRED_REMOTE_STORAGE_KEY);
+    if (!raw) return undefined;
+    const map = JSON.parse(raw) as Record<string, string>;
+    return map[homeChainId];
+  } catch {
+    return undefined;
+  }
+}
+
+function savePreferredRemote(homeChainId: string, remoteChainId: string | undefined) {
+  if (typeof window === 'undefined') return;
+  try {
+    const raw = window.localStorage.getItem(PREFERRED_REMOTE_STORAGE_KEY);
+    const map: Record<string, string> = raw ? JSON.parse(raw) : {};
+    if (remoteChainId) {
+      map[homeChainId] = remoteChainId;
+    } else {
+      delete map[homeChainId];
+    }
+    window.localStorage.setItem(PREFERRED_REMOTE_STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    /* quota / disabled storage — silent */
+  }
+}
+
 export function BridgeConsole({
   initialPhase,
   initialRemoteChainId,
@@ -58,6 +92,26 @@ export function BridgeConsole({
 }) {
   const [preferredRemoteChainId, setPreferredRemoteChainId] = useState<string | undefined>(initialRemoteChainId);
   const bridge = useBridgeState({ preferredRemoteChainId });
+
+  // Hydrate from localStorage on first mount (after we know the home
+  // chain). URL `?remote=` always wins over persisted state.
+  useEffect(() => {
+    if (preferredRemoteChainId || !bridge.homeChain?.id) return;
+    const stored = loadPreferredRemote(bridge.homeChain.id);
+    if (stored && bridge.allRemotes.some((r) => r.chain.id === stored)) {
+      setPreferredRemoteChainId(stored);
+    }
+    // We intentionally only run this once per home chain change — if the
+    // user clears their selection, the auto-pick kicks in.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bridge.homeChain?.id]);
+
+  // Persist any explicit selection. Skipping when no home chain (during
+  // bootstrap) avoids writing under an empty key.
+  useEffect(() => {
+    if (!bridge.homeChain?.id) return;
+    savePreferredRemote(bridge.homeChain.id, preferredRemoteChainId);
+  }, [bridge.homeChain?.id, preferredRemoteChainId]);
   const { events, append, clear: clearActivity, messageCount } = useBridgeActivity();
   const homeSnapshot = useHomeTokenSnapshot({
     homeChain: bridge.homeChain,

--- a/app/console/ictt/_components/bridge-console.tsx
+++ b/app/console/ictt/_components/bridge-console.tsx
@@ -1,0 +1,345 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeftRight } from 'lucide-react';
+import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import { useWalletSwitch } from '@/components/toolbox/hooks/useWalletSwitch';
+import { Note } from '@/components/toolbox/components/Note';
+import { useBridgeState } from './use-bridge-state';
+import { useBridgeActivity } from './use-bridge-activity';
+import { PhaseStrip } from './phase-strip';
+import { ChainPanel } from './chain-panel';
+import { ICMConnection } from './icm-connection';
+import { ActivityFeed } from './activity-feed';
+import { WalletPill } from './wallet-pill';
+import { TokenInspector } from './inspectors/token-inspector';
+import { HomeInspector } from './inspectors/home-inspector';
+import { RemoteInspector } from './inspectors/remote-inspector';
+import { RegisterInspector } from './inspectors/register-inspector';
+import { CollateralInspector } from './inspectors/collateral-inspector';
+import { TransferInspector } from './inspectors/transfer-inspector';
+import { PHASES, type PhaseId } from './types';
+import type { ActivityEvent } from './types';
+
+const ACCENT = '#3B82F6';
+
+const PHASE_TO_NEXT: Record<PhaseId, PhaseId | null> = {
+  token: 'home',
+  home: 'remote',
+  remote: 'register',
+  register: 'collateral',
+  collateral: 'transfer',
+  transfer: null,
+};
+
+/**
+ * Top-level shell for the ICTT Bridge Console. Replaces the 7-route
+ * wizard with a single spatial page: home chain on the left, ICM rail
+ * in the middle, remote chain on the right; a phase strip across the
+ * top, an inspector pane on the bottom-left, and an activity feed on
+ * the bottom-right.
+ *
+ * Phase state is local — no per-phase URL routing. Optional `?phase=…`
+ * search-param deep-link is supported for the redirect targets coming
+ * from the old `/setup/[step]` and `/token-transfer/[step]` routes.
+ */
+export function BridgeConsole({ initialPhase }: { initialPhase?: PhaseId }) {
+  const bridge = useBridgeState();
+  const { events, append, messageCount } = useBridgeActivity();
+  const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
+  const walletChainId = useWalletStore((s) => s.walletChainId);
+  const { safelySwitch } = useWalletSwitch();
+
+  // Compute the first non-blocked, non-done phase as the default. Falls
+  // back to `transfer` (the live phase) when the bridge is fully set up.
+  const computedActive = useMemo<PhaseId>(() => {
+    if (initialPhase && bridge.phaseStatus[initialPhase] !== 'blocked') return initialPhase;
+    for (const p of PHASES) {
+      const s = bridge.phaseStatus[p.id];
+      if (s !== 'done' && s !== 'blocked') return p.id;
+    }
+    return 'transfer';
+  }, [initialPhase, bridge.phaseStatus]);
+
+  const [activePhase, setActivePhase] = useState<PhaseId>(computedActive);
+  const [switching, setSwitching] = useState(false);
+
+  // If the computed phase changes (e.g., because the user just deployed
+  // something), nudge the active phase forward when it's currently
+  // pointing at a blocked / done phase the user hasn't manually picked.
+  useEffect(() => {
+    if (bridge.phaseStatus[activePhase] === 'blocked') {
+      setActivePhase(computedActive);
+    }
+  }, [activePhase, bridge.phaseStatus, computedActive]);
+
+  const handleSwitchChain = async (chainId: number, isTestnet: boolean) => {
+    setSwitching(true);
+    try {
+      await safelySwitch(chainId, isTestnet);
+    } finally {
+      setSwitching(false);
+    }
+  };
+
+  const handleAdvance = () => {
+    const next = PHASE_TO_NEXT[activePhase];
+    if (next && bridge.phaseStatus[next] !== 'blocked') {
+      setActivePhase(next);
+    }
+  };
+
+  const appendActivity = (e: Omit<ActivityEvent, 'id' | 'timestamp'>) => append(e);
+
+  // Choose what to render in the bottom-left inspector slot.
+  const renderInspector = () => {
+    const common = {
+      bridge,
+      accent: ACCENT,
+      onClose: () => setActivePhase(computedActive),
+      onAdvance: handleAdvance,
+      appendActivity,
+      switchChain: handleSwitchChain,
+    };
+    switch (activePhase) {
+      case 'token':
+        return <TokenInspector {...common} />;
+      case 'home':
+        return <HomeInspector {...common} />;
+      case 'remote':
+        return <RemoteInspector {...common} />;
+      case 'register':
+        return <RegisterInspector {...common} />;
+      case 'collateral':
+        return <CollateralInspector {...common} />;
+      case 'transfer':
+        return <TransferInspector {...common} />;
+    }
+  };
+
+  const subtitle = (() => {
+    const homeName = bridge.homeChain?.name ?? '—';
+    const remoteName = bridge.remoteChain?.name ?? '—';
+    const tokenLabel = bridge.tokenAddress ? 'TOKEN' : '—';
+    return `${tokenLabel} · ${homeName} ↔ ${remoteName} · setup ${bridge.progress}% complete`;
+  })();
+
+  // Expected chain for the wallet pill = source-chain for the active
+  // phase. Token / home / collateral need home; remote / register need
+  // remote; transfer needs source side based on direction (default home).
+  const expectedChain = (() => {
+    if (activePhase === 'remote' || activePhase === 'register') return bridge.remoteChain;
+    return bridge.homeChain;
+  })();
+
+  const isWalletConnected = !!walletEVMAddress;
+  const homeWalletConnected =
+    isWalletConnected && bridge.homeChain ? walletChainId === bridge.homeChain.evmChainId : false;
+  const remoteWalletConnected =
+    isWalletConnected && bridge.remoteChain ? walletChainId === bridge.remoteChain.evmChainId : false;
+
+  const icmActive = activePhase === 'register' || activePhase === 'transfer';
+
+  const dimLeft = activePhase === 'remote' || activePhase === 'register';
+  const dimRight = activePhase === 'token' || activePhase === 'home' || activePhase === 'collateral';
+
+  return (
+    <div className="w-full h-full flex flex-col font-sans bg-zinc-50 dark:bg-zinc-950">
+      {/* Top bar */}
+      <div className="border-b border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 px-4 md:px-6 py-3 flex items-center justify-between flex-shrink-0 gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="w-7 h-7 rounded-lg grid place-items-center flex-shrink-0" style={{ background: ACCENT }}>
+            <ArrowLeftRight className="w-4 h-4 text-white" strokeWidth={2.5} />
+          </div>
+          <div className="min-w-0">
+            <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">ICTT Bridge Console</div>
+            <div className="text-[10px] text-zinc-500 dark:text-zinc-400 truncate">{subtitle}</div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <Link
+            href="/console/history"
+            className="hidden md:inline-flex items-center px-3 py-1.5 text-xs font-medium text-zinc-600 dark:text-zinc-300 border border-zinc-200 dark:border-zinc-700 rounded-lg hover:bg-zinc-50 dark:hover:bg-zinc-900"
+          >
+            History
+          </Link>
+          <WalletPill
+            walletAddress={walletEVMAddress}
+            walletChainId={walletChainId}
+            expectedChain={expectedChain}
+            onSwitchChain={
+              expectedChain ? () => handleSwitchChain(expectedChain.evmChainId, !!expectedChain.isTestnet) : undefined
+            }
+          />
+        </div>
+      </div>
+
+      {/* Phase strip */}
+      <PhaseStrip
+        activePhase={activePhase}
+        phaseStatus={bridge.phaseStatus}
+        onPhaseClick={(p) => setActivePhase(p)}
+        accent={ACCENT}
+      />
+
+      {/* Empty state when wallet is disconnected */}
+      {!isWalletConnected && (
+        <div className="flex-1 grid place-items-center px-6 py-10">
+          <div className="max-w-md text-center">
+            <div className="w-12 h-12 rounded-2xl mx-auto mb-4 grid place-items-center" style={{ background: ACCENT }}>
+              <ArrowLeftRight className="w-6 h-6 text-white" strokeWidth={2.5} />
+            </div>
+            <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-2">
+              Connect a wallet to start a bridge
+            </h2>
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+              The bridge console deploys TokenHome on a source chain, TokenRemote on a destination chain, and pairs
+              them via ICM so tokens can move both ways.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {isWalletConnected && (
+        <>
+          {/* Main two-pane layout: stacks vertically below `lg` (≥1024px). */}
+          <div className="grid grid-cols-1 lg:grid-cols-[1fr_8rem_1fr] gap-3 px-4 md:px-5 pt-4 pb-2 flex-shrink-0">
+            <ChainPanel
+              chain={bridge.homeChain}
+              role="HOME · ORIGIN"
+              contracts={bridge.homeContracts}
+              dim={dimLeft}
+              walletConnected={homeWalletConnected}
+              expandedDetails={
+                <CollateralProgressDetail
+                  registered={bridge.registered}
+                  collateralNeeded={bridge.collateralNeeded.toString()}
+                  accent={ACCENT}
+                />
+              }
+              initiallyExpanded={activePhase === 'transfer'}
+            />
+
+            <div className="hidden lg:block">
+              <ICMConnection accent={ACCENT} active={icmActive} count={messageCount} orientation="vertical" />
+            </div>
+
+            <div className="lg:hidden">
+              <ICMConnection accent={ACCENT} active={icmActive} count={messageCount} orientation="horizontal" />
+            </div>
+
+            <ChainPanel
+              chain={bridge.remoteChain}
+              role="REMOTE · DESTINATION"
+              contracts={bridge.remoteContracts}
+              dim={dimRight}
+              walletConnected={remoteWalletConnected}
+              expandedDetails={
+                <PairingStatusDetail
+                  registered={bridge.registered}
+                  lastChecked={bridge.lastChecked}
+                />
+              }
+              initiallyExpanded={activePhase === 'transfer'}
+            />
+          </div>
+
+          {/* Bottom split: Inspector + Activity feed */}
+          <div className="flex-1 grid grid-cols-1 lg:grid-cols-[1fr_360px] gap-3 px-4 md:px-5 pb-5 min-h-0">
+            <div className="min-h-[16rem] flex">
+              <div className="flex-1 flex">{renderInspector()}</div>
+            </div>
+            <div className="min-h-[16rem] flex">
+              <div className="flex-1 flex">
+                <ActivityFeed events={events} />
+              </div>
+            </div>
+          </div>
+
+          {/* Switching indicator */}
+          {switching && (
+            <div className="absolute bottom-4 right-4 z-50">
+              <Note variant="default">Switching wallet network…</Note>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function CollateralProgressDetail({
+  registered,
+  collateralNeeded,
+  accent,
+}: {
+  registered: boolean;
+  collateralNeeded: string;
+  accent: string;
+}) {
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 font-semibold mb-2">
+        Collateral
+      </div>
+      <div className="rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700 p-3 bg-zinc-50/50 dark:bg-zinc-900/30">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-xs text-zinc-600 dark:text-zinc-400">
+            {registered ? 'Status' : 'Awaiting registration'}
+          </span>
+          <span className="text-xs font-mono text-zinc-900 dark:text-zinc-100">
+            {registered ? `${collateralNeeded === '0' ? '✓ funded' : `needs ${collateralNeeded}`}` : '—'}
+          </span>
+        </div>
+        <div className="h-1.5 bg-zinc-200 dark:bg-zinc-800 rounded-full overflow-hidden">
+          <div
+            className="h-full rounded-full transition-all"
+            style={{ width: registered && collateralNeeded === '0' ? '100%' : '0%', background: accent }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PairingStatusDetail({ registered, lastChecked }: { registered: boolean; lastChecked: number | null }) {
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 font-semibold mb-2">
+        Pairing status
+      </div>
+      <div
+        className={`rounded-xl border p-3 ${
+          registered
+            ? 'border-emerald-200 bg-emerald-50/50 dark:border-emerald-900/60 dark:bg-emerald-950/20'
+            : 'border-amber-200 bg-amber-50/60 dark:border-amber-900/60 dark:bg-amber-950/30'
+        }`}
+      >
+        <div className="flex items-center gap-2 mb-1">
+          <span
+            className={`w-1.5 h-1.5 rounded-full ${
+              registered ? 'bg-emerald-500' : 'bg-amber-500 animate-pulse'
+            }`}
+          />
+          <span
+            className={`text-xs font-medium ${
+              registered ? 'text-emerald-800 dark:text-emerald-300' : 'text-amber-800 dark:text-amber-300'
+            }`}
+          >
+            {registered ? 'Paired with Home' : 'Awaiting Home acknowledgement'}
+          </span>
+        </div>
+        {lastChecked && (
+          <p
+            className={`text-[11px] leading-relaxed ${
+              registered ? 'text-emerald-700/80 dark:text-emerald-400/80' : 'text-amber-700/80 dark:text-amber-400/80'
+            }`}
+          >
+            Last polled {Math.max(0, Math.floor((Date.now() - lastChecked) / 1000))}s ago.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/console/ictt/_components/chain-color.ts
+++ b/app/console/ictt/_components/chain-color.ts
@@ -1,0 +1,53 @@
+/**
+ * Chain accent color resolver.
+ *
+ * `L1ListItem` does not carry a color field, so we map well-known chains
+ * to brand colors and fall back to a deterministic palette pick for any
+ * unknown chain. Symmetric with the colored-initials fallback used by
+ * `app/console/my-l1/_components/SwitchChainRail.tsx` for chains without
+ * a logo.
+ */
+
+const KNOWN_CHAIN_COLORS: Record<string, string> = {
+  // Fuji + Mainnet C-Chain (Avalanche red)
+  yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp: '#E84142',
+  '2q9e4r6Mu3U68nU1fYjgbR6JvwrRx36CohpAX5UQxse55x1Q5': '#E84142',
+  // Echo (emerald)
+  '98qnjenm7MBd8G2cPZoRvZrgJC33JGSAAKghsQ6eojbLCeRNp': '#10B981',
+  // Dispatch (purple)
+  '2D8RG4UpSXbPbvPCAWppNJyqTG2i2CAXSkTgmTBBvs7GKNZjsY': '#7C5CFF',
+  // Dexalot (amber)
+  '2TTSLdR6uEM3R5Ukej3YThHSyPf6XCfppAsh5vAuzFA1rY5w7e': '#F59E0B',
+};
+
+const FALLBACK_PALETTE = [
+  '#F43F5E', // rose
+  '#10B981', // emerald
+  '#0EA5E9', // sky
+  '#F59E0B', // amber
+  '#8B5CF6', // violet
+  '#EC4899', // pink
+  '#06B6D4', // cyan
+];
+
+export function chainColor(chainId: string | undefined | null): string {
+  if (!chainId) return '#71717A'; // zinc-500 fallback
+  const known = KNOWN_CHAIN_COLORS[chainId];
+  if (known) return known;
+  // Deterministic hash of chain ID -> palette index. Produces stable
+  // colors across reloads and across chains.
+  let hash = 0;
+  for (let i = 0; i < chainId.length; i++) {
+    hash = (hash * 31 + chainId.charCodeAt(i)) & 0x7fffffff;
+  }
+  return FALLBACK_PALETTE[hash % FALLBACK_PALETTE.length];
+}
+
+export function chainInitial(name: string | undefined | null): string {
+  if (!name) return '?';
+  const trimmed = name.trim();
+  if (!trimmed) return '?';
+  const words = trimmed.split(/\s+/);
+  if (words.length >= 2) return (words[0][0] + words[1][0]).toUpperCase();
+  return trimmed.slice(0, 1).toUpperCase();
+}

--- a/app/console/ictt/_components/chain-panel.tsx
+++ b/app/console/ictt/_components/chain-panel.tsx
@@ -47,8 +47,8 @@ export function ChainPanel({
   return (
     <div
       className={cn(
-        'relative flex-1 rounded-2xl border bg-white dark:bg-zinc-950 transition-opacity',
-        'border-zinc-200 dark:border-zinc-800 overflow-hidden',
+        'relative flex-1 rounded-2xl border bg-card transition-opacity',
+        'border-border overflow-hidden',
         dim && 'opacity-50',
       )}
     >
@@ -64,16 +64,16 @@ export function ChainPanel({
             {chainInitial(name)}
           </div>
           <div className="min-w-0">
-            <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 font-semibold">
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
               {role}
             </div>
-            <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 truncate">{name}</div>
+            <div className="text-sm font-semibold text-foreground truncate">{name}</div>
           </div>
         </div>
         <div className="flex items-center gap-2 flex-shrink-0">
           {headerExtra}
           {walletConnected && (
-            <div className="flex items-center gap-1.5 text-[10px] text-zinc-400 dark:text-zinc-500">
+            <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
               <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
               connected
             </div>
@@ -82,7 +82,7 @@ export function ChainPanel({
             <button
               type="button"
               onClick={() => setExpanded((v) => !v)}
-              className="text-[10px] text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-200 cursor-pointer px-1.5 py-0.5 rounded border border-transparent hover:border-zinc-200 dark:hover:border-zinc-700"
+              className="text-[10px] text-muted-foreground hover:text-foreground cursor-pointer px-1.5 py-0.5 rounded border border-transparent hover:border-border"
             >
               {expanded ? '– collapse' : '+ details'}
             </button>
@@ -92,7 +92,7 @@ export function ChainPanel({
 
       <div className="px-5 pb-4 space-y-3">
         <div>
-          <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 font-semibold mb-1.5">
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold mb-1.5">
             Contracts
           </div>
           {contracts.map((c) => (

--- a/app/console/ictt/_components/chain-panel.tsx
+++ b/app/console/ictt/_components/chain-panel.tsx
@@ -15,6 +15,11 @@ interface ChainPanelProps {
   walletConnected: boolean;
   expandedDetails?: ReactNode;
   initiallyExpanded?: boolean;
+  /**
+   * Extra content rendered next to the role/chain-name in the header.
+   * Used by the right panel for the multi-remote picker dropdown.
+   */
+  headerExtra?: ReactNode;
 }
 
 /**
@@ -33,6 +38,7 @@ export function ChainPanel({
   walletConnected,
   expandedDetails,
   initiallyExpanded = false,
+  headerExtra,
 }: ChainPanelProps) {
   const [expanded, setExpanded] = useState(initiallyExpanded);
   const color = chainColor(chain?.id);
@@ -65,6 +71,7 @@ export function ChainPanel({
           </div>
         </div>
         <div className="flex items-center gap-2 flex-shrink-0">
+          {headerExtra}
           {walletConnected && (
             <div className="flex items-center gap-1.5 text-[10px] text-zinc-400 dark:text-zinc-500">
               <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />

--- a/app/console/ictt/_components/chain-panel.tsx
+++ b/app/console/ictt/_components/chain-panel.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import { cn } from '@/components/toolbox/lib/utils';
+import { chainColor, chainInitial } from './chain-color';
+import { ContractRow } from './contract-row';
+import type { ContractSlot } from './types';
+import type { L1ListItem } from '@/components/toolbox/stores/l1ListStore';
+
+interface ChainPanelProps {
+  chain: L1ListItem | undefined;
+  role: string;
+  contracts: ContractSlot[];
+  dim: boolean;
+  walletConnected: boolean;
+  expandedDetails?: ReactNode;
+  initiallyExpanded?: boolean;
+}
+
+/**
+ * Left or right pane of the bridge. Shows a chain header with role label
+ * and connected indicator, contract rows, and an optional expanded details
+ * slot. Each panel keeps its OWN expand state — the design has a single
+ * shared `forceExpanded` boolean which makes both sides flip together;
+ * we deliberately split that so users can peek at one without opening
+ * both.
+ */
+export function ChainPanel({
+  chain,
+  role,
+  contracts,
+  dim,
+  walletConnected,
+  expandedDetails,
+  initiallyExpanded = false,
+}: ChainPanelProps) {
+  const [expanded, setExpanded] = useState(initiallyExpanded);
+  const color = chainColor(chain?.id);
+  const name = chain?.name ?? '—';
+
+  return (
+    <div
+      className={cn(
+        'relative flex-1 rounded-2xl border bg-white dark:bg-zinc-950 transition-opacity',
+        'border-zinc-200 dark:border-zinc-800 overflow-hidden',
+        dim && 'opacity-50',
+      )}
+    >
+      {/* Top accent strip in the chain's color */}
+      <div className="absolute top-0 left-0 right-0 h-1" style={{ background: color }} />
+
+      <div className="px-5 pt-4 pb-3 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <div
+            className="w-8 h-8 rounded-lg grid place-items-center text-white text-xs font-bold flex-shrink-0"
+            style={{ background: color }}
+          >
+            {chainInitial(name)}
+          </div>
+          <div className="min-w-0">
+            <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 font-semibold">
+              {role}
+            </div>
+            <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 truncate">{name}</div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {walletConnected && (
+            <div className="flex items-center gap-1.5 text-[10px] text-zinc-400 dark:text-zinc-500">
+              <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
+              connected
+            </div>
+          )}
+          {expandedDetails && (
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="text-[10px] text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-200 cursor-pointer px-1.5 py-0.5 rounded border border-transparent hover:border-zinc-200 dark:hover:border-zinc-700"
+            >
+              {expanded ? '– collapse' : '+ details'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="px-5 pb-4 space-y-3">
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 font-semibold mb-1.5">
+            Contracts
+          </div>
+          {contracts.map((c) => (
+            <ContractRow key={c.label} label={c.label} address={c.address} status={c.status} />
+          ))}
+        </div>
+        {expanded && expandedDetails && <div className="space-y-3">{expandedDetails}</div>}
+      </div>
+    </div>
+  );
+}

--- a/app/console/ictt/_components/chain-panel.tsx
+++ b/app/console/ictt/_components/chain-panel.tsx
@@ -89,7 +89,13 @@ export function ChainPanel({
             Contracts
           </div>
           {contracts.map((c) => (
-            <ContractRow key={c.label} label={c.label} address={c.address} status={c.status} />
+            <ContractRow
+              key={c.label}
+              label={c.label}
+              address={c.address}
+              status={c.status}
+              explorerUrl={chain?.explorerUrl}
+            />
           ))}
         </div>
         {expanded && expandedDetails && <div className="space-y-3">{expandedDetails}</div>}

--- a/app/console/ictt/_components/contract-row.tsx
+++ b/app/console/ictt/_components/contract-row.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Copy, Check } from 'lucide-react';
+import { useState } from 'react';
+import { cn } from '@/components/toolbox/lib/utils';
+import type { ContractStatus } from './types';
+
+interface ContractRowProps {
+  label: string;
+  address: string | null;
+  status: ContractStatus;
+}
+
+function truncate(address: string): string {
+  if (address.length <= 14) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+export function ContractRow({ label, address, status }: ContractRowProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!address) return;
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard API unavailable — silent */
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-3 py-2.5 border-b border-zinc-100 dark:border-zinc-800/60 last:border-0">
+      <div className="flex items-center gap-2.5 min-w-0">
+        <span
+          className={cn(
+            'w-1.5 h-1.5 rounded-full flex-shrink-0',
+            status === 'deployed' && 'bg-emerald-500',
+            status === 'pending' && 'bg-amber-500 animate-pulse',
+            status === 'idle' && 'bg-zinc-300 dark:bg-zinc-700',
+          )}
+        />
+        <span className="text-xs text-zinc-500 dark:text-zinc-400 font-medium truncate">{label}</span>
+      </div>
+      {address ? (
+        <button
+          type="button"
+          onClick={handleCopy}
+          title={`Copy ${address}`}
+          className="flex items-center gap-1.5 text-[11px] font-mono text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors cursor-pointer"
+        >
+          <span>{truncate(address)}</span>
+          {copied ? (
+            <Check className="w-3 h-3 text-emerald-500" />
+          ) : (
+            <Copy className="w-3 h-3 opacity-0 group-hover:opacity-100" />
+          )}
+        </button>
+      ) : (
+        <span className="text-[11px] text-zinc-300 dark:text-zinc-600 italic">— not deployed —</span>
+      )}
+    </div>
+  );
+}

--- a/app/console/ictt/_components/contract-row.tsx
+++ b/app/console/ictt/_components/contract-row.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Copy, Check } from 'lucide-react';
+import { Copy, Check, ExternalLink } from 'lucide-react';
 import { useState } from 'react';
 import { cn } from '@/components/toolbox/lib/utils';
 import type { ContractStatus } from './types';
@@ -9,6 +9,11 @@ interface ContractRowProps {
   label: string;
   address: string | null;
   status: ContractStatus;
+  /**
+   * Block-explorer base URL for the chain this contract lives on.
+   * When provided, the address becomes a deep link to /address/<addr>.
+   */
+  explorerUrl?: string;
 }
 
 function truncate(address: string): string {
@@ -16,10 +21,19 @@ function truncate(address: string): string {
   return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }
 
-export function ContractRow({ label, address, status }: ContractRowProps) {
+function buildExplorerLink(explorerUrl: string, address: string): string {
+  // Strip any trailing slash, then append /address/<addr>. Most Avalanche
+  // explorers (subnets.avax.network, snowtrace, etc.) follow this layout.
+  const base = explorerUrl.replace(/\/+$/, '');
+  return `${base}/address/${address}`;
+}
+
+export function ContractRow({ label, address, status, explorerUrl }: ContractRowProps) {
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = async () => {
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
     if (!address) return;
     try {
       await navigator.clipboard.writeText(address);
@@ -31,7 +45,7 @@ export function ContractRow({ label, address, status }: ContractRowProps) {
   };
 
   return (
-    <div className="flex items-center justify-between gap-3 py-2.5 border-b border-zinc-100 dark:border-zinc-800/60 last:border-0">
+    <div className="flex items-center justify-between gap-3 py-2.5 border-b border-zinc-100 dark:border-zinc-800/60 last:border-0 group">
       <div className="flex items-center gap-2.5 min-w-0">
         <span
           className={cn(
@@ -44,19 +58,30 @@ export function ContractRow({ label, address, status }: ContractRowProps) {
         <span className="text-xs text-zinc-500 dark:text-zinc-400 font-medium truncate">{label}</span>
       </div>
       {address ? (
-        <button
-          type="button"
-          onClick={handleCopy}
-          title={`Copy ${address}`}
-          className="flex items-center gap-1.5 text-[11px] font-mono text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors cursor-pointer"
-        >
-          <span>{truncate(address)}</span>
-          {copied ? (
-            <Check className="w-3 h-3 text-emerald-500" />
+        <div className="flex items-center gap-1.5 text-[11px] font-mono text-zinc-600 dark:text-zinc-400">
+          {explorerUrl ? (
+            <a
+              href={buildExplorerLink(explorerUrl, address)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-zinc-900 dark:hover:text-zinc-100 flex items-center gap-1"
+              title={`Open ${address} on block explorer`}
+            >
+              <span>{truncate(address)}</span>
+              <ExternalLink className="w-3 h-3 opacity-0 group-hover:opacity-100" />
+            </a>
           ) : (
-            <Copy className="w-3 h-3 opacity-0 group-hover:opacity-100" />
+            <span title={address}>{truncate(address)}</span>
           )}
-        </button>
+          <button
+            type="button"
+            onClick={handleCopy}
+            title={`Copy ${address}`}
+            className="hover:text-zinc-900 dark:hover:text-zinc-100 cursor-pointer"
+          >
+            {copied ? <Check className="w-3 h-3 text-emerald-500" /> : <Copy className="w-3 h-3 opacity-0 group-hover:opacity-100" />}
+          </button>
+        </div>
       ) : (
         <span className="text-[11px] text-zinc-300 dark:text-zinc-600 italic">— not deployed —</span>
       )}

--- a/app/console/ictt/_components/contract-row.tsx
+++ b/app/console/ictt/_components/contract-row.tsx
@@ -45,26 +45,26 @@ export function ContractRow({ label, address, status, explorerUrl }: ContractRow
   };
 
   return (
-    <div className="flex items-center justify-between gap-3 py-2.5 border-b border-zinc-100 dark:border-zinc-800/60 last:border-0 group">
+    <div className="flex items-center justify-between gap-3 py-2.5 border-b border-border/60 last:border-0 group">
       <div className="flex items-center gap-2.5 min-w-0">
         <span
           className={cn(
             'w-1.5 h-1.5 rounded-full flex-shrink-0',
             status === 'deployed' && 'bg-emerald-500',
             status === 'pending' && 'bg-amber-500 animate-pulse',
-            status === 'idle' && 'bg-zinc-300 dark:bg-zinc-700',
+            status === 'idle' && 'bg-muted-foreground/40',
           )}
         />
-        <span className="text-xs text-zinc-500 dark:text-zinc-400 font-medium truncate">{label}</span>
+        <span className="text-xs text-muted-foreground font-medium truncate">{label}</span>
       </div>
       {address ? (
-        <div className="flex items-center gap-1.5 text-[11px] font-mono text-zinc-600 dark:text-zinc-400">
+        <div className="flex items-center gap-1.5 text-[11px] font-mono text-foreground/80">
           {explorerUrl ? (
             <a
               href={buildExplorerLink(explorerUrl, address)}
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-zinc-900 dark:hover:text-zinc-100 flex items-center gap-1"
+              className="hover:text-foreground flex items-center gap-1"
               title={`Open ${address} on block explorer`}
             >
               <span>{truncate(address)}</span>
@@ -77,13 +77,13 @@ export function ContractRow({ label, address, status, explorerUrl }: ContractRow
             type="button"
             onClick={handleCopy}
             title={`Copy ${address}`}
-            className="hover:text-zinc-900 dark:hover:text-zinc-100 cursor-pointer"
+            className="hover:text-foreground cursor-pointer"
           >
             {copied ? <Check className="w-3 h-3 text-emerald-500" /> : <Copy className="w-3 h-3 opacity-0 group-hover:opacity-100" />}
           </button>
         </div>
       ) : (
-        <span className="text-[11px] text-zinc-300 dark:text-zinc-600 italic">— not deployed —</span>
+        <span className="text-[11px] text-muted-foreground/70 italic">— not deployed —</span>
       )}
     </div>
   );

--- a/app/console/ictt/_components/field-loading.tsx
+++ b/app/console/ictt/_components/field-loading.tsx
@@ -15,7 +15,7 @@ interface FieldLoadingProps {
 export function FieldLoading({ label, className }: FieldLoadingProps) {
   return (
     <div
-      className={`flex items-center gap-1.5 text-[10px] text-zinc-400 dark:text-zinc-500 ${className ?? ''}`}
+      className={`flex items-center gap-1.5 text-[10px] text-muted-foreground ${className ?? ''}`}
     >
       <Loader2 className="w-3 h-3 animate-spin" />
       <span>{label}</span>

--- a/app/console/ictt/_components/field-loading.tsx
+++ b/app/console/ictt/_components/field-loading.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+
+interface FieldLoadingProps {
+  label: string;
+  className?: string;
+}
+
+/**
+ * Tiny inline loading indicator for inspector fields that depend on
+ * cross-chain RPC reads. Shows a small spinner + label so users know
+ * the form isn't frozen — just waiting on a remote chain to respond.
+ */
+export function FieldLoading({ label, className }: FieldLoadingProps) {
+  return (
+    <div
+      className={`flex items-center gap-1.5 text-[10px] text-zinc-400 dark:text-zinc-500 ${className ?? ''}`}
+    >
+      <Loader2 className="w-3 h-3 animate-spin" />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/app/console/ictt/_components/icm-connection.tsx
+++ b/app/console/ictt/_components/icm-connection.tsx
@@ -86,18 +86,16 @@ function ICMPill({ accent, active, count }: { accent: string; active: boolean; c
     <div className="relative z-10 flex flex-col items-center gap-1">
       <div
         className={cn(
-          'px-3 py-2 rounded-xl border bg-white dark:bg-zinc-950 transition-shadow',
-          active
-            ? 'border-zinc-300 dark:border-zinc-700 shadow-sm'
-            : 'border-zinc-200 dark:border-zinc-800',
+          'px-3 py-2 rounded-xl border bg-card transition-shadow',
+          active ? 'border-border shadow-sm' : 'border-border/60',
         )}
       >
         <div className="text-[9px] uppercase tracking-widest font-bold" style={{ color: accent }}>
           ICM
         </div>
-        <div className="text-[10px] text-zinc-500 dark:text-zinc-400 mt-0.5 text-center">{count} msgs</div>
+        <div className="text-[10px] text-muted-foreground mt-0.5 text-center">{count} msgs</div>
       </div>
-      <div className="text-[10px] text-zinc-400 dark:text-zinc-500 text-center px-1 leading-tight">
+      <div className="text-[10px] text-muted-foreground text-center px-1 leading-tight">
         Interchain
         <br />
         Messaging

--- a/app/console/ictt/_components/icm-connection.tsx
+++ b/app/console/ictt/_components/icm-connection.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { cn } from '@/components/toolbox/lib/utils';
+
+interface ICMConnectionProps {
+  accent: string;
+  active: boolean;
+  count: number;
+  orientation?: 'vertical' | 'horizontal';
+}
+
+/**
+ * Center column rail showing ICM as the live link between two chains.
+ * Animates the dashed gradient path when an ICM message is in flight
+ * (active phase = register or transfer). Center pill shows the message
+ * count for the current bridge.
+ *
+ * Two orientations:
+ *   - vertical (default): wide-screen layout, rail runs top-to-bottom in
+ *     the center column between the two chain panels.
+ *   - horizontal: tablet-or-narrow layout, rail runs left-to-right
+ *     between stacked chain panels.
+ */
+export function ICMConnection({ accent, active, count, orientation = 'vertical' }: ICMConnectionProps) {
+  const isVertical = orientation === 'vertical';
+
+  if (isVertical) {
+    return (
+      <div className="flex flex-col items-center justify-center w-32 relative py-4">
+        <svg viewBox="0 0 128 600" preserveAspectRatio="none" className="absolute inset-0 w-full h-full">
+          <defs>
+            <linearGradient id="icm-grad-v" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0" stopColor={accent} stopOpacity="0.6" />
+              <stop offset="0.5" stopColor={accent} stopOpacity="1" />
+              <stop offset="1" stopColor={accent} stopOpacity="0.6" />
+            </linearGradient>
+          </defs>
+          <path
+            d="M 64 0 L 64 600"
+            stroke="url(#icm-grad-v)"
+            strokeWidth="1.5"
+            fill="none"
+            strokeDasharray="4 6"
+            opacity={active ? 1 : 0.3}
+          >
+            {active && (
+              <animate attributeName="stroke-dashoffset" from="0" to="-20" dur="1.2s" repeatCount="indefinite" />
+            )}
+          </path>
+        </svg>
+        <ICMPill accent={accent} active={active} count={count} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center w-full h-20 relative">
+      <svg viewBox="0 0 600 80" preserveAspectRatio="none" className="absolute inset-0 w-full h-full">
+        <defs>
+          <linearGradient id="icm-grad-h" x1="0" x2="1" y1="0" y2="0">
+            <stop offset="0" stopColor={accent} stopOpacity="0.6" />
+            <stop offset="0.5" stopColor={accent} stopOpacity="1" />
+            <stop offset="1" stopColor={accent} stopOpacity="0.6" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M 0 40 L 600 40"
+          stroke="url(#icm-grad-h)"
+          strokeWidth="1.5"
+          fill="none"
+          strokeDasharray="4 6"
+          opacity={active ? 1 : 0.3}
+        >
+          {active && (
+            <animate attributeName="stroke-dashoffset" from="0" to="-20" dur="1.2s" repeatCount="indefinite" />
+          )}
+        </path>
+      </svg>
+      <ICMPill accent={accent} active={active} count={count} />
+    </div>
+  );
+}
+
+function ICMPill({ accent, active, count }: { accent: string; active: boolean; count: number }) {
+  return (
+    <div className="relative z-10 flex flex-col items-center gap-1">
+      <div
+        className={cn(
+          'px-3 py-2 rounded-xl border bg-white dark:bg-zinc-950 transition-shadow',
+          active
+            ? 'border-zinc-300 dark:border-zinc-700 shadow-sm'
+            : 'border-zinc-200 dark:border-zinc-800',
+        )}
+      >
+        <div className="text-[9px] uppercase tracking-widest font-bold" style={{ color: accent }}>
+          ICM
+        </div>
+        <div className="text-[10px] text-zinc-500 dark:text-zinc-400 mt-0.5 text-center">{count} msgs</div>
+      </div>
+      <div className="text-[10px] text-zinc-400 dark:text-zinc-500 text-center px-1 leading-tight">
+        Interchain
+        <br />
+        Messaging
+      </div>
+    </div>
+  );
+}

--- a/app/console/ictt/_components/inspector-panel.tsx
+++ b/app/console/ictt/_components/inspector-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { PHASES, type PhaseId } from './types';
 
 interface InspectorPanelProps {
@@ -11,6 +11,13 @@ interface InspectorPanelProps {
   meta?: string;
   primaryAction?: ReactNode;
   preflight?: ReactNode;
+  /**
+   * When true, shows a `⌘ Enter` / `Ctrl Enter` hint near the meta text
+   * to advertise the keyboard shortcut. Inspectors that bind the
+   * shortcut via `useKeyboardSubmit` should pass this so users can
+   * discover it.
+   */
+  showSubmitShortcut?: boolean;
   children: ReactNode;
 }
 
@@ -34,9 +41,11 @@ export function InspectorPanel({
   meta,
   primaryAction,
   preflight,
+  showSubmitShortcut,
   children,
 }: InspectorPanelProps) {
   const phaseObj = PHASES.find((p) => p.id === phase);
+  const submitChord = useSubmitChord();
 
   return (
     <div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 overflow-hidden flex flex-col min-h-0">
@@ -58,10 +67,31 @@ export function InspectorPanel({
 
       {(meta || primaryAction) && (
         <div className="px-5 py-3 border-t border-zinc-100 dark:border-zinc-800/60 flex items-center justify-between bg-zinc-50/50 dark:bg-zinc-900/30 flex-shrink-0 gap-3">
-          <span className="text-[10px] text-zinc-400 dark:text-zinc-500 truncate">{meta}</span>
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="text-[10px] text-zinc-400 dark:text-zinc-500 truncate">{meta}</span>
+            {showSubmitShortcut && (
+              <kbd className="hidden md:inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 text-[9px] font-mono text-zinc-500 dark:text-zinc-400 flex-shrink-0">
+                {submitChord}
+              </kbd>
+            )}
+          </div>
           {primaryAction && <div className="flex items-center gap-2">{primaryAction}</div>}
         </div>
       )}
     </div>
   );
+}
+
+/**
+ * macOS uses Cmd; everything else uses Ctrl. Detected once at mount;
+ * SSR returns the generic chord so the markup is stable until hydration.
+ */
+function useSubmitChord(): string {
+  const [chord, setChord] = useState('Ctrl + Enter');
+  useEffect(() => {
+    if (typeof navigator === 'undefined') return;
+    const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent || '');
+    setChord(isMac ? '⌘ Enter' : 'Ctrl + Enter');
+  }, []);
+  return chord;
 }

--- a/app/console/ictt/_components/inspector-panel.tsx
+++ b/app/console/ictt/_components/inspector-panel.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { X } from 'lucide-react';
+import { PHASES, type PhaseId } from './types';
+
+interface InspectorPanelProps {
+  phase: PhaseId;
+  accent: string;
+  title: string;
+  description: string;
+  meta?: string;
+  primaryAction?: ReactNode;
+  onClose?: () => void;
+  preflight?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Container for phase-specific contextual content. Replaces the wall-of-
+ * fields in each step of the old wizard with a focused 2-4 field form.
+ *
+ * The phase-specific body is passed as `children`; per-phase modules in
+ * `./inspectors/` provide the form fields and wire `primaryAction` to
+ * the corresponding contract hook. `preflight` slot renders chain-
+ * mismatch / precompile warnings above the form body.
+ */
+export function InspectorPanel({
+  phase,
+  accent,
+  title,
+  description,
+  meta,
+  primaryAction,
+  onClose,
+  preflight,
+  children,
+}: InspectorPanelProps) {
+  const phaseObj = PHASES.find((p) => p.id === phase);
+
+  return (
+    <div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 overflow-hidden flex flex-col min-h-0">
+      <div className="px-5 pt-5 pb-3 border-b border-zinc-100 dark:border-zinc-800/60 flex items-start justify-between gap-3 flex-shrink-0">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="w-1.5 h-1.5 rounded-full" style={{ background: accent }} />
+            <span className="text-[10px] uppercase tracking-widest font-bold" style={{ color: accent }}>
+              {phaseObj?.label ?? phase}
+            </span>
+          </div>
+          <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">{title}</h3>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-1 max-w-md">{description}</p>
+        </div>
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 cursor-pointer p-1 -m-1 rounded"
+            aria-label="Close inspector"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      <div className="px-5 py-4 space-y-4 overflow-y-auto flex-1 min-h-0">
+        {preflight}
+        {children}
+      </div>
+
+      {(meta || primaryAction) && (
+        <div className="px-5 py-3 border-t border-zinc-100 dark:border-zinc-800/60 flex items-center justify-between bg-zinc-50/50 dark:bg-zinc-900/30 flex-shrink-0 gap-3">
+          <span className="text-[10px] text-zinc-400 dark:text-zinc-500 truncate">{meta}</span>
+          {primaryAction && <div className="flex items-center gap-2">{primaryAction}</div>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/console/ictt/_components/inspector-panel.tsx
+++ b/app/console/ictt/_components/inspector-panel.tsx
@@ -48,16 +48,16 @@ export function InspectorPanel({
   const submitChord = useSubmitChord();
 
   return (
-    <div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 overflow-hidden flex flex-col min-h-0">
-      <div className="px-5 pt-5 pb-3 border-b border-zinc-100 dark:border-zinc-800/60 flex flex-col gap-1 flex-shrink-0">
+    <div className="rounded-2xl border border-border bg-card overflow-hidden flex flex-col min-h-0">
+      <div className="px-5 pt-5 pb-3 border-b border-border/60 flex flex-col gap-1 flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="w-1.5 h-1.5 rounded-full" style={{ background: accent }} />
           <span className="text-[10px] uppercase tracking-widest font-bold" style={{ color: accent }}>
             {phaseObj?.label ?? phase}
           </span>
         </div>
-        <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">{title}</h3>
-        <p className="text-xs text-zinc-500 dark:text-zinc-400 max-w-md">{description}</p>
+        <h3 className="text-base font-semibold text-foreground">{title}</h3>
+        <p className="text-xs text-muted-foreground max-w-md">{description}</p>
       </div>
 
       <div className="px-5 py-4 space-y-4 overflow-y-auto flex-1 min-h-0">
@@ -66,11 +66,11 @@ export function InspectorPanel({
       </div>
 
       {(meta || primaryAction) && (
-        <div className="px-5 py-3 border-t border-zinc-100 dark:border-zinc-800/60 flex items-center justify-between bg-zinc-50/50 dark:bg-zinc-900/30 flex-shrink-0 gap-3">
+        <div className="px-5 py-3 border-t border-border/60 flex items-center justify-between bg-muted/30 flex-shrink-0 gap-3">
           <div className="flex items-center gap-2 min-w-0">
-            <span className="text-[10px] text-zinc-400 dark:text-zinc-500 truncate">{meta}</span>
+            <span className="text-[10px] text-muted-foreground truncate">{meta}</span>
             {showSubmitShortcut && (
-              <kbd className="hidden md:inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 text-[9px] font-mono text-zinc-500 dark:text-zinc-400 flex-shrink-0">
+              <kbd className="hidden md:inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border border-border bg-background text-[9px] font-mono text-muted-foreground flex-shrink-0">
                 {submitChord}
               </kbd>
             )}

--- a/app/console/ictt/_components/inspector-panel.tsx
+++ b/app/console/ictt/_components/inspector-panel.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { X } from 'lucide-react';
 import { PHASES, type PhaseId } from './types';
 
 interface InspectorPanelProps {
@@ -11,7 +10,6 @@ interface InspectorPanelProps {
   description: string;
   meta?: string;
   primaryAction?: ReactNode;
-  onClose?: () => void;
   preflight?: ReactNode;
   children: ReactNode;
 }
@@ -24,6 +22,9 @@ interface InspectorPanelProps {
  * `./inspectors/` provide the form fields and wire `primaryAction` to
  * the corresponding contract hook. `preflight` slot renders chain-
  * mismatch / precompile warnings above the form body.
+ *
+ * No close (×) button — the phase strip is the navigation surface;
+ * a redundant close that often resolves to a no-op was confusing.
  */
 export function InspectorPanel({
   phase,
@@ -32,7 +33,6 @@ export function InspectorPanel({
   description,
   meta,
   primaryAction,
-  onClose,
   preflight,
   children,
 }: InspectorPanelProps) {
@@ -40,27 +40,15 @@ export function InspectorPanel({
 
   return (
     <div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 overflow-hidden flex flex-col min-h-0">
-      <div className="px-5 pt-5 pb-3 border-b border-zinc-100 dark:border-zinc-800/60 flex items-start justify-between gap-3 flex-shrink-0">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2 mb-1">
-            <span className="w-1.5 h-1.5 rounded-full" style={{ background: accent }} />
-            <span className="text-[10px] uppercase tracking-widest font-bold" style={{ color: accent }}>
-              {phaseObj?.label ?? phase}
-            </span>
-          </div>
-          <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">{title}</h3>
-          <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-1 max-w-md">{description}</p>
+      <div className="px-5 pt-5 pb-3 border-b border-zinc-100 dark:border-zinc-800/60 flex flex-col gap-1 flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <span className="w-1.5 h-1.5 rounded-full" style={{ background: accent }} />
+          <span className="text-[10px] uppercase tracking-widest font-bold" style={{ color: accent }}>
+            {phaseObj?.label ?? phase}
+          </span>
         </div>
-        {onClose && (
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 cursor-pointer p-1 -m-1 rounded"
-            aria-label="Close inspector"
-          >
-            <X className="w-4 h-4" />
-          </button>
-        )}
+        <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">{title}</h3>
+        <p className="text-xs text-zinc-500 dark:text-zinc-400 max-w-md">{description}</p>
       </div>
 
       <div className="px-5 py-4 space-y-4 overflow-y-auto flex-1 min-h-0">

--- a/app/console/ictt/_components/inspectors/collateral-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/collateral-inspector.tsx
@@ -13,6 +13,7 @@ import { Input } from '@/components/toolbox/components/Input';
 import { Note } from '@/components/toolbox/components/Note';
 import { InspectorPanel } from '../inspector-panel';
 import { usePreflight } from '../use-preflight';
+import { FieldLoading } from '../field-loading';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent } from '../types';
 
@@ -50,6 +51,7 @@ export function CollateralInspector({
   const [allowance, setAllowance] = useState<bigint>(0n);
   const [amount, setAmount] = useState<string>('');
   const [localError, setLocalError] = useState<string | null>(null);
+  const [isReading, setIsReading] = useState(false);
 
   // For ERC20 path: read the token address from the home contract
   // (`getTokenAddress`) plus decimals + the user's allowance to gate the
@@ -59,6 +61,7 @@ export function CollateralInspector({
     let cancelled = false;
     const client = makePublicClientForChain(bridge.homeChain.rpcUrl);
     if (!client) return;
+    setIsReading(true);
     (async () => {
       try {
         if (bridge.homeKind === 'erc20') {
@@ -90,6 +93,8 @@ export function CollateralInspector({
         }
       } catch (e: any) {
         if (!cancelled) setLocalError(`Read failed: ${e?.shortMessage ?? e?.message ?? ''}`);
+      } finally {
+        if (!cancelled) setIsReading(false);
       }
     })();
     return () => {
@@ -225,6 +230,8 @@ export function CollateralInspector({
         type="number"
         helperText={`Pre-filled with collateralNeeded (${collateralNeededFormatted}). Editable — partial funding allowed; top up later.`}
       />
+
+      {isReading && <FieldLoading label="Reading decimals + allowance from home chain…" />}
 
       {bridge.homeKind === 'erc20' && (
         <Note variant="default">

--- a/app/console/ictt/_components/inspectors/collateral-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/collateral-inspector.tsx
@@ -13,6 +13,7 @@ import { Input } from '@/components/toolbox/components/Input';
 import { Note } from '@/components/toolbox/components/Note';
 import { InspectorPanel } from '../inspector-panel';
 import { usePreflight } from '../use-preflight';
+import { useKeyboardSubmit } from '../use-keyboard-submit';
 import { FieldLoading } from '../field-loading';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent } from '../types';
@@ -180,6 +181,12 @@ export function CollateralInspector({
   // decreases as collateral lands. When `needed === 0`, we're 100% funded.
   const fullyFunded = bridge.registered && bridge.collateralNeeded === 0n;
   const error = localError || hookError;
+  // Cmd+Enter binds to whichever primary action is currently visible:
+  // Continue (when fully funded), Approve (when allowance < amount), or
+  // Add collateral (otherwise).
+  const submitHandler = fullyFunded ? onAdvance : needsApproval ? handleApprove : handleAddCollateral;
+  const canSubmit = fullyFunded || (parsedAmount > 0n && status === 'idle');
+  useKeyboardSubmit({ onSubmit: submitHandler, enabled: canSubmit });
 
   return (
     <InspectorPanel
@@ -194,6 +201,7 @@ export function CollateralInspector({
               bridge.homeKind === 'native' ? bridge.homeChain?.coinName ?? 'tokens' : 'tokens'
             }`
       }
+      showSubmitShortcut={canSubmit}
       primaryAction={
         fullyFunded ? (
           <Button onClick={onAdvance} variant="secondary" stickLeft>

--- a/app/console/ictt/_components/inspectors/collateral-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/collateral-inspector.tsx
@@ -250,12 +250,12 @@ export function CollateralInspector({
 
       <div>
         <div className="flex items-center justify-between mb-2 text-xs">
-          <span className="text-zinc-600 dark:text-zinc-400">Funded</span>
-          <span className="font-mono text-zinc-900 dark:text-zinc-100">
+          <span className="text-muted-foreground">Funded</span>
+          <span className="font-mono text-foreground">
             {fullyFunded ? '100%' : `${collateralNeededFormatted} remaining`}
           </span>
         </div>
-        <div className="h-1.5 bg-zinc-200 dark:bg-zinc-800 rounded-full overflow-hidden">
+        <div className="h-1.5 bg-muted rounded-full overflow-hidden">
           <div
             className="h-full rounded-full transition-all"
             style={{ width: fullyFunded ? '100%' : '0%', background: accent }}

--- a/app/console/ictt/_components/inspectors/collateral-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/collateral-inspector.tsx
@@ -3,14 +3,11 @@
 import { useEffect, useState } from 'react';
 import { formatUnits, parseUnits } from 'viem';
 import ERC20TokenHomeABI from '@/contracts/icm-contracts/compiled/ERC20TokenHome.json';
-import NativeTokenHomeABI from '@/contracts/icm-contracts/compiled/NativeTokenHome.json';
 import ExampleERC20 from '@/contracts/icm-contracts/compiled/ExampleERC20.json';
 import { useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
 import { useWalletStore } from '@/components/toolbox/stores/walletStore';
-import { useResolvedWalletClient } from '@/components/toolbox/hooks/useResolvedWalletClient';
 import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
-import useConsoleNotifications from '@/hooks/useConsoleNotifications';
-import { cb58ToHex } from '@/components/tools/common/utils/cb58';
+import { useAddCollateral } from '@/components/toolbox/console/ictt/hooks/useAddCollateral';
 import { Button } from '@/components/toolbox/components/Button';
 import { Input } from '@/components/toolbox/components/Input';
 import { Note } from '@/components/toolbox/components/Note';
@@ -32,6 +29,10 @@ interface CollateralInspectorProps {
  * Collateral phase: fund the Home contract so the bridge can mint on
  * Remote. ERC-20 home requires a two-step (approve + addCollateral)
  * sequence; native home sends value directly.
+ *
+ * On-chain mechanics live in `useAddCollateral`. This inspector owns
+ * just the cross-chain reads (token address, decimals, allowance) used
+ * to drive the UI's approve-vs-deposit gate.
  */
 export function CollateralInspector({
   bridge,
@@ -41,21 +42,20 @@ export function CollateralInspector({
   appendActivity,
   switchChain,
 }: CollateralInspectorProps) {
-  const walletClient = useResolvedWalletClient();
   const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
   const walletChainId = useWalletStore((s) => s.walletChainId);
   const viemChain = useViemChainStore();
-  const { notify } = useConsoleNotifications();
+  const { approve, addCollateral, status, isApproving, isDepositing, error: hookError } = useAddCollateral();
 
   const [decimals, setDecimals] = useState<number>(18);
   const [tokenAddress, setTokenAddress] = useState<string | null>(null);
   const [allowance, setAllowance] = useState<bigint>(0n);
   const [amount, setAmount] = useState<string>('');
-  const [error, setError] = useState<string | null>(null);
-  const [working, setWorking] = useState<'idle' | 'approving' | 'depositing'>('idle');
+  const [localError, setLocalError] = useState<string | null>(null);
 
-  // For ERC20 path: read the token address (the home's `getTokenAddress`)
-  // and the user's allowance. For native path, no approval is needed.
+  // For ERC20 path: read the token address from the home contract
+  // (`getTokenAddress`) plus decimals + the user's allowance to gate the
+  // approve-then-deposit flow. Native path needs no approval.
   useEffect(() => {
     if (!bridge.homeChain?.rpcUrl || !bridge.homeAddress) return;
     let cancelled = false;
@@ -91,15 +91,15 @@ export function CollateralInspector({
           if (!cancelled) setDecimals(18);
         }
       } catch (e: any) {
-        if (!cancelled) setError(`Read failed: ${e?.shortMessage ?? e?.message ?? ''}`);
+        if (!cancelled) setLocalError(`Read failed: ${e?.shortMessage ?? e?.message ?? ''}`);
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [bridge.homeChain?.rpcUrl, bridge.homeAddress, bridge.homeKind, walletEVMAddress, working]);
+  }, [bridge.homeChain?.rpcUrl, bridge.homeAddress, bridge.homeKind, walletEVMAddress, status]);
 
-  // Pre-fill amount with collateralNeeded.
+  // Pre-fill amount with collateralNeeded when known.
   useEffect(() => {
     if (!amount && bridge.collateralNeeded > 0n) {
       setAmount(formatUnits(bridge.collateralNeeded, decimals));
@@ -117,94 +117,56 @@ export function CollateralInspector({
   const needsApproval = bridge.homeKind === 'erc20' && parsedAmount > allowance;
 
   const handleApprove = async () => {
-    setError(null);
-    if (!walletClient?.account || !viemChain || !tokenAddress || !bridge.homeAddress) {
-      setError('Wallet or token not ready');
+    setLocalError(null);
+    if (!tokenAddress || !bridge.homeAddress) {
+      setLocalError('Token or home contract not loaded yet');
       return;
     }
-    setWorking('approving');
     try {
-      const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
-      if (!client) throw new Error('Could not create RPC client');
-      const { request } = await client.simulateContract({
-        address: tokenAddress as `0x${string}`,
-        abi: ExampleERC20.abi,
-        functionName: 'approve',
-        args: [bridge.homeAddress as `0x${string}`, parsedAmount],
-        chain: viemChain,
-        account: walletClient.account,
+      const result = await approve({
+        tokenAddress,
+        homeAddress: bridge.homeAddress,
+        amount: parsedAmount,
       });
-      const writePromise = walletClient.writeContract(request);
-      notify({ type: 'call', name: 'Approve Token' }, writePromise, viemChain);
-      const hash = await writePromise;
-      await client.waitForTransactionReceipt({ hash });
       setAllowance(parsedAmount);
-      appendActivity({ kind: 'collateral', label: 'Approved collateral spend', txHash: hash, chainId: viemChain.id });
+      appendActivity({
+        kind: 'collateral',
+        label: 'Approved collateral spend',
+        txHash: result.hash,
+        chainId: viemChain?.id,
+      });
     } catch (e: any) {
       const msg = e?.shortMessage ?? e?.message ?? 'Approve failed';
-      setError(msg);
       appendActivity({ kind: 'error', label: `Approve failed: ${msg}` });
-    } finally {
-      setWorking('idle');
     }
   };
 
   const handleAddCollateral = async () => {
-    setError(null);
-    if (!walletClient?.account || !viemChain || !bridge.homeAddress || !bridge.remoteChain || !bridge.remoteAddress) {
-      setError('Bridge not fully set up');
+    setLocalError(null);
+    if (!bridge.homeAddress || !bridge.remoteChain || !bridge.remoteAddress) {
+      setLocalError('Bridge not fully set up');
       return;
     }
-    if (parsedAmount === 0n) {
-      setError('Enter an amount');
-      return;
-    }
-    let remoteHex: string;
     try {
-      remoteHex = cb58ToHex(bridge.remoteChain.id);
-    } catch {
-      setError('Could not encode remote chain ID');
-      return;
-    }
-
-    setWorking('depositing');
-    try {
-      const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
-      if (!client) throw new Error('Could not create RPC client');
-
-      const isNative = bridge.homeKind === 'native';
-      const args = isNative
-        ? [remoteHex, bridge.remoteAddress as `0x${string}`]
-        : [remoteHex, bridge.remoteAddress as `0x${string}`, parsedAmount];
-
-      const { request } = await client.simulateContract({
-        address: bridge.homeAddress as `0x${string}`,
-        abi: (isNative ? NativeTokenHomeABI.abi : ERC20TokenHomeABI.abi) as any,
-        functionName: 'addCollateral',
-        args,
-        chain: viemChain,
-        account: walletClient.account,
-        ...(isNative ? { value: parsedAmount } : {}),
+      const result = await addCollateral({
+        homeAddress: bridge.homeAddress,
+        homeKind: bridge.homeKind,
+        remoteChainId: bridge.remoteChain.id,
+        remoteAddress: bridge.remoteAddress,
+        amount: parsedAmount,
       });
-      const writePromise = walletClient.writeContract(request);
-      notify({ type: 'call', name: 'Add Collateral' }, writePromise, viemChain);
-      const hash = await writePromise;
-      await client.waitForTransactionReceipt({ hash });
       appendActivity({
         kind: 'collateral',
         label: `Collateral funded (${amount})`,
         amount,
-        txHash: hash,
-        chainId: viemChain.id,
+        txHash: result.hash,
+        chainId: viemChain?.id,
       });
       bridge.refresh();
       onAdvance();
     } catch (e: any) {
       const msg = e?.shortMessage ?? e?.message ?? 'Add collateral failed';
-      setError(msg);
       appendActivity({ kind: 'error', label: `Add collateral failed: ${msg}` });
-    } finally {
-      setWorking('idle');
     }
   };
 
@@ -215,9 +177,10 @@ export function CollateralInspector({
   const collateralNeededFormatted =
     bridge.collateralNeeded > 0n ? formatUnits(bridge.collateralNeeded, decimals) : '0';
 
-  // Progress: a heuristic since we only know `needed` (decreases as
-  // funded). When needed = 0, we're 100% funded.
+  // Progress is a heuristic — the contract only exposes `needed`, which
+  // decreases as collateral lands. When `needed === 0`, we're 100% funded.
   const fullyFunded = bridge.registered && bridge.collateralNeeded === 0n;
+  const error = localError || hookError;
 
   return (
     <InspectorPanel
@@ -228,7 +191,9 @@ export function CollateralInspector({
       meta={
         fullyFunded
           ? 'Fully collateralized.'
-          : `Remaining: ${collateralNeededFormatted} ${bridge.homeKind === 'native' ? bridge.homeChain?.coinName ?? 'tokens' : 'tokens'}`
+          : `Remaining: ${collateralNeededFormatted} ${
+              bridge.homeKind === 'native' ? bridge.homeChain?.coinName ?? 'tokens' : 'tokens'
+            }`
       }
       primaryAction={
         fullyFunded ? (
@@ -238,9 +203,9 @@ export function CollateralInspector({
         ) : needsApproval ? (
           <Button
             onClick={handleApprove}
-            loading={working === 'approving'}
+            loading={isApproving}
             loadingText="Approving..."
-            disabled={parsedAmount === 0n || working !== 'idle'}
+            disabled={parsedAmount === 0n || status !== 'idle'}
             stickLeft
           >
             Approve →
@@ -248,9 +213,9 @@ export function CollateralInspector({
         ) : (
           <Button
             onClick={handleAddCollateral}
-            loading={working === 'depositing'}
+            loading={isDepositing}
             loadingText="Depositing..."
-            disabled={parsedAmount === 0n || working !== 'idle'}
+            disabled={parsedAmount === 0n || status !== 'idle'}
             stickLeft
           >
             Add collateral →
@@ -283,7 +248,6 @@ export function CollateralInspector({
         </Note>
       )}
 
-      {/* Progress bar */}
       <div>
         <div className="flex items-center justify-between mb-2 text-xs">
           <span className="text-zinc-600 dark:text-zinc-400">Funded</span>

--- a/app/console/ictt/_components/inspectors/collateral-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/collateral-inspector.tsx
@@ -1,0 +1,309 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { formatUnits, parseUnits } from 'viem';
+import ERC20TokenHomeABI from '@/contracts/icm-contracts/compiled/ERC20TokenHome.json';
+import NativeTokenHomeABI from '@/contracts/icm-contracts/compiled/NativeTokenHome.json';
+import ExampleERC20 from '@/contracts/icm-contracts/compiled/ExampleERC20.json';
+import { useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
+import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import { useResolvedWalletClient } from '@/components/toolbox/hooks/useResolvedWalletClient';
+import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
+import useConsoleNotifications from '@/hooks/useConsoleNotifications';
+import { cb58ToHex } from '@/components/tools/common/utils/cb58';
+import { Button } from '@/components/toolbox/components/Button';
+import { Input } from '@/components/toolbox/components/Input';
+import { Note } from '@/components/toolbox/components/Note';
+import { InspectorPanel } from '../inspector-panel';
+import { ChainMismatchBanner } from './preflight-banner';
+import type { BridgeState } from '../use-bridge-state';
+import type { ActivityEvent } from '../types';
+
+interface CollateralInspectorProps {
+  bridge: BridgeState;
+  accent: string;
+  onClose: () => void;
+  onAdvance: () => void;
+  appendActivity: (event: Omit<ActivityEvent, 'id' | 'timestamp'>) => void;
+  switchChain: (chainId: number, isTestnet: boolean) => Promise<void>;
+}
+
+/**
+ * Collateral phase: fund the Home contract so the bridge can mint on
+ * Remote. ERC-20 home requires a two-step (approve + addCollateral)
+ * sequence; native home sends value directly.
+ */
+export function CollateralInspector({
+  bridge,
+  accent,
+  onClose,
+  onAdvance,
+  appendActivity,
+  switchChain,
+}: CollateralInspectorProps) {
+  const walletClient = useResolvedWalletClient();
+  const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
+  const walletChainId = useWalletStore((s) => s.walletChainId);
+  const viemChain = useViemChainStore();
+  const { notify } = useConsoleNotifications();
+
+  const [decimals, setDecimals] = useState<number>(18);
+  const [tokenAddress, setTokenAddress] = useState<string | null>(null);
+  const [allowance, setAllowance] = useState<bigint>(0n);
+  const [amount, setAmount] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
+  const [working, setWorking] = useState<'idle' | 'approving' | 'depositing'>('idle');
+
+  // For ERC20 path: read the token address (the home's `getTokenAddress`)
+  // and the user's allowance. For native path, no approval is needed.
+  useEffect(() => {
+    if (!bridge.homeChain?.rpcUrl || !bridge.homeAddress) return;
+    let cancelled = false;
+    const client = makePublicClientForChain(bridge.homeChain.rpcUrl);
+    if (!client) return;
+    (async () => {
+      try {
+        if (bridge.homeKind === 'erc20') {
+          const tokenAddr = (await client.readContract({
+            address: bridge.homeAddress as `0x${string}`,
+            abi: ERC20TokenHomeABI.abi,
+            functionName: 'getTokenAddress',
+          })) as `0x${string}`;
+          if (cancelled) return;
+          setTokenAddress(tokenAddr);
+          const dec = (await client.readContract({
+            address: tokenAddr,
+            abi: ExampleERC20.abi,
+            functionName: 'decimals',
+          })) as bigint;
+          if (cancelled) return;
+          setDecimals(Number(dec));
+          if (walletEVMAddress) {
+            const allow = (await client.readContract({
+              address: tokenAddr,
+              abi: ExampleERC20.abi,
+              functionName: 'allowance',
+              args: [walletEVMAddress, bridge.homeAddress as `0x${string}`],
+            })) as bigint;
+            if (!cancelled) setAllowance(allow);
+          }
+        } else {
+          if (!cancelled) setDecimals(18);
+        }
+      } catch (e: any) {
+        if (!cancelled) setError(`Read failed: ${e?.shortMessage ?? e?.message ?? ''}`);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [bridge.homeChain?.rpcUrl, bridge.homeAddress, bridge.homeKind, walletEVMAddress, working]);
+
+  // Pre-fill amount with collateralNeeded.
+  useEffect(() => {
+    if (!amount && bridge.collateralNeeded > 0n) {
+      setAmount(formatUnits(bridge.collateralNeeded, decimals));
+    }
+  }, [amount, bridge.collateralNeeded, decimals]);
+
+  const parsedAmount = (() => {
+    try {
+      return amount ? parseUnits(amount, decimals) : 0n;
+    } catch {
+      return 0n;
+    }
+  })();
+
+  const needsApproval = bridge.homeKind === 'erc20' && parsedAmount > allowance;
+
+  const handleApprove = async () => {
+    setError(null);
+    if (!walletClient?.account || !viemChain || !tokenAddress || !bridge.homeAddress) {
+      setError('Wallet or token not ready');
+      return;
+    }
+    setWorking('approving');
+    try {
+      const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
+      if (!client) throw new Error('Could not create RPC client');
+      const { request } = await client.simulateContract({
+        address: tokenAddress as `0x${string}`,
+        abi: ExampleERC20.abi,
+        functionName: 'approve',
+        args: [bridge.homeAddress as `0x${string}`, parsedAmount],
+        chain: viemChain,
+        account: walletClient.account,
+      });
+      const writePromise = walletClient.writeContract(request);
+      notify({ type: 'call', name: 'Approve Token' }, writePromise, viemChain);
+      const hash = await writePromise;
+      await client.waitForTransactionReceipt({ hash });
+      setAllowance(parsedAmount);
+      appendActivity({ kind: 'collateral', label: 'Approved collateral spend', txHash: hash, chainId: viemChain.id });
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? 'Approve failed';
+      setError(msg);
+      appendActivity({ kind: 'error', label: `Approve failed: ${msg}` });
+    } finally {
+      setWorking('idle');
+    }
+  };
+
+  const handleAddCollateral = async () => {
+    setError(null);
+    if (!walletClient?.account || !viemChain || !bridge.homeAddress || !bridge.remoteChain || !bridge.remoteAddress) {
+      setError('Bridge not fully set up');
+      return;
+    }
+    if (parsedAmount === 0n) {
+      setError('Enter an amount');
+      return;
+    }
+    let remoteHex: string;
+    try {
+      remoteHex = cb58ToHex(bridge.remoteChain.id);
+    } catch {
+      setError('Could not encode remote chain ID');
+      return;
+    }
+
+    setWorking('depositing');
+    try {
+      const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
+      if (!client) throw new Error('Could not create RPC client');
+
+      const isNative = bridge.homeKind === 'native';
+      const args = isNative
+        ? [remoteHex, bridge.remoteAddress as `0x${string}`]
+        : [remoteHex, bridge.remoteAddress as `0x${string}`, parsedAmount];
+
+      const { request } = await client.simulateContract({
+        address: bridge.homeAddress as `0x${string}`,
+        abi: (isNative ? NativeTokenHomeABI.abi : ERC20TokenHomeABI.abi) as any,
+        functionName: 'addCollateral',
+        args,
+        chain: viemChain,
+        account: walletClient.account,
+        ...(isNative ? { value: parsedAmount } : {}),
+      });
+      const writePromise = walletClient.writeContract(request);
+      notify({ type: 'call', name: 'Add Collateral' }, writePromise, viemChain);
+      const hash = await writePromise;
+      await client.waitForTransactionReceipt({ hash });
+      appendActivity({
+        kind: 'collateral',
+        label: `Collateral funded (${amount})`,
+        amount,
+        txHash: hash,
+        chainId: viemChain.id,
+      });
+      bridge.refresh();
+      onAdvance();
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? 'Add collateral failed';
+      setError(msg);
+      appendActivity({ kind: 'error', label: `Add collateral failed: ${msg}` });
+    } finally {
+      setWorking('idle');
+    }
+  };
+
+  const onSwitchToHome = bridge.homeChain
+    ? () => switchChain(bridge.homeChain!.evmChainId, !!bridge.homeChain!.isTestnet)
+    : undefined;
+
+  const collateralNeededFormatted =
+    bridge.collateralNeeded > 0n ? formatUnits(bridge.collateralNeeded, decimals) : '0';
+
+  // Progress: a heuristic since we only know `needed` (decreases as
+  // funded). When needed = 0, we're 100% funded.
+  const fullyFunded = bridge.registered && bridge.collateralNeeded === 0n;
+
+  return (
+    <InspectorPanel
+      phase="collateral"
+      accent={accent}
+      title="Add collateral to Home"
+      description="Fund the bridge so users can withdraw on the Remote side. Required before live transfers can flow."
+      meta={
+        fullyFunded
+          ? 'Fully collateralized.'
+          : `Remaining: ${collateralNeededFormatted} ${bridge.homeKind === 'native' ? bridge.homeChain?.coinName ?? 'tokens' : 'tokens'}`
+      }
+      primaryAction={
+        fullyFunded ? (
+          <Button onClick={onAdvance} variant="secondary" stickLeft>
+            Continue → Live
+          </Button>
+        ) : needsApproval ? (
+          <Button
+            onClick={handleApprove}
+            loading={working === 'approving'}
+            loadingText="Approving..."
+            disabled={parsedAmount === 0n || working !== 'idle'}
+            stickLeft
+          >
+            Approve →
+          </Button>
+        ) : (
+          <Button
+            onClick={handleAddCollateral}
+            loading={working === 'depositing'}
+            loadingText="Depositing..."
+            disabled={parsedAmount === 0n || working !== 'idle'}
+            stickLeft
+          >
+            Add collateral →
+          </Button>
+        )
+      }
+      onClose={onClose}
+      preflight={
+        bridge.homeChain ? (
+          <ChainMismatchBanner
+            expectedChain={bridge.homeChain}
+            walletChainId={walletChainId}
+            onSwitch={onSwitchToHome}
+          />
+        ) : null
+      }
+    >
+      <Input
+        label={bridge.homeKind === 'native' ? `Amount (${bridge.homeChain?.coinName ?? 'native'})` : 'Amount (tokens)'}
+        value={amount}
+        onChange={setAmount}
+        type="number"
+        helperText={`Pre-filled with collateralNeeded (${collateralNeededFormatted}). Editable — partial funding allowed; top up later.`}
+      />
+
+      {bridge.homeKind === 'erc20' && (
+        <Note variant="default">
+          ERC-20 collateral needs two transactions: <strong>approve</strong> the home contract, then{' '}
+          <strong>addCollateral</strong>.
+        </Note>
+      )}
+
+      {/* Progress bar */}
+      <div>
+        <div className="flex items-center justify-between mb-2 text-xs">
+          <span className="text-zinc-600 dark:text-zinc-400">Funded</span>
+          <span className="font-mono text-zinc-900 dark:text-zinc-100">
+            {fullyFunded ? '100%' : `${collateralNeededFormatted} remaining`}
+          </span>
+        </div>
+        <div className="h-1.5 bg-zinc-200 dark:bg-zinc-800 rounded-full overflow-hidden">
+          <div
+            className="h-full rounded-full transition-all"
+            style={{ width: fullyFunded ? '100%' : '0%', background: accent }}
+          />
+        </div>
+      </div>
+
+      {error && (
+        <Note variant="destructive">
+          <p>{error}</p>
+        </Note>
+      )}
+    </InspectorPanel>
+  );
+}

--- a/app/console/ictt/_components/inspectors/collateral-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/collateral-inspector.tsx
@@ -12,14 +12,13 @@ import { Button } from '@/components/toolbox/components/Button';
 import { Input } from '@/components/toolbox/components/Input';
 import { Note } from '@/components/toolbox/components/Note';
 import { InspectorPanel } from '../inspector-panel';
-import { ChainMismatchBanner } from './preflight-banner';
+import { usePreflight } from '../use-preflight';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent } from '../types';
 
 interface CollateralInspectorProps {
   bridge: BridgeState;
   accent: string;
-  onClose: () => void;
   onAdvance: () => void;
   appendActivity: (event: Omit<ActivityEvent, 'id' | 'timestamp'>) => void;
   switchChain: (chainId: number, isTestnet: boolean) => Promise<void>;
@@ -37,15 +36,14 @@ interface CollateralInspectorProps {
 export function CollateralInspector({
   bridge,
   accent,
-  onClose,
   onAdvance,
   appendActivity,
   switchChain,
 }: CollateralInspectorProps) {
   const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
-  const walletChainId = useWalletStore((s) => s.walletChainId);
   const viemChain = useViemChainStore();
   const { approve, addCollateral, status, isApproving, isDepositing, error: hookError } = useAddCollateral();
+  const { banner: preflight } = usePreflight({ expectedChain: bridge.homeChain, switchChain });
 
   const [decimals, setDecimals] = useState<number>(18);
   const [tokenAddress, setTokenAddress] = useState<string | null>(null);
@@ -170,10 +168,6 @@ export function CollateralInspector({
     }
   };
 
-  const onSwitchToHome = bridge.homeChain
-    ? () => switchChain(bridge.homeChain!.evmChainId, !!bridge.homeChain!.isTestnet)
-    : undefined;
-
   const collateralNeededFormatted =
     bridge.collateralNeeded > 0n ? formatUnits(bridge.collateralNeeded, decimals) : '0';
 
@@ -222,16 +216,7 @@ export function CollateralInspector({
           </Button>
         )
       }
-      onClose={onClose}
-      preflight={
-        bridge.homeChain ? (
-          <ChainMismatchBanner
-            expectedChain={bridge.homeChain}
-            walletChainId={walletChainId}
-            onSwitch={onSwitchToHome}
-          />
-        ) : null
-      }
+      preflight={preflight}
     >
       <Input
         label={bridge.homeKind === 'native' ? `Amount (${bridge.homeChain?.coinName ?? 'native'})` : 'Amount (tokens)'}

--- a/app/console/ictt/_components/inspectors/home-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/home-inspector.tsx
@@ -12,14 +12,13 @@ import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicCl
 import { useDeployTokenHome } from '@/components/toolbox/console/ictt/hooks/useDeployTokenHome';
 import { InspectorPanel } from '../inspector-panel';
 import { SegmentControl } from '../segment-control';
-import { ChainMismatchBanner } from './preflight-banner';
+import { usePreflight } from '../use-preflight';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent, TokenKind } from '../types';
 
 interface HomeInspectorProps {
   bridge: BridgeState;
   accent: string;
-  onClose: () => void;
   onAdvance: () => void;
   appendActivity: (event: Omit<ActivityEvent, 'id' | 'timestamp'>) => void;
   switchChain: (chainId: number, isTestnet: boolean) => Promise<void>;
@@ -33,15 +32,14 @@ interface HomeInspectorProps {
 export function HomeInspector({
   bridge,
   accent,
-  onClose,
   onAdvance,
   appendActivity,
   switchChain,
 }: HomeInspectorProps) {
   const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
-  const walletChainId = useWalletStore((s) => s.walletChainId);
   const viemChain = useViemChainStore();
   const { run: runDeploy, isDeploying, error: deployError } = useDeployTokenHome();
+  const { banner: preflight } = usePreflight({ expectedChain: bridge.homeChain, switchChain });
 
   const [kind, setKind] = useState<TokenKind>('erc20');
   const [registry, setRegistry] = useState(bridge.homeChain?.wellKnownTeleporterRegistryAddress ?? '');
@@ -111,10 +109,6 @@ export function HomeInspector({
     }
   };
 
-  const onSwitchToHome = bridge.homeChain
-    ? () => switchChain(bridge.homeChain!.evmChainId, !!bridge.homeChain!.isTestnet)
-    : undefined;
-
   const error = localError || deployError;
 
   return (
@@ -135,16 +129,7 @@ export function HomeInspector({
           Deploy TokenHome →
         </Button>
       }
-      onClose={onClose}
-      preflight={
-        bridge.homeChain ? (
-          <ChainMismatchBanner
-            expectedChain={bridge.homeChain}
-            walletChainId={walletChainId}
-            onSwitch={onSwitchToHome}
-          />
-        ) : null
-      }
+      preflight={preflight}
     >
       <div>
         <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">

--- a/app/console/ictt/_components/inspectors/home-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/home-inspector.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import ERC20TokenHome from '@/contracts/icm-contracts/compiled/ERC20TokenHome.json';
+import NativeTokenHome from '@/contracts/icm-contracts/compiled/NativeTokenHome.json';
+import ExampleERC20 from '@/contracts/icm-contracts/compiled/ExampleERC20.json';
+import { useToolboxStore, useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
+import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import { useContractDeployer } from '@/components/toolbox/hooks/contracts';
+import { Button } from '@/components/toolbox/components/Button';
+import { Input } from '@/components/toolbox/components/Input';
+import { Note } from '@/components/toolbox/components/Note';
+import TeleporterRegistryAddressInput from '@/components/toolbox/components/TeleporterRegistryAddressInput';
+import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
+import { InspectorPanel } from '../inspector-panel';
+import { SegmentControl } from '../segment-control';
+import { ChainMismatchBanner } from './preflight-banner';
+import type { BridgeState } from '../use-bridge-state';
+import type { ActivityEvent, TokenKind } from '../types';
+
+interface HomeInspectorProps {
+  bridge: BridgeState;
+  accent: string;
+  onClose: () => void;
+  onAdvance: () => void;
+  appendActivity: (event: Omit<ActivityEvent, 'id' | 'timestamp'>) => void;
+  switchChain: (chainId: number, isTestnet: boolean) => Promise<void>;
+}
+
+/**
+ * Home phase: deploy the TokenHome contract on the origin chain. Fields
+ * pulled from `DeployTokenHome.tsx` but condensed to the bare minimum —
+ * registry, manager, min version, kind. Token address comes from the
+ * previous (token) phase. Decimals auto-fetched.
+ */
+export function HomeInspector({
+  bridge,
+  accent,
+  onClose,
+  onAdvance,
+  appendActivity,
+  switchChain,
+}: HomeInspectorProps) {
+  const { setErc20TokenHomeAddress, setNativeTokenHomeAddress } = useToolboxStore();
+  const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
+  const walletChainId = useWalletStore((s) => s.walletChainId);
+  const viemChain = useViemChainStore();
+  const { deploy, isDeploying } = useContractDeployer();
+
+  const [kind, setKind] = useState<TokenKind>('erc20');
+  const [registry, setRegistry] = useState(bridge.homeChain?.wellKnownTeleporterRegistryAddress ?? '');
+  const [manager, setManager] = useState<string>(walletEVMAddress || '');
+  const [minVersion, setMinVersion] = useState('1');
+  const [decimals, setDecimals] = useState('18');
+  const [error, setError] = useState<string | null>(null);
+
+  // Auto-fetch decimals from the chosen token.
+  useEffect(() => {
+    if (!bridge.tokenAddress || !viemChain) return;
+    const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
+    if (!client) return;
+    let cancelled = false;
+    client
+      .readContract({
+        address: bridge.tokenAddress as `0x${string}`,
+        abi: ExampleERC20.abi,
+        functionName: 'decimals',
+      })
+      .then((d) => !cancelled && setDecimals(String(d)))
+      .catch(() => !cancelled && setError('Could not read decimals from token'));
+    return () => {
+      cancelled = true;
+    };
+  }, [bridge.tokenAddress, viemChain?.id]);
+
+  // Update manager default once wallet connects.
+  useEffect(() => {
+    if (walletEVMAddress && !manager) setManager(walletEVMAddress);
+  }, [walletEVMAddress, manager]);
+
+  // Update registry default when home chain changes.
+  useEffect(() => {
+    if (bridge.homeChain?.wellKnownTeleporterRegistryAddress && !registry) {
+      setRegistry(bridge.homeChain.wellKnownTeleporterRegistryAddress);
+    }
+  }, [bridge.homeChain?.id, registry]);
+
+  const handleDeploy = async () => {
+    setError(null);
+    if (!registry) {
+      setError('Teleporter Registry address is required');
+      return;
+    }
+    if (!bridge.tokenAddress) {
+      setError('Pick or deploy a token first (Token phase)');
+      return;
+    }
+    if (!viemChain) {
+      setError('Wallet not connected');
+      return;
+    }
+
+    try {
+      const args: any[] = [
+        registry as `0x${string}`,
+        (manager || walletEVMAddress) as `0x${string}`,
+        BigInt(minVersion || '1'),
+        bridge.tokenAddress as `0x${string}`,
+      ];
+      if (kind === 'erc20') args.push(BigInt(decimals));
+
+      const result = await deploy({
+        abi: (kind === 'erc20' ? ERC20TokenHome.abi : NativeTokenHome.abi) as any,
+        bytecode: kind === 'erc20' ? ERC20TokenHome.bytecode.object : NativeTokenHome.bytecode.object,
+        args,
+        name: kind === 'erc20' ? 'ERC20TokenHome' : 'NativeTokenHome',
+      });
+
+      if (kind === 'erc20') {
+        setErc20TokenHomeAddress(result.contractAddress);
+      } else {
+        setNativeTokenHomeAddress(result.contractAddress);
+      }
+      appendActivity({
+        kind: 'deploy',
+        label: `${kind === 'erc20' ? 'ERC20TokenHome' : 'NativeTokenHome'} deployed on ${bridge.homeChain?.name ?? 'home'}`,
+        txHash: result.hash,
+        chainId: viemChain.id,
+      });
+      onAdvance();
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? 'Deployment failed';
+      setError(msg);
+      appendActivity({ kind: 'error', label: `TokenHome deploy failed: ${msg}` });
+    }
+  };
+
+  const onSwitchToHome = bridge.homeChain
+    ? () => switchChain(bridge.homeChain!.evmChainId, !!bridge.homeChain!.isTestnet)
+    : undefined;
+
+  return (
+    <InspectorPanel
+      phase="home"
+      accent={accent}
+      title="Deploy TokenHome"
+      description="The custodian contract that holds the canonical supply on the origin chain."
+      meta="Will become the home of the bridge."
+      primaryAction={
+        <Button
+          onClick={handleDeploy}
+          loading={isDeploying}
+          loadingText="Deploying..."
+          disabled={!bridge.tokenAddress || !registry}
+          stickLeft
+        >
+          Deploy TokenHome →
+        </Button>
+      }
+      onClose={onClose}
+      preflight={
+        bridge.homeChain ? (
+          <ChainMismatchBanner
+            expectedChain={bridge.homeChain}
+            walletChainId={walletChainId}
+            onSwitch={onSwitchToHome}
+          />
+        ) : null
+      }
+    >
+      <div>
+        <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">
+          Transferrer kind
+        </label>
+        <SegmentControl<TokenKind>
+          value={kind}
+          onChange={setKind}
+          options={[
+            { value: 'erc20', label: 'ERC20TokenHome' },
+            { value: 'native', label: 'NativeTokenHome' },
+          ]}
+        />
+      </div>
+
+      <TeleporterRegistryAddressInput value={registry} onChange={setRegistry} disabled={isDeploying} />
+
+      <Input
+        label="Teleporter Manager"
+        value={manager}
+        onChange={setManager}
+        disabled={isDeploying}
+        helperText="Address authorized to update the registry. Defaults to your wallet."
+      />
+
+      <div className="grid grid-cols-2 gap-3">
+        <Input
+          label="Min Teleporter Version"
+          value={minVersion}
+          onChange={setMinVersion}
+          type="number"
+          unit="v"
+        />
+        {kind === 'erc20' && <Input label="Decimals" value={decimals} disabled helperText="Auto-fetched" />}
+      </div>
+
+      {!bridge.tokenAddress && (
+        <Note variant="warning">
+          Select a token in the <strong>Token</strong> phase first.
+        </Note>
+      )}
+
+      {error && (
+        <Note variant="destructive">
+          <p>{error}</p>
+        </Note>
+      )}
+    </InspectorPanel>
+  );
+}

--- a/app/console/ictt/_components/inspectors/home-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/home-inspector.tsx
@@ -137,7 +137,7 @@ export function HomeInspector({
       preflight={preflight}
     >
       <div>
-        <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">
+        <label className="block text-[11px] font-medium text-muted-foreground mb-1.5">
           Transferrer kind
         </label>
         <SegmentControl<TokenKind>

--- a/app/console/ictt/_components/inspectors/home-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/home-inspector.tsx
@@ -13,6 +13,7 @@ import { useDeployTokenHome } from '@/components/toolbox/console/ictt/hooks/useD
 import { InspectorPanel } from '../inspector-panel';
 import { SegmentControl } from '../segment-control';
 import { usePreflight } from '../use-preflight';
+import { useKeyboardSubmit } from '../use-keyboard-submit';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent, TokenKind } from '../types';
 
@@ -111,6 +112,9 @@ export function HomeInspector({
 
   const error = localError || deployError;
 
+  const canSubmit = !!bridge.tokenAddress && !!registry && !isDeploying;
+  useKeyboardSubmit({ onSubmit: handleDeploy, enabled: canSubmit });
+
   return (
     <InspectorPanel
       phase="home"
@@ -118,6 +122,7 @@ export function HomeInspector({
       title="Deploy TokenHome"
       description="The custodian contract that holds the canonical supply on the origin chain."
       meta="Will become the home of the bridge."
+      showSubmitShortcut={canSubmit}
       primaryAction={
         <Button
           onClick={handleDeploy}

--- a/app/console/ictt/_components/inspectors/home-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/home-inspector.tsx
@@ -1,17 +1,15 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import ERC20TokenHome from '@/contracts/icm-contracts/compiled/ERC20TokenHome.json';
-import NativeTokenHome from '@/contracts/icm-contracts/compiled/NativeTokenHome.json';
 import ExampleERC20 from '@/contracts/icm-contracts/compiled/ExampleERC20.json';
-import { useToolboxStore, useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
+import { useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
 import { useWalletStore } from '@/components/toolbox/stores/walletStore';
-import { useContractDeployer } from '@/components/toolbox/hooks/contracts';
 import { Button } from '@/components/toolbox/components/Button';
 import { Input } from '@/components/toolbox/components/Input';
 import { Note } from '@/components/toolbox/components/Note';
 import TeleporterRegistryAddressInput from '@/components/toolbox/components/TeleporterRegistryAddressInput';
 import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
+import { useDeployTokenHome } from '@/components/toolbox/console/ictt/hooks/useDeployTokenHome';
 import { InspectorPanel } from '../inspector-panel';
 import { SegmentControl } from '../segment-control';
 import { ChainMismatchBanner } from './preflight-banner';
@@ -28,10 +26,9 @@ interface HomeInspectorProps {
 }
 
 /**
- * Home phase: deploy the TokenHome contract on the origin chain. Fields
- * pulled from `DeployTokenHome.tsx` but condensed to the bare minimum —
- * registry, manager, min version, kind. Token address comes from the
- * previous (token) phase. Decimals auto-fetched.
+ * Home phase: deploy the TokenHome contract on the origin chain. Form
+ * fields collect kind/registry/manager/version; on-chain deployment
+ * lives in `useDeployTokenHome` so this component is purely UI + flow.
  */
 export function HomeInspector({
   bridge,
@@ -41,18 +38,17 @@ export function HomeInspector({
   appendActivity,
   switchChain,
 }: HomeInspectorProps) {
-  const { setErc20TokenHomeAddress, setNativeTokenHomeAddress } = useToolboxStore();
   const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
   const walletChainId = useWalletStore((s) => s.walletChainId);
   const viemChain = useViemChainStore();
-  const { deploy, isDeploying } = useContractDeployer();
+  const { run: runDeploy, isDeploying, error: deployError } = useDeployTokenHome();
 
   const [kind, setKind] = useState<TokenKind>('erc20');
   const [registry, setRegistry] = useState(bridge.homeChain?.wellKnownTeleporterRegistryAddress ?? '');
   const [manager, setManager] = useState<string>(walletEVMAddress || '');
   const [minVersion, setMinVersion] = useState('1');
   const [decimals, setDecimals] = useState('18');
-  const [error, setError] = useState<string | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
 
   // Auto-fetch decimals from the chosen token.
   useEffect(() => {
@@ -67,7 +63,7 @@ export function HomeInspector({
         functionName: 'decimals',
       })
       .then((d) => !cancelled && setDecimals(String(d)))
-      .catch(() => !cancelled && setError('Could not read decimals from token'));
+      .catch(() => !cancelled && setLocalError('Could not read decimals from token'));
     return () => {
       cancelled = true;
     };
@@ -86,51 +82,31 @@ export function HomeInspector({
   }, [bridge.homeChain?.id, registry]);
 
   const handleDeploy = async () => {
-    setError(null);
-    if (!registry) {
-      setError('Teleporter Registry address is required');
-      return;
-    }
+    setLocalError(null);
     if (!bridge.tokenAddress) {
-      setError('Pick or deploy a token first (Token phase)');
+      setLocalError('Pick or deploy a token first (Token phase)');
       return;
     }
-    if (!viemChain) {
-      setError('Wallet not connected');
-      return;
-    }
-
     try {
-      const args: any[] = [
-        registry as `0x${string}`,
-        (manager || walletEVMAddress) as `0x${string}`,
-        BigInt(minVersion || '1'),
-        bridge.tokenAddress as `0x${string}`,
-      ];
-      if (kind === 'erc20') args.push(BigInt(decimals));
-
-      const result = await deploy({
-        abi: (kind === 'erc20' ? ERC20TokenHome.abi : NativeTokenHome.abi) as any,
-        bytecode: kind === 'erc20' ? ERC20TokenHome.bytecode.object : NativeTokenHome.bytecode.object,
-        args,
-        name: kind === 'erc20' ? 'ERC20TokenHome' : 'NativeTokenHome',
+      const result = await runDeploy({
+        kind,
+        registry,
+        manager,
+        minVersion,
+        tokenAddress: bridge.tokenAddress,
+        decimals,
       });
-
-      if (kind === 'erc20') {
-        setErc20TokenHomeAddress(result.contractAddress);
-      } else {
-        setNativeTokenHomeAddress(result.contractAddress);
-      }
       appendActivity({
         kind: 'deploy',
-        label: `${kind === 'erc20' ? 'ERC20TokenHome' : 'NativeTokenHome'} deployed on ${bridge.homeChain?.name ?? 'home'}`,
+        label: `${kind === 'erc20' ? 'ERC20TokenHome' : 'NativeTokenHome'} deployed on ${
+          bridge.homeChain?.name ?? 'home'
+        }`,
         txHash: result.hash,
-        chainId: viemChain.id,
+        chainId: viemChain?.id,
       });
       onAdvance();
     } catch (e: any) {
       const msg = e?.shortMessage ?? e?.message ?? 'Deployment failed';
-      setError(msg);
       appendActivity({ kind: 'error', label: `TokenHome deploy failed: ${msg}` });
     }
   };
@@ -138,6 +114,8 @@ export function HomeInspector({
   const onSwitchToHome = bridge.homeChain
     ? () => switchChain(bridge.homeChain!.evmChainId, !!bridge.homeChain!.isTestnet)
     : undefined;
+
+  const error = localError || deployError;
 
   return (
     <InspectorPanel
@@ -193,13 +171,7 @@ export function HomeInspector({
       />
 
       <div className="grid grid-cols-2 gap-3">
-        <Input
-          label="Min Teleporter Version"
-          value={minVersion}
-          onChange={setMinVersion}
-          type="number"
-          unit="v"
-        />
+        <Input label="Min Teleporter Version" value={minVersion} onChange={setMinVersion} type="number" unit="v" />
         {kind === 'erc20' && <Input label="Decimals" value={decimals} disabled helperText="Auto-fetched" />}
       </div>
 

--- a/app/console/ictt/_components/inspectors/precompile-banner.tsx
+++ b/app/console/ictt/_components/inspectors/precompile-banner.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { ExternalLink, AlertTriangle, Loader2 } from 'lucide-react';
+import type { PrecompileCheck } from '../use-precompile-active';
+
+interface PrecompileBannerProps {
+  check: PrecompileCheck;
+  precompileName: string;
+  chainName: string;
+  docsLink?: string;
+}
+
+/**
+ * Compact precompile-availability banner for the inspector preflight slot.
+ * Mirrors the look of `<ChainMismatchBanner>`. Four states:
+ *   - loading: subtle gray bar with spinner ("Checking…")
+ *   - active: returns null (silent — nothing to warn about)
+ *   - error: gray banner with the error message in mono
+ *   - inactive: amber warning with optional docs link
+ */
+export function PrecompileBanner({ check, precompileName, chainName, docsLink }: PrecompileBannerProps) {
+  if (check.isLoading) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-50/60 dark:bg-zinc-900/30 px-3.5 py-2 text-xs text-zinc-500 dark:text-zinc-400">
+        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+        Checking {precompileName} on {chainName}…
+      </div>
+    );
+  }
+
+  if (check.isActive) return null;
+
+  if (check.error) {
+    return (
+      <div className="flex items-start gap-3 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-50/60 dark:bg-zinc-900/30 px-3.5 py-3">
+        <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-zinc-500 dark:text-zinc-400" />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            Could not verify {precompileName}
+          </p>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 leading-relaxed font-mono break-all">
+            {check.error}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Inactive — hard block.
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50/60 dark:border-amber-900/60 dark:bg-amber-950/30 px-3.5 py-3">
+      <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+          {precompileName} not enabled on {chainName}
+        </p>
+        <p className="text-xs text-amber-700/80 dark:text-amber-400/80 mt-0.5 leading-relaxed">
+          NativeTokenRemote needs this precompile to mint bridged tokens. Enable it in the L1's genesis or upgrade
+          config before deploying.
+        </p>
+        {docsLink && (
+          <a
+            href={docsLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 mt-1.5 text-xs font-medium text-amber-700 dark:text-amber-300 hover:underline"
+          >
+            Learn how to enable it
+            <ExternalLink className="w-3 h-3" />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/console/ictt/_components/inspectors/precompile-banner.tsx
+++ b/app/console/ictt/_components/inspectors/precompile-banner.tsx
@@ -21,7 +21,7 @@ interface PrecompileBannerProps {
 export function PrecompileBanner({ check, precompileName, chainName, docsLink }: PrecompileBannerProps) {
   if (check.isLoading) {
     return (
-      <div className="flex items-center gap-2 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-50/60 dark:bg-zinc-900/30 px-3.5 py-2 text-xs text-zinc-500 dark:text-zinc-400">
+      <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/30 px-3.5 py-2 text-xs text-muted-foreground">
         <Loader2 className="w-3.5 h-3.5 animate-spin" />
         Checking {precompileName} on {chainName}…
       </div>
@@ -32,13 +32,13 @@ export function PrecompileBanner({ check, precompileName, chainName, docsLink }:
 
   if (check.error) {
     return (
-      <div className="flex items-start gap-3 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-50/60 dark:bg-zinc-900/30 px-3.5 py-3">
-        <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-zinc-500 dark:text-zinc-400" />
+      <div className="flex items-start gap-3 rounded-lg border border-border bg-muted/30 px-3.5 py-3">
+        <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+          <p className="text-sm font-medium text-foreground/80">
             Could not verify {precompileName}
           </p>
-          <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 leading-relaxed font-mono break-all">
+          <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed font-mono break-all">
             {check.error}
           </p>
         </div>

--- a/app/console/ictt/_components/inspectors/preflight-banner.tsx
+++ b/app/console/ictt/_components/inspectors/preflight-banner.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { AlertTriangle } from 'lucide-react';
+import type { L1ListItem } from '@/components/toolbox/stores/l1ListStore';
+import { Button } from '@/components/toolbox/components/Button';
+
+interface ChainMismatchBannerProps {
+  expectedChain: L1ListItem;
+  walletChainId: number;
+  onSwitch?: () => void;
+  switching?: boolean;
+}
+
+export function ChainMismatchBanner({
+  expectedChain,
+  walletChainId,
+  onSwitch,
+  switching,
+}: ChainMismatchBannerProps) {
+  if (walletChainId === expectedChain.evmChainId) return null;
+
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50/60 dark:border-amber-900/60 dark:bg-amber-950/30 px-3.5 py-3">
+      <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+          Wrong chain for this action
+        </p>
+        <p className="text-xs text-amber-700/80 dark:text-amber-400/80 mt-0.5 leading-relaxed">
+          Switch your wallet to <strong>{expectedChain.name}</strong> (chain id {expectedChain.evmChainId}) to continue.
+        </p>
+      </div>
+      {onSwitch && (
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onSwitch}
+          loading={switching}
+          loadingText="Switching..."
+          stickLeft
+        >
+          Switch
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/app/console/ictt/_components/inspectors/register-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/register-inspector.tsx
@@ -1,17 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import { zeroAddress } from 'viem';
-import ERC20TokenRemoteABI from '@/contracts/icm-contracts/compiled/ERC20TokenRemote.json';
 import { useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
 import { useWalletStore } from '@/components/toolbox/stores/walletStore';
-import { useResolvedWalletClient } from '@/components/toolbox/hooks/useResolvedWalletClient';
-import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
-import useConsoleNotifications from '@/hooks/useConsoleNotifications';
 import { cb58ToHex } from '@/components/tools/common/utils/cb58';
 import { Button } from '@/components/toolbox/components/Button';
 import { Input } from '@/components/toolbox/components/Input';
 import { Note } from '@/components/toolbox/components/Note';
+import { useRegisterRemote } from '@/components/toolbox/console/ictt/hooks/useRegisterRemote';
 import { InspectorPanel } from '../inspector-panel';
 import { ChainMismatchBanner } from './preflight-banner';
 import { relativeTime } from '../relative-time';
@@ -45,62 +41,37 @@ export function RegisterInspector({
   appendActivity,
   switchChain,
 }: RegisterInspectorProps) {
-  const walletClient = useResolvedWalletClient();
   const walletChainId = useWalletStore((s) => s.walletChainId);
   const viemChain = useViemChainStore();
-  const { notify } = useConsoleNotifications();
-  const [isRegistering, setIsRegistering] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { run: runRegister, isRegistering, error: registerError } = useRegisterRemote();
+  const [localError, setLocalError] = useState<string | null>(null);
 
   const handleRegister = async () => {
-    setError(null);
-    if (!walletClient?.account || !viemChain) {
-      setError('Wallet not connected');
-      return;
-    }
+    setLocalError(null);
     if (!bridge.remoteAddress || !bridge.remoteChain) {
-      setError('Deploy TokenRemote first');
+      setLocalError('Deploy TokenRemote first');
       return;
     }
     if (walletChainId !== bridge.remoteChain.evmChainId) {
-      setError(`Switch wallet to ${bridge.remoteChain.name} first`);
+      setLocalError(`Switch wallet to ${bridge.remoteChain.name} first`);
       return;
     }
 
-    setIsRegistering(true);
     try {
-      const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
-      if (!client) throw new Error('Could not create RPC client for destination');
-
-      const feeInfo: readonly [`0x${string}`, bigint] = [zeroAddress, 0n];
-      const { request } = await client.simulateContract({
-        address: bridge.remoteAddress as `0x${string}`,
-        abi: ERC20TokenRemoteABI.abi,
-        functionName: 'registerWithHome',
-        args: [feeInfo],
-        chain: viemChain,
-        account: walletClient.account,
-      });
-
-      const writePromise = walletClient.writeContract(request);
-      notify({ type: 'call', name: 'Register With Home' }, writePromise, viemChain);
-      const hash = await writePromise;
-      await client.waitForTransactionReceipt({ hash });
-
+      const result = await runRegister({ remoteAddress: bridge.remoteAddress });
       appendActivity({
         kind: 'register',
-        label: `Remote → Home register message sent (${bridge.remoteChain.name} → ${bridge.homeChain?.name ?? 'home'})`,
-        txHash: hash,
-        chainId: viemChain.id,
+        label: `Remote → Home register message sent (${bridge.remoteChain.name} → ${
+          bridge.homeChain?.name ?? 'home'
+        })`,
+        txHash: result.hash,
+        chainId: viemChain?.id,
       });
       bridge.refresh();
       onAdvance();
     } catch (e: any) {
       const msg = e?.shortMessage ?? e?.message ?? 'Register failed';
-      setError(msg);
       appendActivity({ kind: 'error', label: `Register failed: ${msg}` });
-    } finally {
-      setIsRegistering(false);
     }
   };
 
@@ -108,6 +79,7 @@ export function RegisterInspector({
   const onSwitchToRemote = bridge.remoteChain
     ? () => switchChain(bridge.remoteChain!.evmChainId, !!bridge.remoteChain!.isTestnet)
     : undefined;
+  const error = localError || registerError;
 
   return (
     <InspectorPanel
@@ -175,7 +147,8 @@ export function RegisterInspector({
 
       {bridge.registered && (
         <Note variant="success">
-          Remote is registered with Home. Collateral status: {bridge.collateralNeeded === 0n ? 'fully funded' : `needs ${bridge.collateralNeeded.toString()} more`}.
+          Remote is registered with Home. Collateral status:{' '}
+          {bridge.collateralNeeded === 0n ? 'fully funded' : `needs ${bridge.collateralNeeded.toString()} more`}.
         </Note>
       )}
 

--- a/app/console/ictt/_components/inspectors/register-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/register-inspector.tsx
@@ -9,7 +9,7 @@ import { Input } from '@/components/toolbox/components/Input';
 import { Note } from '@/components/toolbox/components/Note';
 import { useRegisterRemote } from '@/components/toolbox/console/ictt/hooks/useRegisterRemote';
 import { InspectorPanel } from '../inspector-panel';
-import { ChainMismatchBanner } from './preflight-banner';
+import { usePreflight } from '../use-preflight';
 import { relativeTime } from '../relative-time';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent } from '../types';
@@ -17,7 +17,6 @@ import type { ActivityEvent } from '../types';
 interface RegisterInspectorProps {
   bridge: BridgeState;
   accent: string;
-  onClose: () => void;
   onAdvance: () => void;
   appendActivity: (event: Omit<ActivityEvent, 'id' | 'timestamp'>) => void;
   switchChain: (chainId: number, isTestnet: boolean) => Promise<void>;
@@ -36,7 +35,6 @@ interface RegisterInspectorProps {
 export function RegisterInspector({
   bridge,
   accent,
-  onClose,
   onAdvance,
   appendActivity,
   switchChain,
@@ -44,6 +42,7 @@ export function RegisterInspector({
   const walletChainId = useWalletStore((s) => s.walletChainId);
   const viemChain = useViemChainStore();
   const { run: runRegister, isRegistering, error: registerError } = useRegisterRemote();
+  const { banner: preflight } = usePreflight({ expectedChain: bridge.remoteChain, switchChain });
   const [localError, setLocalError] = useState<string | null>(null);
 
   const handleRegister = async () => {
@@ -76,9 +75,6 @@ export function RegisterInspector({
   };
 
   const elapsed = bridge.lastChecked ? relativeTime(bridge.lastChecked) : '—';
-  const onSwitchToRemote = bridge.remoteChain
-    ? () => switchChain(bridge.remoteChain!.evmChainId, !!bridge.remoteChain!.isTestnet)
-    : undefined;
   const error = localError || registerError;
 
   return (
@@ -114,16 +110,7 @@ export function RegisterInspector({
           </>
         )
       }
-      onClose={onClose}
-      preflight={
-        bridge.remoteChain ? (
-          <ChainMismatchBanner
-            expectedChain={bridge.remoteChain}
-            walletChainId={walletChainId}
-            onSwitch={onSwitchToRemote}
-          />
-        ) : null
-      }
+      preflight={preflight}
     >
       <Input
         label="From (Remote address)"

--- a/app/console/ictt/_components/inspectors/register-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/register-inspector.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useState } from 'react';
+import { zeroAddress } from 'viem';
+import ERC20TokenRemoteABI from '@/contracts/icm-contracts/compiled/ERC20TokenRemote.json';
+import { useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
+import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import { useResolvedWalletClient } from '@/components/toolbox/hooks/useResolvedWalletClient';
+import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
+import useConsoleNotifications from '@/hooks/useConsoleNotifications';
+import { cb58ToHex } from '@/components/tools/common/utils/cb58';
+import { Button } from '@/components/toolbox/components/Button';
+import { Input } from '@/components/toolbox/components/Input';
+import { Note } from '@/components/toolbox/components/Note';
+import { InspectorPanel } from '../inspector-panel';
+import { ChainMismatchBanner } from './preflight-banner';
+import { relativeTime } from '../relative-time';
+import type { BridgeState } from '../use-bridge-state';
+import type { ActivityEvent } from '../types';
+
+interface RegisterInspectorProps {
+  bridge: BridgeState;
+  accent: string;
+  onClose: () => void;
+  onAdvance: () => void;
+  appendActivity: (event: Omit<ActivityEvent, 'id' | 'timestamp'>) => void;
+  switchChain: (chainId: number, isTestnet: boolean) => Promise<void>;
+}
+
+/**
+ * Register phase: send a registerWithHome ICM message from the remote
+ * contract back to the home contract. The home then sees a CollateralAdded
+ * event with collateralNeeded > 0, after which the bridge moves to the
+ * Collateral phase.
+ *
+ * The action must be sent from the *destination* (remote) chain. Polling
+ * for the registered flag is done by `useBridgeState` — it'll flip the
+ * phase to `done` when the home confirms registration.
+ */
+export function RegisterInspector({
+  bridge,
+  accent,
+  onClose,
+  onAdvance,
+  appendActivity,
+  switchChain,
+}: RegisterInspectorProps) {
+  const walletClient = useResolvedWalletClient();
+  const walletChainId = useWalletStore((s) => s.walletChainId);
+  const viemChain = useViemChainStore();
+  const { notify } = useConsoleNotifications();
+  const [isRegistering, setIsRegistering] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleRegister = async () => {
+    setError(null);
+    if (!walletClient?.account || !viemChain) {
+      setError('Wallet not connected');
+      return;
+    }
+    if (!bridge.remoteAddress || !bridge.remoteChain) {
+      setError('Deploy TokenRemote first');
+      return;
+    }
+    if (walletChainId !== bridge.remoteChain.evmChainId) {
+      setError(`Switch wallet to ${bridge.remoteChain.name} first`);
+      return;
+    }
+
+    setIsRegistering(true);
+    try {
+      const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
+      if (!client) throw new Error('Could not create RPC client for destination');
+
+      const feeInfo: readonly [`0x${string}`, bigint] = [zeroAddress, 0n];
+      const { request } = await client.simulateContract({
+        address: bridge.remoteAddress as `0x${string}`,
+        abi: ERC20TokenRemoteABI.abi,
+        functionName: 'registerWithHome',
+        args: [feeInfo],
+        chain: viemChain,
+        account: walletClient.account,
+      });
+
+      const writePromise = walletClient.writeContract(request);
+      notify({ type: 'call', name: 'Register With Home' }, writePromise, viemChain);
+      const hash = await writePromise;
+      await client.waitForTransactionReceipt({ hash });
+
+      appendActivity({
+        kind: 'register',
+        label: `Remote → Home register message sent (${bridge.remoteChain.name} → ${bridge.homeChain?.name ?? 'home'})`,
+        txHash: hash,
+        chainId: viemChain.id,
+      });
+      bridge.refresh();
+      onAdvance();
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? 'Register failed';
+      setError(msg);
+      appendActivity({ kind: 'error', label: `Register failed: ${msg}` });
+    } finally {
+      setIsRegistering(false);
+    }
+  };
+
+  const elapsed = bridge.lastChecked ? relativeTime(bridge.lastChecked) : '—';
+  const onSwitchToRemote = bridge.remoteChain
+    ? () => switchChain(bridge.remoteChain!.evmChainId, !!bridge.remoteChain!.isTestnet)
+    : undefined;
+
+  return (
+    <InspectorPanel
+      phase="register"
+      accent={accent}
+      title="Register Remote with Home"
+      description="Sends an ICM message from the Remote contract to the Home contract announcing itself. Wait ~30s for delivery."
+      meta={
+        bridge.registered
+          ? `Registered. Last polled ${elapsed} ago.`
+          : `One-way trip. Avg 28s · last polled ${elapsed} ago.`
+      }
+      primaryAction={
+        bridge.registered ? (
+          <Button onClick={onAdvance} variant="secondary" stickLeft>
+            Continue → Collateral
+          </Button>
+        ) : (
+          <Button
+            onClick={handleRegister}
+            loading={isRegistering}
+            loadingText="Sending ICM..."
+            disabled={!bridge.remoteAddress || isRegistering}
+            stickLeft
+          >
+            Send ICM register message →
+          </Button>
+        )
+      }
+      onClose={onClose}
+      preflight={
+        bridge.remoteChain ? (
+          <ChainMismatchBanner
+            expectedChain={bridge.remoteChain}
+            walletChainId={walletChainId}
+            onSwitch={onSwitchToRemote}
+          />
+        ) : null
+      }
+    >
+      <Input
+        label="From (Remote address)"
+        value={bridge.remoteAddress ?? ''}
+        disabled
+        helperText={`On ${bridge.remoteChain?.name ?? 'remote'}`}
+      />
+      <Input
+        label="To (Home blockchain ID, hex)"
+        value={(() => {
+          if (!bridge.homeChain?.id) return '';
+          try {
+            return cb58ToHex(bridge.homeChain.id);
+          } catch {
+            return bridge.homeChain.id;
+          }
+        })()}
+        disabled
+        helperText={`Home contract on ${bridge.homeChain?.name ?? 'home'}: ${bridge.homeAddress ?? '—'}`}
+      />
+
+      {bridge.registered && (
+        <Note variant="success">
+          Remote is registered with Home. Collateral status: {bridge.collateralNeeded === 0n ? 'fully funded' : `needs ${bridge.collateralNeeded.toString()} more`}.
+        </Note>
+      )}
+
+      {error && (
+        <Note variant="destructive">
+          <p>{error}</p>
+        </Note>
+      )}
+    </InspectorPanel>
+  );
+}

--- a/app/console/ictt/_components/inspectors/register-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/register-inspector.tsx
@@ -10,6 +10,7 @@ import { Note } from '@/components/toolbox/components/Note';
 import { useRegisterRemote } from '@/components/toolbox/console/ictt/hooks/useRegisterRemote';
 import { InspectorPanel } from '../inspector-panel';
 import { usePreflight } from '../use-preflight';
+import { useKeyboardSubmit } from '../use-keyboard-submit';
 import { relativeTime } from '../relative-time';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent } from '../types';
@@ -76,6 +77,13 @@ export function RegisterInspector({
 
   const elapsed = bridge.lastChecked ? relativeTime(bridge.lastChecked) : '—';
   const error = localError || registerError;
+  // Cmd+Enter submits the active primary action: "Continue" when the
+  // bridge is registered, otherwise "Send ICM register message".
+  const canSubmit = bridge.registered || (!!bridge.remoteAddress && !isRegistering);
+  useKeyboardSubmit({
+    onSubmit: bridge.registered ? onAdvance : handleRegister,
+    enabled: canSubmit,
+  });
 
   return (
     <InspectorPanel
@@ -88,6 +96,7 @@ export function RegisterInspector({
           ? `Registered. Last polled ${elapsed} ago.`
           : `One-way trip. Avg 28s · last polled ${elapsed} ago.`
       }
+      showSubmitShortcut={canSubmit}
       primaryAction={
         bridge.registered ? (
           <Button onClick={onAdvance} variant="secondary" stickLeft>

--- a/app/console/ictt/_components/inspectors/register-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/register-inspector.tsx
@@ -126,15 +126,20 @@ export function RegisterInspector({
             Continue → Collateral
           </Button>
         ) : (
-          <Button
-            onClick={handleRegister}
-            loading={isRegistering}
-            loadingText="Sending ICM..."
-            disabled={!bridge.remoteAddress || isRegistering}
-            stickLeft
-          >
-            Send ICM register message →
-          </Button>
+          <>
+            <Button onClick={bridge.refresh} variant="outline" size="sm" stickLeft>
+              Check now
+            </Button>
+            <Button
+              onClick={handleRegister}
+              loading={isRegistering}
+              loadingText="Sending ICM..."
+              disabled={!bridge.remoteAddress || isRegistering}
+              stickLeft
+            >
+              Send ICM register message →
+            </Button>
+          </>
         )
       }
       onClose={onClose}

--- a/app/console/ictt/_components/inspectors/remote-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/remote-inspector.tsx
@@ -16,6 +16,7 @@ import { InspectorPanel } from '../inspector-panel';
 import { SegmentControl } from '../segment-control';
 import { usePreflight } from '../use-preflight';
 import { usePrecompileActive } from '../use-precompile-active';
+import { useKeyboardSubmit } from '../use-keyboard-submit';
 import { PrecompileBanner } from './precompile-banner';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent, TokenKind } from '../types';
@@ -201,6 +202,10 @@ export function RemoteInspector({
     }
   };
 
+  const canSubmit =
+    !!bridge.homeAddress && !!destChain && tokenDecimals !== '0' && !isDeploying && !minterMissing;
+  useKeyboardSubmit({ onSubmit: handleDeploy, enabled: canSubmit });
+
   return (
     <InspectorPanel
       phase="remote"
@@ -208,6 +213,7 @@ export function RemoteInspector({
       title="Deploy TokenRemote"
       description="The mirror contract on the destination chain. Mints / burns wrapped representations of the home asset."
       meta="Will need collateral on Home before transfers can flow."
+      showSubmitShortcut={canSubmit}
       primaryAction={
         <Button
           onClick={handleDeploy}

--- a/app/console/ictt/_components/inspectors/remote-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/remote-inspector.tsx
@@ -228,7 +228,7 @@ export function RemoteInspector({
       preflight={preflight}
     >
       <div>
-        <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">Remote kind</label>
+        <label className="block text-[11px] font-medium text-muted-foreground mb-1.5">Remote kind</label>
         <SegmentControl<TokenKind>
           value={kind}
           onChange={setKind}
@@ -240,13 +240,13 @@ export function RemoteInspector({
       </div>
 
       <div>
-        <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">
+        <label className="block text-[11px] font-medium text-muted-foreground mb-1.5">
           Destination chain
         </label>
         <select
           value={destChainId}
           onChange={(e) => setDestChainId(e.target.value)}
-          className="w-full px-3 py-2 bg-white dark:bg-zinc-900 border border-zinc-300 dark:border-zinc-700 rounded-md text-sm"
+          className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm"
         >
           <option value="" disabled>
             Pick a destination chain…

--- a/app/console/ictt/_components/inspectors/remote-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/remote-inspector.tsx
@@ -1,20 +1,17 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import ERC20TokenRemote from '@/contracts/icm-contracts/compiled/ERC20TokenRemote.json';
-import NativeTokenRemote from '@/contracts/icm-contracts/compiled/NativeTokenRemote.json';
+import { useEffect, useState } from 'react';
 import ERC20TokenHomeABI from '@/contracts/icm-contracts/compiled/ERC20TokenHome.json';
 import ExampleERC20 from '@/contracts/icm-contracts/compiled/ExampleERC20.json';
-import { useToolboxStore, useViemChainStore, getToolboxStore } from '@/components/toolbox/stores/toolboxStore';
+import { useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
 import { useL1List, useL1ByChainId } from '@/components/toolbox/stores/l1ListStore';
 import { useWalletStore } from '@/components/toolbox/stores/walletStore';
-import { useContractDeployer } from '@/components/toolbox/hooks/contracts';
 import { Button } from '@/components/toolbox/components/Button';
 import { Input } from '@/components/toolbox/components/Input';
 import { Note } from '@/components/toolbox/components/Note';
 import TeleporterRegistryAddressInput from '@/components/toolbox/components/TeleporterRegistryAddressInput';
 import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
-import { cb58ToHex } from '@/components/tools/common/utils/cb58';
+import { useDeployTokenRemote } from '@/components/toolbox/console/ictt/hooks/useDeployTokenRemote';
 import { InspectorPanel } from '../inspector-panel';
 import { SegmentControl } from '../segment-control';
 import { ChainMismatchBanner } from './preflight-banner';
@@ -47,13 +44,12 @@ export function RemoteInspector({
   appendActivity,
   switchChain,
 }: RemoteInspectorProps) {
-  const { setErc20TokenRemoteAddress, setNativeTokenRemoteAddress } = useToolboxStore();
   const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
   const walletChainId = useWalletStore((s) => s.walletChainId);
   const isTestnet = useWalletStore((s) => s.isTestnet);
   const viemChain = useViemChainStore();
   const l1List = useL1List();
-  const { deploy, isDeploying } = useContractDeployer();
+  const { run: runDeploy, isDeploying, error: deployError } = useDeployTokenRemote();
 
   const [kind, setKind] = useState<TokenKind>('erc20');
   // Destination chain to deploy on — defaults to "first non-home L1" so
@@ -140,15 +136,6 @@ export function RemoteInspector({
     };
   }, [sourceL1?.rpcUrl, bridge.homeAddress]);
 
-  const sourceBlockchainIDHex = useMemo(() => {
-    if (!sourceL1?.id) return null;
-    try {
-      return cb58ToHex(sourceL1.id);
-    } catch {
-      return null;
-    }
-  }, [sourceL1?.id]);
-
   const handleDeploy = async () => {
     setError(null);
     if (!sourceL1 || !bridge.homeAddress) {
@@ -159,74 +146,22 @@ export function RemoteInspector({
       setError('Pick a destination chain');
       return;
     }
-    if (sourceL1.id === destChain.id) {
-      setError('Source and destination must be different chains');
-      return;
-    }
-    if (!sourceBlockchainIDHex) {
-      setError('Could not encode source blockchain ID');
-      return;
-    }
-    if (!registry) {
-      setError('Teleporter Registry address required on destination chain');
-      return;
-    }
-    if (tokenDecimals === '0') {
-      setError('Token decimals not yet fetched');
-      return;
-    }
-    if (kind === 'native') {
-      const reserve = BigInt(initialReserve || '0');
-      if (reserve <= 0n) {
-        setError('Initial reserve imbalance must be greater than zero');
-        return;
-      }
-      const reward = parseInt(burnReward || '0');
-      if (reward < 0 || reward > 100) {
-        setError('Burned-fees reward percentage must be 0–100');
-        return;
-      }
-    }
 
     try {
-      const settings = {
-        teleporterRegistryAddress: registry as `0x${string}`,
-        teleporterManager: (manager || walletEVMAddress) as `0x${string}`,
-        minTeleporterVersion: BigInt(minVersion || '1'),
-        tokenHomeBlockchainID: sourceBlockchainIDHex as `0x${string}`,
-        tokenHomeAddress: bridge.homeAddress as `0x${string}`,
-        tokenHomeDecimals: parseInt(tokenDecimals),
-      };
-
-      const args =
-        kind === 'erc20'
-          ? [settings, tokenName || 'Bridged Token', tokenSymbol || 'BRDG', parseInt(tokenDecimals)]
-          : [settings, tokenSymbol || 'BRDG', BigInt(initialReserve || '1'), BigInt(burnReward || '0')];
-
-      const result = await deploy({
-        abi: (kind === 'erc20' ? ERC20TokenRemote.abi : NativeTokenRemote.abi) as any,
-        bytecode: kind === 'erc20' ? ERC20TokenRemote.bytecode.object : NativeTokenRemote.bytecode.object,
-        args,
-        name: kind === 'erc20' ? 'ERC20TokenRemote' : 'NativeTokenRemote',
+      const result = await runDeploy({
+        kind,
+        sourceChainId: sourceL1.id,
+        sourceHomeAddress: bridge.homeAddress,
+        sourceDecimals: tokenDecimals,
+        registry,
+        manager: manager || walletEVMAddress || '',
+        minVersion,
+        tokenName,
+        tokenSymbol,
+        initialReserveImbalance: kind === 'native' ? initialReserve : undefined,
+        burnedFeesReportingRewardPercentage: kind === 'native' ? burnReward : undefined,
+        destChainId: destChain.id,
       });
-
-      // Save to the destination chain's toolbox store, NOT the home
-      // chain's. Per-chain state model means the address belongs to
-      // whichever chain it was deployed on.
-      const destStore = getToolboxStore(destChain.id);
-      if (kind === 'erc20') {
-        destStore.getState().setErc20TokenRemoteAddress(result.contractAddress);
-      } else {
-        destStore.getState().setNativeTokenRemoteAddress(result.contractAddress);
-      }
-      // Also mirror to the home-chain store's "remote" slot so the home
-      // chain's UI can show what remote was paired (legacy compatibility
-      // with the old wizard flow that set it on the active chain).
-      if (kind === 'erc20') {
-        setErc20TokenRemoteAddress(result.contractAddress);
-      } else {
-        setNativeTokenRemoteAddress(result.contractAddress);
-      }
 
       appendActivity({
         kind: 'deploy',
@@ -237,7 +172,6 @@ export function RemoteInspector({
       onAdvance();
     } catch (e: any) {
       const msg = e?.shortMessage ?? e?.message ?? 'Deployment failed';
-      setError(msg);
       appendActivity({ kind: 'error', label: `TokenRemote deploy failed: ${msg}` });
     }
   };
@@ -347,9 +281,9 @@ export function RemoteInspector({
         </Note>
       ) : null}
 
-      {error && (
+      {(error || deployError) && (
         <Note variant="destructive">
-          <p>{error}</p>
+          <p>{error || deployError}</p>
         </Note>
       )}
     </InspectorPanel>

--- a/app/console/ictt/_components/inspectors/remote-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/remote-inspector.tsx
@@ -14,14 +14,13 @@ import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicCl
 import { useDeployTokenRemote } from '@/components/toolbox/console/ictt/hooks/useDeployTokenRemote';
 import { InspectorPanel } from '../inspector-panel';
 import { SegmentControl } from '../segment-control';
-import { ChainMismatchBanner } from './preflight-banner';
+import { usePreflight } from '../use-preflight';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent, TokenKind } from '../types';
 
 interface RemoteInspectorProps {
   bridge: BridgeState;
   accent: string;
-  onClose: () => void;
   onAdvance: () => void;
   appendActivity: (event: Omit<ActivityEvent, 'id' | 'timestamp'>) => void;
   switchChain: (chainId: number, isTestnet: boolean) => Promise<void>;
@@ -39,14 +38,11 @@ interface RemoteInspectorProps {
 export function RemoteInspector({
   bridge,
   accent,
-  onClose,
   onAdvance,
   appendActivity,
   switchChain,
 }: RemoteInspectorProps) {
   const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
-  const walletChainId = useWalletStore((s) => s.walletChainId);
-  const isTestnet = useWalletStore((s) => s.isTestnet);
   const viemChain = useViemChainStore();
   const l1List = useL1List();
   const { run: runDeploy, isDeploying, error: deployError } = useDeployTokenRemote();
@@ -70,6 +66,7 @@ export function RemoteInspector({
 
   const destChain = useL1ByChainId(destChainId);
   const sourceL1 = bridge.homeChain;
+  const { banner: preflight } = usePreflight({ expectedChain: destChain, switchChain });
 
   // Default destination = first L1 that isn't the home chain.
   useEffect(() => {
@@ -176,10 +173,6 @@ export function RemoteInspector({
     }
   };
 
-  const onSwitchToDest = destChain
-    ? () => switchChain(destChain.evmChainId, destChain.isTestnet ?? isTestnet)
-    : undefined;
-
   return (
     <InspectorPanel
       phase="remote"
@@ -198,12 +191,7 @@ export function RemoteInspector({
           Deploy TokenRemote →
         </Button>
       }
-      onClose={onClose}
-      preflight={
-        destChain ? (
-          <ChainMismatchBanner expectedChain={destChain} walletChainId={walletChainId} onSwitch={onSwitchToDest} />
-        ) : null
-      }
+      preflight={preflight}
     >
       <div>
         <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">Remote kind</label>

--- a/app/console/ictt/_components/inspectors/remote-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/remote-inspector.tsx
@@ -15,8 +15,12 @@ import { useDeployTokenRemote } from '@/components/toolbox/console/ictt/hooks/us
 import { InspectorPanel } from '../inspector-panel';
 import { SegmentControl } from '../segment-control';
 import { usePreflight } from '../use-preflight';
+import { usePrecompileActive } from '../use-precompile-active';
+import { PrecompileBanner } from './precompile-banner';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent, TokenKind } from '../types';
+
+const NATIVE_MINTER_DOCS = '/docs/avalanche-l1s/customize/native-minter';
 
 interface RemoteInspectorProps {
   bridge: BridgeState;
@@ -66,7 +70,31 @@ export function RemoteInspector({
 
   const destChain = useL1ByChainId(destChainId);
   const sourceL1 = bridge.homeChain;
-  const { banner: preflight } = usePreflight({ expectedChain: destChain, switchChain });
+  const { banner: chainBanner } = usePreflight({ expectedChain: destChain, switchChain });
+
+  // Native-minter precompile is required for NativeTokenRemote so the
+  // remote contract can mint bridged tokens. Skip the check (and any
+  // hard-blocking) when the user is deploying an ERC-20 remote — that
+  // path doesn't need the precompile.
+  const minterCheck = usePrecompileActive({
+    configKey: 'contractNativeMinterConfig',
+    rpcUrl: destChain?.rpcUrl,
+    enabled: kind === 'native',
+  });
+  const minterMissing = kind === 'native' && !minterCheck.isLoading && !minterCheck.isActive;
+  const preflight = (
+    <>
+      {chainBanner}
+      {kind === 'native' && (
+        <PrecompileBanner
+          check={minterCheck}
+          precompileName="Native Minter"
+          chainName={destChain?.name ?? 'destination'}
+          docsLink={NATIVE_MINTER_DOCS}
+        />
+      )}
+    </>
+  );
 
   // Default destination = first L1 that isn't the home chain.
   useEffect(() => {
@@ -185,7 +213,7 @@ export function RemoteInspector({
           onClick={handleDeploy}
           loading={isDeploying}
           loadingText="Deploying..."
-          disabled={!bridge.homeAddress || !destChain || tokenDecimals === '0' || isDeploying}
+          disabled={!bridge.homeAddress || !destChain || tokenDecimals === '0' || isDeploying || minterMissing}
           stickLeft
         >
           Deploy TokenRemote →
@@ -256,12 +284,6 @@ export function RemoteInspector({
           </>
         )}
       </div>
-
-      {kind === 'native' && (
-        <Note variant="warning">
-          NativeTokenRemote needs the <strong>Native Minter precompile</strong> active on the destination chain.
-        </Note>
-      )}
 
       {!sourceL1 || !bridge.homeAddress ? (
         <Note variant="warning">

--- a/app/console/ictt/_components/inspectors/remote-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/remote-inspector.tsx
@@ -9,6 +9,7 @@ import { useWalletStore } from '@/components/toolbox/stores/walletStore';
 import { Button } from '@/components/toolbox/components/Button';
 import { Input } from '@/components/toolbox/components/Input';
 import { Note } from '@/components/toolbox/components/Note';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import TeleporterRegistryAddressInput from '@/components/toolbox/components/TeleporterRegistryAddressInput';
 import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
 import { useDeployTokenRemote } from '@/components/toolbox/console/ictt/hooks/useDeployTokenRemote';
@@ -240,25 +241,21 @@ export function RemoteInspector({
       </div>
 
       <div>
-        <label className="block text-[11px] font-medium text-muted-foreground mb-1.5">
-          Destination chain
-        </label>
-        <select
-          value={destChainId}
-          onChange={(e) => setDestChainId(e.target.value)}
-          className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm"
-        >
-          <option value="" disabled>
-            Pick a destination chain…
-          </option>
-          {l1List
-            .filter((l1: { id: string }) => l1.id !== sourceL1?.id)
-            .map((l1: { id: string; name: string; evmChainId: number }) => (
-              <option key={l1.id} value={l1.id}>
-                {l1.name} (chain id {l1.evmChainId})
-              </option>
-            ))}
-        </select>
+        <label className="block text-[11px] font-medium text-muted-foreground mb-1.5">Destination chain</label>
+        <Select value={destChainId} onValueChange={setDestChainId}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Pick a destination chain…" />
+          </SelectTrigger>
+          <SelectContent>
+            {l1List
+              .filter((l1: { id: string }) => l1.id !== sourceL1?.id)
+              .map((l1: { id: string; name: string; evmChainId: number }) => (
+                <SelectItem key={l1.id} value={l1.id}>
+                  {l1.name} (chain id {l1.evmChainId})
+                </SelectItem>
+              ))}
+          </SelectContent>
+        </Select>
       </div>
 
       <TeleporterRegistryAddressInput value={registry} onChange={setRegistry} disabled={isDeploying} />

--- a/app/console/ictt/_components/inspectors/remote-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/remote-inspector.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import ERC20TokenRemote from '@/contracts/icm-contracts/compiled/ERC20TokenRemote.json';
+import NativeTokenRemote from '@/contracts/icm-contracts/compiled/NativeTokenRemote.json';
+import ERC20TokenHomeABI from '@/contracts/icm-contracts/compiled/ERC20TokenHome.json';
+import ExampleERC20 from '@/contracts/icm-contracts/compiled/ExampleERC20.json';
+import { useToolboxStore, useViemChainStore, getToolboxStore } from '@/components/toolbox/stores/toolboxStore';
+import { useL1List, useL1ByChainId } from '@/components/toolbox/stores/l1ListStore';
+import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import { useContractDeployer } from '@/components/toolbox/hooks/contracts';
+import { Button } from '@/components/toolbox/components/Button';
+import { Input } from '@/components/toolbox/components/Input';
+import { Note } from '@/components/toolbox/components/Note';
+import TeleporterRegistryAddressInput from '@/components/toolbox/components/TeleporterRegistryAddressInput';
+import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
+import { cb58ToHex } from '@/components/tools/common/utils/cb58';
+import { InspectorPanel } from '../inspector-panel';
+import { SegmentControl } from '../segment-control';
+import { ChainMismatchBanner } from './preflight-banner';
+import type { BridgeState } from '../use-bridge-state';
+import type { ActivityEvent, TokenKind } from '../types';
+
+interface RemoteInspectorProps {
+  bridge: BridgeState;
+  accent: string;
+  onClose: () => void;
+  onAdvance: () => void;
+  appendActivity: (event: Omit<ActivityEvent, 'id' | 'timestamp'>) => void;
+  switchChain: (chainId: number, isTestnet: boolean) => Promise<void>;
+}
+
+/**
+ * Remote phase: deploy the TokenRemote contract on the destination chain.
+ * Source chain comes from the home phase (where TokenHome was deployed).
+ *
+ * The user must be connected to the *destination* chain to deploy here.
+ * Token name/symbol/decimals are auto-fetched from the source chain's
+ * token home, then passed to the constructor along with the source's
+ * blockchain ID (cb58→hex).
+ */
+export function RemoteInspector({
+  bridge,
+  accent,
+  onClose,
+  onAdvance,
+  appendActivity,
+  switchChain,
+}: RemoteInspectorProps) {
+  const { setErc20TokenRemoteAddress, setNativeTokenRemoteAddress } = useToolboxStore();
+  const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
+  const walletChainId = useWalletStore((s) => s.walletChainId);
+  const isTestnet = useWalletStore((s) => s.isTestnet);
+  const viemChain = useViemChainStore();
+  const l1List = useL1List();
+  const { deploy, isDeploying } = useContractDeployer();
+
+  const [kind, setKind] = useState<TokenKind>('erc20');
+  // Destination chain to deploy on — defaults to "first non-home L1" so
+  // the user gets a sensible suggestion. They can pick any other L1 from
+  // the segment if they prefer.
+  const [destChainId, setDestChainId] = useState<string>('');
+  const [registry, setRegistry] = useState<string>('');
+  const [manager, setManager] = useState<string>(walletEVMAddress || '');
+  const [minVersion, setMinVersion] = useState('1');
+  const [tokenName, setTokenName] = useState('');
+  const [tokenSymbol, setTokenSymbol] = useState('');
+  const [tokenDecimals, setTokenDecimals] = useState('0');
+  // Native-only fields:
+  const [initialReserve, setInitialReserve] = useState('1');
+  const [burnReward, setBurnReward] = useState('0');
+  const [error, setError] = useState<string | null>(null);
+  const [fetching, setFetching] = useState(false);
+
+  const destChain = useL1ByChainId(destChainId);
+  const sourceL1 = bridge.homeChain;
+
+  // Default destination = first L1 that isn't the home chain.
+  useEffect(() => {
+    if (destChainId || !sourceL1) return;
+    const candidate = l1List.find((l1: { id: string }) => l1.id !== sourceL1.id);
+    if (candidate) setDestChainId(candidate.id);
+  }, [destChainId, sourceL1, l1List]);
+
+  // Default registry from destination chain's well-known address.
+  useEffect(() => {
+    if (destChain?.wellKnownTeleporterRegistryAddress && !registry) {
+      setRegistry(destChain.wellKnownTeleporterRegistryAddress);
+    }
+  }, [destChain?.id, registry]);
+
+  // Auto-fetch token details from the source chain's TokenHome.
+  useEffect(() => {
+    if (!sourceL1?.rpcUrl || !bridge.homeAddress) return;
+    setFetching(true);
+    setError(null);
+    const client = makePublicClientForChain(sourceL1.rpcUrl);
+    if (!client) {
+      setFetching(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const tokenAddr = await client.readContract({
+          address: bridge.homeAddress as `0x${string}`,
+          abi: ERC20TokenHomeABI.abi,
+          functionName: 'getTokenAddress',
+        });
+        const [name, symbol, decimals] = await Promise.all([
+          client.readContract({
+            address: tokenAddr as `0x${string}`,
+            abi: ExampleERC20.abi,
+            functionName: 'name',
+          }),
+          client.readContract({
+            address: tokenAddr as `0x${string}`,
+            abi: ExampleERC20.abi,
+            functionName: 'symbol',
+          }),
+          client.readContract({
+            address: tokenAddr as `0x${string}`,
+            abi: ExampleERC20.abi,
+            functionName: 'decimals',
+          }),
+        ]);
+        if (cancelled) return;
+        setTokenName(name as string);
+        setTokenSymbol(symbol as string);
+        setTokenDecimals(String(decimals));
+      } catch (e: any) {
+        if (cancelled) return;
+        setError(`Could not read source token: ${e?.shortMessage ?? e?.message ?? 'unknown'}`);
+      } finally {
+        if (!cancelled) setFetching(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sourceL1?.rpcUrl, bridge.homeAddress]);
+
+  const sourceBlockchainIDHex = useMemo(() => {
+    if (!sourceL1?.id) return null;
+    try {
+      return cb58ToHex(sourceL1.id);
+    } catch {
+      return null;
+    }
+  }, [sourceL1?.id]);
+
+  const handleDeploy = async () => {
+    setError(null);
+    if (!sourceL1 || !bridge.homeAddress) {
+      setError('Deploy TokenHome first');
+      return;
+    }
+    if (!destChain || !viemChain) {
+      setError('Pick a destination chain');
+      return;
+    }
+    if (sourceL1.id === destChain.id) {
+      setError('Source and destination must be different chains');
+      return;
+    }
+    if (!sourceBlockchainIDHex) {
+      setError('Could not encode source blockchain ID');
+      return;
+    }
+    if (!registry) {
+      setError('Teleporter Registry address required on destination chain');
+      return;
+    }
+    if (tokenDecimals === '0') {
+      setError('Token decimals not yet fetched');
+      return;
+    }
+    if (kind === 'native') {
+      const reserve = BigInt(initialReserve || '0');
+      if (reserve <= 0n) {
+        setError('Initial reserve imbalance must be greater than zero');
+        return;
+      }
+      const reward = parseInt(burnReward || '0');
+      if (reward < 0 || reward > 100) {
+        setError('Burned-fees reward percentage must be 0–100');
+        return;
+      }
+    }
+
+    try {
+      const settings = {
+        teleporterRegistryAddress: registry as `0x${string}`,
+        teleporterManager: (manager || walletEVMAddress) as `0x${string}`,
+        minTeleporterVersion: BigInt(minVersion || '1'),
+        tokenHomeBlockchainID: sourceBlockchainIDHex as `0x${string}`,
+        tokenHomeAddress: bridge.homeAddress as `0x${string}`,
+        tokenHomeDecimals: parseInt(tokenDecimals),
+      };
+
+      const args =
+        kind === 'erc20'
+          ? [settings, tokenName || 'Bridged Token', tokenSymbol || 'BRDG', parseInt(tokenDecimals)]
+          : [settings, tokenSymbol || 'BRDG', BigInt(initialReserve || '1'), BigInt(burnReward || '0')];
+
+      const result = await deploy({
+        abi: (kind === 'erc20' ? ERC20TokenRemote.abi : NativeTokenRemote.abi) as any,
+        bytecode: kind === 'erc20' ? ERC20TokenRemote.bytecode.object : NativeTokenRemote.bytecode.object,
+        args,
+        name: kind === 'erc20' ? 'ERC20TokenRemote' : 'NativeTokenRemote',
+      });
+
+      // Save to the destination chain's toolbox store, NOT the home
+      // chain's. Per-chain state model means the address belongs to
+      // whichever chain it was deployed on.
+      const destStore = getToolboxStore(destChain.id);
+      if (kind === 'erc20') {
+        destStore.getState().setErc20TokenRemoteAddress(result.contractAddress);
+      } else {
+        destStore.getState().setNativeTokenRemoteAddress(result.contractAddress);
+      }
+      // Also mirror to the home-chain store's "remote" slot so the home
+      // chain's UI can show what remote was paired (legacy compatibility
+      // with the old wizard flow that set it on the active chain).
+      if (kind === 'erc20') {
+        setErc20TokenRemoteAddress(result.contractAddress);
+      } else {
+        setNativeTokenRemoteAddress(result.contractAddress);
+      }
+
+      appendActivity({
+        kind: 'deploy',
+        label: `${kind === 'erc20' ? 'ERC20TokenRemote' : 'NativeTokenRemote'} deployed on ${destChain.name}`,
+        txHash: result.hash,
+        chainId: viemChain.id,
+      });
+      onAdvance();
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? 'Deployment failed';
+      setError(msg);
+      appendActivity({ kind: 'error', label: `TokenRemote deploy failed: ${msg}` });
+    }
+  };
+
+  const onSwitchToDest = destChain
+    ? () => switchChain(destChain.evmChainId, destChain.isTestnet ?? isTestnet)
+    : undefined;
+
+  return (
+    <InspectorPanel
+      phase="remote"
+      accent={accent}
+      title="Deploy TokenRemote"
+      description="The mirror contract on the destination chain. Mints / burns wrapped representations of the home asset."
+      meta="Will need collateral on Home before transfers can flow."
+      primaryAction={
+        <Button
+          onClick={handleDeploy}
+          loading={isDeploying}
+          loadingText="Deploying..."
+          disabled={!bridge.homeAddress || !destChain || tokenDecimals === '0' || isDeploying}
+          stickLeft
+        >
+          Deploy TokenRemote →
+        </Button>
+      }
+      onClose={onClose}
+      preflight={
+        destChain ? (
+          <ChainMismatchBanner expectedChain={destChain} walletChainId={walletChainId} onSwitch={onSwitchToDest} />
+        ) : null
+      }
+    >
+      <div>
+        <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">Remote kind</label>
+        <SegmentControl<TokenKind>
+          value={kind}
+          onChange={setKind}
+          options={[
+            { value: 'erc20', label: 'ERC20TokenRemote' },
+            { value: 'native', label: 'NativeTokenRemote' },
+          ]}
+        />
+      </div>
+
+      <div>
+        <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">
+          Destination chain
+        </label>
+        <select
+          value={destChainId}
+          onChange={(e) => setDestChainId(e.target.value)}
+          className="w-full px-3 py-2 bg-white dark:bg-zinc-900 border border-zinc-300 dark:border-zinc-700 rounded-md text-sm"
+        >
+          <option value="" disabled>
+            Pick a destination chain…
+          </option>
+          {l1List
+            .filter((l1: { id: string }) => l1.id !== sourceL1?.id)
+            .map((l1: { id: string; name: string; evmChainId: number }) => (
+              <option key={l1.id} value={l1.id}>
+                {l1.name} (chain id {l1.evmChainId})
+              </option>
+            ))}
+        </select>
+      </div>
+
+      <TeleporterRegistryAddressInput value={registry} onChange={setRegistry} disabled={isDeploying} />
+
+      <Input
+        label="Teleporter Manager"
+        value={manager}
+        onChange={setManager}
+        helperText="Defaults to your wallet address."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        <Input label="Min version" value={minVersion} onChange={setMinVersion} type="number" unit="v" />
+        <Input
+          label="Decimals"
+          value={tokenDecimals}
+          disabled
+          helperText={fetching ? 'Reading from source…' : 'From source token'}
+        />
+        {kind === 'erc20' ? (
+          <>
+            <Input label="Name" value={tokenName} disabled />
+            <Input label="Symbol" value={tokenSymbol} disabled />
+          </>
+        ) : (
+          <>
+            <Input label="Initial reserve" value={initialReserve} onChange={setInitialReserve} type="number" />
+            <Input label="Burn reward %" value={burnReward} onChange={setBurnReward} type="number" unit="%" />
+          </>
+        )}
+      </div>
+
+      {kind === 'native' && (
+        <Note variant="warning">
+          NativeTokenRemote needs the <strong>Native Minter precompile</strong> active on the destination chain.
+        </Note>
+      )}
+
+      {!sourceL1 || !bridge.homeAddress ? (
+        <Note variant="warning">
+          Deploy <strong>TokenHome</strong> first (Home phase) so the remote knows where to register.
+        </Note>
+      ) : null}
+
+      {error && (
+        <Note variant="destructive">
+          <p>{error}</p>
+        </Note>
+      )}
+    </InspectorPanel>
+  );
+}

--- a/app/console/ictt/_components/inspectors/token-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/token-inspector.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import ExampleERC20 from '@/contracts/icm-contracts/compiled/ExampleERC20.json';
+import { useToolboxStore, useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
+import {
+  useSelectedL1,
+  useSetWrappedNativeToken,
+  useWrappedNativeToken,
+} from '@/components/toolbox/stores/l1ListStore';
+import { useContractDeployer } from '@/components/toolbox/hooks/contracts';
+import { Button } from '@/components/toolbox/components/Button';
+import { EVMAddressInput } from '@/components/toolbox/components/EVMAddressInput';
+import { Note } from '@/components/toolbox/components/Note';
+import WrappedNativeToken from '@/contracts/icm-contracts/compiled/WrappedNativeToken.json';
+import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
+import { InspectorPanel } from '../inspector-panel';
+import { SegmentControl } from '../segment-control';
+import { ChainMismatchBanner } from './preflight-banner';
+import type { BridgeState } from '../use-bridge-state';
+import type { ActivityEvent } from '../types';
+
+type TokenSource = 'existing' | 'test' | 'wrapped';
+
+interface TokenInspectorProps {
+  bridge: BridgeState;
+  accent: string;
+  onClose: () => void;
+  onAdvance: () => void;
+  appendActivity: (event: Omit<ActivityEvent, 'id' | 'timestamp'>) => void;
+  switchChain: (chainId: number, isTestnet: boolean) => Promise<void>;
+}
+
+/**
+ * Token phase: pick or deploy the home asset.
+ *
+ * Three segment options collapse the current branch flow:
+ *   - existing: paste an ERC-20 contract address (saved as exampleErc20Address)
+ *   - test:    deploy ExampleERC20 with 1M supply
+ *   - wrapped: use or deploy the wrapped-native helper for native flows
+ */
+export function TokenInspector({
+  bridge,
+  accent,
+  onClose,
+  onAdvance,
+  appendActivity,
+  switchChain,
+}: TokenInspectorProps) {
+  const { exampleErc20Address, setExampleErc20Address } = useToolboxStore();
+  const wrapped = useWrappedNativeToken();
+  const setWrapped = useSetWrappedNativeToken();
+  const selectedL1 = useSelectedL1();
+  const viemChain = useViemChainStore();
+  const { deploy, isDeploying } = useContractDeployer();
+  const [source, setSource] = useState<TokenSource>(() =>
+    exampleErc20Address ? 'test' : wrapped ? 'wrapped' : 'existing',
+  );
+  const [pasted, setPasted] = useState(exampleErc20Address || '');
+  const [error, setError] = useState<string | null>(null);
+
+  // Sync pasted field with store on first mount.
+  useEffect(() => {
+    if (!pasted && exampleErc20Address) setPasted(exampleErc20Address);
+  }, [exampleErc20Address]);
+
+  const onSwitchToHome = bridge.homeChain
+    ? () => switchChain(bridge.homeChain!.evmChainId, !!bridge.homeChain!.isTestnet)
+    : undefined;
+
+  const handleDeployTest = async () => {
+    setError(null);
+    try {
+      const result = await deploy({
+        abi: ExampleERC20.abi as any,
+        bytecode: ExampleERC20.bytecode.object,
+        args: [],
+        name: 'ExampleERC20',
+      });
+      setExampleErc20Address(result.contractAddress);
+      appendActivity({
+        kind: 'deploy',
+        label: `Test ERC-20 deployed on ${selectedL1?.name ?? 'home'}`,
+        amount: '1M supply',
+        txHash: result.hash,
+        chainId: viemChain?.id,
+      });
+      onAdvance();
+    } catch (e: any) {
+      setError(e?.shortMessage ?? e?.message ?? 'Deployment failed');
+      appendActivity({ kind: 'error', label: `Test ERC-20 deploy failed: ${e?.shortMessage ?? e?.message ?? ''}` });
+    }
+  };
+
+  const handleDeployWrapped = async () => {
+    setError(null);
+    try {
+      const result = await deploy({
+        abi: WrappedNativeToken.abi as any,
+        bytecode: WrappedNativeToken.bytecode.object,
+        args: [selectedL1?.coinName ?? 'Native'],
+        name: 'WrappedNativeToken',
+      });
+      setWrapped(result.contractAddress);
+      appendActivity({
+        kind: 'deploy',
+        label: `Wrapped native deployed on ${selectedL1?.name ?? 'home'}`,
+        txHash: result.hash,
+        chainId: viemChain?.id,
+      });
+      onAdvance();
+    } catch (e: any) {
+      setError(e?.shortMessage ?? e?.message ?? 'Deployment failed');
+    }
+  };
+
+  const handleUseExisting = async () => {
+    setError(null);
+    if (!pasted) {
+      setError('Enter a token contract address');
+      return;
+    }
+    if (!viemChain) {
+      setError('Wallet not connected');
+      return;
+    }
+    // Static-call the contract to verify it's a valid ERC-20 before saving.
+    try {
+      const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
+      if (!client) throw new Error('Could not create RPC client');
+      await client.readContract({
+        address: pasted as `0x${string}`,
+        abi: ExampleERC20.abi,
+        functionName: 'decimals',
+      });
+      setExampleErc20Address(pasted);
+      appendActivity({
+        kind: 'deploy',
+        label: `Token registered: ${pasted.slice(0, 6)}…${pasted.slice(-4)}`,
+        chainId: viemChain.id,
+      });
+      onAdvance();
+    } catch (e: any) {
+      setError(`Not a valid ERC-20: ${e?.shortMessage ?? e?.message ?? 'unknown'}`);
+    }
+  };
+
+  const action =
+    source === 'existing' ? (
+      <Button onClick={handleUseExisting} disabled={!pasted} stickLeft>
+        Use this token →
+      </Button>
+    ) : source === 'test' ? (
+      <Button onClick={handleDeployTest} loading={isDeploying} loadingText="Deploying..." stickLeft>
+        Deploy test token →
+      </Button>
+    ) : (
+      <Button onClick={handleDeployWrapped} loading={isDeploying} loadingText="Deploying..." stickLeft>
+        Deploy wrapped native →
+      </Button>
+    );
+
+  return (
+    <InspectorPanel
+      phase="token"
+      accent={accent}
+      title="Choose home asset"
+      description="The token whose value will move across chains. Use an existing ERC-20, deploy a test token, or use the wrapped-native helper for native flows."
+      meta={source === 'existing' ? 'Reads name, symbol, decimals via static call.' : 'Deploys to the home chain.'}
+      primaryAction={action}
+      onClose={onClose}
+      preflight={
+        bridge.homeChain ? (
+          <ChainMismatchBanner
+            expectedChain={bridge.homeChain}
+            walletChainId={selectedL1?.evmChainId ?? -1}
+            onSwitch={onSwitchToHome}
+          />
+        ) : null
+      }
+    >
+      <div>
+        <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">Token type</label>
+        <SegmentControl<TokenSource>
+          value={source}
+          onChange={setSource}
+          options={[
+            { value: 'existing', label: 'Existing ERC-20' },
+            { value: 'test', label: 'Deploy test token' },
+            { value: 'wrapped', label: 'Wrapped native' },
+          ]}
+        />
+      </div>
+
+      {source === 'existing' && (
+        <EVMAddressInput
+          label="Token contract address"
+          value={pasted}
+          onChange={setPasted}
+          helperText="Paste an existing ERC-20. Decimals are fetched via a static call."
+        />
+      )}
+
+      {source === 'test' && (
+        <Note variant="default">
+          Will deploy <strong>ExampleERC20</strong> with 1,000,000 supply minted to your wallet on{' '}
+          <strong>{selectedL1?.name ?? 'the home chain'}</strong>.
+        </Note>
+      )}
+
+      {source === 'wrapped' && (
+        <Note variant="default">
+          {wrapped ? (
+            <>
+              Wrapped native already available at <code className="font-mono">{wrapped}</code>. Click below to confirm
+              the choice.
+            </>
+          ) : (
+            <>
+              Will deploy <strong>WrappedNativeToken</strong> for{' '}
+              <strong>{selectedL1?.coinName ?? 'native'}</strong> so the home contract can hold collateral.
+            </>
+          )}
+        </Note>
+      )}
+
+      {error && (
+        <Note variant="destructive">
+          <p>{error}</p>
+        </Note>
+      )}
+    </InspectorPanel>
+  );
+}

--- a/app/console/ictt/_components/inspectors/token-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/token-inspector.tsx
@@ -16,7 +16,7 @@ import WrappedNativeToken from '@/contracts/icm-contracts/compiled/WrappedNative
 import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
 import { InspectorPanel } from '../inspector-panel';
 import { SegmentControl } from '../segment-control';
-import { ChainMismatchBanner } from './preflight-banner';
+import { usePreflight } from '../use-preflight';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent } from '../types';
 
@@ -25,7 +25,6 @@ type TokenSource = 'existing' | 'test' | 'wrapped';
 interface TokenInspectorProps {
   bridge: BridgeState;
   accent: string;
-  onClose: () => void;
   onAdvance: () => void;
   appendActivity: (event: Omit<ActivityEvent, 'id' | 'timestamp'>) => void;
   switchChain: (chainId: number, isTestnet: boolean) => Promise<void>;
@@ -42,7 +41,6 @@ interface TokenInspectorProps {
 export function TokenInspector({
   bridge,
   accent,
-  onClose,
   onAdvance,
   appendActivity,
   switchChain,
@@ -64,9 +62,7 @@ export function TokenInspector({
     if (!pasted && exampleErc20Address) setPasted(exampleErc20Address);
   }, [exampleErc20Address]);
 
-  const onSwitchToHome = bridge.homeChain
-    ? () => switchChain(bridge.homeChain!.evmChainId, !!bridge.homeChain!.isTestnet)
-    : undefined;
+  const { banner: preflight } = usePreflight({ expectedChain: bridge.homeChain, switchChain });
 
   const handleDeployTest = async () => {
     setError(null);
@@ -168,16 +164,7 @@ export function TokenInspector({
       description="The token whose value will move across chains. Use an existing ERC-20, deploy a test token, or use the wrapped-native helper for native flows."
       meta={source === 'existing' ? 'Reads name, symbol, decimals via static call.' : 'Deploys to the home chain.'}
       primaryAction={action}
-      onClose={onClose}
-      preflight={
-        bridge.homeChain ? (
-          <ChainMismatchBanner
-            expectedChain={bridge.homeChain}
-            walletChainId={selectedL1?.evmChainId ?? -1}
-            onSwitch={onSwitchToHome}
-          />
-        ) : null
-      }
+      preflight={preflight}
     >
       <div>
         <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">Token type</label>

--- a/app/console/ictt/_components/inspectors/token-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/token-inspector.tsx
@@ -17,6 +17,7 @@ import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicCl
 import { InspectorPanel } from '../inspector-panel';
 import { SegmentControl } from '../segment-control';
 import { usePreflight } from '../use-preflight';
+import { useKeyboardSubmit } from '../use-keyboard-submit';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent } from '../types';
 
@@ -156,6 +157,11 @@ export function TokenInspector({
       </Button>
     );
 
+  const submitHandler =
+    source === 'existing' ? handleUseExisting : source === 'test' ? handleDeployTest : handleDeployWrapped;
+  const canSubmit = source === 'existing' ? !!pasted && !isDeploying : !isDeploying;
+  useKeyboardSubmit({ onSubmit: submitHandler, enabled: canSubmit });
+
   return (
     <InspectorPanel
       phase="token"
@@ -163,6 +169,7 @@ export function TokenInspector({
       title="Choose home asset"
       description="The token whose value will move across chains. Use an existing ERC-20, deploy a test token, or use the wrapped-native helper for native flows."
       meta={source === 'existing' ? 'Reads name, symbol, decimals via static call.' : 'Deploys to the home chain.'}
+      showSubmitShortcut={canSubmit}
       primaryAction={action}
       preflight={preflight}
     >

--- a/app/console/ictt/_components/inspectors/token-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/token-inspector.tsx
@@ -174,7 +174,7 @@ export function TokenInspector({
       preflight={preflight}
     >
       <div>
-        <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">Token type</label>
+        <label className="block text-[11px] font-medium text-muted-foreground mb-1.5">Token type</label>
         <SegmentControl<TokenSource>
           value={source}
           onChange={setSource}

--- a/app/console/ictt/_components/inspectors/transfer-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/transfer-inspector.tsx
@@ -16,6 +16,7 @@ import { EVMAddressInput } from '@/components/toolbox/components/EVMAddressInput
 import { InspectorPanel } from '../inspector-panel';
 import { SegmentControl } from '../segment-control';
 import { usePreflight } from '../use-preflight';
+import { FieldLoading } from '../field-loading';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent } from '../types';
 
@@ -59,6 +60,7 @@ export function TransferInspector({
   const [decimals, setDecimals] = useState(18);
   const [tokenSymbol, setTokenSymbol] = useState('TKN');
   const [localError, setLocalError] = useState<string | null>(null);
+  const [isReading, setIsReading] = useState(false);
 
   const sourceChain = direction === 'home-to-remote' ? bridge.homeChain : bridge.remoteChain;
   const destChain = direction === 'home-to-remote' ? bridge.remoteChain : bridge.homeChain;
@@ -76,6 +78,7 @@ export function TransferInspector({
     let cancelled = false;
     const client = makePublicClientForChain(sourceChain.rpcUrl);
     if (!client) return;
+    setIsReading(true);
     (async () => {
       try {
         if (direction === 'home-to-remote' && bridge.homeKind === 'erc20') {
@@ -117,6 +120,8 @@ export function TransferInspector({
         }
       } catch {
         /* leave defaults */
+      } finally {
+        if (!cancelled) setIsReading(false);
       }
     })();
     return () => {
@@ -213,6 +218,8 @@ export function TransferInspector({
       </div>
 
       <Input label={`Amount (${tokenSymbol})`} value={amount} onChange={setAmount} type="number" />
+
+      {isReading && <FieldLoading label={`Reading decimals + symbol from ${sourceChain?.name ?? 'source'}…`} />}
 
       <EVMAddressInput
         label="Recipient"

--- a/app/console/ictt/_components/inspectors/transfer-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/transfer-inspector.tsx
@@ -15,7 +15,7 @@ import { Note } from '@/components/toolbox/components/Note';
 import { EVMAddressInput } from '@/components/toolbox/components/EVMAddressInput';
 import { InspectorPanel } from '../inspector-panel';
 import { SegmentControl } from '../segment-control';
-import { ChainMismatchBanner } from './preflight-banner';
+import { usePreflight } from '../use-preflight';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent } from '../types';
 
@@ -24,7 +24,6 @@ const DEFAULT_GAS_LIMIT = 250_000n;
 interface TransferInspectorProps {
   bridge: BridgeState;
   accent: string;
-  onClose: () => void;
   onAdvance: () => void;
   appendActivity: (event: Omit<ActivityEvent, 'id' | 'timestamp'>) => void;
   switchChain: (chainId: number, isTestnet: boolean) => Promise<void>;
@@ -45,7 +44,6 @@ interface TransferInspectorProps {
 export function TransferInspector({
   bridge,
   accent,
-  onClose,
   onAdvance,
   appendActivity,
   switchChain,
@@ -53,7 +51,7 @@ export function TransferInspector({
   const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
   const walletChainId = useWalletStore((s) => s.walletChainId);
   const viemChain = useViemChainStore();
-  const { run: runSend, status, isApproving, isSending, isWorking, error: hookError } = useSendTransfer();
+  const { run: runSend, status, isApproving, isWorking, error: hookError } = useSendTransfer();
 
   const [direction, setDirection] = useState<TransferDirection>('home-to-remote');
   const [amount, setAmount] = useState('');
@@ -173,9 +171,7 @@ export function TransferInspector({
     }
   };
 
-  const onSwitchToSource = sourceChain
-    ? () => switchChain(sourceChain.evmChainId, !!sourceChain.isTestnet)
-    : undefined;
+  const { banner: preflight } = usePreflight({ expectedChain: sourceChain, switchChain });
   const error = localError || hookError;
 
   return (
@@ -196,12 +192,7 @@ export function TransferInspector({
           Send →
         </Button>
       }
-      onClose={onClose}
-      preflight={
-        sourceChain ? (
-          <ChainMismatchBanner expectedChain={sourceChain} walletChainId={walletChainId} onSwitch={onSwitchToSource} />
-        ) : null
-      }
+      preflight={preflight}
     >
       <div>
         <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">Direction</label>

--- a/app/console/ictt/_components/inspectors/transfer-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/transfer-inspector.tsx
@@ -1,0 +1,336 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { formatUnits, parseUnits, zeroAddress } from 'viem';
+import ERC20TokenHomeABI from '@/contracts/icm-contracts/compiled/ERC20TokenHome.json';
+import NativeTokenHomeABI from '@/contracts/icm-contracts/compiled/NativeTokenHome.json';
+import ERC20TokenRemoteABI from '@/contracts/icm-contracts/compiled/ERC20TokenRemote.json';
+import NativeTokenRemoteABI from '@/contracts/icm-contracts/compiled/NativeTokenRemote.json';
+import ExampleERC20 from '@/contracts/icm-contracts/compiled/ExampleERC20.json';
+import { useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
+import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import { useResolvedWalletClient } from '@/components/toolbox/hooks/useResolvedWalletClient';
+import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
+import useConsoleNotifications from '@/hooks/useConsoleNotifications';
+import { cb58ToHex } from '@/components/tools/common/utils/cb58';
+import { Button } from '@/components/toolbox/components/Button';
+import { Input } from '@/components/toolbox/components/Input';
+import { Note } from '@/components/toolbox/components/Note';
+import { EVMAddressInput } from '@/components/toolbox/components/EVMAddressInput';
+import { InspectorPanel } from '../inspector-panel';
+import { SegmentControl } from '../segment-control';
+import { ChainMismatchBanner } from './preflight-banner';
+import type { BridgeState } from '../use-bridge-state';
+import type { ActivityEvent } from '../types';
+
+const DEFAULT_GAS_LIMIT = 250_000n;
+
+type Direction = 'home-to-remote' | 'remote-to-home';
+
+interface TransferInspectorProps {
+  bridge: BridgeState;
+  accent: string;
+  onClose: () => void;
+  onAdvance: () => void;
+  appendActivity: (event: Omit<ActivityEvent, 'id' | 'timestamp'>) => void;
+  switchChain: (chainId: number, isTestnet: boolean) => Promise<void>;
+}
+
+/**
+ * Live transfer phase: cross-chain send via the bridge.
+ *
+ *   home → remote: call `send(SendTokensInput, amount)` on TokenHome
+ *                  (ERC-20: needs approve first; Native: passes value)
+ *   remote → home: call `send(SendTokensInput, amount)` on TokenRemote
+ *                  (Native: passes value; ERC-20: burns from balance)
+ */
+export function TransferInspector({
+  bridge,
+  accent,
+  onClose,
+  onAdvance,
+  appendActivity,
+  switchChain,
+}: TransferInspectorProps) {
+  const walletClient = useResolvedWalletClient();
+  const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
+  const walletChainId = useWalletStore((s) => s.walletChainId);
+  const viemChain = useViemChainStore();
+  const { notify } = useConsoleNotifications();
+
+  const [direction, setDirection] = useState<Direction>('home-to-remote');
+  const [amount, setAmount] = useState('');
+  const [recipient, setRecipient] = useState<string>(walletEVMAddress || '');
+  const [error, setError] = useState<string | null>(null);
+  const [working, setWorking] = useState<'idle' | 'approving' | 'sending'>('idle');
+  const [decimals, setDecimals] = useState(18);
+  const [tokenSymbol, setTokenSymbol] = useState('TKN');
+
+  // Determine source/destination based on direction.
+  const sourceChain = direction === 'home-to-remote' ? bridge.homeChain : bridge.remoteChain;
+  const destChain = direction === 'home-to-remote' ? bridge.remoteChain : bridge.homeChain;
+  const sourceContract = direction === 'home-to-remote' ? bridge.homeAddress : bridge.remoteAddress;
+  const sourceKind = direction === 'home-to-remote' ? bridge.homeKind : bridge.remoteKind;
+  const destContract = direction === 'home-to-remote' ? bridge.remoteAddress : bridge.homeAddress;
+
+  useEffect(() => {
+    if (walletEVMAddress) setRecipient(walletEVMAddress);
+  }, [walletEVMAddress]);
+
+  // Auto-fetch decimals + symbol from source.
+  useEffect(() => {
+    if (!sourceChain?.rpcUrl || !sourceContract) return;
+    let cancelled = false;
+    const client = makePublicClientForChain(sourceChain.rpcUrl);
+    if (!client) return;
+    (async () => {
+      try {
+        if (direction === 'home-to-remote' && bridge.homeKind === 'erc20') {
+          const tokenAddr = (await client.readContract({
+            address: sourceContract as `0x${string}`,
+            abi: ERC20TokenHomeABI.abi,
+            functionName: 'getTokenAddress',
+          })) as `0x${string}`;
+          const [d, s] = await Promise.all([
+            client.readContract({ address: tokenAddr, abi: ExampleERC20.abi, functionName: 'decimals' }),
+            client.readContract({ address: tokenAddr, abi: ExampleERC20.abi, functionName: 'symbol' }),
+          ]);
+          if (!cancelled) {
+            setDecimals(Number(d));
+            setTokenSymbol(String(s));
+          }
+        } else if (direction === 'remote-to-home') {
+          const [d, s] = await Promise.all([
+            client.readContract({
+              address: sourceContract as `0x${string}`,
+              abi: ERC20TokenRemoteABI.abi,
+              functionName: 'decimals',
+            }),
+            client.readContract({
+              address: sourceContract as `0x${string}`,
+              abi: ERC20TokenRemoteABI.abi,
+              functionName: 'symbol',
+            }),
+          ]);
+          if (!cancelled) {
+            setDecimals(Number(d));
+            setTokenSymbol(String(s));
+          }
+        } else {
+          if (!cancelled) {
+            setDecimals(18);
+            setTokenSymbol(sourceChain.coinName ?? 'NATIVE');
+          }
+        }
+      } catch {
+        /* leave defaults */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sourceChain?.rpcUrl, sourceContract, direction, bridge.homeKind]);
+
+  const parsedAmount = (() => {
+    try {
+      return amount ? parseUnits(amount, decimals) : 0n;
+    } catch {
+      return 0n;
+    }
+  })();
+
+  const handleSend = async () => {
+    setError(null);
+    if (!walletClient?.account || !viemChain) {
+      setError('Wallet not connected');
+      return;
+    }
+    if (!sourceChain || !destChain || !sourceContract || !destContract) {
+      setError('Bridge not fully set up');
+      return;
+    }
+    if (walletChainId !== sourceChain.evmChainId) {
+      setError(`Switch wallet to ${sourceChain.name}`);
+      return;
+    }
+    if (parsedAmount === 0n) {
+      setError('Enter an amount');
+      return;
+    }
+
+    let destBlockchainIDHex: string;
+    try {
+      destBlockchainIDHex = cb58ToHex(destChain.id);
+    } catch {
+      setError('Could not encode destination blockchain ID');
+      return;
+    }
+
+    setWorking('sending');
+    try {
+      const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
+      if (!client) throw new Error('Could not create RPC client');
+
+      // ERC20 home: needs approve before send.
+      if (direction === 'home-to-remote' && bridge.homeKind === 'erc20') {
+        setWorking('approving');
+        const tokenAddr = (await client.readContract({
+          address: sourceContract as `0x${string}`,
+          abi: ERC20TokenHomeABI.abi,
+          functionName: 'getTokenAddress',
+        })) as `0x${string}`;
+        const allowance = (await client.readContract({
+          address: tokenAddr,
+          abi: ExampleERC20.abi,
+          functionName: 'allowance',
+          args: [walletClient.account.address, sourceContract as `0x${string}`],
+        })) as bigint;
+        if (allowance < parsedAmount) {
+          const { request: approveRequest } = await client.simulateContract({
+            address: tokenAddr,
+            abi: ExampleERC20.abi,
+            functionName: 'approve',
+            args: [sourceContract as `0x${string}`, parsedAmount],
+            chain: viemChain,
+            account: walletClient.account,
+          });
+          const approvePromise = walletClient.writeContract(approveRequest);
+          notify({ type: 'call', name: 'Approve for Send' }, approvePromise, viemChain);
+          const approveHash = await approvePromise;
+          await client.waitForTransactionReceipt({ hash: approveHash });
+          appendActivity({
+            kind: 'collateral',
+            label: 'Approved tokens for send',
+            txHash: approveHash,
+            chainId: viemChain.id,
+          });
+        }
+        setWorking('sending');
+      }
+
+      const sendInput = {
+        destinationBlockchainID: destBlockchainIDHex as `0x${string}`,
+        destinationTokenTransferrerAddress: destContract as `0x${string}`,
+        recipient: (recipient || walletEVMAddress) as `0x${string}`,
+        primaryFeeTokenAddress: zeroAddress,
+        primaryFee: 0n,
+        secondaryFee: 0n,
+        requiredGasLimit: DEFAULT_GAS_LIMIT,
+        multiHopFallback: zeroAddress,
+      };
+
+      const isHomeNative = direction === 'home-to-remote' && bridge.homeKind === 'native';
+      const isRemoteNative = direction === 'remote-to-home' && bridge.remoteKind === 'native';
+      const isNativeValue = isHomeNative || isRemoteNative;
+
+      const homeAbi = direction === 'home-to-remote' ? (bridge.homeKind === 'erc20' ? ERC20TokenHomeABI.abi : NativeTokenHomeABI.abi) : null;
+      const remoteAbi =
+        direction === 'remote-to-home'
+          ? bridge.remoteKind === 'erc20'
+            ? ERC20TokenRemoteABI.abi
+            : NativeTokenRemoteABI.abi
+          : null;
+
+      const { request } = await client.simulateContract({
+        address: sourceContract as `0x${string}`,
+        abi: (homeAbi ?? remoteAbi) as any,
+        functionName: 'send',
+        args: isNativeValue ? [sendInput] : [sendInput, parsedAmount],
+        chain: viemChain,
+        account: walletClient.account,
+        ...(isNativeValue ? { value: parsedAmount } : {}),
+      });
+
+      const writePromise = walletClient.writeContract(request);
+      notify({ type: 'call', name: 'Send Tokens' }, writePromise, viemChain);
+      const hash = await writePromise;
+      await client.waitForTransactionReceipt({ hash });
+
+      appendActivity({
+        kind: 'send',
+        label: `Sent ${tokenSymbol} ${sourceChain.name} → ${destChain.name}`,
+        amount: amount,
+        txHash: hash,
+        chainId: viemChain.id,
+      });
+      bridge.refresh();
+      onAdvance();
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? 'Send failed';
+      setError(msg);
+      appendActivity({ kind: 'error', label: `Send failed: ${msg}` });
+    } finally {
+      setWorking('idle');
+    }
+  };
+
+  const onSwitchToSource = sourceChain
+    ? () => switchChain(sourceChain.evmChainId, !!sourceChain.isTestnet)
+    : undefined;
+
+  return (
+    <InspectorPanel
+      phase="transfer"
+      accent={accent}
+      title="Send tokens"
+      description="Bridge live. Tokens move Home ↔ Remote via ICM."
+      meta={`Arrival ETA ≈ 25s after origin tx confirms · gas ${DEFAULT_GAS_LIMIT.toString()}`}
+      primaryAction={
+        <Button
+          onClick={handleSend}
+          loading={working !== 'idle'}
+          loadingText={working === 'approving' ? 'Approving...' : 'Sending...'}
+          disabled={!sourceContract || !destContract || parsedAmount === 0n || working !== 'idle'}
+          stickLeft
+        >
+          Send →
+        </Button>
+      }
+      onClose={onClose}
+      preflight={
+        sourceChain ? (
+          <ChainMismatchBanner expectedChain={sourceChain} walletChainId={walletChainId} onSwitch={onSwitchToSource} />
+        ) : null
+      }
+    >
+      <div>
+        <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">Direction</label>
+        <SegmentControl<Direction>
+          value={direction}
+          onChange={setDirection}
+          options={[
+            {
+              value: 'home-to-remote',
+              label: `${bridge.homeChain?.name ?? 'Home'} → ${bridge.remoteChain?.name ?? 'Remote'}`,
+            },
+            {
+              value: 'remote-to-home',
+              label: `${bridge.remoteChain?.name ?? 'Remote'} → ${bridge.homeChain?.name ?? 'Home'}`,
+            },
+          ]}
+        />
+      </div>
+
+      <Input label={`Amount (${tokenSymbol})`} value={amount} onChange={setAmount} type="number" />
+
+      <EVMAddressInput
+        label="Recipient"
+        value={recipient}
+        onChange={setRecipient}
+        helperText="Defaults to your wallet address."
+      />
+
+      {!bridge.registered || bridge.collateralNeeded > 0n ? (
+        <Note variant="warning">
+          Bridge not yet collateralized. Sends will fail until you complete the <strong>Collateral</strong> phase.
+        </Note>
+      ) : null}
+
+      {error && (
+        <Note variant="destructive">
+          <p>{error}</p>
+        </Note>
+      )}
+    </InspectorPanel>
+  );
+}

--- a/app/console/ictt/_components/inspectors/transfer-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/transfer-inspector.tsx
@@ -16,6 +16,7 @@ import { EVMAddressInput } from '@/components/toolbox/components/EVMAddressInput
 import { InspectorPanel } from '../inspector-panel';
 import { SegmentControl } from '../segment-control';
 import { usePreflight } from '../use-preflight';
+import { useKeyboardSubmit } from '../use-keyboard-submit';
 import { FieldLoading } from '../field-loading';
 import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent } from '../types';
@@ -178,6 +179,8 @@ export function TransferInspector({
 
   const { banner: preflight } = usePreflight({ expectedChain: sourceChain, switchChain });
   const error = localError || hookError;
+  const canSubmit = !!sourceContract && !!destContract && parsedAmount > 0n && !isWorking;
+  useKeyboardSubmit({ onSubmit: handleSend, enabled: canSubmit });
 
   return (
     <InspectorPanel
@@ -186,6 +189,7 @@ export function TransferInspector({
       title="Send tokens"
       description="Bridge live. Tokens move Home ↔ Remote via ICM."
       meta={`Arrival ETA ≈ 25s after origin tx confirms · gas ${DEFAULT_GAS_LIMIT.toString()}`}
+      showSubmitShortcut={canSubmit}
       primaryAction={
         <Button
           onClick={handleSend}

--- a/app/console/ictt/_components/inspectors/transfer-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/transfer-inspector.tsx
@@ -204,7 +204,7 @@ export function TransferInspector({
       preflight={preflight}
     >
       <div>
-        <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">Direction</label>
+        <label className="block text-[11px] font-medium text-muted-foreground mb-1.5">Direction</label>
         <SegmentControl<TransferDirection>
           value={direction}
           onChange={setDirection}

--- a/app/console/ictt/_components/inspectors/transfer-inspector.tsx
+++ b/app/console/ictt/_components/inspectors/transfer-inspector.tsx
@@ -1,18 +1,14 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { formatUnits, parseUnits, zeroAddress } from 'viem';
+import { parseUnits } from 'viem';
 import ERC20TokenHomeABI from '@/contracts/icm-contracts/compiled/ERC20TokenHome.json';
-import NativeTokenHomeABI from '@/contracts/icm-contracts/compiled/NativeTokenHome.json';
 import ERC20TokenRemoteABI from '@/contracts/icm-contracts/compiled/ERC20TokenRemote.json';
-import NativeTokenRemoteABI from '@/contracts/icm-contracts/compiled/NativeTokenRemote.json';
 import ExampleERC20 from '@/contracts/icm-contracts/compiled/ExampleERC20.json';
 import { useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
 import { useWalletStore } from '@/components/toolbox/stores/walletStore';
-import { useResolvedWalletClient } from '@/components/toolbox/hooks/useResolvedWalletClient';
 import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
-import useConsoleNotifications from '@/hooks/useConsoleNotifications';
-import { cb58ToHex } from '@/components/tools/common/utils/cb58';
+import { useSendTransfer, type TransferDirection } from '@/components/toolbox/console/ictt/hooks/useSendTransfer';
 import { Button } from '@/components/toolbox/components/Button';
 import { Input } from '@/components/toolbox/components/Input';
 import { Note } from '@/components/toolbox/components/Note';
@@ -24,8 +20,6 @@ import type { BridgeState } from '../use-bridge-state';
 import type { ActivityEvent } from '../types';
 
 const DEFAULT_GAS_LIMIT = 250_000n;
-
-type Direction = 'home-to-remote' | 'remote-to-home';
 
 interface TransferInspectorProps {
   bridge: BridgeState;
@@ -40,9 +34,13 @@ interface TransferInspectorProps {
  * Live transfer phase: cross-chain send via the bridge.
  *
  *   home → remote: call `send(SendTokensInput, amount)` on TokenHome
- *                  (ERC-20: needs approve first; Native: passes value)
+ *                  (ERC-20: approve-then-send; Native: passes value)
  *   remote → home: call `send(SendTokensInput, amount)` on TokenRemote
  *                  (Native: passes value; ERC-20: burns from balance)
+ *
+ * On-chain mechanics (approve + send + ABI selection by direction/kind)
+ * live in `useSendTransfer`. This inspector reads source-side decimals
+ * and symbol for display only.
  */
 export function TransferInspector({
   bridge,
@@ -52,21 +50,18 @@ export function TransferInspector({
   appendActivity,
   switchChain,
 }: TransferInspectorProps) {
-  const walletClient = useResolvedWalletClient();
   const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
   const walletChainId = useWalletStore((s) => s.walletChainId);
   const viemChain = useViemChainStore();
-  const { notify } = useConsoleNotifications();
+  const { run: runSend, status, isApproving, isSending, isWorking, error: hookError } = useSendTransfer();
 
-  const [direction, setDirection] = useState<Direction>('home-to-remote');
+  const [direction, setDirection] = useState<TransferDirection>('home-to-remote');
   const [amount, setAmount] = useState('');
   const [recipient, setRecipient] = useState<string>(walletEVMAddress || '');
-  const [error, setError] = useState<string | null>(null);
-  const [working, setWorking] = useState<'idle' | 'approving' | 'sending'>('idle');
   const [decimals, setDecimals] = useState(18);
   const [tokenSymbol, setTokenSymbol] = useState('TKN');
+  const [localError, setLocalError] = useState<string | null>(null);
 
-  // Determine source/destination based on direction.
   const sourceChain = direction === 'home-to-remote' ? bridge.homeChain : bridge.remoteChain;
   const destChain = direction === 'home-to-remote' ? bridge.remoteChain : bridge.homeChain;
   const sourceContract = direction === 'home-to-remote' ? bridge.homeAddress : bridge.remoteAddress;
@@ -77,7 +72,7 @@ export function TransferInspector({
     if (walletEVMAddress) setRecipient(walletEVMAddress);
   }, [walletEVMAddress]);
 
-  // Auto-fetch decimals + symbol from source.
+  // Auto-fetch decimals + symbol from source for display + parsing.
   useEffect(() => {
     if (!sourceChain?.rpcUrl || !sourceContract) return;
     let cancelled = false;
@@ -140,133 +135,48 @@ export function TransferInspector({
   })();
 
   const handleSend = async () => {
-    setError(null);
-    if (!walletClient?.account || !viemChain) {
-      setError('Wallet not connected');
-      return;
-    }
+    setLocalError(null);
     if (!sourceChain || !destChain || !sourceContract || !destContract) {
-      setError('Bridge not fully set up');
+      setLocalError('Bridge not fully set up');
       return;
     }
     if (walletChainId !== sourceChain.evmChainId) {
-      setError(`Switch wallet to ${sourceChain.name}`);
-      return;
-    }
-    if (parsedAmount === 0n) {
-      setError('Enter an amount');
+      setLocalError(`Switch wallet to ${sourceChain.name}`);
       return;
     }
 
-    let destBlockchainIDHex: string;
     try {
-      destBlockchainIDHex = cb58ToHex(destChain.id);
-    } catch {
-      setError('Could not encode destination blockchain ID');
-      return;
-    }
-
-    setWorking('sending');
-    try {
-      const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
-      if (!client) throw new Error('Could not create RPC client');
-
-      // ERC20 home: needs approve before send.
-      if (direction === 'home-to-remote' && bridge.homeKind === 'erc20') {
-        setWorking('approving');
-        const tokenAddr = (await client.readContract({
-          address: sourceContract as `0x${string}`,
-          abi: ERC20TokenHomeABI.abi,
-          functionName: 'getTokenAddress',
-        })) as `0x${string}`;
-        const allowance = (await client.readContract({
-          address: tokenAddr,
-          abi: ExampleERC20.abi,
-          functionName: 'allowance',
-          args: [walletClient.account.address, sourceContract as `0x${string}`],
-        })) as bigint;
-        if (allowance < parsedAmount) {
-          const { request: approveRequest } = await client.simulateContract({
-            address: tokenAddr,
-            abi: ExampleERC20.abi,
-            functionName: 'approve',
-            args: [sourceContract as `0x${string}`, parsedAmount],
-            chain: viemChain,
-            account: walletClient.account,
-          });
-          const approvePromise = walletClient.writeContract(approveRequest);
-          notify({ type: 'call', name: 'Approve for Send' }, approvePromise, viemChain);
-          const approveHash = await approvePromise;
-          await client.waitForTransactionReceipt({ hash: approveHash });
-          appendActivity({
-            kind: 'collateral',
-            label: 'Approved tokens for send',
-            txHash: approveHash,
-            chainId: viemChain.id,
-          });
-        }
-        setWorking('sending');
-      }
-
-      const sendInput = {
-        destinationBlockchainID: destBlockchainIDHex as `0x${string}`,
-        destinationTokenTransferrerAddress: destContract as `0x${string}`,
-        recipient: (recipient || walletEVMAddress) as `0x${string}`,
-        primaryFeeTokenAddress: zeroAddress,
-        primaryFee: 0n,
-        secondaryFee: 0n,
+      const result = await runSend({
+        direction,
+        sourceContract,
+        sourceKind,
+        destContract,
+        destChainId: destChain.id,
+        recipient: recipient || walletEVMAddress || '',
+        amount: parsedAmount,
         requiredGasLimit: DEFAULT_GAS_LIMIT,
-        multiHopFallback: zeroAddress,
-      };
-
-      const isHomeNative = direction === 'home-to-remote' && bridge.homeKind === 'native';
-      const isRemoteNative = direction === 'remote-to-home' && bridge.remoteKind === 'native';
-      const isNativeValue = isHomeNative || isRemoteNative;
-
-      const homeAbi = direction === 'home-to-remote' ? (bridge.homeKind === 'erc20' ? ERC20TokenHomeABI.abi : NativeTokenHomeABI.abi) : null;
-      const remoteAbi =
-        direction === 'remote-to-home'
-          ? bridge.remoteKind === 'erc20'
-            ? ERC20TokenRemoteABI.abi
-            : NativeTokenRemoteABI.abi
-          : null;
-
-      const { request } = await client.simulateContract({
-        address: sourceContract as `0x${string}`,
-        abi: (homeAbi ?? remoteAbi) as any,
-        functionName: 'send',
-        args: isNativeValue ? [sendInput] : [sendInput, parsedAmount],
-        chain: viemChain,
-        account: walletClient.account,
-        ...(isNativeValue ? { value: parsedAmount } : {}),
+        approveBeforeSend: direction === 'home-to-remote' && bridge.homeKind === 'erc20',
       });
-
-      const writePromise = walletClient.writeContract(request);
-      notify({ type: 'call', name: 'Send Tokens' }, writePromise, viemChain);
-      const hash = await writePromise;
-      await client.waitForTransactionReceipt({ hash });
 
       appendActivity({
         kind: 'send',
         label: `Sent ${tokenSymbol} ${sourceChain.name} → ${destChain.name}`,
-        amount: amount,
-        txHash: hash,
-        chainId: viemChain.id,
+        amount,
+        txHash: result.hash,
+        chainId: viemChain?.id,
       });
       bridge.refresh();
       onAdvance();
     } catch (e: any) {
       const msg = e?.shortMessage ?? e?.message ?? 'Send failed';
-      setError(msg);
       appendActivity({ kind: 'error', label: `Send failed: ${msg}` });
-    } finally {
-      setWorking('idle');
     }
   };
 
   const onSwitchToSource = sourceChain
     ? () => switchChain(sourceChain.evmChainId, !!sourceChain.isTestnet)
     : undefined;
+  const error = localError || hookError;
 
   return (
     <InspectorPanel
@@ -278,9 +188,9 @@ export function TransferInspector({
       primaryAction={
         <Button
           onClick={handleSend}
-          loading={working !== 'idle'}
-          loadingText={working === 'approving' ? 'Approving...' : 'Sending...'}
-          disabled={!sourceContract || !destContract || parsedAmount === 0n || working !== 'idle'}
+          loading={isWorking}
+          loadingText={isApproving ? 'Approving...' : 'Sending...'}
+          disabled={!sourceContract || !destContract || parsedAmount === 0n || isWorking}
           stickLeft
         >
           Send →
@@ -295,7 +205,7 @@ export function TransferInspector({
     >
       <div>
         <label className="block text-[11px] font-medium text-zinc-600 dark:text-zinc-400 mb-1.5">Direction</label>
-        <SegmentControl<Direction>
+        <SegmentControl<TransferDirection>
           value={direction}
           onChange={setDirection}
           options={[
@@ -325,6 +235,13 @@ export function TransferInspector({
           Bridge not yet collateralized. Sends will fail until you complete the <strong>Collateral</strong> phase.
         </Note>
       ) : null}
+
+      {/* Status badge while transaction is in flight */}
+      {status !== 'idle' && (
+        <Note variant="default">
+          {isApproving ? 'Approving spend on source contract…' : 'Submitting send transaction…'}
+        </Note>
+      )}
 
       {error && (
         <Note variant="destructive">

--- a/app/console/ictt/_components/phase-strip.tsx
+++ b/app/console/ictt/_components/phase-strip.tsx
@@ -8,78 +8,68 @@ interface PhaseStripProps {
   activePhase: PhaseId;
   phaseStatus: Record<PhaseId, PhaseStatus>;
   onPhaseClick: (phase: PhaseId) => void;
-  accent: string;
 }
 
 /**
- * Top-of-page phase strip. Replaces `step-flow.tsx` for ICTT only — the
- * generic stepper still powers 50+ other console flows.
+ * Bridge console's phase navigation. Visually mirrors the shared
+ * `components/console/step-flow.tsx` stepper (same border / background
+ * tokens, `→` separators, numbered circles, `Check` for done) so the
+ * ICTT page reads as part of the console rather than a one-off design.
  *
- * Phases render as pills connected by 1px lines. Active pill takes the
- * accent color. Done pills are emerald with a check icon. Blocked pills
- * are grayed out and disabled. Connector color reflects the *previous*
- * phase's done-ness.
+ * The differences vs step-flow are functional, not visual:
+ *   - Phase state is driven by on-chain reads (idle/active/done/blocked)
+ *     rather than URL position
+ *   - Blocked phases get a disabled treatment + tooltip; clicks are
+ *     ignored so users can't deep-link into a phase that needs prior
+ *     work first
  */
-export function PhaseStrip({ activePhase, phaseStatus, onPhaseClick, accent }: PhaseStripProps) {
+export function PhaseStrip({ activePhase, phaseStatus, onPhaseClick }: PhaseStripProps) {
   return (
-    <div className="border-b border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 px-4 md:px-6 py-3">
-      <div className="flex items-center gap-1 md:gap-2 overflow-x-auto">
+    <nav className="border-b border-border bg-background px-4 md:px-6 py-3">
+      <ol className="flex flex-wrap items-center justify-center gap-3 text-sm">
         {PHASES.map((phase, index) => {
           const status = phaseStatus[phase.id];
           const isActive = activePhase === phase.id;
           const isDone = status === 'done';
           const isBlocked = status === 'blocked';
-          const previousDone = index === 0 || phaseStatus[PHASES[index - 1].id] === 'done';
 
           return (
-            <div key={phase.id} className="flex items-center flex-shrink-0">
+            <li key={phase.id} className="flex items-center gap-3">
               <button
                 type="button"
                 onClick={() => !isBlocked && onPhaseClick(phase.id)}
                 disabled={isBlocked}
-                title={isBlocked ? `Complete previous phase first` : phase.description}
-                style={isActive && !isDone ? { background: accent, borderColor: accent, color: '#fff' } : undefined}
+                title={isBlocked ? 'Complete previous phase first' : phase.description}
                 className={cn(
-                  'group flex items-center gap-2 px-3 py-1.5 rounded-xl border text-xs font-medium transition-all',
-                  isActive && !isDone && 'shadow-sm',
-                  isDone &&
-                    'bg-emerald-50 border-emerald-200 text-emerald-700 dark:bg-emerald-950/40 dark:border-emerald-900/60 dark:text-emerald-300',
-                  !isActive &&
-                    !isDone &&
-                    !isBlocked &&
-                    'bg-white border-zinc-200 text-zinc-600 hover:border-zinc-300 dark:bg-zinc-900 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-600 cursor-pointer',
-                  isBlocked &&
-                    'bg-zinc-50 border-zinc-200 text-zinc-400 cursor-not-allowed dark:bg-zinc-900/50 dark:border-zinc-800 dark:text-zinc-600',
+                  'inline-flex items-center gap-2 rounded-lg px-3 py-1.5 border transition-colors',
+                  isActive
+                    ? 'border-primary text-primary'
+                    : isDone
+                      ? 'border-green-300 dark:border-green-700 text-green-600 dark:text-green-400'
+                      : 'border-border text-muted-foreground',
+                  isBlocked && 'opacity-50 cursor-not-allowed',
+                  !isBlocked && !isActive && 'hover:border-foreground/30 cursor-pointer',
                 )}
               >
                 <span
                   className={cn(
-                    'w-5 h-5 rounded-full grid place-items-center text-[10px] font-semibold',
-                    isDone && 'bg-white/40 text-emerald-800 dark:bg-emerald-900/60 dark:text-emerald-200',
-                    isActive && !isDone && 'bg-white/25',
-                    !isActive &&
-                      !isDone &&
-                      !isBlocked &&
-                      'bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500',
-                    isBlocked && 'bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-600',
+                    'flex h-6 w-6 items-center justify-center rounded-full text-xs',
+                    isActive
+                      ? 'bg-primary text-primary-foreground'
+                      : isDone
+                        ? 'bg-green-500 text-white'
+                        : 'bg-muted text-muted-foreground',
                   )}
                 >
-                  {isDone ? <Check className="w-3 h-3" strokeWidth={2.5} /> : index + 1}
+                  {isDone ? <Check className="h-3.5 w-3.5" /> : index + 1}
                 </span>
                 <span>{phase.label}</span>
               </button>
-              {index < PHASES.length - 1 && (
-                <div
-                  className={cn(
-                    'mx-1 md:mx-2 w-4 md:w-8 h-px',
-                    previousDone ? 'bg-emerald-300 dark:bg-emerald-800' : 'bg-zinc-200 dark:bg-zinc-800',
-                  )}
-                />
-              )}
-            </div>
+              {index < PHASES.length - 1 && <span className="text-muted-foreground/50 ml-3">→</span>}
+            </li>
           );
         })}
-      </div>
-    </div>
+      </ol>
+    </nav>
   );
 }

--- a/app/console/ictt/_components/phase-strip.tsx
+++ b/app/console/ictt/_components/phase-strip.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { Check } from 'lucide-react';
+import { cn } from '@/components/toolbox/lib/utils';
+import { PHASES, type PhaseId, type PhaseStatus } from './types';
+
+interface PhaseStripProps {
+  activePhase: PhaseId;
+  phaseStatus: Record<PhaseId, PhaseStatus>;
+  onPhaseClick: (phase: PhaseId) => void;
+  accent: string;
+}
+
+/**
+ * Top-of-page phase strip. Replaces `step-flow.tsx` for ICTT only — the
+ * generic stepper still powers 50+ other console flows.
+ *
+ * Phases render as pills connected by 1px lines. Active pill takes the
+ * accent color. Done pills are emerald with a check icon. Blocked pills
+ * are grayed out and disabled. Connector color reflects the *previous*
+ * phase's done-ness.
+ */
+export function PhaseStrip({ activePhase, phaseStatus, onPhaseClick, accent }: PhaseStripProps) {
+  return (
+    <div className="border-b border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 px-4 md:px-6 py-3">
+      <div className="flex items-center gap-1 md:gap-2 overflow-x-auto">
+        {PHASES.map((phase, index) => {
+          const status = phaseStatus[phase.id];
+          const isActive = activePhase === phase.id;
+          const isDone = status === 'done';
+          const isBlocked = status === 'blocked';
+          const previousDone = index === 0 || phaseStatus[PHASES[index - 1].id] === 'done';
+
+          return (
+            <div key={phase.id} className="flex items-center flex-shrink-0">
+              <button
+                type="button"
+                onClick={() => !isBlocked && onPhaseClick(phase.id)}
+                disabled={isBlocked}
+                title={isBlocked ? `Complete previous phase first` : phase.description}
+                style={isActive && !isDone ? { background: accent, borderColor: accent, color: '#fff' } : undefined}
+                className={cn(
+                  'group flex items-center gap-2 px-3 py-1.5 rounded-xl border text-xs font-medium transition-all',
+                  isActive && !isDone && 'shadow-sm',
+                  isDone &&
+                    'bg-emerald-50 border-emerald-200 text-emerald-700 dark:bg-emerald-950/40 dark:border-emerald-900/60 dark:text-emerald-300',
+                  !isActive &&
+                    !isDone &&
+                    !isBlocked &&
+                    'bg-white border-zinc-200 text-zinc-600 hover:border-zinc-300 dark:bg-zinc-900 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-600 cursor-pointer',
+                  isBlocked &&
+                    'bg-zinc-50 border-zinc-200 text-zinc-400 cursor-not-allowed dark:bg-zinc-900/50 dark:border-zinc-800 dark:text-zinc-600',
+                )}
+              >
+                <span
+                  className={cn(
+                    'w-5 h-5 rounded-full grid place-items-center text-[10px] font-semibold',
+                    isDone && 'bg-white/40 text-emerald-800 dark:bg-emerald-900/60 dark:text-emerald-200',
+                    isActive && !isDone && 'bg-white/25',
+                    !isActive &&
+                      !isDone &&
+                      !isBlocked &&
+                      'bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500',
+                    isBlocked && 'bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-600',
+                  )}
+                >
+                  {isDone ? <Check className="w-3 h-3" strokeWidth={2.5} /> : index + 1}
+                </span>
+                <span>{phase.label}</span>
+              </button>
+              {index < PHASES.length - 1 && (
+                <div
+                  className={cn(
+                    'mx-1 md:mx-2 w-4 md:w-8 h-px',
+                    previousDone ? 'bg-emerald-300 dark:bg-emerald-800' : 'bg-zinc-200 dark:bg-zinc-800',
+                  )}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/console/ictt/_components/relative-time.ts
+++ b/app/console/ictt/_components/relative-time.ts
@@ -1,0 +1,16 @@
+/**
+ * Tiny relative-time formatter. Returns short labels like `2s`, `5m`,
+ * `1h`, `3d`. Anything older than a week falls back to absolute date.
+ */
+export function relativeTime(timestamp: number, now = Date.now()): string {
+  const diff = Math.max(0, now - timestamp);
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d`;
+  return new Date(timestamp).toLocaleDateString();
+}

--- a/app/console/ictt/_components/remote-picker.tsx
+++ b/app/console/ictt/_components/remote-picker.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronDown } from 'lucide-react';
 import type { L1ListItem } from '@/components/toolbox/stores/l1ListStore';
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
 import { chainColor } from './chain-color';
 
 interface RemotePickerProps {
@@ -12,28 +13,37 @@ interface RemotePickerProps {
 
 /**
  * Compact dropdown for switching between deployed remotes when the user
- * has paired the same Home with multiple Remote chains. Renders inline
- * as a chip with the active chain's color + name + chevron. Hidden by
- * the parent when only one remote exists.
+ * has paired the same Home with multiple Remote chains. Renders as a
+ * styled trigger pill (chain dot + name) on top of the shared `<Select>`
+ * primitive so the dropdown menu inherits the project's design system
+ * (animations, dark mode, focus states).
+ *
+ * Hidden by the parent when only one remote exists.
  */
 export function RemotePicker({ remotes, selected, onChange }: RemotePickerProps) {
   return (
-    <label className="relative inline-flex items-center gap-1.5 px-2 py-1 rounded-md border border-border bg-background hover:border-foreground/30 cursor-pointer transition-colors text-[11px] font-medium text-foreground/80">
-      <span className="w-1.5 h-1.5 rounded-full" style={{ background: chainColor(selected.id) }} />
-      <span className="truncate max-w-[8rem]">{selected.name}</span>
-      <ChevronDown className="w-3 h-3 text-muted-foreground" />
-      <select
-        value={selected.id}
-        onChange={(e) => onChange(e.target.value)}
-        className="absolute inset-0 opacity-0 cursor-pointer"
-        aria-label="Switch active remote"
+    <Select value={selected.id} onValueChange={onChange}>
+      <SelectTrigger
+        size="sm"
+        className="h-7 px-2 gap-1.5 text-[11px] font-medium text-foreground/80 [&>svg]:hidden"
       >
+        <span className="w-1.5 h-1.5 rounded-full" style={{ background: chainColor(selected.id) }} />
+        <span className="truncate max-w-[8rem]">{selected.name}</span>
+        <ChevronDown className="w-3 h-3 text-muted-foreground" />
+      </SelectTrigger>
+      <SelectContent>
         {remotes.map((r) => (
-          <option key={r.chain.id} value={r.chain.id}>
-            {r.chain.name} — {r.address.slice(0, 6)}…{r.address.slice(-4)}
-          </option>
+          <SelectItem key={r.chain.id} value={r.chain.id}>
+            <span className="flex items-center gap-2">
+              <span className="w-1.5 h-1.5 rounded-full flex-shrink-0" style={{ background: chainColor(r.chain.id) }} />
+              <span>{r.chain.name}</span>
+              <span className="text-muted-foreground font-mono text-[10px]">
+                {r.address.slice(0, 6)}…{r.address.slice(-4)}
+              </span>
+            </span>
+          </SelectItem>
         ))}
-      </select>
-    </label>
+      </SelectContent>
+    </Select>
   );
 }

--- a/app/console/ictt/_components/remote-picker.tsx
+++ b/app/console/ictt/_components/remote-picker.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ChevronDown } from 'lucide-react';
+import type { L1ListItem } from '@/components/toolbox/stores/l1ListStore';
+import { chainColor } from './chain-color';
+
+interface RemotePickerProps {
+  remotes: { chain: L1ListItem; address: string }[];
+  selected: L1ListItem;
+  onChange: (chainId: string) => void;
+}
+
+/**
+ * Compact dropdown for switching between deployed remotes when the user
+ * has paired the same Home with multiple Remote chains. Renders inline
+ * as a chip with the active chain's color + name + chevron. Hidden by
+ * the parent when only one remote exists.
+ */
+export function RemotePicker({ remotes, selected, onChange }: RemotePickerProps) {
+  return (
+    <label className="relative inline-flex items-center gap-1.5 px-2 py-1 rounded-md border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 hover:border-zinc-300 dark:hover:border-zinc-700 cursor-pointer transition-colors text-[11px] font-medium text-zinc-700 dark:text-zinc-300">
+      <span className="w-1.5 h-1.5 rounded-full" style={{ background: chainColor(selected.id) }} />
+      <span className="truncate max-w-[8rem]">{selected.name}</span>
+      <ChevronDown className="w-3 h-3 text-zinc-400" />
+      <select
+        value={selected.id}
+        onChange={(e) => onChange(e.target.value)}
+        className="absolute inset-0 opacity-0 cursor-pointer"
+        aria-label="Switch active remote"
+      >
+        {remotes.map((r) => (
+          <option key={r.chain.id} value={r.chain.id}>
+            {r.chain.name} — {r.address.slice(0, 6)}…{r.address.slice(-4)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/app/console/ictt/_components/remote-picker.tsx
+++ b/app/console/ictt/_components/remote-picker.tsx
@@ -18,10 +18,10 @@ interface RemotePickerProps {
  */
 export function RemotePicker({ remotes, selected, onChange }: RemotePickerProps) {
   return (
-    <label className="relative inline-flex items-center gap-1.5 px-2 py-1 rounded-md border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 hover:border-zinc-300 dark:hover:border-zinc-700 cursor-pointer transition-colors text-[11px] font-medium text-zinc-700 dark:text-zinc-300">
+    <label className="relative inline-flex items-center gap-1.5 px-2 py-1 rounded-md border border-border bg-background hover:border-foreground/30 cursor-pointer transition-colors text-[11px] font-medium text-foreground/80">
       <span className="w-1.5 h-1.5 rounded-full" style={{ background: chainColor(selected.id) }} />
       <span className="truncate max-w-[8rem]">{selected.name}</span>
-      <ChevronDown className="w-3 h-3 text-zinc-400" />
+      <ChevronDown className="w-3 h-3 text-muted-foreground" />
       <select
         value={selected.id}
         onChange={(e) => onChange(e.target.value)}

--- a/app/console/ictt/_components/reset-bridge-button.tsx
+++ b/app/console/ictt/_components/reset-bridge-button.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState } from 'react';
+import { RotateCcw } from 'lucide-react';
+import { getToolboxStore } from '@/components/toolbox/stores/toolboxStore';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/toolbox/components/AlertDialog';
+
+interface ResetBridgeButtonProps {
+  homeChainId: string | undefined;
+  remoteChainIds: string[];
+  onAfterReset: () => void;
+  /** Disable the button entirely when nothing has been deployed yet. */
+  hasAnythingToReset: boolean;
+}
+
+/**
+ * Top-bar action that clears the current bridge state and starts the
+ * user over from the Token phase. Useful when iterating during testing —
+ * the alternative is opening DevTools and manually clearing localStorage
+ * keys.
+ *
+ * Scope of the reset:
+ *   - Home chain's toolbox store: ICTT-specific keys (token + home +
+ *     legacy mirror remote)
+ *   - Each remote chain's toolbox store: ICTT remote keys only
+ *   - The bridge activity feed (delegated to the parent via
+ *     `onAfterReset`)
+ *
+ * Explicitly does NOT touch: teleporter registry, validator manager,
+ * staking manager, or any non-ICTT toolbox keys. Other tools running
+ * on the same chain are unaffected.
+ */
+export function ResetBridgeButton({
+  homeChainId,
+  remoteChainIds,
+  onAfterReset,
+  hasAnythingToReset,
+}: ResetBridgeButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleReset = () => {
+    if (homeChainId) {
+      const home = getToolboxStore(homeChainId).getState();
+      home.setExampleErc20Address('');
+      home.setErc20TokenHomeAddress('');
+      home.setNativeTokenHomeAddress('');
+      // Legacy compatibility — the old wizard also wrote remote addresses
+      // to the active chain's store. Clear them so reset is total.
+      home.setErc20TokenRemoteAddress('');
+      home.setNativeTokenRemoteAddress('');
+    }
+    for (const remoteId of remoteChainIds) {
+      const remote = getToolboxStore(remoteId).getState();
+      remote.setErc20TokenRemoteAddress('');
+      remote.setNativeTokenRemoteAddress('');
+    }
+    onAfterReset();
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={!hasAnythingToReset}
+        title={hasAnythingToReset ? 'Reset bridge' : 'Nothing to reset yet'}
+        className="hidden md:inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-zinc-600 dark:text-zinc-300 border border-zinc-200 dark:border-zinc-700 rounded-lg hover:bg-zinc-50 dark:hover:bg-zinc-900 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+      >
+        <RotateCcw className="w-3.5 h-3.5" />
+        Reset
+      </button>
+
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reset this bridge?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Clears the deployed token, TokenHome, and TokenRemote contract addresses for this bridge so you can start
+              over. The on-chain contracts stay deployed — only your local references are removed. Activity history is
+              also cleared.
+              <br />
+              <br />
+              Other tools (Teleporter Registry, validator manager, etc.) are not affected.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="danger" onClick={handleReset}>
+              Reset bridge
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/app/console/ictt/_components/reset-bridge-button.tsx
+++ b/app/console/ictt/_components/reset-bridge-button.tsx
@@ -74,7 +74,7 @@ export function ResetBridgeButton({
         onClick={() => setOpen(true)}
         disabled={!hasAnythingToReset}
         title={hasAnythingToReset ? 'Reset bridge' : 'Nothing to reset yet'}
-        className="hidden md:inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-zinc-600 dark:text-zinc-300 border border-zinc-200 dark:border-zinc-700 rounded-lg hover:bg-zinc-50 dark:hover:bg-zinc-900 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+        className="hidden md:inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-foreground/80 border border-border rounded-lg hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
       >
         <RotateCcw className="w-3.5 h-3.5" />
         Reset

--- a/app/console/ictt/_components/segment-control.tsx
+++ b/app/console/ictt/_components/segment-control.tsx
@@ -24,7 +24,7 @@ interface SegmentControlProps<T extends string> {
  */
 export function SegmentControl<T extends string>({ options, value, onChange, className }: SegmentControlProps<T>) {
   return (
-    <div className={cn('inline-flex p-0.5 bg-zinc-100 dark:bg-zinc-900 rounded-lg', className)}>
+    <div className={cn('inline-flex p-0.5 bg-muted rounded-lg', className)}>
       {options.map((opt) => {
         const isActive = opt.value === value;
         return (
@@ -37,8 +37,8 @@ export function SegmentControl<T extends string>({ options, value, onChange, cla
             className={cn(
               'px-2.5 py-1.5 text-xs font-medium rounded-md transition-colors',
               isActive
-                ? 'bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 shadow-sm'
-                : 'text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200',
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
               opt.disabled && 'opacity-40 cursor-not-allowed',
               !opt.disabled && 'cursor-pointer',
             )}

--- a/app/console/ictt/_components/segment-control.tsx
+++ b/app/console/ictt/_components/segment-control.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { cn } from '@/components/toolbox/lib/utils';
+
+interface SegmentOption<T extends string> {
+  value: T;
+  label: string;
+  disabled?: boolean;
+  tooltip?: string;
+}
+
+interface SegmentControlProps<T extends string> {
+  options: SegmentOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  className?: string;
+}
+
+/**
+ * Inline segmented switcher used by the inspectors instead of stacked
+ * RadioGroup or "or"-separated branch options. Used for token type
+ * (existing/test/wrapped), home/remote kind (erc20/native), and transfer
+ * direction (home→remote / remote→home).
+ */
+export function SegmentControl<T extends string>({ options, value, onChange, className }: SegmentControlProps<T>) {
+  return (
+    <div className={cn('inline-flex p-0.5 bg-zinc-100 dark:bg-zinc-900 rounded-lg', className)}>
+      {options.map((opt) => {
+        const isActive = opt.value === value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            disabled={opt.disabled}
+            title={opt.tooltip ?? opt.label}
+            onClick={() => !opt.disabled && onChange(opt.value)}
+            className={cn(
+              'px-2.5 py-1.5 text-xs font-medium rounded-md transition-colors',
+              isActive
+                ? 'bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 shadow-sm'
+                : 'text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200',
+              opt.disabled && 'opacity-40 cursor-not-allowed',
+              !opt.disabled && 'cursor-pointer',
+            )}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/console/ictt/_components/shortcuts-overlay.tsx
+++ b/app/console/ictt/_components/shortcuts-overlay.tsx
@@ -56,7 +56,7 @@ export function ShortcutsOverlay() {
         type="button"
         onClick={() => setOpen(true)}
         title="Keyboard shortcuts"
-        className="hidden md:inline-flex items-center justify-center w-8 h-8 text-zinc-500 dark:text-zinc-400 border border-zinc-200 dark:border-zinc-700 rounded-lg hover:bg-zinc-50 dark:hover:bg-zinc-900 cursor-pointer"
+        className="hidden md:inline-flex items-center justify-center w-8 h-8 text-muted-foreground border border-border rounded-lg hover:bg-muted cursor-pointer"
       >
         <Keyboard className="w-4 h-4" />
       </button>
@@ -74,7 +74,7 @@ export function ShortcutsOverlay() {
               <button
                 type="button"
                 onClick={() => setOpen(false)}
-                className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 cursor-pointer p-1 -m-1 rounded"
+                className="text-muted-foreground hover:text-foreground cursor-pointer p-1 -m-1 rounded"
                 aria-label="Close"
               >
                 <X className="w-4 h-4" />
@@ -85,12 +85,12 @@ export function ShortcutsOverlay() {
           <div className="space-y-3">
             {SHORTCUTS.map((s) => (
               <div key={s.keys.join('+')} className="flex items-center justify-between gap-3">
-                <span className="text-sm text-zinc-700 dark:text-zinc-300">{s.description}</span>
+                <span className="text-sm text-foreground/80">{s.description}</span>
                 <div className="flex items-center gap-1 flex-shrink-0">
                   {s.keys.map((k, i) => (
                     <kbd
                       key={i}
-                      className="inline-flex items-center justify-center min-w-[1.75rem] h-7 px-2 rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-xs font-mono text-zinc-700 dark:text-zinc-300"
+                      className="inline-flex items-center justify-center min-w-[1.75rem] h-7 px-2 rounded border border-border bg-background text-xs font-mono text-foreground/80"
                     >
                       {k}
                     </kbd>

--- a/app/console/ictt/_components/shortcuts-overlay.tsx
+++ b/app/console/ictt/_components/shortcuts-overlay.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Keyboard, X } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/toolbox/components/AlertDialog';
+
+interface Shortcut {
+  keys: string[];
+  description: string;
+}
+
+const SHORTCUTS: Shortcut[] = [
+  { keys: ['?'], description: 'Show this overlay' },
+  { keys: ['←', '→'], description: 'Move between phases (skips blocked)' },
+  { keys: ['⌘', 'Enter'], description: 'Submit the active inspector primary action (macOS)' },
+  { keys: ['Ctrl', 'Enter'], description: 'Submit the active inspector primary action (others)' },
+];
+
+/**
+ * Discoverability surface for the keyboard shortcuts. Opens via the
+ * `?` keystroke (when not focused inside an editable field) or via the
+ * trigger button in the top bar. Uses the project's `<AlertDialog>`
+ * primitive to stay visually consistent with the reset-bridge confirm.
+ *
+ * The trigger is exposed so the BridgeConsole can render it inline in
+ * the top bar's action group.
+ */
+export function ShortcutsOverlay() {
+  const [open, setOpen] = useState(false);
+
+  // `?` opens the overlay. Not bound when the user is inside an
+  // editable field — let them type literal question marks normally.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== '?') return;
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+        return;
+      }
+      e.preventDefault();
+      setOpen(true);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        title="Keyboard shortcuts"
+        className="hidden md:inline-flex items-center justify-center w-8 h-8 text-zinc-500 dark:text-zinc-400 border border-zinc-200 dark:border-zinc-700 rounded-lg hover:bg-zinc-50 dark:hover:bg-zinc-900 cursor-pointer"
+      >
+        <Keyboard className="w-4 h-4" />
+      </button>
+
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <AlertDialogTitle>Keyboard shortcuts</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Power-user shortcuts for the bridge console. None require Shift.
+                </AlertDialogDescription>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 cursor-pointer p-1 -m-1 rounded"
+                aria-label="Close"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+          </AlertDialogHeader>
+
+          <div className="space-y-3">
+            {SHORTCUTS.map((s) => (
+              <div key={s.keys.join('+')} className="flex items-center justify-between gap-3">
+                <span className="text-sm text-zinc-700 dark:text-zinc-300">{s.description}</span>
+                <div className="flex items-center gap-1 flex-shrink-0">
+                  {s.keys.map((k, i) => (
+                    <kbd
+                      key={i}
+                      className="inline-flex items-center justify-center min-w-[1.75rem] h-7 px-2 rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-xs font-mono text-zinc-700 dark:text-zinc-300"
+                    >
+                      {k}
+                    </kbd>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/app/console/ictt/_components/shortcuts-overlay.tsx
+++ b/app/console/ictt/_components/shortcuts-overlay.tsx
@@ -1,14 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Keyboard, X } from 'lucide-react';
-import {
-  AlertDialog,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/toolbox/components/AlertDialog';
+import { Keyboard } from 'lucide-react';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 
 interface Shortcut {
   keys: string[];
@@ -25,11 +19,11 @@ const SHORTCUTS: Shortcut[] = [
 /**
  * Discoverability surface for the keyboard shortcuts. Opens via the
  * `?` keystroke (when not focused inside an editable field) or via the
- * trigger button in the top bar. Uses the project's `<AlertDialog>`
- * primitive to stay visually consistent with the reset-bridge confirm.
+ * trigger button in the top bar.
  *
- * The trigger is exposed so the BridgeConsole can render it inline in
- * the top bar's action group.
+ * Uses the project's `<Dialog>` primitive since this is informational
+ * — `<AlertDialog>` is reserved for destructive confirmations like
+ * Reset Bridge.
  */
 export function ShortcutsOverlay() {
   const [open, setOpen] = useState(false);
@@ -61,26 +55,12 @@ export function ShortcutsOverlay() {
         <Keyboard className="w-4 h-4" />
       </button>
 
-      <AlertDialog open={open} onOpenChange={setOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <AlertDialogTitle>Keyboard shortcuts</AlertDialogTitle>
-                <AlertDialogDescription>
-                  Power-user shortcuts for the bridge console. None require Shift.
-                </AlertDialogDescription>
-              </div>
-              <button
-                type="button"
-                onClick={() => setOpen(false)}
-                className="text-muted-foreground hover:text-foreground cursor-pointer p-1 -m-1 rounded"
-                aria-label="Close"
-              >
-                <X className="w-4 h-4" />
-              </button>
-            </div>
-          </AlertDialogHeader>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Keyboard shortcuts</DialogTitle>
+            <DialogDescription>Power-user shortcuts for the bridge console. None require Shift.</DialogDescription>
+          </DialogHeader>
 
           <div className="space-y-3">
             {SHORTCUTS.map((s) => (
@@ -99,8 +79,8 @@ export function ShortcutsOverlay() {
               </div>
             ))}
           </div>
-        </AlertDialogContent>
-      </AlertDialog>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/app/console/ictt/_components/token-snapshot.tsx
+++ b/app/console/ictt/_components/token-snapshot.tsx
@@ -26,11 +26,11 @@ export function TokenSnapshotPanel({
 
   return (
     <div>
-      <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 font-semibold mb-2">
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold mb-2">
         {title}
       </div>
       {error ? (
-        <div className="text-[11px] text-zinc-400 dark:text-zinc-500 bg-zinc-50/50 dark:bg-zinc-900/30 border border-zinc-100 dark:border-zinc-800 rounded-lg px-3 py-2">
+        <div className="text-[11px] text-muted-foreground bg-muted/30 border border-border/60 rounded-lg px-3 py-2">
           Could not load snapshot.
         </div>
       ) : (
@@ -50,9 +50,9 @@ export function TokenSnapshotPanel({
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-lg bg-zinc-50 dark:bg-zinc-900/60 border border-zinc-100 dark:border-zinc-800 px-2.5 py-2">
-      <div className="text-[10px] text-zinc-400 dark:text-zinc-500 uppercase tracking-wider">{label}</div>
-      <div className="text-xs font-mono font-semibold text-zinc-900 dark:text-zinc-100 mt-0.5 truncate">{value}</div>
+    <div className="rounded-lg bg-muted/40 border border-border/60 px-2.5 py-2">
+      <div className="text-[10px] text-muted-foreground uppercase tracking-wider">{label}</div>
+      <div className="text-xs font-mono font-semibold text-foreground mt-0.5 truncate">{value}</div>
     </div>
   );
 }

--- a/app/console/ictt/_components/token-snapshot.tsx
+++ b/app/console/ictt/_components/token-snapshot.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import type { TokenSnapshot } from './use-token-snapshot';
+import { formatTokenAmount } from './use-token-snapshot';
+
+interface TokenSnapshotPanelProps {
+  title: string;
+  snapshot: TokenSnapshot;
+  showBridged?: boolean;
+  bridgedLabel?: string;
+}
+
+/**
+ * Three-cell stat block used in the expanded chain panels. Cells shrink
+ * to "—" when no data exists yet (e.g., before TokenHome is deployed).
+ * Loading state shows a faint shimmer rather than a spinner so it
+ * doesn't visually compete with the active phase indicators.
+ */
+export function TokenSnapshotPanel({
+  title,
+  snapshot,
+  showBridged = true,
+  bridgedLabel = 'Bridged',
+}: TokenSnapshotPanelProps) {
+  const { symbol, decimals, totalSupply, bridged, isLoading, error } = snapshot;
+
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 font-semibold mb-2">
+        {title}
+      </div>
+      {error ? (
+        <div className="text-[11px] text-zinc-400 dark:text-zinc-500 bg-zinc-50/50 dark:bg-zinc-900/30 border border-zinc-100 dark:border-zinc-800 rounded-lg px-3 py-2">
+          Could not load snapshot.
+        </div>
+      ) : (
+        <div className={`grid grid-cols-3 gap-2 ${isLoading ? 'animate-pulse' : ''}`}>
+          <Stat label="Supply" value={formatTokenAmount(totalSupply, decimals)} />
+          <Stat label="Decimals" value={String(decimals)} />
+          {showBridged ? (
+            <Stat label={bridgedLabel} value={formatTokenAmount(bridged, decimals)} />
+          ) : (
+            <Stat label="Symbol" value={symbol} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg bg-zinc-50 dark:bg-zinc-900/60 border border-zinc-100 dark:border-zinc-800 px-2.5 py-2">
+      <div className="text-[10px] text-zinc-400 dark:text-zinc-500 uppercase tracking-wider">{label}</div>
+      <div className="text-xs font-mono font-semibold text-zinc-900 dark:text-zinc-100 mt-0.5 truncate">{value}</div>
+    </div>
+  );
+}

--- a/app/console/ictt/_components/types.ts
+++ b/app/console/ictt/_components/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared types for the ICTT Bridge Console.
+ *
+ * The bridge is modeled as a spatial object with two chains (home/remote)
+ * linked by ICM. Each phase represents a step in constructing or operating
+ * the bridge. Phase status is derived from on-chain contract state plus
+ * local indexer reads.
+ */
+export type PhaseId = 'token' | 'home' | 'remote' | 'register' | 'collateral' | 'transfer';
+
+export type PhaseStatus = 'idle' | 'active' | 'done' | 'blocked';
+
+export type ContractStatus = 'idle' | 'pending' | 'deployed';
+
+export type TokenKind = 'erc20' | 'native';
+
+export interface PhaseDescriptor {
+  id: PhaseId;
+  label: string;
+  description: string;
+}
+
+export const PHASES: PhaseDescriptor[] = [
+  { id: 'token', label: 'Token', description: 'Pick or deploy the home asset' },
+  { id: 'home', label: 'Home', description: 'Deploy TokenHome on origin chain' },
+  { id: 'remote', label: 'Remote', description: 'Deploy TokenRemote on destination' },
+  { id: 'register', label: 'Register', description: 'Pair Remote ↔ Home over ICM' },
+  { id: 'collateral', label: 'Collateral', description: 'Fund the bridge' },
+  { id: 'transfer', label: 'Live', description: 'Send tokens across' },
+];
+
+export interface ContractSlot {
+  label: string;
+  address: string | null;
+  status: ContractStatus;
+}
+
+export interface ActivityEvent {
+  id: string;
+  kind: 'deploy' | 'register' | 'send' | 'collateral' | 'error';
+  label: string;
+  amount?: string;
+  timestamp: number;
+  txHash?: string;
+  chainId?: number;
+}

--- a/app/console/ictt/_components/use-bridge-activity.ts
+++ b/app/console/ictt/_components/use-bridge-activity.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ActivityEvent } from './types';
+
+const STORAGE_KEY = 'ictt-bridge-activity-v1';
+const MAX_EVENTS = 50;
+
+function readLocal(): ActivityEvent[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.slice(0, MAX_EVENTS) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeLocal(events: ActivityEvent[]) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(events.slice(0, MAX_EVENTS)));
+  } catch {
+    /* ignore quota errors */
+  }
+}
+
+/**
+ * Local activity log for the bridge console. Stores the user's optimistic
+ * events (deploy, register, addCollateral, send) in localStorage so the
+ * activity feed shows recent work even after a page reload.
+ *
+ * The redesign plan also wires `/api/ictt-stats` for historic events; v1
+ * uses local-only to avoid coupling the new UI to indexer aggregation
+ * shape changes. Indexer-sourced events can be merged in a follow-up.
+ */
+export function useBridgeActivity() {
+  const [events, setEvents] = useState<ActivityEvent[]>(() => readLocal());
+  const persistRef = useRef(events);
+
+  useEffect(() => {
+    persistRef.current = events;
+    writeLocal(events);
+  }, [events]);
+
+  const append = useCallback((event: Omit<ActivityEvent, 'id' | 'timestamp'> & { timestamp?: number }) => {
+    const next: ActivityEvent = {
+      ...event,
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      timestamp: event.timestamp ?? Date.now(),
+    };
+    setEvents((prev) => [next, ...prev].slice(0, MAX_EVENTS));
+  }, []);
+
+  const clear = useCallback(() => setEvents([]), []);
+
+  // Counts useful for the ICM rail.
+  const messageCount = useMemo(
+    () => events.filter((e) => e.kind === 'register' || e.kind === 'send').length,
+    [events],
+  );
+
+  return { events, append, clear, messageCount };
+}

--- a/app/console/ictt/_components/use-bridge-state.ts
+++ b/app/console/ictt/_components/use-bridge-state.ts
@@ -1,0 +1,251 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useToolboxStore, getToolboxStore } from '@/components/toolbox/stores/toolboxStore';
+import { useSelectedL1, useL1List, useWrappedNativeToken } from '@/components/toolbox/stores/l1ListStore';
+import type { L1ListItem } from '@/components/toolbox/stores/l1ListStore';
+import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
+import { cb58ToHex } from '@/components/tools/common/utils/cb58';
+import ERC20TokenHomeABI from '@/contracts/icm-contracts/compiled/ERC20TokenHome.json';
+import type { ContractSlot, PhaseId, PhaseStatus, TokenKind } from './types';
+
+interface RegistrationStatus {
+  registered: boolean;
+  collateralNeeded: bigint;
+  homeAddress: string | null;
+  homeChainId: string | null;
+  lastChecked: number | null;
+}
+
+const EMPTY_STATUS: RegistrationStatus = {
+  registered: false,
+  collateralNeeded: 0n,
+  homeAddress: null,
+  homeChainId: null,
+  lastChecked: null,
+};
+
+/**
+ * Derives bridge phase state from existing stores + on-chain reads.
+ *
+ * The bridge has 6 phases (token → home → remote → register → collateral
+ * → transfer). Phase status is derived from `useToolboxStore` keys +
+ * cross-chain reads against the home contract for registration and
+ * collateral state. No store schema changes — just a lightweight read
+ * layer over what already exists.
+ */
+export function useBridgeState() {
+  const homeChain = useSelectedL1();
+  const wrappedNative = useWrappedNativeToken();
+  const l1List = useL1List();
+  const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
+  const isTestnet = useWalletStore((s) => s.isTestnet);
+
+  // Toolbox store reads for the home (selected) chain
+  const {
+    exampleErc20Address,
+    erc20TokenHomeAddress,
+    nativeTokenHomeAddress,
+    erc20TokenRemoteAddress,
+    nativeTokenRemoteAddress,
+  } = useToolboxStore();
+
+  // Active home contract — picks ERC20 over native if both exist.
+  const homeKind: TokenKind = nativeTokenHomeAddress && !erc20TokenHomeAddress ? 'native' : 'erc20';
+  const homeAddress = homeKind === 'erc20' ? erc20TokenHomeAddress : nativeTokenHomeAddress;
+
+  // Active remote contract on the home chain's store (1:1 v1).
+  const remoteKind: TokenKind = nativeTokenRemoteAddress && !erc20TokenRemoteAddress ? 'native' : 'erc20';
+  const remoteAddress = remoteKind === 'erc20' ? erc20TokenRemoteAddress : nativeTokenRemoteAddress;
+
+  // Token address — exampleErc20 if user deployed test token, else
+  // wrappedNative if native flow, else null. Stays null until user picks.
+  const tokenAddress: string | null = exampleErc20Address || wrappedNative || null;
+
+  // Find the remote chain by scanning all toolbox stores in l1List.
+  // Returns the first L1 (other than home) that has a TokenRemote
+  // pointing at our home contract. v1 = 1:1, so first match wins.
+  const remoteChain = useMemo<L1ListItem | undefined>(() => {
+    if (!homeAddress || !homeChain) return undefined;
+    for (const candidate of l1List) {
+      if (candidate.id === homeChain.id) continue;
+      const candidateStore = getToolboxStore(candidate.id).getState();
+      if (candidateStore.erc20TokenRemoteAddress || candidateStore.nativeTokenRemoteAddress) {
+        return candidate;
+      }
+    }
+    return undefined;
+  }, [homeAddress, homeChain, l1List]);
+
+  // Look up the active remote on remoteChain's store. Falls back to the
+  // home-chain's stored value when remoteChain is the same chain (which
+  // shouldn't happen, but guards against bad state).
+  const activeRemote = useMemo(() => {
+    if (!remoteChain) {
+      return { address: remoteAddress, kind: remoteKind };
+    }
+    const remoteStore = getToolboxStore(remoteChain.id).getState();
+    if (remoteStore.nativeTokenRemoteAddress) {
+      return { address: remoteStore.nativeTokenRemoteAddress, kind: 'native' as TokenKind };
+    }
+    if (remoteStore.erc20TokenRemoteAddress) {
+      return { address: remoteStore.erc20TokenRemoteAddress, kind: 'erc20' as TokenKind };
+    }
+    return { address: null as string | null, kind: 'erc20' as TokenKind };
+  }, [remoteChain, remoteAddress, remoteKind]);
+
+  // Poll the home contract for registration + collateral status whenever
+  // we have a complete home/remote pair.
+  const [status, setStatus] = useState<RegistrationStatus>(EMPTY_STATUS);
+  const [pollTick, setPollTick] = useState(0);
+
+  useEffect(() => {
+    if (!homeChain || !homeAddress || !remoteChain || !activeRemote.address) {
+      setStatus(EMPTY_STATUS);
+      return;
+    }
+
+    let cancelled = false;
+    const homeClient = makePublicClientForChain(homeChain.rpcUrl);
+    if (!homeClient) return;
+
+    const remoteBlockchainIDHex = (() => {
+      try {
+        return cb58ToHex(remoteChain.id);
+      } catch {
+        return null;
+      }
+    })();
+    if (!remoteBlockchainIDHex) return;
+
+    (async () => {
+      try {
+        const settings = (await homeClient.readContract({
+          address: homeAddress as `0x${string}`,
+          abi: ERC20TokenHomeABI.abi,
+          functionName: 'getRemoteTokenTransferrerSettings',
+          args: [remoteBlockchainIDHex, activeRemote.address as `0x${string}`],
+        })) as {
+          registered: boolean;
+          collateralNeeded: bigint;
+          tokenMultiplier: bigint;
+          multiplyOnRemote: boolean;
+        };
+        if (cancelled) return;
+        setStatus({
+          registered: settings.registered,
+          collateralNeeded: settings.collateralNeeded,
+          homeAddress,
+          homeChainId: homeChain.id,
+          lastChecked: Date.now(),
+        });
+      } catch (err) {
+        // Polling read failures are non-fatal — keep last known state.
+        // Console logs would spam during chain-switch transitions.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [homeChain?.id, homeAddress, remoteChain?.id, activeRemote.address, pollTick]);
+
+  // Active phase polling — re-trigger every 5s while the bridge is
+  // mid-setup (not yet collateralized) so the UI reflects ICM message
+  // delivery without a manual refresh.
+  useEffect(() => {
+    if (!homeAddress || !activeRemote.address) return;
+    const fullyCollateralized = status.registered && status.collateralNeeded === 0n;
+    if (fullyCollateralized) return;
+    const t = setInterval(() => setPollTick((n) => n + 1), 5000);
+    return () => clearInterval(t);
+  }, [homeAddress, activeRemote.address, status.registered, status.collateralNeeded]);
+
+  // Phase-by-phase status derivation.
+  const phaseStatus = useMemo<Record<PhaseId, PhaseStatus>>(() => {
+    const tokenDone = !!tokenAddress;
+    const homeDone = !!homeAddress;
+    const remoteDone = !!activeRemote.address;
+    const registerDone = status.registered;
+    const collateralDone = status.registered && status.collateralNeeded === 0n;
+
+    return {
+      token: tokenDone ? 'done' : 'idle',
+      home: homeDone ? 'done' : tokenDone ? 'idle' : 'blocked',
+      remote: remoteDone ? 'done' : homeDone ? 'idle' : 'blocked',
+      register: registerDone ? 'done' : remoteDone ? 'idle' : 'blocked',
+      collateral: collateralDone ? 'done' : registerDone ? 'idle' : 'blocked',
+      transfer: collateralDone ? 'idle' : 'blocked',
+    };
+  }, [tokenAddress, homeAddress, activeRemote.address, status.registered, status.collateralNeeded]);
+
+  // Progress percentage (0-100) — share of completed setup phases. The
+  // transfer phase is counted as part of "setup" only when at least one
+  // send has happened, but for v1 we just count the 5 setup phases.
+  const progress = useMemo(() => {
+    const setupPhases: PhaseId[] = ['token', 'home', 'remote', 'register', 'collateral'];
+    const done = setupPhases.filter((p) => phaseStatus[p] === 'done').length;
+    return Math.round((done / setupPhases.length) * 100);
+  }, [phaseStatus]);
+
+  // Contract slot summaries for the chain panels.
+  const homeContracts: ContractSlot[] = useMemo(
+    () => [
+      {
+        label: 'Token',
+        address: tokenAddress,
+        status: tokenAddress ? 'deployed' : 'idle',
+      },
+      {
+        label: 'TokenHome',
+        address: homeAddress,
+        status: homeAddress ? 'deployed' : 'idle',
+      },
+      {
+        label: 'Collateral',
+        address: null,
+        status: status.registered && status.collateralNeeded === 0n ? 'deployed' : status.registered ? 'pending' : 'idle',
+      },
+    ],
+    [tokenAddress, homeAddress, status.registered, status.collateralNeeded],
+  );
+
+  const remoteContracts: ContractSlot[] = useMemo(
+    () => [
+      {
+        label: 'TokenRemote',
+        address: activeRemote.address,
+        status: activeRemote.address ? 'deployed' : 'idle',
+      },
+      {
+        label: 'Registered with Home',
+        address: null,
+        status: status.registered ? 'deployed' : activeRemote.address ? 'pending' : 'idle',
+      },
+    ],
+    [activeRemote.address, status.registered],
+  );
+
+  return {
+    homeChain,
+    remoteChain,
+    walletEVMAddress,
+    isTestnet,
+    homeKind,
+    remoteKind: activeRemote.kind,
+    tokenAddress,
+    homeAddress,
+    remoteAddress: activeRemote.address,
+    registered: status.registered,
+    collateralNeeded: status.collateralNeeded,
+    lastChecked: status.lastChecked,
+    phaseStatus,
+    progress,
+    homeContracts,
+    remoteContracts,
+    refresh: () => setPollTick((n) => n + 1),
+  };
+}
+
+export type BridgeState = ReturnType<typeof useBridgeState>;

--- a/app/console/ictt/_components/use-bridge-state.ts
+++ b/app/console/ictt/_components/use-bridge-state.ts
@@ -26,6 +26,21 @@ const EMPTY_STATUS: RegistrationStatus = {
   lastChecked: null,
 };
 
+interface UseBridgeStateArgs {
+  /**
+   * Optional override for which deployed remote to treat as the active
+   * one. Used by the multi-remote picker in the remote panel header.
+   * When unset, falls back to the first L1 with a deployed remote.
+   */
+  preferredRemoteChainId?: string;
+}
+
+interface RemoteCandidate {
+  chain: L1ListItem;
+  address: string;
+  kind: TokenKind;
+}
+
 /**
  * Derives bridge phase state from existing stores + on-chain reads.
  *
@@ -35,7 +50,8 @@ const EMPTY_STATUS: RegistrationStatus = {
  * collateral state. No store schema changes — just a lightweight read
  * layer over what already exists.
  */
-export function useBridgeState() {
+export function useBridgeState(args: UseBridgeStateArgs = {}) {
+  const { preferredRemoteChainId } = args;
   const homeChain = useSelectedL1();
   const wrappedNative = useWrappedNativeToken();
   const l1List = useL1List();
@@ -63,37 +79,40 @@ export function useBridgeState() {
   // wrappedNative if native flow, else null. Stays null until user picks.
   const tokenAddress: string | null = exampleErc20Address || wrappedNative || null;
 
-  // Find the remote chain by scanning all toolbox stores in l1List.
-  // Returns the first L1 (other than home) that has a TokenRemote
-  // pointing at our home contract. v1 = 1:1, so first match wins.
-  const remoteChain = useMemo<L1ListItem | undefined>(() => {
-    if (!homeAddress || !homeChain) return undefined;
-    for (const candidate of l1List) {
-      if (candidate.id === homeChain.id) continue;
-      const candidateStore = getToolboxStore(candidate.id).getState();
-      if (candidateStore.erc20TokenRemoteAddress || candidateStore.nativeTokenRemoteAddress) {
-        return candidate;
+  // All deployed remotes — every L1 (other than home) with a TokenRemote
+  // address in its per-chain toolbox store. The picker UI uses this list;
+  // the active remote is selected from here.
+  const allRemotes = useMemo<RemoteCandidate[]>(() => {
+    if (!homeChain) return [];
+    const candidates: RemoteCandidate[] = [];
+    for (const l1 of l1List) {
+      if (l1.id === homeChain.id) continue;
+      const store = getToolboxStore(l1.id).getState();
+      if (store.nativeTokenRemoteAddress) {
+        candidates.push({ chain: l1, address: store.nativeTokenRemoteAddress, kind: 'native' });
+      } else if (store.erc20TokenRemoteAddress) {
+        candidates.push({ chain: l1, address: store.erc20TokenRemoteAddress, kind: 'erc20' });
       }
     }
-    return undefined;
-  }, [homeAddress, homeChain, l1List]);
+    return candidates;
+  }, [homeChain, l1List]);
 
-  // Look up the active remote on remoteChain's store. Falls back to the
-  // home-chain's stored value when remoteChain is the same chain (which
-  // shouldn't happen, but guards against bad state).
-  const activeRemote = useMemo(() => {
-    if (!remoteChain) {
-      return { address: remoteAddress, kind: remoteKind };
+  // Pick the active remote: explicit preference if it matches a deployed
+  // remote, otherwise the first deployed remote. Returns undefined when
+  // no remote has been deployed yet.
+  const activeRemoteEntry = useMemo<RemoteCandidate | undefined>(() => {
+    if (allRemotes.length === 0) return undefined;
+    if (preferredRemoteChainId) {
+      const preferred = allRemotes.find((r) => r.chain.id === preferredRemoteChainId);
+      if (preferred) return preferred;
     }
-    const remoteStore = getToolboxStore(remoteChain.id).getState();
-    if (remoteStore.nativeTokenRemoteAddress) {
-      return { address: remoteStore.nativeTokenRemoteAddress, kind: 'native' as TokenKind };
-    }
-    if (remoteStore.erc20TokenRemoteAddress) {
-      return { address: remoteStore.erc20TokenRemoteAddress, kind: 'erc20' as TokenKind };
-    }
-    return { address: null as string | null, kind: 'erc20' as TokenKind };
-  }, [remoteChain, remoteAddress, remoteKind]);
+    return allRemotes[0];
+  }, [allRemotes, preferredRemoteChainId]);
+
+  const remoteChain = activeRemoteEntry?.chain;
+  const activeRemote = activeRemoteEntry
+    ? { address: activeRemoteEntry.address, kind: activeRemoteEntry.kind }
+    : { address: remoteAddress, kind: remoteKind };
 
   // Poll the home contract for registration + collateral status whenever
   // we have a complete home/remote pair.
@@ -230,6 +249,9 @@ export function useBridgeState() {
   return {
     homeChain,
     remoteChain,
+    /** Every L1 (other than home) with a deployed TokenRemote. Used by
+     *  the remote panel's picker when more than one remote exists. */
+    allRemotes,
     walletEVMAddress,
     isTestnet,
     homeKind,

--- a/app/console/ictt/_components/use-keyboard-submit.ts
+++ b/app/console/ictt/_components/use-keyboard-submit.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface KeyboardSubmitArgs {
+  onSubmit: () => void;
+  /** When false (e.g., while a deploy is in flight), the shortcut is
+   *  ignored. Mirrors the disabled state of the visible primary button. */
+  enabled: boolean;
+}
+
+/**
+ * Binds Cmd+Enter (macOS) / Ctrl+Enter (others) to the inspector's
+ * primary action. Listens at the window level so the shortcut works
+ * even when an inspector input has focus, but ignores the keystroke
+ * when typing inside a textarea (where Enter has its own meaning) or
+ * when a modifier-only key is held without Enter.
+ */
+export function useKeyboardSubmit({ onSubmit, enabled }: KeyboardSubmitArgs) {
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'Enter') return;
+      if (!(e.metaKey || e.ctrlKey)) return;
+      // Don't hijack textarea Enter — the user might be inside a
+      // multi-line note. Inputs are fine to intercept since they're
+      // single-line and Enter would normally submit.
+      const target = e.target as HTMLElement | null;
+      if (target?.tagName === 'TEXTAREA') return;
+      e.preventDefault();
+      onSubmit();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onSubmit, enabled]);
+}

--- a/app/console/ictt/_components/use-precompile-active.ts
+++ b/app/console/ictt/_components/use-precompile-active.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
+import { getActiveRulesAt } from '@/components/toolbox/coreViem';
+
+type PrecompileConfigKey =
+  | 'warpConfig'
+  | 'contractDeployerAllowListConfig'
+  | 'txAllowListConfig'
+  | 'feeManagerConfig'
+  | 'rewardManagerConfig'
+  | 'contractNativeMinterConfig';
+
+export interface PrecompileCheck {
+  isActive: boolean;
+  isLoading: boolean;
+  error: string | null;
+}
+
+const INITIAL: PrecompileCheck = { isActive: false, isLoading: false, error: null };
+
+/**
+ * Lightweight precompile-availability check for inspector preflight slots.
+ *
+ * Mirrors the underlying logic of `<CheckPrecompile>` but returns plain
+ * state (no JSX, no full-page hero) so callers can render compact warnings
+ * and gate primary actions inline.
+ *
+ * Skips entirely when `rpcUrl` is undefined — the caller decides whether
+ * to require the check (e.g., remote inspector only checks the
+ * native-minter precompile when the user picks `NativeTokenRemote`).
+ */
+export function usePrecompileActive(args: {
+  configKey: PrecompileConfigKey;
+  rpcUrl: string | undefined;
+  enabled?: boolean;
+}): PrecompileCheck {
+  const { configKey, rpcUrl, enabled = true } = args;
+  const [state, setState] = useState<PrecompileCheck>(INITIAL);
+
+  useEffect(() => {
+    if (!enabled || !rpcUrl) {
+      setState(INITIAL);
+      return;
+    }
+    let cancelled = false;
+    setState({ isActive: false, isLoading: true, error: null });
+
+    (async () => {
+      try {
+        const client = makePublicClientForChain(rpcUrl);
+        if (!client) throw new Error('Could not create RPC client');
+        const data = await getActiveRulesAt(client);
+        // Match `<CheckPrecompile>`: presence of a timestamp (including 0
+        // for genesis-activated precompiles) means the precompile is on.
+        const isActive = data.precompiles?.[configKey]?.timestamp !== undefined;
+        if (!cancelled) setState({ isActive, isLoading: false, error: null });
+      } catch (e: any) {
+        if (!cancelled) {
+          setState({
+            isActive: false,
+            isLoading: false,
+            error: e?.shortMessage ?? e?.message ?? 'Precompile check failed',
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [configKey, rpcUrl, enabled]);
+
+  return state;
+}

--- a/app/console/ictt/_components/use-preflight.tsx
+++ b/app/console/ictt/_components/use-preflight.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import type { L1ListItem } from '@/components/toolbox/stores/l1ListStore';
+import { ChainMismatchBanner } from './inspectors/preflight-banner';
+
+interface PreflightArgs {
+  /**
+   * The chain the active inspector requires the wallet to be on. When
+   * not provided (e.g., during bootstrap before any chain is selected),
+   * preflight is suppressed entirely.
+   */
+  expectedChain: L1ListItem | undefined;
+  /**
+   * Switch-chain callback. When the wallet is on a different chain, the
+   * banner renders a button that calls this. The bridge console wires
+   * `useWalletSwitch().safelySwitch` here.
+   */
+  switchChain: (chainId: number, isTestnet: boolean) => Promise<void>;
+}
+
+interface PreflightResult {
+  /** Banner JSX to drop into the inspector's `preflight` slot, or null
+   *  when the wallet is already on the expected chain. */
+  banner: React.ReactNode;
+  /** True when the wallet is on the expected chain (or no expectation). */
+  isReady: boolean;
+}
+
+/**
+ * Centralizes the chain-mismatch preflight check that every inspector
+ * needs. Each inspector previously rolled its own `onSwitchToX` callback
+ * and rendered the banner conditionally; this hook reduces that to one
+ * line: `const { banner } = usePreflight(expectedChain, switchChain);`.
+ */
+export function usePreflight({ expectedChain, switchChain }: PreflightArgs): PreflightResult {
+  const walletChainId = useWalletStore((s) => s.walletChainId);
+
+  return useMemo(() => {
+    if (!expectedChain) return { banner: null, isReady: true };
+    const isReady = walletChainId === expectedChain.evmChainId;
+    if (isReady) return { banner: null, isReady: true };
+
+    const onSwitch = () => switchChain(expectedChain.evmChainId, !!expectedChain.isTestnet);
+    return {
+      banner: (
+        <ChainMismatchBanner expectedChain={expectedChain} walletChainId={walletChainId} onSwitch={onSwitch} />
+      ),
+      isReady: false,
+    };
+  }, [expectedChain, walletChainId, switchChain]);
+}

--- a/app/console/ictt/_components/use-token-snapshot.ts
+++ b/app/console/ictt/_components/use-token-snapshot.ts
@@ -1,0 +1,209 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { formatUnits } from 'viem';
+import ERC20TokenHomeABI from '@/contracts/icm-contracts/compiled/ERC20TokenHome.json';
+import NativeTokenHomeABI from '@/contracts/icm-contracts/compiled/NativeTokenHome.json';
+import ERC20TokenRemoteABI from '@/contracts/icm-contracts/compiled/ERC20TokenRemote.json';
+import ExampleERC20 from '@/contracts/icm-contracts/compiled/ExampleERC20.json';
+import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
+import { cb58ToHex } from '@/components/tools/common/utils/cb58';
+import type { L1ListItem } from '@/components/toolbox/stores/l1ListStore';
+import type { TokenKind } from './types';
+
+export interface TokenSnapshot {
+  symbol: string;
+  decimals: number;
+  totalSupply: bigint;
+  bridged: bigint; // home: getTransferredBalance(remoteChainID); remote: same as totalSupply
+  isLoading: boolean;
+  error: string | null;
+}
+
+const EMPTY_SNAPSHOT: TokenSnapshot = {
+  symbol: '—',
+  decimals: 18,
+  totalSupply: 0n,
+  bridged: 0n,
+  isLoading: false,
+  error: null,
+};
+
+/**
+ * Reads token snapshot data for the home side of a bridge:
+ *   - symbol/decimals from the underlying ERC20/native token
+ *   - totalSupply from the underlying token
+ *   - bridged from `getTransferredBalance(remoteBlockchainID)` on the home
+ *
+ * Native homes hold the native gas token, so totalSupply isn't a useful
+ * metric there — we surface the home contract's own balance instead.
+ */
+export function useHomeTokenSnapshot(args: {
+  homeChain?: L1ListItem;
+  homeAddress: string | null;
+  homeKind: TokenKind;
+  remoteChainId?: string;
+}): TokenSnapshot {
+  const { homeChain, homeAddress, homeKind, remoteChainId } = args;
+  const [snapshot, setSnapshot] = useState<TokenSnapshot>(EMPTY_SNAPSHOT);
+
+  useEffect(() => {
+    if (!homeChain?.rpcUrl || !homeAddress) {
+      setSnapshot(EMPTY_SNAPSHOT);
+      return;
+    }
+    let cancelled = false;
+    setSnapshot((s) => ({ ...s, isLoading: true, error: null }));
+    const client = makePublicClientForChain(homeChain.rpcUrl);
+    if (!client) {
+      setSnapshot({ ...EMPTY_SNAPSHOT, error: 'Could not create RPC client' });
+      return;
+    }
+
+    (async () => {
+      try {
+        const homeAbi = (homeKind === 'erc20' ? ERC20TokenHomeABI.abi : NativeTokenHomeABI.abi) as any;
+        const tokenAddress = (await client.readContract({
+          address: homeAddress as `0x${string}`,
+          abi: homeAbi,
+          functionName: 'getTokenAddress',
+        })) as `0x${string}`;
+
+        // ERC20: read symbol/decimals/totalSupply from the underlying token.
+        // Native: the wrapped-native helper exposes these too, so the same
+        // path works for both — but we still use the kind-specific ABI for
+        // safety on the home itself.
+        const [symbol, decimals, totalSupply] = await Promise.all([
+          client.readContract({ address: tokenAddress, abi: ExampleERC20.abi, functionName: 'symbol' }),
+          client.readContract({ address: tokenAddress, abi: ExampleERC20.abi, functionName: 'decimals' }),
+          client.readContract({ address: tokenAddress, abi: ExampleERC20.abi, functionName: 'totalSupply' }),
+        ]);
+
+        // bridged = getTransferredBalance(remoteBlockchainIDHex)
+        let bridged = 0n;
+        if (remoteChainId) {
+          try {
+            const remoteHex = cb58ToHex(remoteChainId);
+            bridged = (await client.readContract({
+              address: homeAddress as `0x${string}`,
+              abi: homeAbi,
+              functionName: 'getTransferredBalance',
+              args: [remoteHex],
+            })) as bigint;
+          } catch {
+            /* getTransferredBalance may revert if remote not registered yet */
+          }
+        }
+
+        if (cancelled) return;
+        setSnapshot({
+          symbol: String(symbol),
+          decimals: Number(decimals),
+          totalSupply: totalSupply as bigint,
+          bridged,
+          isLoading: false,
+          error: null,
+        });
+      } catch (e: any) {
+        if (cancelled) return;
+        setSnapshot({
+          ...EMPTY_SNAPSHOT,
+          error: `Read failed: ${e?.shortMessage ?? e?.message ?? 'unknown'}`,
+          isLoading: false,
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [homeChain?.rpcUrl, homeAddress, homeKind, remoteChainId]);
+
+  return snapshot;
+}
+
+/**
+ * Reads remote-side token snapshot:
+ *   - symbol/decimals/totalSupply from the remote contract (it IS the
+ *     wrapped token in the ERC-20 case; native remote exposes the same).
+ *   - bridged is symmetrical to totalSupply on the remote (everything
+ *     minted there came over the bridge).
+ */
+export function useRemoteTokenSnapshot(args: {
+  remoteChain?: L1ListItem;
+  remoteAddress: string | null;
+}): TokenSnapshot {
+  const { remoteChain, remoteAddress } = args;
+  const [snapshot, setSnapshot] = useState<TokenSnapshot>(EMPTY_SNAPSHOT);
+
+  useEffect(() => {
+    if (!remoteChain?.rpcUrl || !remoteAddress) {
+      setSnapshot(EMPTY_SNAPSHOT);
+      return;
+    }
+    let cancelled = false;
+    setSnapshot((s) => ({ ...s, isLoading: true, error: null }));
+    const client = makePublicClientForChain(remoteChain.rpcUrl);
+    if (!client) {
+      setSnapshot({ ...EMPTY_SNAPSHOT, error: 'Could not create RPC client' });
+      return;
+    }
+
+    (async () => {
+      try {
+        const [symbol, decimals, totalSupply] = await Promise.all([
+          client.readContract({
+            address: remoteAddress as `0x${string}`,
+            abi: ERC20TokenRemoteABI.abi,
+            functionName: 'symbol',
+          }),
+          client.readContract({
+            address: remoteAddress as `0x${string}`,
+            abi: ERC20TokenRemoteABI.abi,
+            functionName: 'decimals',
+          }),
+          client.readContract({
+            address: remoteAddress as `0x${string}`,
+            abi: ERC20TokenRemoteABI.abi,
+            functionName: 'totalSupply',
+          }),
+        ]);
+
+        if (cancelled) return;
+        setSnapshot({
+          symbol: String(symbol),
+          decimals: Number(decimals),
+          totalSupply: totalSupply as bigint,
+          bridged: totalSupply as bigint,
+          isLoading: false,
+          error: null,
+        });
+      } catch (e: any) {
+        if (cancelled) return;
+        setSnapshot({
+          ...EMPTY_SNAPSHOT,
+          error: `Read failed: ${e?.shortMessage ?? e?.message ?? 'unknown'}`,
+          isLoading: false,
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [remoteChain?.rpcUrl, remoteAddress]);
+
+  return snapshot;
+}
+
+export function formatTokenAmount(value: bigint, decimals: number, maxFractionDigits = 4): string {
+  if (value === 0n) return '0';
+  const formatted = formatUnits(value, decimals);
+  const num = Number(formatted);
+  if (!isFinite(num)) return formatted;
+  // Compact display for large numbers
+  if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(2)}M`;
+  if (num >= 1_000) return `${(num / 1_000).toFixed(2)}K`;
+  if (num < 0.0001 && num > 0) return '<0.0001';
+  return num.toLocaleString(undefined, { maximumFractionDigits: maxFractionDigits });
+}

--- a/app/console/ictt/_components/wallet-pill.tsx
+++ b/app/console/ictt/_components/wallet-pill.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { cn } from '@/components/toolbox/lib/utils';
+import type { L1ListItem } from '@/components/toolbox/stores/l1ListStore';
+
+interface WalletPillProps {
+  walletAddress: string;
+  walletChainId: number;
+  expectedChain?: L1ListItem;
+  onSwitchChain?: () => void;
+}
+
+/**
+ * Top-bar wallet status indicator. Three states:
+ *   - disconnected: zinc pill with "Not connected"
+ *   - connected to expected chain: emerald pill with "Wallet connected"
+ *   - connected to wrong chain: amber pill with "Switch to <chain>" CTA
+ *
+ * The expected chain is determined by the active phase (e.g., for the
+ * "remote" phase the wallet must be on the remote chain). Bridge console
+ * passes `expectedChain` based on the inspector's preflight requirement.
+ */
+export function WalletPill({ walletAddress, walletChainId, expectedChain, onSwitchChain }: WalletPillProps) {
+  if (!walletAddress) {
+    return (
+      <div className="flex items-center gap-2 px-2.5 py-1.5 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-lg">
+        <span className="w-1.5 h-1.5 rounded-full bg-zinc-400" />
+        <span className="text-[11px] font-medium text-zinc-600 dark:text-zinc-400">Not connected</span>
+      </div>
+    );
+  }
+
+  const isOnExpected = !expectedChain || walletChainId === expectedChain.evmChainId;
+
+  if (!isOnExpected) {
+    return (
+      <button
+        type="button"
+        onClick={onSwitchChain}
+        className={cn(
+          'flex items-center gap-2 px-2.5 py-1.5 rounded-lg border cursor-pointer transition-colors',
+          'bg-amber-50 border-amber-200 text-amber-700 hover:bg-amber-100',
+          'dark:bg-amber-950/40 dark:border-amber-900/60 dark:text-amber-300 dark:hover:bg-amber-950/60',
+        )}
+      >
+        <span className="w-1.5 h-1.5 rounded-full bg-amber-500 animate-pulse" />
+        <span className="text-[11px] font-medium">Switch to {expectedChain.name}</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 px-2.5 py-1.5 bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-200 dark:border-emerald-900/60 rounded-lg">
+      <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+      <span className="text-[11px] font-medium text-emerald-700 dark:text-emerald-300">Wallet connected</span>
+    </div>
+  );
+}

--- a/app/console/ictt/_components/wallet-pill.tsx
+++ b/app/console/ictt/_components/wallet-pill.tsx
@@ -23,9 +23,9 @@ interface WalletPillProps {
 export function WalletPill({ walletAddress, walletChainId, expectedChain, onSwitchChain }: WalletPillProps) {
   if (!walletAddress) {
     return (
-      <div className="flex items-center gap-2 px-2.5 py-1.5 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-lg">
-        <span className="w-1.5 h-1.5 rounded-full bg-zinc-400" />
-        <span className="text-[11px] font-medium text-zinc-600 dark:text-zinc-400">Not connected</span>
+      <div className="flex items-center gap-2 px-2.5 py-1.5 bg-muted border border-border rounded-lg">
+        <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground" />
+        <span className="text-[11px] font-medium text-muted-foreground">Not connected</span>
       </div>
     );
   }

--- a/app/console/ictt/page.tsx
+++ b/app/console/ictt/page.tsx
@@ -4,13 +4,19 @@ import type { PhaseId } from './_components/types';
 const VALID_PHASES: PhaseId[] = ['token', 'home', 'remote', 'register', 'collateral', 'transfer'];
 
 interface PageProps {
-  searchParams?: Promise<{ phase?: string }>;
+  searchParams?: Promise<{ phase?: string; remote?: string }>;
 }
 
 /**
  * Single-page entry for the ICTT Bridge Console. Replaces the legacy
  * `/console/ictt/setup/[step]` and `/console/ictt/token-transfer/[step]`
  * wizards. Old URLs 301-redirect here with `?phase=…` deep links.
+ *
+ * Deep-link query params:
+ *   - `phase`: one of token/home/remote/register/collateral/transfer
+ *   - `remote`: blockchain ID (cb58) of the active remote — useful when
+ *     the user has paired the same Home with multiple Remote chains
+ *     and wants to share a link to a specific bridge config
  *
  * The negative margins reach back through the parent console layout's
  * padding so the console fills the full content area edge-to-edge,
@@ -20,11 +26,12 @@ export default async function Page({ searchParams }: PageProps) {
   const params = (await searchParams) ?? {};
   const initialPhase =
     params.phase && VALID_PHASES.includes(params.phase as PhaseId) ? (params.phase as PhaseId) : undefined;
+  const initialRemoteChainId = typeof params.remote === 'string' && params.remote.length > 0 ? params.remote : undefined;
 
   return (
     <div className="-mx-4 md:-mx-8 -mt-4 md:-mt-8 min-h-[calc(100vh-3rem)] flex">
       <div className="flex-1 flex">
-        <BridgeConsole initialPhase={initialPhase} />
+        <BridgeConsole initialPhase={initialPhase} initialRemoteChainId={initialRemoteChainId} />
       </div>
     </div>
   );

--- a/app/console/ictt/page.tsx
+++ b/app/console/ictt/page.tsx
@@ -1,0 +1,31 @@
+import { BridgeConsole } from './_components/bridge-console';
+import type { PhaseId } from './_components/types';
+
+const VALID_PHASES: PhaseId[] = ['token', 'home', 'remote', 'register', 'collateral', 'transfer'];
+
+interface PageProps {
+  searchParams?: Promise<{ phase?: string }>;
+}
+
+/**
+ * Single-page entry for the ICTT Bridge Console. Replaces the legacy
+ * `/console/ictt/setup/[step]` and `/console/ictt/token-transfer/[step]`
+ * wizards. Old URLs 301-redirect here with `?phase=…` deep links.
+ *
+ * The negative margins reach back through the parent console layout's
+ * padding so the console fills the full content area edge-to-edge,
+ * matching the design's full-bleed top bar / phase strip.
+ */
+export default async function Page({ searchParams }: PageProps) {
+  const params = (await searchParams) ?? {};
+  const initialPhase =
+    params.phase && VALID_PHASES.includes(params.phase as PhaseId) ? (params.phase as PhaseId) : undefined;
+
+  return (
+    <div className="-mx-4 md:-mx-8 -mt-4 md:-mt-8 min-h-[calc(100vh-3rem)] flex">
+      <div className="flex-1 flex">
+        <BridgeConsole initialPhase={initialPhase} />
+      </div>
+    </div>
+  );
+}

--- a/app/console/ictt/setup/[step]/page.tsx
+++ b/app/console/ictt/setup/[step]/page.tsx
@@ -1,8 +1,22 @@
-import IcttSetupClientPage from "./client-page";
+import { redirect } from 'next/navigation';
 
+const STEP_TO_PHASE: Record<string, string> = {
+  'deploy-test-erc20': 'token',
+  'deploy-wrapped-native': 'token',
+  'deploy-source-token': 'token',
+  'deploy-token-home': 'home',
+  'deploy-remote': 'remote',
+  'erc20-remote': 'remote',
+  'native-remote': 'remote',
+  'register-with-home': 'register',
+  'add-collateral': 'collateral',
+};
+
+// Legacy per-step routes (deploy-test-erc20, deploy-token-home, …) now
+// 301-redirect to the unified bridge console with the corresponding
+// phase preselected. Maps to the new phase IDs in `_components/types.ts`.
 export default async function Page({ params }: { params: Promise<{ step: string }> }) {
-    const { step } = await params;
-    return (
-        <IcttSetupClientPage currentStepKey={step} />
-    );
+  const { step } = await params;
+  const phase = STEP_TO_PHASE[step];
+  redirect(phase ? `/console/ictt?phase=${phase}` : '/console/ictt');
 }

--- a/app/console/ictt/setup/page.tsx
+++ b/app/console/ictt/setup/page.tsx
@@ -1,7 +1,8 @@
-import { redirect } from "next/navigation";
+import { redirect } from 'next/navigation';
 
+// Legacy entry — bridge setup is now folded into the unified
+// /console/ictt page. We preserve this route as a 301 to avoid breaking
+// any external links that pointed at the old setup wizard.
 export default function Page() {
-  redirect("/console/ictt/setup/deploy-test-erc20");
+  redirect('/console/ictt');
 }
-
-

--- a/app/console/ictt/token-transfer/[step]/page.tsx
+++ b/app/console/ictt/token-transfer/[step]/page.tsx
@@ -1,8 +1,15 @@
-import IcttTokenTransferClientPage from "./client-page";
+import { redirect } from 'next/navigation';
 
+const STEP_TO_PHASE: Record<string, string> = {
+  'add-collateral': 'collateral',
+  'test-send': 'transfer',
+};
+
+// Legacy per-step routes for token-transfer flow now redirect to the
+// unified console. `add-collateral` maps to the Collateral phase;
+// `test-send` maps to the Live (transfer) phase.
 export default async function Page({ params }: { params: Promise<{ step: string }> }) {
-    const { step } = await params;
-    return (
-        <IcttTokenTransferClientPage currentStepKey={step} />
-    );
+  const { step } = await params;
+  const phase = STEP_TO_PHASE[step];
+  redirect(phase ? `/console/ictt?phase=${phase}` : '/console/ictt?phase=transfer');
 }

--- a/app/console/ictt/token-transfer/page.tsx
+++ b/app/console/ictt/token-transfer/page.tsx
@@ -1,7 +1,7 @@
-import { redirect } from "next/navigation";
+import { redirect } from 'next/navigation';
 
+// Legacy entry — token transfer is now folded into the unified
+// /console/ictt page (Live phase). 301 to preserve any old links.
 export default function Page() {
-  redirect("/console/ictt/token-transfer/add-collateral");
+  redirect('/console/ictt?phase=transfer');
 }
-
-

--- a/components/console/console-sidebar.tsx
+++ b/components/console/console-sidebar.tsx
@@ -29,7 +29,6 @@ import {
   Rocket,
   LayoutDashboard,
   LayoutGrid,
-  Workflow,
   Lock,
   BookOpen,
   Search,
@@ -266,13 +265,8 @@ const data = {
           icon: MessagesSquare,
         },
         {
-          title: "Token Bridge",
-          url: "/console/ictt/setup",
-          icon: Workflow,
-        },
-        {
-          title: "Token Transfer",
-          url: "/console/ictt/token-transfer",
+          title: "ICTT Bridge Console",
+          url: "/console/ictt",
           icon: ArrowLeftRight,
         },
       ],

--- a/components/toolbox/console/ictt/hooks/useAddCollateral.ts
+++ b/components/toolbox/console/ictt/hooks/useAddCollateral.ts
@@ -1,0 +1,145 @@
+'use client';
+
+import { useState } from 'react';
+import ERC20TokenHomeABI from '@/contracts/icm-contracts/compiled/ERC20TokenHome.json';
+import NativeTokenHomeABI from '@/contracts/icm-contracts/compiled/NativeTokenHome.json';
+import ExampleERC20 from '@/contracts/icm-contracts/compiled/ExampleERC20.json';
+import { useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
+import { useResolvedWalletClient } from '@/components/toolbox/hooks/useResolvedWalletClient';
+import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
+import useConsoleNotifications from '@/hooks/useConsoleNotifications';
+import { cb58ToHex } from '@/components/tools/common/utils/cb58';
+import type { TokenKind } from '@/app/console/ictt/_components/types';
+
+export interface ApproveCollateralArgs {
+  tokenAddress: string;
+  homeAddress: string;
+  amount: bigint;
+}
+
+export interface AddCollateralArgs {
+  homeAddress: string;
+  homeKind: TokenKind;
+  remoteChainId: string;
+  remoteAddress: string;
+  amount: bigint;
+}
+
+/**
+ * Hook for the two-step collateral funding flow:
+ *   1. (ERC-20 only) `approve(home, amount)` on the underlying token
+ *   2. `addCollateral(remoteChainID, remoteAddr [, amount])` on TokenHome
+ *
+ * The hook itself doesn't own the approve/deposit ordering — that's
+ * the inspector's job since it depends on the live allowance read.
+ * Each function is independently callable. Status is exposed as a
+ * three-way machine: 'idle' | 'approving' | 'depositing'.
+ */
+export function useAddCollateral() {
+  const walletClient = useResolvedWalletClient();
+  const viemChain = useViemChainStore();
+  const { notify } = useConsoleNotifications();
+  const [status, setStatus] = useState<'idle' | 'approving' | 'depositing'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const approve = async (args: ApproveCollateralArgs): Promise<{ hash: string }> => {
+    setError(null);
+    if (!walletClient?.account || !viemChain) {
+      const msg = 'Wallet not connected';
+      setError(msg);
+      throw new Error(msg);
+    }
+    setStatus('approving');
+    try {
+      const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
+      if (!client) throw new Error('Could not create RPC client');
+      const { request } = await client.simulateContract({
+        address: args.tokenAddress as `0x${string}`,
+        abi: ExampleERC20.abi,
+        functionName: 'approve',
+        args: [args.homeAddress as `0x${string}`, args.amount],
+        chain: viemChain,
+        account: walletClient.account,
+      });
+      const writePromise = walletClient.writeContract(request);
+      notify({ type: 'call', name: 'Approve Token' }, writePromise, viemChain);
+      const hash = await writePromise;
+      await client.waitForTransactionReceipt({ hash });
+      return { hash };
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? 'Approve failed';
+      setError(msg);
+      throw e;
+    } finally {
+      setStatus('idle');
+    }
+  };
+
+  const addCollateral = async (args: AddCollateralArgs): Promise<{ hash: string }> => {
+    setError(null);
+    if (!walletClient?.account || !viemChain) {
+      const msg = 'Wallet not connected';
+      setError(msg);
+      throw new Error(msg);
+    }
+    if (args.amount === 0n) {
+      const msg = 'Amount must be greater than zero';
+      setError(msg);
+      throw new Error(msg);
+    }
+
+    let remoteHex: string;
+    try {
+      remoteHex = cb58ToHex(args.remoteChainId);
+    } catch {
+      const msg = 'Could not encode remote chain ID';
+      setError(msg);
+      throw new Error(msg);
+    }
+
+    setStatus('depositing');
+    try {
+      const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
+      if (!client) throw new Error('Could not create RPC client');
+
+      const isNative = args.homeKind === 'native';
+      // Native: amount is sent as `value`; the addCollateral signature
+      // takes only (chainID, remote). ERC-20: amount is the third arg
+      // and `value` is omitted.
+      const callArgs = isNative
+        ? [remoteHex, args.remoteAddress as `0x${string}`]
+        : [remoteHex, args.remoteAddress as `0x${string}`, args.amount];
+
+      const { request } = await client.simulateContract({
+        address: args.homeAddress as `0x${string}`,
+        abi: (isNative ? NativeTokenHomeABI.abi : ERC20TokenHomeABI.abi) as any,
+        functionName: 'addCollateral',
+        args: callArgs,
+        chain: viemChain,
+        account: walletClient.account,
+        ...(isNative ? { value: args.amount } : {}),
+      });
+      const writePromise = walletClient.writeContract(request);
+      notify({ type: 'call', name: 'Add Collateral' }, writePromise, viemChain);
+      const hash = await writePromise;
+      await client.waitForTransactionReceipt({ hash });
+      return { hash };
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? 'Add collateral failed';
+      setError(msg);
+      throw e;
+    } finally {
+      setStatus('idle');
+    }
+  };
+
+  return {
+    approve,
+    addCollateral,
+    status,
+    isApproving: status === 'approving',
+    isDepositing: status === 'depositing',
+    error,
+    reset: () => setError(null),
+  };
+}

--- a/components/toolbox/console/ictt/hooks/useDeployTokenHome.ts
+++ b/components/toolbox/console/ictt/hooks/useDeployTokenHome.ts
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import ERC20TokenHome from '@/contracts/icm-contracts/compiled/ERC20TokenHome.json';
+import NativeTokenHome from '@/contracts/icm-contracts/compiled/NativeTokenHome.json';
+import { useToolboxStore, useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
+import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import { useContractDeployer } from '@/components/toolbox/hooks/contracts';
+import type { TokenKind } from '@/app/console/ictt/_components/types';
+
+export interface DeployTokenHomeArgs {
+  kind: TokenKind;
+  /** Teleporter Registry address on the home chain */
+  registry: string;
+  /** Address authorized to update the registry; defaults to wallet */
+  manager: string;
+  /** Minimum Teleporter version */
+  minVersion: string;
+  /** Underlying ERC-20 (or wrapped-native) token address */
+  tokenAddress: string;
+  /** Token decimals; auto-fetched by inspector before calling run() */
+  decimals: string;
+}
+
+export interface DeployTokenHomeResult {
+  hash: string;
+  contractAddress: string;
+}
+
+/**
+ * Hook that owns the on-chain TokenHome deployment. Encapsulates the
+ * contract-specific arg layout (`ERC20TokenHome` vs `NativeTokenHome`)
+ * and the per-kind store write so the inspector only needs to collect
+ * the form fields and call `run(args)`.
+ */
+export function useDeployTokenHome() {
+  const { setErc20TokenHomeAddress, setNativeTokenHomeAddress } = useToolboxStore();
+  const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
+  const viemChain = useViemChainStore();
+  const { deploy, isDeploying } = useContractDeployer();
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (args: DeployTokenHomeArgs): Promise<DeployTokenHomeResult> => {
+    setError(null);
+
+    if (!viemChain) {
+      const msg = 'Wallet not connected';
+      setError(msg);
+      throw new Error(msg);
+    }
+    if (!args.registry) {
+      const msg = 'Teleporter Registry address is required';
+      setError(msg);
+      throw new Error(msg);
+    }
+    if (!args.tokenAddress) {
+      const msg = 'Token address is required';
+      setError(msg);
+      throw new Error(msg);
+    }
+
+    const constructorArgs: any[] = [
+      args.registry as `0x${string}`,
+      (args.manager || walletEVMAddress) as `0x${string}`,
+      BigInt(args.minVersion || '1'),
+      args.tokenAddress as `0x${string}`,
+    ];
+    if (args.kind === 'erc20') constructorArgs.push(BigInt(args.decimals || '0'));
+
+    try {
+      const result = await deploy({
+        abi: (args.kind === 'erc20' ? ERC20TokenHome.abi : NativeTokenHome.abi) as any,
+        bytecode: args.kind === 'erc20' ? ERC20TokenHome.bytecode.object : NativeTokenHome.bytecode.object,
+        args: constructorArgs,
+        name: args.kind === 'erc20' ? 'ERC20TokenHome' : 'NativeTokenHome',
+      });
+
+      if (args.kind === 'erc20') {
+        setErc20TokenHomeAddress(result.contractAddress);
+      } else {
+        setNativeTokenHomeAddress(result.contractAddress);
+      }
+
+      return { hash: result.hash, contractAddress: result.contractAddress };
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? 'Deployment failed';
+      setError(msg);
+      throw e;
+    }
+  };
+
+  return { run, isDeploying, error, reset: () => setError(null) };
+}

--- a/components/toolbox/console/ictt/hooks/useDeployTokenRemote.ts
+++ b/components/toolbox/console/ictt/hooks/useDeployTokenRemote.ts
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState } from 'react';
+import ERC20TokenRemote from '@/contracts/icm-contracts/compiled/ERC20TokenRemote.json';
+import NativeTokenRemote from '@/contracts/icm-contracts/compiled/NativeTokenRemote.json';
+import { getToolboxStore, useToolboxStore, useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
+import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import { useContractDeployer } from '@/components/toolbox/hooks/contracts';
+import { cb58ToHex } from '@/components/tools/common/utils/cb58';
+import type { TokenKind } from '@/app/console/ictt/_components/types';
+
+export interface DeployTokenRemoteArgs {
+  kind: TokenKind;
+  /** Source chain blockchain ID (cb58) — where TokenHome lives */
+  sourceChainId: string;
+  /** TokenHome contract address on source chain */
+  sourceHomeAddress: string;
+  /** Source-chain token decimals (read from underlying token) */
+  sourceDecimals: string;
+  /** Teleporter Registry address on the destination chain */
+  registry: string;
+  /** Address authorized to update the registry; defaults to wallet */
+  manager: string;
+  /** Minimum Teleporter version */
+  minVersion: string;
+  /** ERC-20 only: token name */
+  tokenName?: string;
+  /** Token symbol — required for both ERC-20 and Native */
+  tokenSymbol: string;
+  /** Native only: initial reserve imbalance (wei) */
+  initialReserveImbalance?: string;
+  /** Native only: burned-fees reporting reward percentage (0-100) */
+  burnedFeesReportingRewardPercentage?: string;
+  /** Destination chain ID — used to mirror the deployed address into
+   *  the destination chain's per-chain toolbox store. */
+  destChainId: string;
+}
+
+export interface DeployTokenRemoteResult {
+  hash: string;
+  contractAddress: string;
+}
+
+/**
+ * Hook that owns the on-chain TokenRemote deployment. Validates inputs,
+ * encodes the source-chain blockchain ID (cb58→hex), packs the
+ * constructor settings struct, and writes the deployed address to BOTH
+ * the destination-chain's per-chain toolbox store (where the contract
+ * lives) and the active toolbox store (legacy compatibility with the old
+ * wizard's flow that wrote to whichever chain the wallet was on).
+ */
+export function useDeployTokenRemote() {
+  const { setErc20TokenRemoteAddress, setNativeTokenRemoteAddress } = useToolboxStore();
+  const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
+  const viemChain = useViemChainStore();
+  const { deploy, isDeploying } = useContractDeployer();
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (args: DeployTokenRemoteArgs): Promise<DeployTokenRemoteResult> => {
+    setError(null);
+
+    if (!viemChain) {
+      const msg = 'Wallet not connected';
+      setError(msg);
+      throw new Error(msg);
+    }
+    if (!args.sourceChainId || !args.sourceHomeAddress) {
+      const msg = 'Source chain + TokenHome address required';
+      setError(msg);
+      throw new Error(msg);
+    }
+    if (args.sourceChainId === args.destChainId) {
+      const msg = 'Source and destination must be different chains';
+      setError(msg);
+      throw new Error(msg);
+    }
+    if (!args.registry) {
+      const msg = 'Teleporter Registry address required on destination';
+      setError(msg);
+      throw new Error(msg);
+    }
+    if (args.sourceDecimals === '0') {
+      const msg = 'Source token decimals not yet fetched';
+      setError(msg);
+      throw new Error(msg);
+    }
+    if (args.kind === 'native') {
+      const reserve = BigInt(args.initialReserveImbalance || '0');
+      if (reserve <= 0n) {
+        const msg = 'Initial reserve imbalance must be greater than zero';
+        setError(msg);
+        throw new Error(msg);
+      }
+      const reward = parseInt(args.burnedFeesReportingRewardPercentage || '0');
+      if (reward < 0 || reward > 100) {
+        const msg = 'Burned-fees reward percentage must be 0–100';
+        setError(msg);
+        throw new Error(msg);
+      }
+    }
+
+    let sourceBlockchainIDHex: string;
+    try {
+      sourceBlockchainIDHex = cb58ToHex(args.sourceChainId);
+    } catch {
+      const msg = 'Could not encode source blockchain ID';
+      setError(msg);
+      throw new Error(msg);
+    }
+
+    const settings = {
+      teleporterRegistryAddress: args.registry as `0x${string}`,
+      teleporterManager: (args.manager || walletEVMAddress) as `0x${string}`,
+      minTeleporterVersion: BigInt(args.minVersion || '1'),
+      tokenHomeBlockchainID: sourceBlockchainIDHex as `0x${string}`,
+      tokenHomeAddress: args.sourceHomeAddress as `0x${string}`,
+      tokenHomeDecimals: parseInt(args.sourceDecimals),
+    };
+
+    const constructorArgs =
+      args.kind === 'erc20'
+        ? [settings, args.tokenName || 'Bridged Token', args.tokenSymbol || 'BRDG', parseInt(args.sourceDecimals)]
+        : [
+            settings,
+            args.tokenSymbol || 'BRDG',
+            BigInt(args.initialReserveImbalance || '1'),
+            BigInt(args.burnedFeesReportingRewardPercentage || '0'),
+          ];
+
+    try {
+      const result = await deploy({
+        abi: (args.kind === 'erc20' ? ERC20TokenRemote.abi : NativeTokenRemote.abi) as any,
+        bytecode: args.kind === 'erc20' ? ERC20TokenRemote.bytecode.object : NativeTokenRemote.bytecode.object,
+        args: constructorArgs,
+        name: args.kind === 'erc20' ? 'ERC20TokenRemote' : 'NativeTokenRemote',
+      });
+
+      // Save to the destination chain's per-chain toolbox store. This is
+      // the canonical location since per-chain storage is how the existing
+      // toolboxStore is keyed.
+      const destStore = getToolboxStore(args.destChainId).getState();
+      if (args.kind === 'erc20') {
+        destStore.setErc20TokenRemoteAddress(result.contractAddress);
+        // Mirror to active store for legacy compatibility with code paths
+        // that read from the currently-selected chain's store.
+        setErc20TokenRemoteAddress(result.contractAddress);
+      } else {
+        destStore.setNativeTokenRemoteAddress(result.contractAddress);
+        setNativeTokenRemoteAddress(result.contractAddress);
+      }
+
+      return { hash: result.hash, contractAddress: result.contractAddress };
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? 'Deployment failed';
+      setError(msg);
+      throw e;
+    }
+  };
+
+  return { run, isDeploying, error, reset: () => setError(null) };
+}

--- a/components/toolbox/console/ictt/hooks/useRegisterRemote.ts
+++ b/components/toolbox/console/ictt/hooks/useRegisterRemote.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState } from 'react';
+import { zeroAddress } from 'viem';
+import ERC20TokenRemoteABI from '@/contracts/icm-contracts/compiled/ERC20TokenRemote.json';
+import { useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
+import { useResolvedWalletClient } from '@/components/toolbox/hooks/useResolvedWalletClient';
+import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
+import useConsoleNotifications from '@/hooks/useConsoleNotifications';
+
+export interface RegisterRemoteArgs {
+  /** TokenRemote contract address on the destination chain */
+  remoteAddress: string;
+}
+
+export interface RegisterRemoteResult {
+  hash: string;
+}
+
+/**
+ * Hook that owns the registerWithHome ICM message send. The wallet must
+ * be connected to the destination (remote) chain since the call is on
+ * the remote contract; the message is delivered to the home contract by
+ * Teleporter relayers within ~30s.
+ *
+ * Both the ERC20TokenRemote and NativeTokenRemote ABIs expose
+ * `registerWithHome(feeInfo)`, so we use the ERC20 ABI for both.
+ */
+export function useRegisterRemote() {
+  const walletClient = useResolvedWalletClient();
+  const viemChain = useViemChainStore();
+  const { notify } = useConsoleNotifications();
+  const [isRegistering, setIsRegistering] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (args: RegisterRemoteArgs): Promise<RegisterRemoteResult> => {
+    setError(null);
+    if (!walletClient?.account || !viemChain) {
+      const msg = 'Wallet not connected';
+      setError(msg);
+      throw new Error(msg);
+    }
+    if (!args.remoteAddress) {
+      const msg = 'Remote contract address required';
+      setError(msg);
+      throw new Error(msg);
+    }
+
+    setIsRegistering(true);
+    try {
+      const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
+      if (!client) throw new Error('Could not create RPC client for destination');
+
+      // feeInfo = (feeTokenAddress, amount). Zero-address + 0 means no
+      // primary fee token; the caller pays gas in the chain's native
+      // currency. Matches the existing wizard's behavior in
+      // RegisterWithHome.tsx.
+      const feeInfo: readonly [`0x${string}`, bigint] = [zeroAddress, 0n];
+      const { request } = await client.simulateContract({
+        address: args.remoteAddress as `0x${string}`,
+        abi: ERC20TokenRemoteABI.abi,
+        functionName: 'registerWithHome',
+        args: [feeInfo],
+        chain: viemChain,
+        account: walletClient.account,
+      });
+
+      const writePromise = walletClient.writeContract(request);
+      notify({ type: 'call', name: 'Register With Home' }, writePromise, viemChain);
+      const hash = await writePromise;
+      await client.waitForTransactionReceipt({ hash });
+      return { hash };
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? 'Register failed';
+      setError(msg);
+      throw e;
+    } finally {
+      setIsRegistering(false);
+    }
+  };
+
+  return { run, isRegistering, error, reset: () => setError(null) };
+}

--- a/components/toolbox/console/ictt/hooks/useSendTransfer.ts
+++ b/components/toolbox/console/ictt/hooks/useSendTransfer.ts
@@ -1,0 +1,186 @@
+'use client';
+
+import { useState } from 'react';
+import { zeroAddress } from 'viem';
+import ERC20TokenHomeABI from '@/contracts/icm-contracts/compiled/ERC20TokenHome.json';
+import NativeTokenHomeABI from '@/contracts/icm-contracts/compiled/NativeTokenHome.json';
+import ERC20TokenRemoteABI from '@/contracts/icm-contracts/compiled/ERC20TokenRemote.json';
+import NativeTokenRemoteABI from '@/contracts/icm-contracts/compiled/NativeTokenRemote.json';
+import ExampleERC20 from '@/contracts/icm-contracts/compiled/ExampleERC20.json';
+import { useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
+import { useResolvedWalletClient } from '@/components/toolbox/hooks/useResolvedWalletClient';
+import { makePublicClientForChain } from '@/components/toolbox/hooks/usePublicClientForChain';
+import useConsoleNotifications from '@/hooks/useConsoleNotifications';
+import { cb58ToHex } from '@/components/tools/common/utils/cb58';
+import type { TokenKind } from '@/app/console/ictt/_components/types';
+
+const DEFAULT_GAS_LIMIT = 250_000n;
+
+export type TransferDirection = 'home-to-remote' | 'remote-to-home';
+
+export interface SendTransferArgs {
+  direction: TransferDirection;
+  /** Source-side TokenHome or TokenRemote contract address */
+  sourceContract: string;
+  /** Source-side kind (matters for ERC-20 vs Native ABI selection) */
+  sourceKind: TokenKind;
+  /** Destination-side TokenRemote or TokenHome contract address */
+  destContract: string;
+  /** Destination chain blockchain ID (cb58); cb58→hex'd for the call */
+  destChainId: string;
+  /** Recipient on the destination chain */
+  recipient: string;
+  /** Amount in the source token's smallest unit */
+  amount: bigint;
+  /** Optional gas limit override; defaults to 250000 */
+  requiredGasLimit?: bigint;
+  /**
+   * Whether to attempt a pre-send approve(source, amount) on the
+   * underlying token. Only used for `home-to-remote` ERC-20 sends.
+   * The inspector decides this based on the live allowance read.
+   */
+  approveBeforeSend?: boolean;
+}
+
+/**
+ * Hook that owns the cross-chain `send(...)` flow.
+ *
+ *   home → remote: calls `send(SendTokensInput, amount)` on TokenHome.
+ *                  ERC-20 needs an approve first; Native passes value.
+ *   remote → home: calls `send(SendTokensInput, amount)` on TokenRemote.
+ *                  Native passes value; ERC-20 burns from balance.
+ *
+ * The Teleporter relayer delivers the message to the destination
+ * contract, where tokens are minted (or unlocked, depending on direction).
+ */
+export function useSendTransfer() {
+  const walletClient = useResolvedWalletClient();
+  const viemChain = useViemChainStore();
+  const { notify } = useConsoleNotifications();
+  const [status, setStatus] = useState<'idle' | 'approving' | 'sending'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (args: SendTransferArgs): Promise<{ hash: string }> => {
+    setError(null);
+    if (!walletClient?.account || !viemChain) {
+      const msg = 'Wallet not connected';
+      setError(msg);
+      throw new Error(msg);
+    }
+    if (args.amount === 0n) {
+      const msg = 'Amount must be greater than zero';
+      setError(msg);
+      throw new Error(msg);
+    }
+
+    let destBlockchainIDHex: string;
+    try {
+      destBlockchainIDHex = cb58ToHex(args.destChainId);
+    } catch {
+      const msg = 'Could not encode destination blockchain ID';
+      setError(msg);
+      throw new Error(msg);
+    }
+
+    const client = makePublicClientForChain(viemChain.rpcUrls.default.http[0], [], viemChain);
+    if (!client) {
+      const msg = 'Could not create RPC client';
+      setError(msg);
+      throw new Error(msg);
+    }
+
+    // Pre-send approve for ERC-20 home → remote sends.
+    if (args.approveBeforeSend && args.direction === 'home-to-remote' && args.sourceKind === 'erc20') {
+      setStatus('approving');
+      try {
+        const tokenAddr = (await client.readContract({
+          address: args.sourceContract as `0x${string}`,
+          abi: ERC20TokenHomeABI.abi,
+          functionName: 'getTokenAddress',
+        })) as `0x${string}`;
+        const allowance = (await client.readContract({
+          address: tokenAddr,
+          abi: ExampleERC20.abi,
+          functionName: 'allowance',
+          args: [walletClient.account.address, args.sourceContract as `0x${string}`],
+        })) as bigint;
+
+        if (allowance < args.amount) {
+          const { request } = await client.simulateContract({
+            address: tokenAddr,
+            abi: ExampleERC20.abi,
+            functionName: 'approve',
+            args: [args.sourceContract as `0x${string}`, args.amount],
+            chain: viemChain,
+            account: walletClient.account,
+          });
+          const approvePromise = walletClient.writeContract(request);
+          notify({ type: 'call', name: 'Approve for Send' }, approvePromise, viemChain);
+          const approveHash = await approvePromise;
+          await client.waitForTransactionReceipt({ hash: approveHash });
+        }
+      } catch (e: any) {
+        const msg = e?.shortMessage ?? e?.message ?? 'Approve failed';
+        setError(msg);
+        setStatus('idle');
+        throw e;
+      }
+    }
+
+    setStatus('sending');
+    try {
+      const sendInput = {
+        destinationBlockchainID: destBlockchainIDHex as `0x${string}`,
+        destinationTokenTransferrerAddress: args.destContract as `0x${string}`,
+        recipient: args.recipient as `0x${string}`,
+        primaryFeeTokenAddress: zeroAddress,
+        primaryFee: 0n,
+        secondaryFee: 0n,
+        requiredGasLimit: args.requiredGasLimit ?? DEFAULT_GAS_LIMIT,
+        multiHopFallback: zeroAddress,
+      };
+
+      // home-to-remote uses TokenHome ABI; remote-to-home uses TokenRemote
+      // ABI. Native variants pass `value`; ERC-20 variants pass amount as
+      // a second positional arg.
+      const isHomeToRemote = args.direction === 'home-to-remote';
+      const isNativeValue =
+        (isHomeToRemote && args.sourceKind === 'native') || (!isHomeToRemote && args.sourceKind === 'native');
+
+      const abi = isHomeToRemote
+        ? ((args.sourceKind === 'erc20' ? ERC20TokenHomeABI.abi : NativeTokenHomeABI.abi) as any)
+        : ((args.sourceKind === 'erc20' ? ERC20TokenRemoteABI.abi : NativeTokenRemoteABI.abi) as any);
+
+      const { request } = await client.simulateContract({
+        address: args.sourceContract as `0x${string}`,
+        abi,
+        functionName: 'send',
+        args: isNativeValue ? [sendInput] : [sendInput, args.amount],
+        chain: viemChain,
+        account: walletClient.account,
+        ...(isNativeValue ? { value: args.amount } : {}),
+      });
+      const writePromise = walletClient.writeContract(request);
+      notify({ type: 'call', name: 'Send Tokens' }, writePromise, viemChain);
+      const hash = await writePromise;
+      await client.waitForTransactionReceipt({ hash });
+      return { hash };
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? 'Send failed';
+      setError(msg);
+      throw e;
+    } finally {
+      setStatus('idle');
+    }
+  };
+
+  return {
+    run,
+    status,
+    isApproving: status === 'approving',
+    isSending: status === 'sending',
+    isWorking: status !== 'idle',
+    error,
+    reset: () => setError(null),
+  };
+}


### PR DESCRIPTION
## Summary

Replaces the 7-route ICTT wizard (`/console/ictt/setup/[step]` × 5 + `/console/ictt/token-transfer/[step]` × 2) with a single unified Bridge Console at `/console/ictt`. The bridge becomes a first-class spatial object — Home chain on the left, Remote on the right, ICM rail between them — with a phase strip on top and a contextual inspector pane on the bottom-left.

Built incrementally across 17 commits over the [planned phases](https://github.com/ava-labs/builders-hub/blob/feat/ictt-bridge-console-redesign/.) (A → F + follow-up polish):

**Architecture**
- New `app/console/ictt/page.tsx` single-page entry. Phase state is local, with `?phase=...&remote=...` deep-link support. Old per-step routes 301-redirect.
- Bridge state derives from existing `useToolboxStore` keys plus on-chain reads against the home contract (`getRemoteTokenTransferrerSettings`) for registration + collateral status. No store schema changes.
- 5 contract hooks extracted under `components/toolbox/console/ictt/hooks/` (deploy home, deploy remote, register, add collateral, send transfer). Inspectors are now thin form-only wrappers around these hooks.
- 6 inspector modules under `app/console/ictt/_components/inspectors/`, one per phase. Each has a chain-mismatch preflight (centralized in `usePreflight`), `Cmd+Enter` shortcut, error/loading state.

**Key features**
- **Spatial layout**: two `<ChainPanel>`s + animated SVG `<ICMConnection>` rail, accent-colored per chain (`chainColor()` resolver matching `SwitchChainRail`).
- **Live polling**: 5s poll on `getRemoteTokenTransferrerSettings` flips phases to done as the bridge progresses; ICM rail animates only during register/transfer.
- **Token snapshot**: home + remote panels expand to show real on-chain `totalSupply`, `decimals`, `getTransferredBalance` per remote.
- **Multi-remote support**: when a Home pairs with multiple Remotes, the right-panel header shows a chain picker. Selection persists per home chain in localStorage.
- **Native-minter precompile gate**: hard-blocks `NativeTokenRemote` deploy when the destination chain doesn't have the precompile enabled (via lightweight `usePrecompileActive` + compact banner).
- **Activity feed**: local optimistic events, transaction explorer links, empty-state CTA pointing at the Token phase.
- **Keyboard nav**: `←/→` to switch phases (skips blocked), `⌘ Enter` to submit primary action, `?` for the shortcut overlay.
- **Reset bridge** button with confirm — clears ICTT-specific keys on home + remote stores; leaves other tools untouched.
- **Sticky header + phase strip** at `top-12` so navigation is always reachable.
- **Tablet-graceful**: two-pane stacks vertically below `lg`; ICM rail rotates from vertical to horizontal.

**Files**
- New: `app/console/ictt/page.tsx`, `app/console/ictt/_components/*` (~25 files), `components/toolbox/console/ictt/hooks/*` (5 files)
- Modified: `app/console/ictt/setup/page.tsx` + `[step]/page.tsx`, `app/console/ictt/token-transfer/page.tsx` + `[step]/page.tsx` (now redirect), `components/console/console-sidebar.tsx` (collapsed two ICTT entries to one)
- **Not touched**: `components/console/step-flow.tsx` (still powers 50+ other flows), `components/toolbox/stores/*`, `app/api/ictt-stats/route.ts`, the legacy step components in `components/toolbox/console/ictt/setup/*` (still used by the chat-driven flow via `lib/chat/registry.tsx`).

## Test plan

- [ ] Visit `/console/ictt` with no wallet — see "Connect a wallet to start a bridge" empty state
- [ ] Connect Core wallet on Fuji → confirm wallet pill turns green, home panel shows Fuji, phase strip is at Token
- [ ] Click Token → choose `Deploy test ERC-20` → click button → verify `exampleErc20Address` set in localStorage, contract row deploys, phase auto-advances to Home
- [ ] Click Home → registry auto-fills → click `Deploy TokenHome` → verify `erc20TokenHomeAddress` set, advance to Remote
- [ ] Click Remote → see chain-mismatch banner (we're still on Fuji); click "Switch" → wallet switches to Echo → banner clears → click `Deploy TokenRemote`
- [ ] Click Register → click `Send ICM register message` → ICM rail animates → within ~30s, polling flips status to registered
- [ ] Click Collateral → wallet auto-prompts switch to Fuji → enter amount → Approve → wait for confirm → Add collateral → progress bar fills, advance to Live
- [ ] Click Live → enter amount + recipient → click Send → verify approval (if ERC-20) → send → activity feed shows source + destination tx
- [ ] Try `NativeTokenRemote` on a chain without the native-minter precompile — confirm deploy button is disabled and amber banner shows
- [ ] Press `?` → shortcuts overlay opens
- [ ] Press `→` repeatedly → phase strip moves right, skipping blocked phases
- [ ] Press `Cmd+Enter` while on Home phase with valid form → deploys
- [ ] Click Reset → confirm dialog → confirm → all addresses clear, phase resets to Token
- [ ] Reload page after picking a different remote (e.g., Echo for Fuji home) → preference is restored
- [ ] Visit `/console/ictt/setup/deploy-token-home` → 307 redirects to `/console/ictt?phase=home`
- [ ] Visit `/console/ictt/token-transfer/test-send` → 307 redirects to `/console/ictt?phase=transfer`
- [ ] Resize to tablet width (~768px) → two-pane stacks vertically, ICM rail rotates, phase strip stays sticky
- [ ] Verify chat-driven ICTT flow (`/api/chat` flows that import `app/console/ictt/setup/steps`) still works — legacy step components unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)