### PR TITLE
fix(user-button): open profile when clicking the avatar

### DIFF
--- a/components/login/user-button/UserButton.tsx
+++ b/components/login/user-button/UserButton.tsx
@@ -169,9 +169,10 @@ export function UserButton() {
     );
   }
 
-  // Authenticated — hover opens a small account menu (Profile + Sign Out).
-  // The pill itself no longer navigates on click; the dropdown is the only
-  // path so the user has an explicit choice every time.
+  // Authenticated — hover opens a small account menu (Profile, extras,
+  // Sign out), while clicking the avatar navigates straight to /profile.
+  // Without the explicit onClick the Radix trigger would just toggle the
+  // hover-opened menu shut, so a click on the pill did nothing.
   return (
     <>
       <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
@@ -183,8 +184,9 @@ export function UserButton() {
           <DropdownMenuTrigger asChild>
             <button
               type="button"
-              aria-label="Account menu"
+              aria-label="Profile"
               className={WRAPPER_CLASS}
+              onClick={() => router.push('/profile')}
             >
               {renderAvatar()}
             </button>


### PR DESCRIPTION
## Problem

In the authenticated navbar account menu (`components/login/user-button/UserButton.tsx`), the dropdown opens on **hover**, but the avatar button was wrapped in a Radix `DropdownMenuTrigger` with **no `onClick`**.

That created a self-cancelling interaction:
1. Hover the avatar → `onMouseEnter` sets `menuOpen = true` → menu opens.
2. Click the avatar → Radix's trigger toggles the (already-open) menu **shut**.

Net result: clicking the avatar did nothing instead of navigating anywhere.

## Fix

- Add `onClick={() => router.push('/profile')}` to the avatar button so a click goes straight to the profile page. This mirrors the unauthenticated branch, which already uses programmatic navigation in its `onClick`.
- Relabel the button `aria-label` from `"Account menu"` to `"Profile"` to match the primary action.
- Hover still exposes the secondary actions (Sign out, and role-based extras like Event Management / Evaluate Hackathons).

## Behavior after

- **Hover** avatar → account menu appears (unchanged).
- **Click** avatar → navigates to `/profile`.
- Menu items continue to work as before.

## Notes

- `tsc --noEmit` passes (ran via the pre-commit lint-staged hook).
- On touch devices (no true hover), a tap now navigates to `/profile`; Sign out remains reachable from the profile page's `IdentityHero`. Happy to branch on pointer type as a follow-up if we'd prefer touch users still get the dropdown.