### PR TITLE
fix(console): omit isTestnet from wallet_addEthereumChain for non-Cor…

### DIFF
--- a/components/toolbox/providers/modals/AddChainModal.tsx
+++ b/components/toolbox/providers/modals/AddChainModal.tsx
@@ -225,6 +225,7 @@ function AddChainModalInner() {
       // blockExplorerUrls is per EIP-3085 optional; when set, the wallet
       // shows the same explorer link the in-app L1 dashboard treats as
       // default (Firn for Quick L1 deploys).
+      const isCoreWallet = useWalletStore.getState().walletType === 'core';
       await walletClient.request({
         method: 'wallet_addEthereumChain',
         params: [
@@ -234,7 +235,7 @@ function AddChainModalInner() {
             nativeCurrency: { name: chainData.coinName, symbol: chainData.coinName, decimals: 18 },
             rpcUrls: [chainData.rpcUrl],
             blockExplorerUrls: chainData.explorerUrl ? [chainData.explorerUrl] : undefined,
-            isTestnet: chainData.isTestnet,
+            ...(isCoreWallet ? { isTestnet: chainData.isTestnet } : {}),
           },
         ] as any,
       });


### PR DESCRIPTION
Fixed Metamask "add to wallet" button for chain IDs. It should work with other wallets that aren't core (in case we want to add more wallets to the console in the future.