### PR TITLE
fix(docs): repair ACP-236 rename and dead build-custom-vm links

### DIFF
--- a/components/navigation/docs-nav-config.tsx
+++ b/components/navigation/docs-nav-config.tsx
@@ -173,10 +173,10 @@ export const acpsOptions: NavOption[] = [
     url: '/docs/acps/194-streaming-asynchronous-execution',
   },
   {
-    title: 'Continuous Staking',
+    title: 'Auto-Renewed Staking',
     description: 'ACP-236',
     icon: <Book className="w-5 h-5" />,
-    url: '/docs/acps/236-continuous-staking',
+    url: '/docs/acps/236-auto-renewed-staking',
   },
   {
     title: 'ValidatorManager Contract',

--- a/content/docs/acps/meta.json
+++ b/content/docs/acps/meta.json
@@ -8,7 +8,7 @@
     "index",
     "---Standards Track ACPs---",
     "247-delegation-multiplier-increase-maximum-validator-weight-reduction",
-    "236-continuous-staking",
+    "236-auto-renewed-staking",
     "226-dynamic-minimum-block-times",
     "224-dynamic-gas-limit-in-subnet-evm",
     "209-eip7702-style-account-abstraction",

--- a/content/docs/nodes/architecture/virtual-machines.mdx
+++ b/content/docs/nodes/architecture/virtual-machines.mdx
@@ -455,7 +455,7 @@ func (vm *VM) CreateHandlers(ctx context.Context) (map[string]http.Handler, erro
   <Card title="Networking" href="/docs/nodes/architecture/networking">
     Learn how VMs communicate over the network
   </Card>
-  <Card title="Build a Custom VM" href="/docs/avalanche-l1s/build-custom-vm">
+  <Card title="Build a Custom VM" href="/docs/avalanche-l1s/virtual-machines-index">
     Start building your own Virtual Machine
   </Card>
 </Cards>

--- a/content/docs/primary-network/validate/staking-for-finance-professionals.mdx
+++ b/content/docs/primary-network/validate/staking-for-finance-professionals.mdx
@@ -230,7 +230,7 @@ For detailed technical implementation support, refer to the [How to Stake](/docs
 ## Coming Soon: Continuous Staking (ACP-236)
 
 <Callout type="info" title="Proposed — Not Yet Live">
-[ACP-236: Continuous Staking](/docs/acps/236-continuous-staking) is currently in **Proposed** status. The features below will require a network upgrade to implement. This section is provided for planning purposes.
+[ACP-236: Auto-Renewed Staking](/docs/acps/236-auto-renewed-staking) is currently in **Proposed** status. The features below will require a network upgrade to implement. This section is provided for planning purposes.
 </Callout>
 
 ### What Is Continuous Staking?

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -73,6 +73,20 @@ const config = {
   },
   async redirects() {
     return [
+      // ── Renamed/moved pages ──
+      {
+        // ACP-236 was renamed upstream (avalanche-foundation/ACPs):
+        // "Continuous Staking" (236-continuous-staking) → "Auto-Renewed Staking" (236-auto-renewed-staking)
+        source: '/docs/acps/236-continuous-staking',
+        destination: '/docs/acps/236-auto-renewed-staking',
+        permanent: true,
+      },
+      {
+        // "Build a Custom VM" landing now lives in the Custom Virtual Machines section
+        source: '/docs/avalanche-l1s/build-custom-vm',
+        destination: '/docs/avalanche-l1s/virtual-machines-index',
+        permanent: true,
+      },
       // ── Folder-index 500 fixes (no index.mdx → redirect to first child) ──
       {
         source: '/docs/api-reference/webhook-api/tutorials',


### PR DESCRIPTION
## What

Fixes two broken Builders Hub links reported in Slack:

1. **`/docs/acps/236-continuous-staking`** (ACPs dropdown → "Continuous Staking ACP-236") → **404**
2. **`/docs/avalanche-l1s/build-custom-vm`** (linked from the *Virtual Machines* node-architecture page) → **404**

## Root cause

ACP docs under `content/docs/acps/*.mdx` are **gitignored and regenerated at deploy time** by `utils/remote-content/acps.mts`, which reads ACP directory names live from `avalanche-foundation/ACPs`. Upstream **renamed the ACP-236 directory** from `236-continuous-staking` ("Continuous Staking") to `236-auto-renewed-staking` ("Auto-Renewed Staking").

So production's generated page silently moved to `/docs/acps/236-auto-renewed-staking` (live, 200), while the **hardcoded** nav link, an in-doc link, and the committed `meta.json` snapshot kept pointing at the dead old slug → 404.

`build-custom-vm` had no target page at all; only an internal `<Card>` linked to it. Its natural home is the *Custom Virtual Machines* section index, `virtual-machines-index` (live, 200).

## Changes

- **nav** (`docs-nav-config.tsx`): dropdown item retitled to **Auto-Renewed Staking**, URL → `236-auto-renewed-staking`
- **redirects** (`next.config.mjs`):
  - `/docs/acps/236-continuous-staking` → `/docs/acps/236-auto-renewed-staking`
  - `/docs/avalanche-l1s/build-custom-vm` → `/docs/avalanche-l1s/virtual-machines-index`
  - (catches external/bookmarked links, `permanent: true` to match file convention)
- **`virtual-machines.mdx`**: fixed the dead "Build a Custom VM" Card href
- **`staking-for-finance-professionals.mdx`**: fixed the dead in-content ACP-236 link + display text
- **`acps/meta.json`**: updated the committed slug snapshot (regenerated at build; fixed for honesty)

## Verification

- `…/docs/acps/236-auto-renewed-staking` → 200; old slug now redirects instead of 404
- ACP-236 MDX compiles clean (not a rendering issue)
- `node --check next.config.mjs` passes

## Follow-up (not in this PR)

ACP slugs are remote-synced and volatile (236 already renamed once; `247` and others in the committed `meta.json` are also stale vs upstream). Hardcoded ACP links in `docs-nav-config.tsx` are future-404s — worth a systematic rename-redirect or removing hardcoded ACP links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)