### PR TITLE
fix(console): deployless multicall breaks reads on deployer-allowlist L1s

### DIFF
--- a/components/toolbox/components/SelectValidationID.tsx
+++ b/components/toolbox/components/SelectValidationID.tsx
@@ -148,15 +148,34 @@ export default function SelectValidationID({
       if (contracts.length === 0) return;
 
       try {
-        const results = await chainPublicClient.multicall({
-          contracts: contracts.map((c) => ({
-            address: c.address,
-            abi: c.abi as Abi,
-            functionName: c.functionName,
-            args: c.args,
-          })),
-          allowFailure: true,
-        });
+        const mapped = contracts.map((c) => ({
+          address: c.address,
+          abi: c.abi as Abi,
+          functionName: c.functionName,
+          args: c.args,
+        }));
+
+        let results;
+        try {
+          results = await chainPublicClient.multicall({
+            contracts: mapped,
+            allowFailure: true,
+            deployless: true,
+          });
+        } catch {
+          // Deployless multicall is rejected by the Contract Deployer Allowlist
+          // precompile on permissioned L1s — fall back to sequential reads.
+          results = await Promise.all(
+            mapped.map(async (c) => {
+              try {
+                const result = await chainPublicClient.readContract(c);
+                return { status: 'success' as const, result };
+              } catch (error) {
+                return { status: 'failure' as const, error: error as Error };
+              }
+            }),
+          );
+        }
 
         const statusMap: Record<string, number> = {};
         validatorsWithId.forEach((v, i) => {

--- a/components/toolbox/hooks/contracts/useBatchRead.ts
+++ b/components/toolbox/hooks/contracts/useBatchRead.ts
@@ -18,15 +18,18 @@ export interface BatchReadContract {
 export type BatchReadResult = { status: 'success'; result: unknown } | { status: 'failure'; error: Error };
 
 /**
- * Returns a `batchRead` function that executes multiple contract reads
- * in a single RPC call using viem's deployless multicall.
+ * Returns a `batchRead` function that executes multiple contract reads.
  *
- * Deployless multicall injects Multicall3 bytecode via `eth_call` state
- * override, so it works on any EVM chain without requiring Multicall3
- * to be deployed on-chain. Zero gas cost.
+ * Primary path: viem's deployless multicall (one `eth_call`, zero gas) —
+ * Multicall3 bytecode is injected so no on-chain deployment is required.
+ * `deployless: true` is passed explicitly because the client no longer
+ * enables `batch.multicall` (see useChainPublicClient for why).
  *
- * The public client is configured with `batch.multicall.deployless: true`
- * in `useChainPublicClient`, so all multicall calls auto-use deployless mode.
+ * Fallback path: L1s that enable the Subnet-EVM Contract Deployer Allowlist
+ * precompile reject the deployless multicall's contract-creation `eth_call`
+ * ("tx.origin … is not authorized to deploy a contract"). When that happens
+ * we transparently fall back to sequential plain `eth_call` reads, which the
+ * precompile permits.
  *
  * @param publicClient - The viem public client (from useChainPublicClient)
  */
@@ -37,17 +40,34 @@ export function useBatchRead(publicClient: PublicClient | null) {
         throw new Error('Public client not available');
       }
 
-      const results = await publicClient.multicall({
-        contracts: contracts.map((c) => ({
-          address: c.address,
-          abi: c.abi as Abi,
-          functionName: c.functionName,
-          args: c.args ?? [],
-        })),
-        allowFailure: true,
-      });
+      const mapped = contracts.map((c) => ({
+        address: c.address,
+        abi: c.abi as Abi,
+        functionName: c.functionName,
+        args: c.args ?? [],
+      }));
 
-      return results as BatchReadResult[];
+      try {
+        const results = await publicClient.multicall({
+          contracts: mapped,
+          allowFailure: true,
+          deployless: true,
+        });
+        return results as BatchReadResult[];
+      } catch {
+        // Deployless multicall is blocked by the Contract Deployer Allowlist
+        // precompile on permissioned L1s — fall back to sequential reads.
+        return Promise.all(
+          mapped.map(async (c): Promise<BatchReadResult> => {
+            try {
+              const result = await publicClient.readContract(c);
+              return { status: 'success', result };
+            } catch (error) {
+              return { status: 'failure', error: error as Error };
+            }
+          }),
+        );
+      }
     };
   }, [publicClient]);
 }

--- a/components/toolbox/hooks/useChainPublicClient.ts
+++ b/components/toolbox/hooks/useChainPublicClient.ts
@@ -22,14 +22,20 @@ export function useChainPublicClient(): PublicClient | null {
 
   return useMemo(() => {
     if (!viemChain) return null;
+    // We deliberately do NOT enable `batch.multicall` here. viem aggregates
+    // batched reads via Multicall3; when Multicall3 isn't deployed on-chain
+    // (the norm for freshly-created L1s) it falls back to a *deployless*
+    // contract-creation `eth_call`. L1s that enable the Subnet-EVM Contract
+    // Deployer Allowlist precompile reject that call for ANY sender
+    // ("tx.origin … is not authorized to deploy a contract"), which silently
+    // broke every read on permissioned L1s — e.g. ProxySetup's
+    // `getProxyImplementation`. Plain individual `eth_call`s have no such
+    // restriction, so single reads go through unbatched. Call sites that
+    // genuinely need batching opt into `multicall({ deployless: true })`
+    // explicitly, with a sequential fallback (see useBatchRead).
     const base = createPublicClient({
       chain: viemChain,
       transport: http(viemChain.rpcUrls.default.http[0]),
-      batch: {
-        multicall: {
-          deployless: true,
-        },
-      },
     });
 
     const originalWait = base.waitForTransactionReceipt.bind(base);

--- a/components/toolbox/hooks/usePublicClientForChain.ts
+++ b/components/toolbox/hooks/usePublicClientForChain.ts
@@ -45,14 +45,14 @@ export function makePublicClientForChain(
 
   if (!rpcUrl) return null;
 
+  // No `batch.multicall`: viem's deployless multicall fallback issues a
+  // contract-creation `eth_call`, which the Subnet-EVM Contract Deployer
+  // Allowlist precompile rejects on permissioned L1s (for any `from`).
+  // Single reads use plain `eth_call`; batch call sites opt into
+  // `multicall({ deployless: true })` explicitly with a sequential fallback.
   const base = createPublicClient({
     chain,
     transport: http(rpcUrl),
-    batch: {
-      multicall: {
-        deployless: true,
-      },
-    },
   });
 
   // Wrap `readContract` to auto-inject the connected wallet address as the


### PR DESCRIPTION
## Summary

The Proxy Setup step (`/console/create-l1/proxy-setup`) — and in fact **every on-chain read** in the console — fails on permissioned L1s that enable the **Contract Deployer Allowlist** precompile. The symptom users see is a misleading error:

> Failed to read current implementation. ProxyAdmin may not be compatible.

The ProxyAdmin is fine. The real cause is viem's **deployless multicall**, introduced in `c4094d0e0` (Apr 14), which is fundamentally incompatible with the deployer-allowlist precompile.

## Root cause

`useChainPublicClient` / `usePublicClientForChain` set `batch.multicall.deployless: true`. With that config, viem (`call.js`) routes **every** `readContract` through `scheduleMulticall`. Since Multicall3 is **not deployed** at the canonical address on freshly-created L1s, `deployless: true` forces viem to issue a **contract-creation `eth_call`** (Multicall3 bytecode as init code, no `to`).

L1s running the Subnet-EVM **Contract Deployer Allowlist** precompile reject that call:

```
-32000: tx.origin 0x00…00 is not authorized to deploy a contract
```

viem throws, and `ProxySetup`'s bare `catch` rewrites it into the "ProxyAdmin may not be compatible" message. The EIP-1967 admin-slot read still works because it's a raw `eth_getStorageAt` that never touches multicall — which is why only the *implementation* read fails.

## Evidence (verified against a live allowlist L1)

| Probe | Result |
|---|---|
| Direct `eth_call` → `getProxyImplementation(proxy)` on the ProxyAdmin | ✅ returns the implementation address |
| `eth_getCode` at canonical Multicall3 `0xcA11…ca11` | ❌ not deployed (`0x`) |
| Deployless (creation) `eth_call`, `from = 0x0` | ❌ rejected |
| Deployless (creation) `eth_call`, `from = 0x…01` | ❌ rejected |
| Deployless (creation) `eth_call`, `from = random EOA` | ❌ rejected |

The last three matter: **injecting a non-zero `from` does not bypass the precompile** for contract-creation calls. The "any non-zero address bypasses it" assumption documented in `makePublicClientForChain`'s `PREVIEW_ACCOUNT` comment does not hold here — only plain (non-creation) `eth_call`s are permitted.

## The fix

- **`useChainPublicClient` / `usePublicClientForChain`** — drop `batch.multicall` so single reads use plain `eth_call` (no deploy gate). This restores the pre-Apr-14 behavior and fixes `ProxySetup` plus every other single-read step on allowlist L1s.
- **`useBatchRead` / `SelectValidationID`** — these genuinely need multicall, so they now pass `deployless: true` **explicitly** (they previously inherited it from the client config; `multicall.js:54`). They also gain a **sequential `eth_call` fallback** for when the deployless multicall is rejected — so the validator preflight engine and validation-ID status badges work on allowlist L1s too (they never have since the engine shipped).

### Behavior matrix after this change

| Chain | Single reads | Batched reads (`useBatchRead` / `SelectValidationID`) |
|---|---|---|
| Non-allowlist L1 / C-Chain | plain `eth_call` ✅ | deployless multicall ✅ (unchanged) |
| Deployer-allowlist L1 | plain `eth_call` ✅ (**fixed**) | deployless throws → sequential `eth_call` fallback ✅ (**fixed**) |

## Testing

- `tsc --noEmit`: no new type errors in the four changed files (repo has unrelated pre-existing errors).
- Verified the underlying read path against a live allowlist L1 RPC (table above): with `batch.multicall` removed, `getProxyImplementation` resolves via plain `eth_call`.

To verify in-app: connect a wallet to a permissioned L1 with the deployer allowlist enabled and open the Proxy Setup step — the implementation now loads and the **Upgrade Proxy** button enables.
