### PR TITLE
fix: return raw nAVAX integer from avaxToSafeNAvaxNumber

### DIFF
--- a/components/toolbox/console/primary-network/CrossChainTransfer.tsx
+++ b/components/toolbox/console/primary-network/CrossChainTransfer.tsx
@@ -36,8 +36,7 @@ const EXPORT_FEE_BUFFER_NAVAX = 1_000_000;
 // drift, so we floor in the integer domain and divide back only once.
 function avaxToSafeNAvaxNumber(avax: number): number {
   if (!Number.isFinite(avax) || avax <= 0) return 0;
-  const nAvax = Math.floor(avax * 1e9);
-  return nAvax > 0 ? nAvax / 1e9 : 0;
+  return Math.floor(avax * 1e9);
 }
 
 const metadata: ConsoleToolMetadata = {


### PR DESCRIPTION
# Bug fix
The `avaxToSafeNAvaxNumber` function was converting to nAVAX then immediately dividing back, so BigInt() received a float and threw as shown bellow. 
<img width="877" height="813" alt="image" src="https://github.com/user-attachments/assets/a12b1013-5e15-4210-ad37-b3de3e4d48f3" />
Now the helper function returns the integer directly.