### PR TITLE
fix(mobile): restore nav burger and hide chat bubble on stats

### DIFF
--- a/components/chat/chat-bubble.tsx
+++ b/components/chat/chat-bubble.tsx
@@ -125,6 +125,10 @@ export function ChatBubble() {
     return null;
   }
 
+  // On /stats, hide the bubble on mobile via CSS (charts there are dense and
+  // the floating button steals tap targets). Desktop stats still shows it.
+  const hideOnMobile = pathname.startsWith('/stats');
+
   const handleBubbleClick = () => {
     if (state === 'collapsed') {
       setShowPrompt(false);
@@ -167,7 +171,13 @@ export function ChatBubble() {
   };
 
   return (
-    <div className="chatbot-container fixed bottom-6 right-6 z-50 flex flex-col items-end gap-3" data-chatbot>
+    <div
+      className={cn(
+        'chatbot-container fixed bottom-6 right-6 z-50 flex-col items-end gap-3',
+        hideOnMobile ? 'hidden md:flex' : 'flex',
+      )}
+      data-chatbot
+    >
       {/* Prompt tooltip */}
       {mounted && (
         <div

--- a/components/chat/chat-bubble.tsx
+++ b/components/chat/chat-bubble.tsx
@@ -125,9 +125,11 @@ export function ChatBubble() {
     return null;
   }
 
-  // On /stats, hide the bubble on mobile via CSS (charts there are dense and
-  // the floating button steals tap targets). Desktop stats still shows it.
-  const hideOnMobile = pathname.startsWith('/stats');
+  // On /stats and /explorer, hide the bubble on mobile via CSS — those pages
+  // are dense (charts, tables, search results) and the floating button steals
+  // tap targets. Desktop still shows it.
+  const hideOnMobile =
+    pathname.startsWith('/stats') || pathname.startsWith('/explorer');
 
   const handleBubbleClick = () => {
     if (state === 'collapsed') {

--- a/components/navigation/navbar-dropdown-injector.tsx
+++ b/components/navigation/navbar-dropdown-injector.tsx
@@ -1,64 +1,92 @@
 'use client';
 
-import { useEffect } from 'react';
-import { createRoot } from 'react-dom/client';
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { NavbarDropdown } from './navbar-dropdown';
 
 /**
- * Injects custom navbar dropdown at ≤1023px breakpoint
- * Replaces fumadocs' dropdown which has CSS specificity issues with Tailwind v4
+ * Mounts the custom navbar dropdown at ≤1023px breakpoint.
+ *
+ * Renders via createPortal (not createRoot) so the portal stays inside the
+ * parent React tree and inherits providers like SessionProvider. A previous
+ * createRoot-based version broke when NavbarDropdown started calling
+ * useSession() — the detached root had no provider and the component crashed,
+ * leaving an empty <li> with no burger button.
  */
 export function NavbarDropdownInjector() {
+  const [container, setContainer] = useState<HTMLLIElement | null>(null);
+  const [isMobile, setIsMobile] = useState(false);
+
   useEffect(() => {
-    const checkAndInject = () => {
-      const isMobile = window.innerWidth <= 1023;
-      
-      if (!isMobile) {
-        // Remove if exists
-        const existing = document.querySelector('[data-custom-navbar-dropdown]');
-        if (existing) {
-          existing.remove();
-        }
-        return;
-      }
-
-      const navbar = document.querySelector('nav[aria-label="Main"]') || document.querySelector('header[aria-label="Main"]');
-      if (!navbar) return;
-
-      // Check if already exists
-      if (navbar.querySelector('[data-custom-navbar-dropdown]')) {
-        return;
-      }
-
-      // Find the right side container (where search icon is)
-      const rightContainer = navbar.querySelector('ul.flex.flex-row.items-center.ms-auto') ||
-                            navbar.querySelector('ul.ms-auto');
-      if (!rightContainer) return;
-
-      // Create container
-      const container = document.createElement('li');
-      container.setAttribute('data-custom-navbar-dropdown', 'true');
-      container.className = 'list-none';
-      
-      // Append at the end (after search icon)
-      rightContainer.appendChild(container);
-
-      // Render React component
-      const root = createRoot(container);
-      root.render(<NavbarDropdown />);
-    };
-
-    checkAndInject();
-    const resizeHandler = () => checkAndInject();
-    window.addEventListener('resize', resizeHandler);
-    const timeout = setTimeout(checkAndInject, 100);
-
-    return () => {
-      window.removeEventListener('resize', resizeHandler);
-      clearTimeout(timeout);
-    };
+    const update = () => setIsMobile(window.innerWidth <= 1023);
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
   }, []);
 
-  return null;
-}
+  useEffect(() => {
+    if (!isMobile) {
+      document
+        .querySelectorAll('[data-custom-navbar-dropdown]')
+        .forEach((el) => el.remove());
+      setContainer(null);
+      return;
+    }
 
+    let injected: HTMLLIElement | null = null;
+    let cancelled = false;
+
+    const tryInject = (): boolean => {
+      if (cancelled) return false;
+
+      const navbar =
+        document.querySelector('nav[aria-label="Main"]') ||
+        document.querySelector('header[aria-label="Main"]');
+      if (!navbar) return false;
+
+      const existing = navbar.querySelector<HTMLLIElement>(
+        '[data-custom-navbar-dropdown]',
+      );
+      if (existing) {
+        injected = existing;
+        setContainer(existing);
+        return true;
+      }
+
+      const rightContainer =
+        navbar.querySelector('ul.flex.flex-row.items-center.ms-auto') ||
+        navbar.querySelector('ul.ms-auto');
+      if (!rightContainer) return false;
+
+      const li = document.createElement('li');
+      li.setAttribute('data-custom-navbar-dropdown', 'true');
+      li.className = 'list-none';
+      rightContainer.appendChild(li);
+      injected = li;
+      setContainer(li);
+      return true;
+    };
+
+    if (tryInject()) {
+      return () => {
+        cancelled = true;
+        if (injected?.parentNode) injected.parentNode.removeChild(injected);
+      };
+    }
+
+    // Navbar wasn't ready yet — watch for it to appear / re-render.
+    const observer = new MutationObserver(() => {
+      if (tryInject()) observer.disconnect();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+      if (injected?.parentNode) injected.parentNode.removeChild(injected);
+    };
+  }, [isMobile]);
+
+  if (!container) return null;
+  return createPortal(<NavbarDropdown />, container);
+}


### PR DESCRIPTION
## Summary

- Mobile navbar burger has been invisible on every page since commit `d661de2c3` ("refactor: update authentication handling"). That commit added `useSession()` to `NavbarDropdown`, but the dropdown is mounted with `createRoot` into a side-tree React root in `navbar-dropdown-injector.tsx`. Side-tree roots don't inherit context, so there's no `SessionProvider` — `useSession()` throws and the component crashes silently, leaving just the empty `<li>` we appended.
- Switch the injector to `createPortal`, which **does** inherit context from the parent React tree, so `SessionProvider` (and every other provider) is visible to `NavbarDropdown` again. Also adds a `MutationObserver` so the dropdown still mounts when the navbar appears asynchronously, not only on the initial render tick.
- Hide the `ChatBubble` on `/stats` below `md` via Tailwind (`hidden md:flex`). The floating button was overlapping dense charts on mobile and grabbing taps.

## Test plan

- [ ] On a viewport ≤1023px, the chevron burger appears in the navbar on `/` and other top-level pages.
- [ ] Opening the burger shows the menu sections (Academy, Docs, Console, Stats, etc.) and the login icon (or profile icon when signed in).
- [ ] On desktop (>1023px) the burger is hidden and the regular nav links remain.
- [ ] On `/stats/*` at mobile widths (<768px), the AI chat bubble in the bottom-right is gone. On `/stats/*` at desktop widths it's still there.
- [ ] On non-stats pages, the chat bubble still appears on mobile.