### PR TITLE
feat/console l1 setup and relayer fix

### DIFF
--- a/components/toolbox/components/StorageRequirements.tsx
+++ b/components/toolbox/components/StorageRequirements.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo } from 'react';
 
+type StorageVariant = 'primary' | 'l1';
+
 interface StorageRequirementsProps {
   nodeType: 'validator' | 'rpc' | 'archival';
   pruningEnabled: boolean;
@@ -9,6 +11,15 @@ interface StorageRequirementsProps {
   stateSyncEnabled: boolean;
   debugEnabled?: boolean;
   network?: 'mainnet' | 'fuji';
+  /**
+   * Storage baseline profile. `'primary'` uses real Avalanche C-Chain
+   * measurements (~13 TB archival mainnet). `'l1'` uses much smaller
+   * numbers anchored on the typical Avalanche L1 baseline shown in the L1
+   * node setup tile (~200 GB pruned validator mainnet, ~40 GB Fuji). L1
+   * storage varies enormously with chain activity — the L1 figures are
+   * conservative averages, not precise predictions. Default `'primary'`.
+   */
+  variant?: StorageVariant;
 }
 
 interface StorageEstimate {
@@ -18,18 +29,63 @@ interface StorageEstimate {
   oneYearTotal: number;
 }
 
-// Storage estimates in GB (decimal)
-// Real data: Validator ~300GB with state sync, RPC slightly more
-// Archival: 12.1 TiB ≈ 13.3 TB, grows ~0.64 TiB/month ≈ 700 GB/month
-// Debug tracing adds ~20% overhead (stores execution traces)
+// Baseline figures in GB, per profile. Values are picked so that the
+// "typical validator" cell (pruned + state sync + skip TX index) matches
+// the visible figure in the corresponding node setup's Set up Instance
+// tile, keeping the right-sidebar storage estimate consistent with the
+// hardware-spec callout.
+//
+// Sources:
+//   - Primary Network: real C-Chain measurements. Validator ~300 GB with
+//     state sync, RPC ~350 GB. Archival 12.1 TiB ≈ 13.3 TB, growing
+//     ~0.64 TiB/mo ≈ 700 GB/mo. Fuji at ~15% of mainnet.
+//   - L1: anchored on the existing "~40 GB Fuji / ~200 GB Mainnet"
+//     baseline used in the L1 node setup hardware tile (validator + state
+//     sync + skip tx index). Archival figures scaled ~4x pruned to reflect
+//     full-history storage being substantially larger than pruned, but
+//     nowhere near the 13 TB C-Chain archival since L1s are smaller,
+//     lower-volume chains. Growth rates assume light-to-moderate L1
+//     traffic; user is reminded that real values track actual chain
+//     throughput.
+interface ProfileBaseline {
+  archival: { initial: number; monthly: number };
+  prunedSyncSkip: { initial: number; monthly: number }; // pruned + state sync + skip tx idx
+  prunedSyncFull: { initial: number; monthly: number }; // pruned + state sync + full tx idx
+  prunedNoSyncSkip: { initial: number; monthly: number }; // pruned + replay + skip tx idx
+  prunedNoSyncFull: { initial: number; monthly: number }; // pruned + replay + full tx idx
+  fujiMultiplier: number;
+}
+
+const STORAGE_BASELINES: Record<StorageVariant, ProfileBaseline> = {
+  primary: {
+    archival: { initial: 13300, monthly: 700 },
+    prunedSyncSkip: { initial: 300, monthly: 80 },
+    prunedSyncFull: { initial: 350, monthly: 100 },
+    prunedNoSyncSkip: { initial: 450, monthly: 80 },
+    prunedNoSyncFull: { initial: 500, monthly: 100 },
+    fujiMultiplier: 0.15,
+  },
+  l1: {
+    archival: { initial: 800, monthly: 35 },
+    prunedSyncSkip: { initial: 200, monthly: 10 },
+    prunedSyncFull: { initial: 240, monthly: 12 },
+    prunedNoSyncSkip: { initial: 260, monthly: 10 },
+    prunedNoSyncFull: { initial: 300, monthly: 12 },
+    // 200 GB Mainnet → 40 GB Fuji matches the Set up Instance tile (40/200=0.2)
+    fujiMultiplier: 0.2,
+  },
+};
+
 const getStorageEstimate = (
   pruningEnabled: boolean,
   skipTxIndexing: boolean,
   stateSyncEnabled: boolean,
   debugEnabled: boolean,
   network: 'mainnet' | 'fuji',
+  variant: StorageVariant,
 ): StorageEstimate => {
-  const mult = network === 'fuji' ? 0.15 : 1;
+  const profile = STORAGE_BASELINES[variant];
+  const mult = network === 'fuji' ? profile.fujiMultiplier : 1;
   // Debug tracing stores execution traces, adding ~20% storage overhead
   const debugMult = debugEnabled ? 1.2 : 1;
 
@@ -37,19 +93,16 @@ const getStorageEstimate = (
   let monthlyGrowth: number;
 
   if (!pruningEnabled) {
-    // Archival: full historical state
-    initial = 13300 * mult;
-    monthlyGrowth = 700 * mult;
+    initial = profile.archival.initial * mult;
+    monthlyGrowth = profile.archival.monthly * mult;
   } else if (stateSyncEnabled) {
-    // Pruned + State Sync
-    // Validator (no TX index): ~300 GB
-    // RPC (with TX index): ~350 GB
-    initial = (skipTxIndexing ? 300 : 350) * mult;
-    monthlyGrowth = (skipTxIndexing ? 80 : 100) * mult;
+    const cell = skipTxIndexing ? profile.prunedSyncSkip : profile.prunedSyncFull;
+    initial = cell.initial * mult;
+    monthlyGrowth = cell.monthly * mult;
   } else {
-    // Pruned + No State Sync (full replay from genesis)
-    initial = (skipTxIndexing ? 450 : 500) * mult;
-    monthlyGrowth = (skipTxIndexing ? 80 : 100) * mult;
+    const cell = skipTxIndexing ? profile.prunedNoSyncSkip : profile.prunedNoSyncFull;
+    initial = cell.initial * mult;
+    monthlyGrowth = cell.monthly * mult;
   }
 
   // Apply debug multiplier to growth rate (traces accumulate over time)
@@ -71,15 +124,16 @@ export function StorageRequirements({
   stateSyncEnabled,
   debugEnabled = false,
   network = 'mainnet',
+  variant = 'primary',
 }: StorageRequirementsProps) {
   const estimate = useMemo(
-    () => getStorageEstimate(pruningEnabled, skipTxIndexing, stateSyncEnabled, debugEnabled, network),
-    [pruningEnabled, skipTxIndexing, stateSyncEnabled, debugEnabled, network],
+    () => getStorageEstimate(pruningEnabled, skipTxIndexing, stateSyncEnabled, debugEnabled, network, variant),
+    [pruningEnabled, skipTxIndexing, stateSyncEnabled, debugEnabled, network, variant],
   );
 
   // Reference lines don't include debug overhead for clearer comparison
-  const prunedRef = getStorageEstimate(true, false, true, false, network);
-  const archivalRef = getStorageEstimate(false, false, false, false, network);
+  const prunedRef = getStorageEstimate(true, false, true, false, network, variant);
+  const archivalRef = getStorageEstimate(false, false, false, false, network, variant);
 
   const maxStorage = archivalRef.oneYearTotal;
   const isArchival = !pruningEnabled;

--- a/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
+++ b/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
@@ -15,6 +15,7 @@ import { Steps, Step } from 'fumadocs-ui/components/steps';
 import { SyntaxHighlightedJSON } from '../../components/genesis/SyntaxHighlightedJSON';
 import { ReverseProxySetup } from '../../components/ReverseProxySetup';
 import { DockerInstallation } from '../../components/DockerInstallation';
+import { StorageRequirements } from '../../components/StorageRequirements';
 import { GenesisHighlightProvider, useGenesisHighlight } from '../../components/genesis/GenesisHighlightContext';
 import { SUBNET_EVM_VM_ID } from '@/constants/console';
 import {
@@ -416,97 +417,6 @@ curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"info.getNodeID"}' \\
       githubUrl="https://github.com/ava-labs/builders-hub/edit/master/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx"
     >
       <Steps>
-        {showPrerequisites && (
-          <Step>
-            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-1">Set up Instance</h3>
-            <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-4">
-              Provision a server with the following specifications.
-            </p>
-
-            {/* Hardware requirements - compact grid (matches Primary Network setup) */}
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
-              <div className="bg-zinc-50 dark:bg-zinc-900/50 rounded-lg p-3 border border-zinc-200 dark:border-zinc-800">
-                <div className="flex items-center gap-2 mb-1">
-                  <svg className="w-4 h-4 text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z"
-                    />
-                  </svg>
-                  <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">CPU</span>
-                </div>
-                <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">4 vCPU</div>
-              </div>
-              <div className="bg-zinc-50 dark:bg-zinc-900/50 rounded-lg p-3 border border-zinc-200 dark:border-zinc-800">
-                <div className="flex items-center gap-2 mb-1">
-                  <svg className="w-4 h-4 text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
-                    />
-                  </svg>
-                  <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">RAM</span>
-                </div>
-                <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">8 GB</div>
-              </div>
-              <div className="bg-zinc-50 dark:bg-zinc-900/50 rounded-lg p-3 border border-zinc-200 dark:border-zinc-800">
-                <div className="flex items-center gap-2 mb-1">
-                  <svg className="w-4 h-4 text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"
-                    />
-                  </svg>
-                  <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">Storage</span>
-                </div>
-                <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                  {isTestnet ? '~40 GB Fuji' : '~200 GB Mainnet'}
-                </div>
-              </div>
-              <div className="bg-zinc-50 dark:bg-zinc-900/50 rounded-lg p-3 border border-zinc-200 dark:border-zinc-800">
-                <div className="flex items-center gap-2 mb-1">
-                  <ShieldCheck className="w-4 h-4 text-zinc-500" />
-                  <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">Open ports</span>
-                </div>
-                <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">9651 P2P · 9650 RPC</div>
-              </div>
-            </div>
-
-            <div className="flex items-start gap-2 text-xs text-zinc-600 dark:text-zinc-400">
-              <AlertCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-zinc-500" />
-              <span>
-                For a production L1 we recommend <strong>5+ validator nodes</strong> spread across regions. A single
-                node is fine for local dev and quick demos.
-              </span>
-            </div>
-          </Step>
-        )}
-
-        {showPrerequisites && (
-          <Step>
-            <DockerInstallation includeCompose={false} />
-
-            <p className="mt-4 text-sm text-zinc-500 dark:text-zinc-400">
-              If you do not want to use Docker, you can follow the{' '}
-              <a
-                href="https://github.com/ava-labs/avalanchego?tab=readme-ov-file#installation"
-                target="_blank"
-                className="text-blue-500 hover:underline"
-                rel="noreferrer"
-              >
-                manual installation instructions
-              </a>
-              .
-            </p>
-          </Step>
-        )}
-
         <Step>
           <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-1">Configure Node Settings</h3>
           <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-4">
@@ -921,9 +831,110 @@ curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"info.getNodeID"}' \\
                   )}
                 </div>
               </div>
+
+              {/* Storage Requirements Visualization (matches Primary Network setup) */}
+              <StorageRequirements
+                nodeType={nodeType}
+                pruningEnabled={cfg.pruningEnabled}
+                skipTxIndexing={cfg.skipTxIndexing}
+                stateSyncEnabled={cfg.stateSyncEnabled}
+                debugEnabled={cfg.enableDebugTrace}
+                network={selectedNetwork}
+              />
             </div>
           </div>
         </Step>
+
+        {showPrerequisites && (
+          <Step>
+            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-1">Set up Instance</h3>
+            <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-4">
+              Provision a server with the following specifications.
+            </p>
+
+            {/* Hardware requirements - compact grid (matches Primary Network setup) */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+              <div className="bg-zinc-50 dark:bg-zinc-900/50 rounded-lg p-3 border border-zinc-200 dark:border-zinc-800">
+                <div className="flex items-center gap-2 mb-1">
+                  <svg className="w-4 h-4 text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z"
+                    />
+                  </svg>
+                  <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">CPU</span>
+                </div>
+                <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">4 vCPU</div>
+              </div>
+              <div className="bg-zinc-50 dark:bg-zinc-900/50 rounded-lg p-3 border border-zinc-200 dark:border-zinc-800">
+                <div className="flex items-center gap-2 mb-1">
+                  <svg className="w-4 h-4 text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                    />
+                  </svg>
+                  <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">RAM</span>
+                </div>
+                <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">8 GB</div>
+              </div>
+              <div className="bg-zinc-50 dark:bg-zinc-900/50 rounded-lg p-3 border border-zinc-200 dark:border-zinc-800">
+                <div className="flex items-center gap-2 mb-1">
+                  <svg className="w-4 h-4 text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"
+                    />
+                  </svg>
+                  <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">Storage</span>
+                </div>
+                <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                  {isTestnet ? '~40 GB Fuji' : '~200 GB Mainnet'}
+                </div>
+              </div>
+              <div className="bg-zinc-50 dark:bg-zinc-900/50 rounded-lg p-3 border border-zinc-200 dark:border-zinc-800">
+                <div className="flex items-center gap-2 mb-1">
+                  <ShieldCheck className="w-4 h-4 text-zinc-500" />
+                  <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">Open ports</span>
+                </div>
+                <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">9651 P2P · 9650 RPC</div>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-2 text-xs text-zinc-600 dark:text-zinc-400">
+              <AlertCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-zinc-500" />
+              <span>
+                For a production L1 we recommend <strong>5+ validator nodes</strong> spread across regions. A single
+                node is fine for local dev and quick demos.
+              </span>
+            </div>
+          </Step>
+        )}
+
+        {showPrerequisites && (
+          <Step>
+            <DockerInstallation includeCompose={false} />
+
+            <p className="mt-4 text-sm text-zinc-500 dark:text-zinc-400">
+              If you do not want to use Docker, you can follow the{' '}
+              <a
+                href="https://github.com/ava-labs/avalanchego?tab=readme-ov-file#installation"
+                target="_blank"
+                className="text-blue-500 hover:underline"
+                rel="noreferrer"
+              >
+                manual installation instructions
+              </a>
+              .
+            </p>
+          </Step>
+        )}
 
         <Step>
           <h3 className="text-xl font-bold mb-4">Select L1</h3>

--- a/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
+++ b/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
@@ -170,12 +170,6 @@ function AvalanchegoDockerInner({
   // has debug trace flipped back on without touching the checkbox.
   const debugTraceUserSet = useRef(false);
 
-  // Same pattern for nodeType: Fuji defaults to 'archival' (Both validator +
-  // RPC) since that's the common single-box testnet shape. A manual click on
-  // any of the three role buttons sets this ref so the user's choice survives
-  // Mainnet ↔ Fuji round-trips.
-  const nodeTypeUserSet = useRef(false);
-
   const { addToWallet, isAdding: isAddingToWallet } = useAddToWallet();
   const l1ListStore = useL1ListStore();
 
@@ -279,14 +273,14 @@ function AvalanchegoDockerInner({
     setCfg((c) => ({ ...c, enableDebugTrace: selectedNetwork === 'fuji' }));
   }, [selectedNetwork]);
 
-  // Auto-select Both (validator + RPC) when the user is on Fuji and hasn't
-  // explicitly picked a role yet. Honours `forceNodeType` (the Create L1
-  // wizard pins this to 'validator') and respects manual overrides.
+  // Default to running both Validator + RPC on Fuji — the common single-box
+  // testnet shape. Effect only re-fires when selectedNetwork actually changes,
+  // so a manual mid-Fuji click on Validator or RPC still sticks. The reset
+  // happens cleanly on every Mainnet → Fuji entry, matching the user's mental
+  // model of "picking Fuji starts a fresh testnet flow".
   useEffect(() => {
     if (forceNodeType) return;
-    if (selectedNetwork === 'fuji' && !nodeTypeUserSet.current) {
-      setNodeType('archival');
-    }
+    if (selectedNetwork === 'fuji') setNodeType('archival');
   }, [selectedNetwork, forceNodeType]);
 
   // L1 lookup — refetch on subnet/network change, with AbortController.
@@ -352,7 +346,6 @@ function AvalanchegoDockerInner({
     setConfigJson('');
     setShowAdvancedSettings(false);
     debugTraceUserSet.current = false;
-    nodeTypeUserSet.current = false;
     setCfg({
       enableDebugTrace: selectedNetwork === 'fuji',
       adminApiEnabled: false,
@@ -560,10 +553,7 @@ curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"info.getNodeID"}' \\
                   <div className="grid grid-cols-3 gap-2">
                     <button
                       type="button"
-                      onClick={() => {
-                        nodeTypeUserSet.current = true;
-                        setNodeType('validator');
-                      }}
+                      onClick={() => setNodeType('validator')}
                       className={`p-3 rounded-xl border-2 text-left transition-all ${
                         nodeType === 'validator'
                           ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
@@ -575,10 +565,7 @@ curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"info.getNodeID"}' \\
                     </button>
                     <button
                       type="button"
-                      onClick={() => {
-                        nodeTypeUserSet.current = true;
-                        setNodeType('rpc');
-                      }}
+                      onClick={() => setNodeType('rpc')}
                       className={`p-3 rounded-xl border-2 text-left transition-all ${
                         nodeType === 'rpc'
                           ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
@@ -590,10 +577,7 @@ curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"info.getNodeID"}' \\
                     </button>
                     <button
                       type="button"
-                      onClick={() => {
-                        nodeTypeUserSet.current = true;
-                        setNodeType('archival');
-                      }}
+                      onClick={() => setNodeType('archival')}
                       className={`p-3 rounded-xl border-2 text-left transition-all ${
                         nodeType === 'archival'
                           ? isTestnet

--- a/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
+++ b/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
@@ -14,6 +14,7 @@ import { Button } from '../../components/Button';
 import { Steps, Step } from 'fumadocs-ui/components/steps';
 import { SyntaxHighlightedJSON } from '../../components/genesis/SyntaxHighlightedJSON';
 import { ReverseProxySetup } from '../../components/ReverseProxySetup';
+import { DockerInstallation } from '../../components/DockerInstallation';
 import { GenesisHighlightProvider, useGenesisHighlight } from '../../components/genesis/GenesisHighlightContext';
 import { SUBNET_EVM_VM_ID } from '@/constants/console';
 import {
@@ -27,13 +28,11 @@ import {
   AlertCircle,
   AlertTriangle,
   Database,
-  HardDrive,
   ChevronDown,
   ShieldCheck,
   KeyRound,
   Key,
   FileText,
-  Server,
   Terminal,
   CheckCircle2,
   Copy,
@@ -409,50 +408,92 @@ curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"info.getNodeID"}' \\
       <Steps>
         {showPrerequisites && (
           <Step>
-            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-1">Prerequisites</h3>
+            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-1">Set up Instance</h3>
             <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-4">
-              Before you start, make sure your host machine is ready.
+              Provision a server with the following specifications.
             </p>
 
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-              <div className="rounded-lg p-3 border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50">
-                <Server className="w-4 h-4 text-zinc-500 mb-2" />
-                <div className="text-xs font-medium text-zinc-900 dark:text-zinc-100">Docker 20.10+</div>
-                <div className="text-[10px] text-zinc-500 mt-1">
-                  <a
-                    href="https://docs.docker.com/engine/install/"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-blue-500 hover:underline"
-                  >
-                    Install guide
-                  </a>
+            {/* Hardware requirements - compact grid (matches Primary Network setup) */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+              <div className="bg-zinc-50 dark:bg-zinc-900/50 rounded-lg p-3 border border-zinc-200 dark:border-zinc-800">
+                <div className="flex items-center gap-2 mb-1">
+                  <svg className="w-4 h-4 text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z"
+                    />
+                  </svg>
+                  <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">CPU</span>
+                </div>
+                <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">4 vCPU</div>
+              </div>
+              <div className="bg-zinc-50 dark:bg-zinc-900/50 rounded-lg p-3 border border-zinc-200 dark:border-zinc-800">
+                <div className="flex items-center gap-2 mb-1">
+                  <svg className="w-4 h-4 text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                    />
+                  </svg>
+                  <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">RAM</span>
+                </div>
+                <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">8 GB</div>
+              </div>
+              <div className="bg-zinc-50 dark:bg-zinc-900/50 rounded-lg p-3 border border-zinc-200 dark:border-zinc-800">
+                <div className="flex items-center gap-2 mb-1">
+                  <svg className="w-4 h-4 text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"
+                    />
+                  </svg>
+                  <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">Storage</span>
+                </div>
+                <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                  {isTestnet ? '~40 GB Fuji' : '~200 GB Mainnet'}
                 </div>
               </div>
-              <div className="rounded-lg p-3 border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50">
-                <HardDrive className="w-4 h-4 text-zinc-500 mb-2" />
-                <div className="text-xs font-medium text-zinc-900 dark:text-zinc-100">Disk</div>
-                <div className="text-[10px] text-zinc-500 mt-1">{isTestnet ? '~40 GB Fuji' : '~200 GB Mainnet'}</div>
-              </div>
-              <div className="rounded-lg p-3 border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50">
-                <Database className="w-4 h-4 text-zinc-500 mb-2" />
-                <div className="text-xs font-medium text-zinc-900 dark:text-zinc-100">RAM / CPU</div>
-                <div className="text-[10px] text-zinc-500 mt-1">8 GB RAM · 4 vCPU</div>
-              </div>
-              <div className="rounded-lg p-3 border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50">
-                <ShieldCheck className="w-4 h-4 text-zinc-500 mb-2" />
-                <div className="text-xs font-medium text-zinc-900 dark:text-zinc-100">Open ports</div>
-                <div className="text-[10px] text-zinc-500 mt-1">9651 (P2P), 9650 (RPC opt.)</div>
+              <div className="bg-zinc-50 dark:bg-zinc-900/50 rounded-lg p-3 border border-zinc-200 dark:border-zinc-800">
+                <div className="flex items-center gap-2 mb-1">
+                  <ShieldCheck className="w-4 h-4 text-zinc-500" />
+                  <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">Open ports</span>
+                </div>
+                <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">9651 P2P · 9650 RPC</div>
               </div>
             </div>
 
-            <div className="mt-4 flex items-start gap-2 text-xs text-zinc-600 dark:text-zinc-400">
+            <div className="flex items-start gap-2 text-xs text-zinc-600 dark:text-zinc-400">
               <AlertCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-zinc-500" />
               <span>
                 For a production L1 we recommend <strong>5+ validator nodes</strong> spread across regions. A single
                 node is fine for local dev and quick demos.
               </span>
             </div>
+          </Step>
+        )}
+
+        {showPrerequisites && (
+          <Step>
+            <DockerInstallation includeCompose={false} />
+
+            <p className="mt-4 text-sm text-zinc-500 dark:text-zinc-400">
+              If you do not want to use Docker, you can follow the{' '}
+              <a
+                href="https://github.com/ava-labs/avalanchego?tab=readme-ov-file#installation"
+                target="_blank"
+                className="text-blue-500 hover:underline"
+                rel="noreferrer"
+              >
+                manual installation instructions
+              </a>
+              .
+            </p>
           </Step>
         )}
 

--- a/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
+++ b/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
@@ -170,6 +170,12 @@ function AvalanchegoDockerInner({
   // has debug trace flipped back on without touching the checkbox.
   const debugTraceUserSet = useRef(false);
 
+  // Same pattern for nodeType: Fuji defaults to 'archival' (Both validator +
+  // RPC) since that's the common single-box testnet shape. A manual click on
+  // any of the three role buttons sets this ref so the user's choice survives
+  // Mainnet ↔ Fuji round-trips.
+  const nodeTypeUserSet = useRef(false);
+
   const { addToWallet, isAdding: isAddingToWallet } = useAddToWallet();
   const l1ListStore = useL1ListStore();
 
@@ -273,6 +279,16 @@ function AvalanchegoDockerInner({
     setCfg((c) => ({ ...c, enableDebugTrace: selectedNetwork === 'fuji' }));
   }, [selectedNetwork]);
 
+  // Auto-select Both (validator + RPC) when the user is on Fuji and hasn't
+  // explicitly picked a role yet. Honours `forceNodeType` (the Create L1
+  // wizard pins this to 'validator') and respects manual overrides.
+  useEffect(() => {
+    if (forceNodeType) return;
+    if (selectedNetwork === 'fuji' && !nodeTypeUserSet.current) {
+      setNodeType('archival');
+    }
+  }, [selectedNetwork, forceNodeType]);
+
   // L1 lookup — refetch on subnet/network change, with AbortController.
   useEffect(() => {
     setSubnetIdError(null);
@@ -336,6 +352,7 @@ function AvalanchegoDockerInner({
     setConfigJson('');
     setShowAdvancedSettings(false);
     debugTraceUserSet.current = false;
+    nodeTypeUserSet.current = false;
     setCfg({
       enableDebugTrace: selectedNetwork === 'fuji',
       adminApiEnabled: false,
@@ -543,7 +560,10 @@ curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"info.getNodeID"}' \\
                   <div className="grid grid-cols-3 gap-2">
                     <button
                       type="button"
-                      onClick={() => setNodeType('validator')}
+                      onClick={() => {
+                        nodeTypeUserSet.current = true;
+                        setNodeType('validator');
+                      }}
                       className={`p-3 rounded-xl border-2 text-left transition-all ${
                         nodeType === 'validator'
                           ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
@@ -555,7 +575,10 @@ curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"info.getNodeID"}' \\
                     </button>
                     <button
                       type="button"
-                      onClick={() => setNodeType('rpc')}
+                      onClick={() => {
+                        nodeTypeUserSet.current = true;
+                        setNodeType('rpc');
+                      }}
                       className={`p-3 rounded-xl border-2 text-left transition-all ${
                         nodeType === 'rpc'
                           ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
@@ -567,7 +590,10 @@ curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"info.getNodeID"}' \\
                     </button>
                     <button
                       type="button"
-                      onClick={() => setNodeType('archival')}
+                      onClick={() => {
+                        nodeTypeUserSet.current = true;
+                        setNodeType('archival');
+                      }}
                       className={`p-3 rounded-xl border-2 text-left transition-all ${
                         nodeType === 'archival'
                           ? isTestnet

--- a/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
+++ b/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
@@ -832,7 +832,10 @@ curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"info.getNodeID"}' \\
                 </div>
               </div>
 
-              {/* Storage Requirements Visualization (matches Primary Network setup) */}
+              {/* Storage Requirements Visualization (matches Primary Network setup).
+                  variant="l1" anchors the baseline on the ~40 GB Fuji / ~200 GB
+                  Mainnet figures shown in the Set up Instance tile — Primary
+                  Network's 13 TB archival numbers don't apply to L1s. */}
               <StorageRequirements
                 nodeType={nodeType}
                 pruningEnabled={cfg.pruningEnabled}
@@ -840,6 +843,7 @@ curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"info.getNodeID"}' \\
                 stateSyncEnabled={cfg.stateSyncEnabled}
                 debugEnabled={cfg.enableDebugTrace}
                 network={selectedNetwork}
+                variant="l1"
               />
             </div>
           </div>

--- a/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
+++ b/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
@@ -340,7 +340,7 @@ function AvalanchegoDockerInner({
     setSubnetId(defaultSubnetId ?? createChainSubnetId ?? '');
     setSubnet(null);
     setBlockchainInfo(null);
-    setNodeType(forceNodeType ?? 'validator');
+    setNodeType(forceNodeType ?? (walletIsTestnet ? 'archival' : 'validator'));
     setDomain('');
     setSubnetIdError(null);
     setSelectedRPCBlockchainId('');

--- a/components/toolbox/console/toolbox/tools.ts
+++ b/components/toolbox/console/toolbox/tools.ts
@@ -638,7 +638,7 @@ const FLOW_SUBSTEPS: Record<string, Array<{ name: string; path: string }>> = {
   '/console/icm/setup': [
     { name: 'Deploy Teleporter Messenger', path: '/console/icm/setup/icm-messenger' },
     { name: 'Deploy Teleporter Registry', path: '/console/icm/setup/icm-registry' },
-    { name: 'Setup ICM Relayer', path: '/console/icm/setup/icm-relayer-type' },
+    { name: 'Setup ICM Relayer', path: '/console/icm/setup/self-hosted-relayer' },
     { name: 'Deploy ICM Demo', path: '/console/icm/setup/deploy-icm-demo' },
     { name: 'Send ICM Message', path: '/console/icm/setup/send-icm-demo-message' },
   ],

--- a/hooks/useFavoriteTools.ts
+++ b/hooks/useFavoriteTools.ts
@@ -28,14 +28,25 @@ const MANDATORY_PATHS = new Set<string>([
   '/console/encrypted-erc/deploy',
 ]);
 
+// One-shot remap for favorites that used to point at URLs that no longer
+// resolve. Hydrated localStorage entries get rewritten on load so a stale
+// pin doesn't become a permanently broken star.
+const LEGACY_FAVORITE_PATHS: Readonly<Record<string, string>> = {
+  // `icm-relayer-type` is a branch container key, never a navigable URL.
+  // The first option in that branch is the natural default.
+  '/console/icm/setup/icm-relayer-type': '/console/icm/setup/self-hosted-relayer',
+};
+
 function normalizeFavorites(value: unknown): Set<string> {
   if (!Array.isArray(value)) return new Set();
-  return new Set(
-    value.filter(
-      (p): p is string =>
-        typeof p === 'string' && p.length > 0 && !MANDATORY_PATHS.has(p),
-    ),
-  );
+  const result = new Set<string>();
+  for (const raw of value) {
+    if (typeof raw !== 'string' || raw.length === 0) continue;
+    const path = LEGACY_FAVORITE_PATHS[raw] ?? raw;
+    if (MANDATORY_PATHS.has(path)) continue;
+    result.add(path);
+  }
+  return result;
 }
 
 const favoritesPref = createLocalPref<Set<string>>({
@@ -93,15 +104,9 @@ export function useFavoriteTools(): UseFavoriteTools {
     [setValue],
   );
 
-  const isStarred = useCallback(
-    (path: string) => MANDATORY_PATHS.has(path) || favorites.has(path),
-    [favorites],
-  );
+  const isStarred = useCallback((path: string) => MANDATORY_PATHS.has(path) || favorites.has(path), [favorites]);
 
-  const isUserStarred = useCallback(
-    (path: string) => favorites.has(path),
-    [favorites],
-  );
+  const isUserStarred = useCallback((path: string) => favorites.has(path), [favorites]);
 
   const isMandatory = useCallback((path: string) => MANDATORY_PATHS.has(path), []);
 


### PR DESCRIPTION
## Summary

  Five related console toolbox improvements:

  - **L1 node setup mirrors Primary Network's structure.** The L1 prerequisites are now split across two dedicated steps (`Set up Instance` + `Install Docker`) using Primary Network's
  compact CPU / RAM / Storage tile design, with the shared `<DockerInstallation />` component embedded directly so users get copy-paste install commands instead of an external link. The
  step order also matches Primary now: `Configure Node Settings → Set up Instance → Install Docker → Select L1 → …` (was prerequisites-first). The Configure Node Settings right sidebar now
  also includes `<StorageRequirements />` alongside the Configuration Preview.

  - **Fuji auto-selects "Both" on every entry.** When `selectedNetwork` transitions to `'fuji'`, `nodeType` snaps to `'archival'` (which renders as "Both / Validator + RPC" on testnet). A
  manual mid-Fuji click on Validator or RPC still sticks (the effect doesn't re-fire while `selectedNetwork` is unchanged), but a Mainnet ↔ Fuji round-trip cleanly resets to "Both" —
  matching the mental model of "picking Fuji starts a fresh testnet flow". Honours the wizard's `forceNodeType` prop so the Create-L1 path stays validator-only.

  - **`StorageRequirements` is now L1-aware.** Added a `variant: 'primary' | 'l1'` prop. Default stays `'primary'` (unchanged C-Chain numbers — 13 TB archival, ~300 GB pruned validator).
  The new `'l1'` profile anchors on the `~40 GB Fuji / ~200 GB Mainnet` baseline already shown in the Set up Instance tile, with archival scaled `~4x` pruned. All baseline numbers live in a
   single `STORAGE_BASELINES` constant for easy tuning. Without this change, Fuji "Both" was projecting `~2 TB` (C-Chain math) on a Fuji L1 setup — wildly misleading.

  - **Dead `Setup ICM Relayer` search hit.** Searching "setup" used to surface a link to `/console/icm/setup/icm-relayer-type`, which is a branch *container* key in the step-flow registry
  and never renders (`Step "icm-relayer-type" not found.`). `FLOW_SUBSTEPS` in `components/toolbox/console/toolbox/tools.ts` now points to `/console/icm/setup/self-hosted-relayer` (the
  first valid branch option), which fixes the sidebar search, Cmd-K palette, and ToolboxBoard in one place.

  - **Stale favorite migration.** `hooks/useFavoriteTools.ts` adds a `LEGACY_FAVORITE_PATHS` map that remaps any persisted `/console/icm/setup/icm-relayer-type` to
  `/console/icm/setup/self-hosted-relayer` on hydrate. Users with the broken URL pinned get silently migrated; the `Set`-based normalize also dedupes if both old and new paths exist.

  No new components introduced — `DockerInstallation` and `StorageRequirements` were already exported from `components/toolbox/components/`.

  ## Test plan

  - [ ] `/console/layer-1/l1-node-setup` shows steps in order: `Configure Node Settings → Set up Instance → Install Docker → Select L1 → …`.
  - [ ] Configure Node Settings right sidebar shows both the Configuration Preview JSON AND the Storage Requirements chart.
  - [ ] On Fuji "Both": Storage Requirements shows ~160 GB initial / +7 GB·mo / →244 GB after 1 year (NOT 2 TB).
  - [ ] On Mainnet "Validator" (skipTxIndexing on): Storage Requirements shows 200 GB / +10 GB·mo — matches the Set up Instance tile.
  - [ ] On Fuji "Validator": Storage Requirements shows 40 GB / +2 GB·mo — matches the Set up Instance tile.
  - [ ] Set up Instance hardware tile flips between `~40 GB Fuji` and `~200 GB Mainnet` storage as the network selector toggles.
  - [ ] Install Docker step renders the same `<DockerInstallation />` tabs (Ubuntu/Debian, Amazon Linux 2023+, Fedora, macOS) as `/console/primary-network/node-setup`.
  - [ ] Fresh load on a Fuji wallet: role auto-defaults to "Both" (third button lit amber).
  - [ ] Mainnet ↔ Fuji round-trip without touching any role button: returns to "Both" on every Fuji entry.
  - [ ] On Fuji, click "Validator" → "Validator" stays selected. Then click Mainnet, then Fuji again → resets to "Both".
  - [ ] Click "Start over" → state clears; next Fuji entry snaps to "Both".
  - [ ] Create-L1 wizard route (`forceNodeType: 'validator'`) still hides the role selector and shows the two new prereq steps in the new order.
  - [ ] Generated `docker run` command and chain config in the final step reflect the chosen role (Both ⇒ validator + RPC flags + port 9650 exposed).
  - [ ] Sidebar search "setup" → click `Setup ICM Relayer` → routes to `/console/icm/setup/self-hosted-relayer` and renders the ICMRelayer component (no "not found").
  - [ ] Cmd-K palette `setup ICM` → same.
  - [ ] DevTools: `localStorage.setItem('console:favorite-tools', JSON.stringify(['/console/icm/setup/icm-relayer-type']))` → reload → persisted entry is migrated to
  `/console/icm/setup/self-hosted-relayer` and clicking the pinned star navigates correctly.
  - [ ] DevTools: set localStorage with both old and new paths → reload → only one entry persists (dedupe).
  - [ ] `npx eslint --max-warnings 0` clean on all touched files.
  - [ ] `./scripts/check-console-design.sh` clean on all touched console files.
  - [ ] `yarn tsc --noEmit` clean (run `yarn prisma generate` first if you hit stale-client errors on unrelated files).