### PR TITLE
fix(layer-1): open SSH + 80/443 in L1 node firewall step

### DIFF
--- a/components/toolbox/components/ReverseProxySetup.tsx
+++ b/components/toolbox/components/ReverseProxySetup.tsx
@@ -85,6 +85,12 @@ export const ReverseProxySetup: React.FC<ReverseProxySetupProps> = ({
 
         {domain && (
           <>
+            <p className="mt-4">
+              Open ports 80 and 443 so Let&apos;s Encrypt can reach Caddy. On a cloud host, open them in your{' '}
+              <strong>Security Group</strong> too — the host firewall alone is not enough.
+            </p>
+            <DynamicCodeBlock lang="bash" code={`sudo ufw allow 80,443/tcp comment 'Caddy / ACME'`} />
+
             <p className="mt-4">Run the following command on the machine of your node:</p>
             <DynamicCodeBlock lang="bash" code={generateReverseProxyCommand(domain)} />
           </>

--- a/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
+++ b/components/toolbox/console/layer-1/AvalancheGoDockerL1.tsx
@@ -1132,12 +1132,15 @@ curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"info.getNodeID"}' \\
                 lang="bash"
                 code={
                   isRPC
-                    ? `# Open P2P and RPC ports
+                    ? `# Open SSH, P2P, RPC, and reverse-proxy ports
+sudo ufw allow OpenSSH
 sudo ufw allow 9651/tcp comment 'AvalancheGo P2P'
 sudo ufw allow 9650/tcp comment 'AvalancheGo RPC'
+sudo ufw allow 80,443/tcp comment 'Caddy reverse proxy (TLS)'
 sudo ufw --force enable
 sudo ufw status`
-                    : `# Open P2P port only (validators don't expose RPC)
+                    : `# Open SSH and P2P ports (validators don't expose RPC)
+sudo ufw allow OpenSSH
 sudo ufw allow 9651/tcp comment 'AvalancheGo P2P'
 sudo ufw --force enable
 sudo ufw status`
@@ -1146,7 +1149,7 @@ sudo ufw status`
 
               <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-3">
                 {isRPC
-                  ? 'RPC nodes need both ports open. Consider using a reverse proxy (nginx) for SSL termination on port 9650.'
+                  ? 'On a cloud host (AWS/GCP/Azure), open these same ports in your Security Group too — the host firewall alone is not enough.'
                   : 'Validators only need the P2P port. The RPC port is bound to localhost for security.'}
               </p>
             </Step>


### PR DESCRIPTION
## Problem

The L1 node setup's **Configure Firewall** step enables `ufw` allowing only `9650`/`9651`, then `ufw --force enable`. With `ufw`'s default `deny (incoming)`, that silently drops:
- **22 (SSH)** → users lock themselves out of their own box
- **80/443** → the Caddy reverse proxy this same flow generates can't complete Let's Encrypt's ACME challenge

Symptom in Caddy logs: `Timeout during connect (likely firewall problem)`.

## Fix

- `AvalancheGoDockerL1.tsx` firewall step: add `ufw allow OpenSSH` for **all** node types, and `80,443/tcp` for RPC nodes (Caddy/TLS).
- `ReverseProxySetup.tsx`: surface the 80/443 requirement + note that cloud **Security Groups** must also be opened (host firewall alone isn't enough).
- Drop the stale "nginx on 9650" hint — the flow uses Caddy on 80/443.

Hit in the field on a fresh AWS Ubuntu node.