### PR TITLE
fix(wallet): handle MetaMask 4100 unauthorized error when adding chain

### DIFF
--- a/hooks/useAddToWallet.ts
+++ b/hooks/useAddToWallet.ts
@@ -93,7 +93,7 @@ export function useAddToWallet(): UseAddToWalletReturn {
       } catch (switchError: any) {
         // Error 4902 means chain not found - we need to add it
         // Error -32603 is also used by some wallets for chain not found
-        if (switchError.code === 4902 || switchError.code === -32603) {
+        if (switchError.code === 4902 || switchError.code === -32603 || switchError.code === 4100) {
           // Chain not added yet, proceed to add it
           await window.ethereum.request({
             method: "wallet_addEthereumChain",


### PR DESCRIPTION
- MetaMask returns error code `4100` (unauthorized) when the site hasn't been connected in the current session
- The existing code only handled `4902` (chain not found) and `-32603`, so `4100` fell through to the error handler showing \"Failed to add chain\"
- Fix treats `4100` the same as `4902` — proceeds to `wallet_addEthereumChain` which triggers MetaMask's proper approval popup