### PR TITLE
fix(console): persist firn explorer url from quick-l1

### DIFF
--- a/components/toolbox/console/create-l1/basic/BasicSetupComplete.tsx
+++ b/components/toolbox/console/create-l1/basic/BasicSetupComplete.tsx
@@ -254,6 +254,12 @@ export default function BasicSetupComplete({ job }: { job: DeploymentJob }) {
         // brand-new chain yet (in which case it would otherwise fall back
         // to mainnet and mislabel the chain in the dashboard).
         isTestnet: job.request.network === 'fuji',
+        // Persist the per-L1 Firn URL the user just saw on this screen so
+        // the My L1 dashboard's ExplorerMenu picks it as default even on
+        // the wallet-only fallback path (managed-side data unavailable,
+        // mid-load, post-Firn-TTL). Undefined when the orchestrator did
+        // not return an explorer (e.g. the local mock path).
+        explorerUrl: result.explorer?.url,
       });
     } finally {
       setAddingToWallet(false);

--- a/components/toolbox/providers/modals/AddChainModal.tsx
+++ b/components/toolbox/providers/modals/AddChainModal.tsx
@@ -222,6 +222,9 @@ function AddChainModalInner() {
 
       // wallet_addEthereumChain directly instead of viem's addChain —
       // only this path forwards Core wallet's proprietary isTestnet flag.
+      // blockExplorerUrls is per EIP-3085 optional; when set, the wallet
+      // shows the same explorer link the in-app L1 dashboard treats as
+      // default (Firn for Quick L1 deploys).
       await walletClient.request({
         method: 'wallet_addEthereumChain',
         params: [
@@ -230,6 +233,7 @@ function AddChainModalInner() {
             chainName: chainData.name,
             nativeCurrency: { name: chainData.coinName, symbol: chainData.coinName, decimals: 18 },
             rpcUrls: [chainData.rpcUrl],
+            blockExplorerUrls: chainData.explorerUrl ? [chainData.explorerUrl] : undefined,
             isTestnet: chainData.isTestnet,
           },
         ] as any,
@@ -295,6 +299,11 @@ function AddChainModalInner() {
         validatorManagerBlockchainId: data.validatorManagerBlockchainId || undefined,
         logoUrl: data.logoUrl,
         genesisData: validatedGenesis,
+        // Forwarded from the caller (Quick L1 passes result.explorer.url here)
+        // so the persisted L1ListItem.explorerUrl matches the URL the user
+        // saw on the deployment success screen — making it the default
+        // explorer in the My L1 dashboard's ExplorerMenu.
+        explorerUrl: options?.explorerUrl,
       };
 
       await addChainDirect(chainData);

--- a/types/wallet.ts
+++ b/types/wallet.ts
@@ -20,6 +20,14 @@ export interface AddChainOptions {
      * configured.
      */
     genesisData?: string;
+    /**
+     * Optional block explorer URL the caller wants persisted on the
+     * resulting L1ListItem. Quick L1 passes `result.explorer.url` here so
+     * the per-L1 Firn URL survives the wallet-add hop and becomes the
+     * dashboard's default explorer — matching what the user just saw on
+     * the deployment success screen.
+     */
+    explorerUrl?: string;
 }
 
 export interface ChainData {
@@ -38,6 +46,10 @@ export interface ChainData {
     /** Optional stringified genesis JSON. Carried through Add Chain so the
      *  Copy Genesis button on the L1 detail page can serve it. */
     genesisData?: string;
+    /** Optional block explorer URL. Carried through Add Chain to seed
+     *  L1ListItem.explorerUrl, which drives the default selection in the
+     *  dashboard's <ExplorerMenu> via lib/explorers.ts Firn detection. */
+    explorerUrl?: string;
 }
 
 export type AddChainResult = 


### PR DESCRIPTION
## Summary

  The Firn block explorer URL shown on the Quick L1 deployment success screen was being **discarded** during the "Add to wallet" hop, so the My L1 dashboard's `<ExplorerMenu>` no longer
  defaulted to Firn whenever the managed-side data wasn't available (post-Firn TTL, mid-load, signed-out, errored). The dashboard fell back to "Builder Hub Explorer" instead — different
  from what the user just saw on the finish screen.
  
  **Root cause:** `AddChainOptions` and `ChainData` (`types/wallet.ts`) had no `explorerUrl` field, so `BasicSetupComplete.handleAddToWallet` had no way to thread `result.explorer.url` into
   `l1ListStore.addL1(...)`. The persisted `L1ListItem` ended up with `explorerUrl: undefined`, and the wallet-only fallback path on the dashboard then resolved the default to Builder Hub
  Explorer instead of Firn.

  **Fix** (3 files, +27 / -0):

  - **`types/wallet.ts`** — Add optional `explorerUrl?: string` to `AddChainOptions` and `ChainData`. Follows the same passthrough pattern as `genesisData`.
  - **`components/toolbox/providers/modals/AddChainModal.tsx`**
    - `onSubmit` now carries `explorerUrl: options?.explorerUrl` into the built `chainData`, which `addChainDirect` forwards to `getL1ListStore(...).getState().addL1(chainData)`.
    - `addChainDirect`'s `wallet_addEthereumChain` call now forwards `blockExplorerUrls` (per EIP-3085) so MetaMask / Core wallet also shows the matching explorer link — keeping the in-app
  dashboard and the wallet UI in sync.
  - **`components/toolbox/console/create-l1/basic/BasicSetupComplete.tsx`** — `handleAddToWallet` now passes `explorerUrl: result.explorer?.url` to `addChain(...)`. This is the exact same
  URL already rendered on the success screen ("Block Explorer" detail row + "Public Block Explorer" footer link).

  **Why this is enough**

  - `metadataFromWalletItem` (`lib/console/my-l1/types.ts:82-112`) already exposes `explorerUrl` and drops undefined values, so merging a wallet entry over a managed `CombinedL1` won't
  clobber the server-derived Firn URL on the managed path.
  - `walletItemToCombined` (`lib/console/my-l1/types.ts:61-73`) already reads `w.explorerUrl`, so the wallet-only fallback path will now surface the persisted Firn URL.
  - `ExplorerMenu` (`components/console/ExplorerMenu.tsx`) calls `getExplorerOptions({ customExplorerUrl })` and the `firn` option lands at index 0 for any `*.firn.gg` URL
  (`lib/explorers.ts:120-127`) — which is the default for both the single-button render and the dropdown's first row.
  - The orchestrator's `ExplorerResult.slug` and the dashboard's server-side derivation at `lib/console/my-l1s.ts:122` both use `blockchainId.toLowerCase().slice(0, 8)`, so persisting the
  orchestrator's URL doesn't conflict with the server's reconstruction.
  - The mock-orchestrator dev path (`lib/quick-l1/mock-orchestrator.ts:169-210`) doesn't set `result.explorer`, so `result.explorer?.url` is `undefined` and the persisted
  `L1ListItem.explorerUrl` stays `undefined` — same as before, no regression in local dev.

  **Out of scope**

  - Advanced PoA / PoS create-L1 flow (no auto-shown explorer during creation; uses a separate `SelfHostedExplorer` BlockScout wizard).
  - Manual "Add Chain" path — no orchestrator-issued explorer URL to forward.
  - Mock-orchestrator providing a fake `result.explorer.url` for local dev.
  - Adding unit tests for the Firn-first ordering in `tests/unit/console/explorers.test.ts` (worth a follow-up; kept this diff tight).

  ## Test plan

  - [ ] On Fuji with `QUICK_L1_SERVICE_URL` pointing at the real orchestrator, run a Quick L1 deploy to completion.
  - [ ] On the success screen, note the "Block Explorer" URL (a `https://<8>.firn.gg` URL).
  - [ ] Click "Add ... to wallet" → confirm the `AddChainModal` opens with RPC pre-filled, then click "Add Chain".
  - [ ] In the browser's MetaMask / Core wallet, open the new network's settings and verify the block explorer URL is the same Firn URL.
  - [ ] In DevTools → Application → Local Storage → `…-l1-list-store-testnet`, confirm the new entry has `explorerUrl` set to the same Firn URL.
  - [ ] Navigate to `/console/my-l1?chain=<chainId>`. Confirm the single "Open Explorer" button (or the first dropdown item) links to the Firn URL and is labeled "Firn Explorer".
  - [ ] Sign out, then revisit `/console/my-l1` — the wallet-only fallback should still default to Firn (previously it would have flipped to "Builder Hub Explorer").
  - [ ] Sanity-check existing flows: import an external L1 manually through the Add Chain modal without an `explorerUrl` — confirm no regression (the L1 is still added, the dashboard shows
  Builder Hub Explorer as today).