### PR TITLE
Fix managed node slot accounting

### DIFF
--- a/app/api/managed-testnet-nodes/[subnetId]/[nodeIndex]/route.ts
+++ b/app/api/managed-testnet-nodes/[subnetId]/[nodeIndex]/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getUserId, validateSubnetId, jsonOk, jsonError } from '../../utils';
 import { prisma } from '@/prisma/prisma';
-import { ManagedTestnetNodesServiceURLs } from '../../constants';
-import { extractServiceErrorMessage } from '../../utils';
+import { builderHubDeleteNode, ManagedTestnetNodeServiceRequestError } from '../../service';
 
 /**
  * GET /api/managed-testnet-nodes/[subnetId]/[nodeIndex]
@@ -65,53 +64,37 @@ async function handleDeleteNode(subnetId: string, nodeIndex: number): Promise<Ne
       }
     });
 
-    // Attempt to delete from Builder Hub (even if no local record) then, if local exists, mark terminated
-    const password = process.env.MANAGED_TESTNET_NODE_SERVICE_PASSWORD;
-    if (!password) {
-      return jsonError(503, 'Builder Hub service is not configured');
-    }
-    
     try {
-      const response = await fetch(ManagedTestnetNodesServiceURLs.deleteNode(subnetId, nodeIndex, password), {
-        method: 'DELETE',
-        headers: {
-          'Accept': 'application/json'
-        }
-      });
-
-      if (response.ok || response.status === 404) {
-        if (nodeRegistration) {
-          await prisma.nodeRegistration.updateMany({
-            where: {
-              user_id: userId,
-              subnet_id: subnetId,
-              node_index: nodeIndex
-            },
-            data: { status: 'terminated' }
-          });
-        }
-
-        // Return success even if no local record existed
-        return jsonOk({
-          success: true,
-          deletedExternally: response.status !== 404,
-          message: response.status === 404
-            ? 'Node was already deleted / expired in Builder Hub. It is now removed from your account.'
-            : 'Node deleted in Builder Hub and removed from your account.',
-          node: nodeRegistration ? {
+      const { deletedExternally } = await builderHubDeleteNode(subnetId, nodeIndex);
+      if (nodeRegistration) {
+        await prisma.nodeRegistration.updateMany({
+          where: {
+            user_id: userId,
             subnet_id: subnetId,
-            node_index: nodeIndex,
-            status: 'terminated'
-          } : undefined
+            node_index: nodeIndex
+          },
+          data: { status: 'terminated' }
         });
       }
 
-      const message = await extractServiceErrorMessage(response) || 'Failed to delete node from Builder Hub.';
-      return jsonError(502, message);
+      // Return success even if no local record existed
+      return jsonOk({
+        success: true,
+        deletedExternally,
+        message: deletedExternally
+          ? 'Node deleted in Builder Hub and removed from your account.'
+          : 'Node was already deleted / expired in Builder Hub. It is now removed from your account.',
+        node: nodeRegistration ? {
+          subnet_id: subnetId,
+          node_index: nodeIndex,
+          status: 'terminated'
+        } : undefined
+      });
 
     } catch (hubError) {
-      console.error('Builder Hub request failed:', hubError);
-      return jsonError(503, 'Builder Hub was unreachable.', hubError);
+      const status = hubError instanceof ManagedTestnetNodeServiceRequestError ? hubError.status : 500;
+      const message = hubError instanceof Error ? hubError.message : 'Failed to delete node from Builder Hub.';
+      return jsonError(status, message, hubError);
     }
 
   } catch (error) {

--- a/app/api/managed-testnet-nodes/route.ts
+++ b/app/api/managed-testnet-nodes/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { rateLimited, getUserId, validateSubnetId, jsonOk, jsonError } from './utils';
-import { builderHubAddNode, selectNewestNode, createDbNode, getUserNodes } from './service';
+import {
+  builderHubAddNode,
+  builderHubDeleteNode,
+  createDbNode,
+  getUserNodes,
+  ManagedTestnetNodeServiceRequestError,
+  selectNewestNode,
+} from './service';
 import { getBlockchainInfo } from '../../../components/toolbox/coreViem/utils/glacier';
 import { CreateNodeRequest, SubnetStatusResponse } from './types';
 import { prisma } from '@/prisma/prisma';
@@ -84,7 +91,14 @@ async function handleCreateNode(request: NextRequest): Promise<NextResponse> {
     if (data.nodes && data.nodes.length > 0) {
       const newestNode = selectNewestNode(data.nodes);
       const createdNode = await createDbNode({ userId: userId!, subnetId, blockchainId, newestNode, chainName });
-      if (!createdNode) return jsonError(409, 'Node already exists for this user (active)');
+      if (!createdNode) {
+        try {
+          await builderHubDeleteNode(subnetId, newestNode.nodeIndex);
+        } catch (rollbackError) {
+          console.error('Failed to roll back managed node assignment:', rollbackError);
+        }
+        return jsonError(409, 'Node already exists for this user (active)');
+      }
 
       let awardedBadges: AwardedConsoleBadge[] = [];
       try { awardedBadges = await checkAndAwardConsoleBadges(userId!, 'node_registration'); }
@@ -118,8 +132,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
 /**
  * DELETE /api/managed-testnet-nodes?id=NODE_DB_ID
- * Account-only removal: marks a node as terminated by its DB id when node_index is unknown.
- * Used to clean up nodes that were created before we had the node_index field.
+ * Removes a node by its DB id. When the row has node_index, delete the
+ * external managed-node assignment first so the service frees that subnet
+ * slot. Legacy rows without node_index can only be removed from the account.
  */
 export async function DELETE(request: NextRequest): Promise<NextResponse> {
   const { userId, error } = await getUserId();
@@ -134,8 +149,30 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
     const record = await prisma.nodeRegistration.findFirst({ where: { id, user_id: userId } });
     if (!record) return jsonError(404, 'Node not found');
 
+    if (record.node_index !== null && record.node_index !== undefined) {
+      try {
+        const { deletedExternally } = await builderHubDeleteNode(record.subnet_id, record.node_index);
+        await prisma.nodeRegistration.update({ where: { id }, data: { status: 'terminated' } });
+        return jsonOk({
+          success: true,
+          deletedExternally,
+          message: deletedExternally
+            ? 'Node deleted in Builder Hub and removed from your account.'
+            : 'Node was already deleted / expired in Builder Hub. It is now removed from your account.',
+        });
+      } catch (hubError) {
+        const status = hubError instanceof ManagedTestnetNodeServiceRequestError ? hubError.status : 500;
+        const message = hubError instanceof Error ? hubError.message : 'Failed to delete node from Builder Hub.';
+        return jsonError(status, message, hubError);
+      }
+    }
+
     await prisma.nodeRegistration.update({ where: { id }, data: { status: 'terminated' } });
-    return jsonOk({ success: true, message: 'Node removed from your account.' });
+    return jsonOk({
+      success: true,
+      deletedExternally: false,
+      message: 'Node removed from your account. This legacy record had no node index to delete externally.',
+    });
   } catch (e) {
     return jsonError(500, e instanceof Error ? e.message : 'Failed to remove node');
   }

--- a/app/api/managed-testnet-nodes/service.ts
+++ b/app/api/managed-testnet-nodes/service.ts
@@ -1,7 +1,17 @@
 import { prisma } from '@/prisma/prisma';
 import { ManagedTestnetNodesServiceURLs } from './constants';
 import { SubnetStatusResponse, NodeInfo, SubnetStatusResponseSchema, ServiceErrorSchema } from './types';
-import { toDateFromEpoch, NODE_TTL_MS } from './utils';
+import { toDateFromEpoch, NODE_TTL_MS, extractServiceErrorMessage } from './utils';
+
+export class ManagedTestnetNodeServiceRequestError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'ManagedTestnetNodeServiceRequestError';
+    this.status = status;
+  }
+}
 
 export async function builderHubAddNode(
   subnetId: string,
@@ -45,7 +55,34 @@ export async function builderHubAddNode(
 }
 
 export function selectNewestNode(nodes: NodeInfo[]): NodeInfo {
-  return nodes.reduce((latest, current) => current.nodeIndex > latest.nodeIndex ? current : latest);
+  return nodes.reduce((latest, current) => current.dateCreated > latest.dateCreated ? current : latest);
+}
+
+export async function builderHubDeleteNode(
+  subnetId: string,
+  nodeIndex: number,
+): Promise<{ deletedExternally: boolean }> {
+  const password = process.env.MANAGED_TESTNET_NODE_SERVICE_PASSWORD;
+  if (!password) {
+    throw new ManagedTestnetNodeServiceRequestError(503, 'Builder Hub service is not configured');
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(ManagedTestnetNodesServiceURLs.deleteNode(subnetId, nodeIndex, password), {
+      method: 'DELETE',
+      headers: { 'Accept': 'application/json' },
+    });
+  } catch {
+    throw new ManagedTestnetNodeServiceRequestError(503, 'Builder Hub was unreachable.');
+  }
+
+  if (response.ok || response.status === 404) {
+    return { deletedExternally: response.status !== 404 };
+  }
+
+  const message = await extractServiceErrorMessage(response) || 'Failed to delete node from Builder Hub.';
+  throw new ManagedTestnetNodeServiceRequestError(502, message);
 }
 
 export async function createDbNode(params: {
@@ -117,5 +154,3 @@ export async function getUserNodes(userId: string) {
   });
   return nodes;
 }
-
-


### PR DESCRIPTION
## Summary

Fix managed testnet node slot bookkeeping in Builders Hub so deleted or failed node operations do not leave hidden managed-node assignments behind.

## Root Cause

Builders Hub selected the newly-created node from the managed-node service response by highest `nodeIndex`. After deleting a lower-index node, the service can reuse that lower index, so Builders Hub could register the wrong existing node and leave the newly-created service assignment orphaned.

The My L1 dashboard delete path also removed nodes only from the Builders Hub database when deleting by DB id. That made the node disappear from the UI without freeing the matching assignment in the managed-node service.

## Changes

- Select the newly-created managed node by `dateCreated` instead of highest `nodeIndex`.
- Add a shared `builderHubDeleteNode` helper for external managed-node deletion.
- Use the shared helper in both delete routes.
- Delete the external assignment before marking a DB-id node terminated when `node_index` is available.
- Roll back the external assignment when the service creates a node but the local DB insert conflicts.
- Preserve legacy DB-id cleanup for rows that do not have `node_index`.

## Validation

- `node --check app/api/managed-testnet-nodes/service.ts`
- `node --check app/api/managed-testnet-nodes/route.ts`
- `node --check "app/api/managed-testnet-nodes/[subnetId]/[nodeIndex]/route.ts"`
- `git diff --check`

Full `tsc --noEmit` was attempted in a fresh clone, but is not a useful signal without running postinstall-generated artifacts: Prisma and `.source` types were missing, and unrelated existing type errors failed first.

## Deployment Notes

This PR should be deployed with the managed-node service fix that cleans expired assignments before enforcing the per-subnet node cap.
