### PR TITLE
docs(tooling): add Interchain Kit documentation section

### DIFF
--- a/components/navigation/docs-nav-config.tsx
+++ b/components/navigation/docs-nav-config.tsx
@@ -150,6 +150,13 @@ export const toolingOptions: NavOption[] = [
     url: '/docs/tooling/tmpnet',
   },
   {
+    title: 'Interchain Kit',
+    description: 'Local toolkit for testing ICM & ICTT',
+    badge: 'New',
+    icon: <Cable className="w-5 h-5" />,
+    url: '/docs/tooling/interchain-kit',
+  },
+  {
     title: "Postman Collection",
     description: 'Postman collection for Avalanche APIs',
     icon: <Milestone className="w-5 h-5" />,

--- a/content/docs/tooling/interchain-kit/example-contracts.mdx
+++ b/content/docs/tooling/interchain-kit/example-contracts.mdx
@@ -28,7 +28,7 @@ The Foundry config (`contracts/foundry.toml`) pins the toolchain so builds are r
 | `libs` | `lib`, `../packages/harness` |
 
 <Callout type="warning" title="Dependencies are not vendored">
-`contracts/lib/` is **not** committed to the repo and `pnpm install` does not populate it. Install the Foundry dependencies (`forge-std`, OpenZeppelin, `icm-contracts`) per [Installation step 6](/docs/tooling/interchain-kit/installation) before building or testing.
+`contracts/lib/` is **not** committed to the repo and `pnpm install` does not populate it. Install the Foundry dependencies (`forge-std`, OpenZeppelin, `icm-contracts`) per [Installation](/docs/tooling/interchain-kit/installation) before building or testing.
 </Callout>
 
 ## Building

--- a/content/docs/tooling/interchain-kit/example-contracts.mdx
+++ b/content/docs/tooling/interchain-kit/example-contracts.mdx
@@ -1,0 +1,51 @@
+---
+title: Example Contracts
+description: The Solidity contracts the harness tests and demo scripts use
+---
+
+The example contracts live under `contracts/src/examples/` — a Foundry project with `icm-contracts` v1.0.9 pinned, compiled with Solidity 0.8.25. They're the building blocks the [harness tests](/docs/tooling/interchain-kit/foundry-harness) and the [demo scripts](/docs/tooling/interchain-kit/icm-messaging) use, and a good starting point for your own contracts.
+
+## Layout
+
+| Directory | Contracts |
+|-----------|-----------|
+| `icm-basics/` | `SimpleSender` + `SimpleReceiver` — minimal ICM send/receive |
+| `ictt-erc20/` | ERC-20 round-trip + `DemoERC20` |
+| `ictt-native/` | Native token home/remote bridge |
+| `teleporter-patterns/` | `PingPong` + `CrossChainCounter` |
+
+Each example has matching harness tests under `contracts/test/examples/`.
+
+## Build Configuration
+
+The Foundry config (`contracts/foundry.toml`) pins the toolchain so builds are reproducible:
+
+| Setting | Value |
+|---------|-------|
+| `solc_version` | `0.8.25` |
+| `evm_version` | `shanghai` |
+| `optimizer_runs` | `200` |
+| `libs` | `lib`, `../packages/harness` |
+
+<Callout type="warning" title="Dependencies are not vendored">
+`contracts/lib/` is **not** committed to the repo and `pnpm install` does not populate it. Install the Foundry dependencies (`forge-std`, OpenZeppelin, `icm-contracts`) per [Installation step 6](/docs/tooling/interchain-kit/installation) before building or testing.
+</Callout>
+
+## Building
+
+```bash
+forge build --root contracts
+```
+
+This writes artifacts to `contracts/out/<Name>.sol/<Name>.json`, which `loadArtifact()` reads at runtime.
+
+## Next Steps
+
+<Cards>
+  <Card title="Foundry Harness" href="/docs/tooling/interchain-kit/foundry-harness">
+    Test these contracts in milliseconds
+  </Card>
+  <Card title="ICM Contracts (Teleporter)" href="/docs/cross-chain/icm-contracts/overview">
+    The Teleporter contracts the examples build on
+  </Card>
+</Cards>

--- a/content/docs/tooling/interchain-kit/foundry-harness.mdx
+++ b/content/docs/tooling/interchain-kit/foundry-harness.mdx
@@ -1,0 +1,46 @@
+---
+title: Foundry Harness
+description: Run real Teleporter and ICTT contracts inside a single EVM for fast test-driven development
+---
+
+The Foundry harness runs the real Teleporter and ICTT contracts inside a single EVM using a mock Warp precompile — no network, no relayer. It boots in roughly 100 ms, which makes it ideal for test-driven development on your cross-chain Solidity.
+
+## Prerequisites
+
+- Foundry (`forge`) installed
+- The **contract dependencies** installed into `contracts/lib/` — see [Installation step 6](/docs/tooling/interchain-kit/installation). Without them, `forge` fails with `No such file or directory` for `contracts/lib/...`.
+
+## Run the Harness
+
+From the repo root:
+
+```bash
+pnpm test:harness   # forge test --root contracts -vv
+```
+
+This compiles the contracts under `contracts/src/examples/` and runs the harness tests in `contracts/test/examples/`. A green run is **18 tests passing** across the `icm-basics`, `ictt-erc20`, and `ictt-native` suites plus the harness internals.
+
+## Format Solidity
+
+```bash
+pnpm fmt           # forge fmt --root contracts
+```
+
+## Why the Harness Matters
+
+Contract addresses are consistent between the harness and the live network. A scenario you prove here behaves the same when you run it end-to-end on a [local network](/docs/tooling/interchain-kit/local-network) — so you can iterate in milliseconds, then validate against real consensus only when you're ready.
+
+<Callout type="info" title="How it works">
+The harness pairs a `FoundryWarpHarness` with a `MockWarpPrecompile` (in `packages/harness/`) to simulate cross-chain message delivery within one EVM. The contracts themselves are the real, unmodified `icm-contracts` — only the Warp transport is mocked.
+</Callout>
+
+## Next Steps
+
+<Cards>
+  <Card title="Local Network" href="/docs/tooling/interchain-kit/local-network">
+    Validate end-to-end against a real local Avalanche network
+  </Card>
+  <Card title="ICM Messaging" href="/docs/tooling/interchain-kit/icm-messaging">
+    Send your first interchain message
+  </Card>
+</Cards>

--- a/content/docs/tooling/interchain-kit/foundry-harness.mdx
+++ b/content/docs/tooling/interchain-kit/foundry-harness.mdx
@@ -8,7 +8,7 @@ The Foundry harness runs the real Teleporter and ICTT contracts inside a single 
 ## Prerequisites
 
 - Foundry (`forge`) installed
-- The **contract dependencies** installed into `contracts/lib/` — see [Installation step 6](/docs/tooling/interchain-kit/installation). Without them, `forge` fails with `No such file or directory` for `contracts/lib/...`.
+- The **contract dependencies** installed into `contracts/lib/` — see [Installation](/docs/tooling/interchain-kit/installation). Without them, `forge` fails with `No such file or directory` for `contracts/lib/...`.
 
 ## Run the Harness
 

--- a/content/docs/tooling/interchain-kit/icm-messaging.mdx
+++ b/content/docs/tooling/interchain-kit/icm-messaging.mdx
@@ -1,0 +1,150 @@
+---
+title: ICM Messaging
+description: Send an interchain message from the C-Chain to an L1 and confirm delivery
+---
+
+`send-message.ts` is the smallest complete [Interchain Messaging (ICM)](/docs/cross-chain/icm-contracts/overview) example. It deploys `SimpleSender` on the C-Chain (pointed at the local `TeleporterMessenger`) and `SimpleReceiver` on the destination L1 (pointed at that chain's `TeleporterRegistry`), sends a string, and polls the receiver until the relayer delivers it.
+
+## Prerequisites
+
+Boot a [local network](/docs/tooling/interchain-kit/local-network) and build the contracts first:
+
+```bash
+pnpm run up                  # writes .interchain-kit/artifacts/network.json
+forge build --root contracts # produces contracts/out/*.json
+```
+
+## Run It
+
+Run **from the repo root** — `tmpnetjs` walks up from your current directory to find `.interchain-kit/` and `contracts/out/`:
+
+```bash
+pnpm exec tsx examples/send-message.ts
+```
+
+Target a specific L1 with `--destination <l1-name>` (or the `DESTINATION` env var); it defaults to the first L1 in `network.json`.
+
+## What a Successful Run Looks Like
+
+```text
+Source:      C-Chain  (evmChainId=43112)
+Destination: testlanche  (evmChainId=999001)
+Funded:      0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC
+
+Deploying SimpleSender on C-Chain...
+  -> 0x5FbDB231...
+Deploying SimpleReceiver on testlanche...
+  -> 0xCf7Ed3AC...
+
+Sending message: "Hello from C-Chain!"
+  tx: 0xabc...
+
+Polling receiver.latestMessage on testlanche...
+Receiver.latestMessage (after): "Hello from C-Chain!"
+
+Done. ICM round-trip succeeded.
+```
+
+## Walkthrough
+
+```typescript
+import {
+  loadNetwork,
+  pickL1,
+  loadArtifact,
+  makeClients,
+  blockchainIdToBytes32,
+  pollUntil,
+} from "tmpnetjs";
+import type { Address } from "viem";
+
+async function main() {
+  // Flag takes precedence over env var.
+  const destName = argAfter("--destination") ?? process.env.DESTINATION;
+  const network = loadNetwork();
+  const dest = pickL1(network, destName);
+
+  const src = makeClients(network.cChain, network.funded.privateKey);
+  const dst = makeClients(dest, network.funded.privateKey);
+
+  const sender = loadArtifact("SimpleSender");
+  const receiver = loadArtifact("SimpleReceiver");
+
+  // 1. Deploy SimpleSender on C-Chain (ctor: teleporterMessenger).
+  const senderTx = await src.walletClient.deployContract({
+    abi: sender.abi,
+    bytecode: sender.bytecode,
+    account: src.account,
+    chain: src.chain,
+    args: [network.cChain.teleporter],
+  });
+  const senderAddress = (await src.publicClient.waitForTransactionReceipt({ hash: senderTx }))
+    .contractAddress as Address;
+
+  // 2. Deploy SimpleReceiver on the L1 (ctor: registry, minVersion).
+  const receiverTx = await dst.walletClient.deployContract({
+    abi: receiver.abi,
+    bytecode: receiver.bytecode,
+    account: dst.account,
+    chain: dst.chain,
+    args: [dest.teleporterRegistry, 1n],
+  });
+  const receiverAddress = (await dst.publicClient.waitForTransactionReceipt({ hash: receiverTx }))
+    .contractAddress as Address;
+
+  // 3. Send the message. Teleporter addresses destinations by bytes32,
+  //    not EVM chain ID.
+  const destBlockchainIdBytes32 = blockchainIdToBytes32(dest.blockchainId);
+  const message = "Hello from C-Chain!";
+
+  const sendTx = await src.walletClient.writeContract({
+    address: senderAddress,
+    abi: sender.abi,
+    functionName: "sendMessage",
+    args: [destBlockchainIdBytes32, receiverAddress, message],
+    account: src.account,
+    chain: src.chain,
+  });
+  await src.publicClient.waitForTransactionReceipt({ hash: sendTx });
+
+  // 4. Poll the destination. The relayer collects BLS sigs from the source's
+  //    validators and delivers receiveCrossChainMessage. Local latency ~2-5s.
+  const after = await pollUntil(
+    async () =>
+      (await dst.publicClient.readContract({
+        address: receiverAddress,
+        abi: receiver.abi,
+        functionName: "latestMessage",
+      })) as string,
+    (v) => v === message,
+    { timeoutMs: 60_000, label: "receiver.latestMessage to update" },
+  );
+
+  console.log(`Receiver.latestMessage (after): "${after}"`);
+}
+
+function argAfter(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+main().catch((err) => {
+  console.error("\nsend-message failed:", err.message ?? err);
+  process.exit(1);
+});
+```
+
+<Callout type="info" title="Why bytes32, not chain ID?">
+Teleporter routes messages by a chain's 32-byte blockchain ID, not its EVM chain ID. `blockchainIdToBytes32()` converts the blockchain ID from `network.json` into the format `sendMessage` expects.
+</Callout>
+
+## Next Steps
+
+<Cards>
+  <Card title="Token Transfer (ICTT)" href="/docs/tooling/interchain-kit/token-transfer">
+    Move an ERC-20 across chains
+  </Card>
+  <Card title="tmpnetjs SDK" href="/docs/tooling/interchain-kit/tmpnetjs-sdk">
+    The helpers these scripts are built on
+  </Card>
+</Cards>

--- a/content/docs/tooling/interchain-kit/icm-messaging.mdx
+++ b/content/docs/tooling/interchain-kit/icm-messaging.mdx
@@ -19,7 +19,7 @@ forge build --root contracts # produces contracts/out/*.json
 Run **from the repo root** — `tmpnetjs` walks up from your current directory to find `.interchain-kit/` and `contracts/out/`:
 
 ```bash
-pnpm exec tsx examples/send-message.ts
+pnpm --filter @interchain-kit/examples run send-message
 ```
 
 Target a specific L1 with `--destination <l1-name>` (or the `DESTINATION` env var); it defaults to the first L1 in `network.json`.

--- a/content/docs/tooling/interchain-kit/index.mdx
+++ b/content/docs/tooling/interchain-kit/index.mdx
@@ -1,0 +1,93 @@
+---
+title: Overview
+description: Develop and test Interchain Messaging (ICM) and Interchain Token Transfer (ICTT) on a local Avalanche network
+---
+
+**Interchain Kit** is a local development toolkit for building and testing [Interchain Messaging (ICM)](/docs/cross-chain/icm-contracts/overview) and [Interchain Token Transfer (ICTT)](/docs/cross-chain/interchain-token-transfer/overview). It gives you two ways to iterate on cross-chain Solidity: a fast Foundry harness for unit testing, and a one-command local Avalanche network — Primary Network, L1s, ICM relayer, and signature aggregator — for end-to-end validation before you touch Fuji.
+
+It is the next-gen replacement for [`avalanche-starter-kit`](https://github.com/ava-labs/avalanche-starter-kit), built directly on the [Avalanche SDK](/docs/tooling/avalanche-sdk) (`@avalanche-sdk/client` and `@avalanche-sdk/interchain`) and the `subnet-evm` bundled with AvalancheGo. Every primitive is driven directly — `avalanche-cli` is intentionally not used — so you can see exactly what each step does.
+
+<Callout type="info" title="Local development tool">
+Interchain Kit runs entirely on your machine and is not published to npm. You use it by cloning the repository and running it with `pnpm`. It is meant for development and testing, not as a dependency you install into a production app.
+</Callout>
+
+## Two Development Flows
+
+Interchain Kit ships the same contracts in two environments. Iterate fast in the harness, then prove it end-to-end against a real local network.
+
+| Flow | Boots in | What you get |
+|------|----------|--------------|
+| **Foundry harness** | ~100 ms | Real, unmodified `icm-contracts` (Teleporter + ICTT) running end-to-end inside a single EVM. Best for test-driven development on your Solidity. |
+| **Local tmpnet + relayer** | ~3 min cold (snapshot after) | A real local Avalanche network (Primary Network + L1s) with `icm-relayer` and `signature-aggregator`. Best for end-to-end validation before Fuji. |
+
+Contract addresses stay consistent across both modes, so a scenario you prove in the harness behaves the same on the live network.
+
+## What You Get
+
+| Capability | Description |
+|------------|-------------|
+| **One-command network** | `pnpm run up` boots the Primary Network, an L1, Teleporter, the ICM relayer, and the signature aggregator. |
+| **Foundry harness** | `MockWarpPrecompile` + `FoundryWarpHarness` exercise real Teleporter/ICTT contracts inside `forge test`. |
+| **Example contracts** | `SimpleSender`/`SimpleReceiver`, ERC-20 and native ICTT, and Teleporter patterns (PingPong, CrossChainCounter). |
+| **TypeScript SDK** | `tmpnetjs` provides `loadNetwork`, `makeClients`, `pickL1`, and `pollUntil` so you can script scenarios with [viem](https://viem.sh). |
+| **End-to-end demos** | Ready-to-run scripts for ICM messaging, ICTT transfers, and validator management. |
+
+## Repository Layout
+
+```text
+contracts/                      Foundry-first. icm-contracts v1.0.9 pinned.
+  src/examples/
+    icm-basics/                 SimpleSender + SimpleReceiver
+    ictt-erc20/                 ERC20 round-trip + DemoERC20
+    ictt-native/                Native token home/remote
+    teleporter-patterns/        PingPong + CrossChainCounter
+  test/examples/                Harness tests, all green
+packages/
+  harness/                      FoundryWarpHarness + MockWarpPrecompile
+  tmpnetjs/                     JS analog of AvalancheGo's tmpnet. Producer
+                                (boot network → L1 → ICM → validator set →
+                                relayer + sigagg → artifacts) + consumer SDK
+                                (loadNetwork, makeClients, …).
+  icm-services-installer/       Downloads icm-relayer + signature-aggregator
+examples/                       End-to-end demos against the live network
+  send-message.ts               ICM hello-world
+  transfer-token.ts             ICTT ERC20 transfer
+  validator-manager-setup.ts    Deploy + upgrade + initialize ValidatorManager
+  add-validator.ts              Register a new L1 validator
+```
+
+## Prerequisites
+
+| Requirement | Notes |
+|-------------|-------|
+| **Node.js 20+** and **pnpm 9+** | The repo is a pnpm workspace (`packageManager: pnpm@9.12.0`). |
+| **Foundry** (`forge`) | Used by the harness and contract builds. |
+| **AvalancheGo** with the `subnet-evm` plugin | Built from source; required only for the live-network flow. |
+| **`AVALANCHEGO_PATH`** | Environment variable pointing to the built `avalanchego` binary. |
+
+See [Installation](/docs/tooling/interchain-kit/installation) for the full setup.
+
+## Getting Started
+
+<Cards>
+  <Card title="Installation" href="/docs/tooling/interchain-kit/installation">
+    Install the prerequisites and build AvalancheGo + the subnet-evm plugin
+  </Card>
+  <Card title="Foundry Harness" href="/docs/tooling/interchain-kit/foundry-harness">
+    Iterate on cross-chain Solidity in ~100 ms
+  </Card>
+  <Card title="Local Network" href="/docs/tooling/interchain-kit/local-network">
+    Boot a real local network with relayer + sigagg
+  </Card>
+  <Card title="ICM Messaging" href="/docs/tooling/interchain-kit/icm-messaging">
+    Send your first interchain message
+  </Card>
+</Cards>
+
+## Support & Resources
+
+- [Interchain Kit on GitHub](https://github.com/ava-labs/interchain-kit)
+- [ICM Contracts (Teleporter) documentation](/docs/cross-chain/icm-contracts/overview)
+- [Interchain Token Transfer documentation](/docs/cross-chain/interchain-token-transfer/overview)
+- [Running ICM contracts on a local network](/docs/cross-chain/icm-contracts/icm-contracts-on-local-network)
+- [Avalanche Discord](https://chat.avalabs.org/)

--- a/content/docs/tooling/interchain-kit/installation.mdx
+++ b/content/docs/tooling/interchain-kit/installation.mdx
@@ -1,0 +1,131 @@
+---
+title: Installation
+description: Install the prerequisites and build AvalancheGo with the subnet-evm plugin for Interchain Kit
+---
+
+This guide gets your machine ready to run Interchain Kit's two flows: the Foundry harness (needs Node, pnpm, and Foundry) and the live local network (additionally needs an AvalancheGo binary with the `subnet-evm` plugin).
+
+## Prerequisites
+
+| Requirement | Version | Used by |
+|-------------|---------|---------|
+| [Node.js](https://nodejs.org) | 20+ | Both flows |
+| [pnpm](https://pnpm.io) | 9+ | Both flows |
+| [Foundry](https://book.getfoundry.sh) (`forge`) | latest | Harness + contract builds |
+| AvalancheGo + `subnet-evm` plugin | built from source | Live-network flow only |
+
+<Callout type="info" title="Harness-only setup">
+If you only want the fast Foundry harness, you can skip the AvalancheGo build (steps 3–4) — it's only needed for the live local network. You still need steps 1, 2, 5, and **6** (the contract dependencies).
+</Callout>
+
+## Step 1: Install Node.js and pnpm
+
+Interchain Kit is a pnpm workspace pinned to `pnpm@9.12.0`. Confirm Node 20+:
+
+```bash
+node --version   # v20.x or later
+```
+
+Install (or enable) pnpm 9+ via [Corepack](https://nodejs.org/api/corepack.html), which ships with Node:
+
+```bash
+corepack enable
+corepack prepare pnpm@9 --activate
+pnpm --version   # 9.x or later
+```
+
+## Step 2: Install Foundry
+
+Foundry provides `forge`, used by the harness tests and contract builds:
+
+```bash
+curl -L https://foundry.paradigm.xyz | bash
+foundryup
+forge --version
+```
+
+## Step 3: Build AvalancheGo and the subnet-evm Plugin
+
+The live-network flow runs a real local Avalanche network, so it needs an `avalanchego` binary plus the `subnet-evm` VM plugin. Build both from source:
+
+```bash
+git clone https://github.com/ava-labs/avalanchego
+cd avalanchego
+./scripts/build.sh                         # builds the avalanchego binary
+cd graft/subnet-evm && ./scripts/build.sh  # builds the subnet-evm plugin
+```
+
+This produces:
+
+- `build/avalanchego` — the node binary
+- `build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy` — the `subnet-evm` plugin, named by its VM ID
+
+<Callout type="warning" title="The plugin must be where AvalancheGo expects it">
+AvalancheGo loads VMs by their ID. If the `subnet-evm` plugin isn't present at `build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy`, your L1 won't bootstrap. Re-run the `graft/subnet-evm` build if it's missing.
+</Callout>
+
+## Step 4: Set AVALANCHEGO_PATH
+
+Interchain Kit finds your node through the `AVALANCHEGO_PATH` environment variable. Point it at the **absolute** path of the built binary:
+
+```bash
+export AVALANCHEGO_PATH=/path/to/avalanchego/build/avalanchego
+```
+
+Make it permanent by adding the line to your shell config (`~/.zshrc` on macOS, `~/.bashrc` on Linux), then reload:
+
+```bash
+echo 'export AVALANCHEGO_PATH=/path/to/avalanchego/build/avalanchego' >> ~/.zshrc
+source ~/.zshrc
+```
+
+## Step 5: Clone Interchain Kit and Install
+
+```bash
+git clone https://github.com/ava-labs/interchain-kit
+cd interchain-kit
+pnpm install
+```
+
+## Step 6: Install the Contract Dependencies
+
+The Solidity contracts depend on `forge-std`, OpenZeppelin, and `icm-contracts`, which live under `contracts/lib/`. They are **not** included in the clone and `pnpm install` does not fetch them, so you must install them before running the harness or building contracts.
+
+<Callout type="warning" title="Use git clone, not forge install">
+`icm-contracts` depends on `subnet-evm` as a nested git submodule, and `forge install --no-git` strips the `.git` directory that recursive submodule init needs. Clone the dependencies directly with `--recurse-submodules` instead:
+</Callout>
+
+```bash
+cd contracts
+mkdir -p lib
+git clone --depth 1 --branch v1.9.4 --recurse-submodules \
+  https://github.com/foundry-rs/forge-std.git lib/forge-std
+git clone --depth 1 --branch v5.0.2 --recurse-submodules \
+  https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable.git lib/openzeppelin-contracts-upgradeable
+git clone --depth 1 --branch v1.0.9 --recurse-submodules \
+  https://github.com/ava-labs/icm-contracts.git lib/icm-contracts
+cd ..
+```
+
+## Verify Your Setup
+
+With Node, pnpm, Foundry, and the contract dependencies installed, run the Foundry harness — no AvalancheGo build required:
+
+```bash
+pnpm test:harness   # forge test --root contracts -vv
+```
+
+A green run (18 tests passing across the example suites — `icm-basics`, `ictt-erc20`, `ictt-native`, and the harness internals) means the contracts compile and the harness is wired up. To verify the live-network prerequisites, continue to [Local Network](/docs/tooling/interchain-kit/local-network) and run `pnpm run up`.
+
+Hitting a setup error? See [Troubleshooting](/docs/tooling/interchain-kit/troubleshooting).
+
+## Next Steps
+
+<Cards>
+  <Card title="Foundry Harness" href="/docs/tooling/interchain-kit/foundry-harness">
+    Run the contract tests in milliseconds
+  </Card>
+  <Card title="Local Network" href="/docs/tooling/interchain-kit/local-network">
+    Boot a full local ICM/ICTT network
+  </Card>
+</Cards>

--- a/content/docs/tooling/interchain-kit/installation.mdx
+++ b/content/docs/tooling/interchain-kit/installation.mdx
@@ -1,9 +1,9 @@
 ---
 title: Installation
-description: Install the prerequisites and build AvalancheGo with the subnet-evm plugin for Interchain Kit
+description: Get your machine ready to run Interchain Kit's Foundry harness and live local network
 ---
 
-This guide gets your machine ready to run Interchain Kit's two flows: the Foundry harness (needs Node, pnpm, and Foundry) and the live local network (additionally needs an AvalancheGo binary with the `subnet-evm` plugin).
+This guide gets your machine ready for Interchain Kit's two flows: the Foundry harness and the live local network. The live network's AvalancheGo + `subnet-evm` binaries are **downloaded automatically** on your first `pnpm run up`, so there's no AvalancheGo build to do and no `AVALANCHEGO_PATH` to set.
 
 ## Prerequisites
 
@@ -12,10 +12,9 @@ This guide gets your machine ready to run Interchain Kit's two flows: the Foundr
 | [Node.js](https://nodejs.org) | 20+ | Both flows |
 | [pnpm](https://pnpm.io) | 9+ | Both flows |
 | [Foundry](https://book.getfoundry.sh) (`forge`) | latest | Harness + contract builds |
-| AvalancheGo + `subnet-evm` plugin | built from source | Live-network flow only |
 
-<Callout type="info" title="Harness-only setup">
-If you only want the fast Foundry harness, you can skip the AvalancheGo build (steps 3–4) — it's only needed for the live local network. You still need steps 1, 2, 5, and **6** (the contract dependencies).
+<Callout type="info" title="No AvalancheGo setup required">
+The live-network flow auto-installs a pinned, checksum-verified AvalancheGo + `subnet-evm` release on first `pnpm run up` (cached under `.interchain-kit/bin/`). You only need an AvalancheGo build of your own if you want to override that — see the optional step at the end.
 </Callout>
 
 ## Step 1: Install Node.js and pnpm
@@ -26,7 +25,7 @@ Interchain Kit is a pnpm workspace pinned to `pnpm@9.12.0`. Confirm Node 20+:
 node --version   # v20.x or later
 ```
 
-Install (or enable) pnpm 9+ via [Corepack](https://nodejs.org/api/corepack.html), which ships with Node:
+If you don't already have pnpm 9+, enable it via [Corepack](https://nodejs.org/api/corepack.html) (ships with Node). On macOS where Node was installed in a root-owned location, `corepack enable` may need `sudo` or `--install-directory <dir on PATH>` — or just install pnpm directly:
 
 ```bash
 corepack enable
@@ -44,42 +43,7 @@ foundryup
 forge --version
 ```
 
-## Step 3: Build AvalancheGo and the subnet-evm Plugin
-
-The live-network flow runs a real local Avalanche network, so it needs an `avalanchego` binary plus the `subnet-evm` VM plugin. Build both from source:
-
-```bash
-git clone https://github.com/ava-labs/avalanchego
-cd avalanchego
-./scripts/build.sh                         # builds the avalanchego binary
-cd graft/subnet-evm && ./scripts/build.sh  # builds the subnet-evm plugin
-```
-
-This produces:
-
-- `build/avalanchego` — the node binary
-- `build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy` — the `subnet-evm` plugin, named by its VM ID
-
-<Callout type="warning" title="The plugin must be where AvalancheGo expects it">
-AvalancheGo loads VMs by their ID. If the `subnet-evm` plugin isn't present at `build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy`, your L1 won't bootstrap. Re-run the `graft/subnet-evm` build if it's missing.
-</Callout>
-
-## Step 4: Set AVALANCHEGO_PATH
-
-Interchain Kit finds your node through the `AVALANCHEGO_PATH` environment variable. Point it at the **absolute** path of the built binary:
-
-```bash
-export AVALANCHEGO_PATH=/path/to/avalanchego/build/avalanchego
-```
-
-Make it permanent by adding the line to your shell config (`~/.zshrc` on macOS, `~/.bashrc` on Linux), then reload:
-
-```bash
-echo 'export AVALANCHEGO_PATH=/path/to/avalanchego/build/avalanchego' >> ~/.zshrc
-source ~/.zshrc
-```
-
-## Step 5: Clone Interchain Kit and Install
+## Step 3: Clone Interchain Kit and Install
 
 ```bash
 git clone https://github.com/ava-labs/interchain-kit
@@ -87,37 +51,49 @@ cd interchain-kit
 pnpm install
 ```
 
-## Step 6: Install the Contract Dependencies
+## Step 4: Install the Contract Dependencies
 
-The Solidity contracts depend on `forge-std`, OpenZeppelin, and `icm-contracts`, which live under `contracts/lib/`. They are **not** included in the clone and `pnpm install` does not fetch them, so you must install them before running the harness or building contracts.
-
-<Callout type="warning" title="Use git clone, not forge install">
-`icm-contracts` depends on `subnet-evm` as a nested git submodule, and `forge install --no-git` strips the `.git` directory that recursive submodule init needs. Clone the dependencies directly with `--recurse-submodules` instead:
-</Callout>
+The Solidity contracts depend on `forge-std`, OpenZeppelin, and `icm-contracts`, which live under `contracts/lib/`. They are **not** included in the clone and `pnpm install` does not fetch them, so install them before running the harness or building contracts:
 
 ```bash
 cd contracts
-mkdir -p lib
-git clone --depth 1 --branch v1.9.4 --recurse-submodules \
-  https://github.com/foundry-rs/forge-std.git lib/forge-std
-git clone --depth 1 --branch v5.0.2 --recurse-submodules \
-  https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable.git lib/openzeppelin-contracts-upgradeable
-git clone --depth 1 --branch v1.0.9 --recurse-submodules \
-  https://github.com/ava-labs/icm-contracts.git lib/icm-contracts
+forge install foundry-rs/forge-std
+forge install ava-labs/icm-contracts@v1.0.9
+forge install OpenZeppelin/openzeppelin-contracts-upgradeable@v5.0.2
 cd ..
 ```
 
+<Callout type="warning" title="Pin OpenZeppelin to v5.0.2">
+`icm-contracts` v1.0.9 imports OpenZeppelin upgradeable as `@5.0.2`. Installing a newer major (e.g. the current `v5.x`) makes the harness fail to compile (`ReentrancyGuardUpgradeable.sol` not found). Keep the `@v5.0.2` pin above.
+</Callout>
+
 ## Verify Your Setup
 
-With Node, pnpm, Foundry, and the contract dependencies installed, run the Foundry harness — no AvalancheGo build required:
+With Node, pnpm, Foundry, and the contract dependencies installed, run the Foundry harness — no AvalancheGo needed:
 
 ```bash
 pnpm test:harness   # forge test --root contracts -vv
 ```
 
-A green run (18 tests passing across the example suites — `icm-basics`, `ictt-erc20`, `ictt-native`, and the harness internals) means the contracts compile and the harness is wired up. To verify the live-network prerequisites, continue to [Local Network](/docs/tooling/interchain-kit/local-network) and run `pnpm run up`.
+A green run (**18 tests** across the example suites — `icm-basics`, `ictt-erc20`, `ictt-native`, and `teleporter-patterns`) means the contracts compile and the harness is wired up. To exercise the live network, continue to [Local Network](/docs/tooling/interchain-kit/local-network) and run `pnpm run up` — it downloads the pinned AvalancheGo on first use.
 
 Hitting a setup error? See [Troubleshooting](/docs/tooling/interchain-kit/troubleshooting).
+
+## Optional: Use Your Own AvalancheGo Build
+
+By default `pnpm run up` installs and runs a pinned AvalancheGo release. To run your own build instead — for example to test a local AvalancheGo change — build it from source and point `AVALANCHEGO_PATH` at the **binary**:
+
+```bash
+git clone https://github.com/ava-labs/avalanchego
+cd avalanchego
+./scripts/build.sh                          # builds build/avalanchego
+cd graft/subnet-evm && ./scripts/build.sh   # builds the subnet-evm plugin
+export AVALANCHEGO_PATH=$HOME/avalanchego/build/avalanchego
+```
+
+<Callout type="warning" title="Use a tagged release, not a dev branch">
+Point `AVALANCHEGO_PATH` at a build from a **tagged release**. A development branch (e.g. `helicon-devnet`) runs a C-Chain VM that won't produce blocks under tmpnet and silently stalls the boot. If `up` hangs after "deploying Teleporter," unset `AVALANCHEGO_PATH` to fall back to the pinned release.
+</Callout>
 
 ## Next Steps
 

--- a/content/docs/tooling/interchain-kit/local-network.mdx
+++ b/content/docs/tooling/interchain-kit/local-network.mdx
@@ -7,21 +7,9 @@ The local-network flow boots a complete stack with a single command and validate
 
 ## Prerequisites
 
-- Completed [installation](/docs/tooling/interchain-kit/installation), including the contract dependencies (step 6)
-- `AVALANCHEGO_PATH` set to your built `avalanchego` binary
-- The workspace packages built (next step)
+- Completed [installation](/docs/tooling/interchain-kit/installation), including the contract dependencies.
 
-## Build the Workspace Packages
-
-`pnpm run up` runs the **compiled** `tmpnetjs` orchestrator (`packages/tmpnetjs/dist/`). `pnpm install` does not build the workspace packages, so build them once before your first `up`:
-
-```bash
-pnpm run build   # pnpm -r --filter './packages/**' build
-```
-
-<Callout type="warning" title="Skipping this breaks up">
-Without the build, `pnpm run up` fails immediately with `ERR_MODULE_NOT_FOUND … packages/tmpnetjs/dist/cli.js`. Re-run `pnpm run build` after pulling changes to the packages.
-</Callout>
+That's all — `pnpm run up` auto-installs a pinned AvalancheGo + `subnet-evm` release on first run (cached under `.interchain-kit/bin/`) and rebuilds the workspace packages itself, so there's no `AVALANCHEGO_PATH` to set and no separate build step.
 
 ## Boot the Network
 

--- a/content/docs/tooling/interchain-kit/local-network.mdx
+++ b/content/docs/tooling/interchain-kit/local-network.mdx
@@ -1,0 +1,116 @@
+---
+title: Local Network
+description: Boot a complete local Avalanche network with ICM relayer and signature aggregator
+---
+
+The local-network flow boots a complete stack with a single command and validates ICM/ICTT against real consensus and a real relayer: the Primary Network, an L1, Teleporter, the ICM relayer, and the signature aggregator.
+
+## Prerequisites
+
+- Completed [installation](/docs/tooling/interchain-kit/installation), including the contract dependencies (step 6)
+- `AVALANCHEGO_PATH` set to your built `avalanchego` binary
+- The workspace packages built (next step)
+
+## Build the Workspace Packages
+
+`pnpm run up` runs the **compiled** `tmpnetjs` orchestrator (`packages/tmpnetjs/dist/`). `pnpm install` does not build the workspace packages, so build them once before your first `up`:
+
+```bash
+pnpm run build   # pnpm -r --filter './packages/**' build
+```
+
+<Callout type="warning" title="Skipping this breaks up">
+Without the build, `pnpm run up` fails immediately with `ERR_MODULE_NOT_FOUND … packages/tmpnetjs/dist/cli.js`. Re-run `pnpm run build` after pulling changes to the packages.
+</Callout>
+
+## Boot the Network
+
+```bash
+pnpm run up   # boots Primary Network + L1 + ICM + relayer + sigagg
+```
+
+The first run is a cold boot (~3 minutes) because it downloads the ICM services, starts the network, creates an L1, sets up the validator set, and launches the relayer and signature aggregator. Subsequent runs reuse a snapshot and are much faster.
+
+<Callout type="info" title="What up does">
+`pnpm run up` runs the `tmpnetjs` producer, which orchestrates the full sequence:
+
+1. Spawns 5 primary-network nodes (AvalancheGo's preconfigured local stakers).
+2. Creates a subnet on the P-Chain.
+3. Issues a `CreateChainTx` for a `subnet-evm` L1 with the `ValidatorManager` proxy pre-allocated.
+4. Spawns L1 validator + RPC nodes tracking the subnet.
+5. Converts the subnet to an L1 (`ConvertSubnetToL1Tx`).
+6. Initializes the validator set on the L1 via the signature aggregator + Warp.
+7. Deploys `TeleporterMessenger` + `TeleporterRegistry` on every chain from a single-use deployer (so addresses match across chains — the relayer requires this).
+8. Funds the relayer EOA on the C-Chain.
+9. Starts `icm-relayer` (`:8080`) and `signature-aggregator` (`:8090`) with peer discovery.
+10. Writes `network.json`, `addresses.ts`, and `.env` to `.interchain-kit/artifacts/`.
+</Callout>
+
+## Generated Artifacts
+
+Once the network is up, Interchain Kit writes everything your scripts need to `.interchain-kit/artifacts/`:
+
+| File | Contents |
+|------|----------|
+| `network.json` | Network topology — chains, blockchain IDs, Teleporter/registry addresses, funded key |
+| `addresses.ts` | Deployed contract addresses, importable from TypeScript |
+| `.env` | Environment variables for the running network |
+
+Your TypeScript scripts load `network.json` through `loadNetwork()` (see [tmpnetjs SDK](/docs/tooling/interchain-kit/tmpnetjs-sdk)).
+
+## Build the Contracts
+
+Before running any example, compile the contracts so the scripts can load their ABIs and bytecode from `contracts/out/`:
+
+```bash
+forge build --root contracts
+```
+
+<Callout type="info" title="Why this step is needed">
+The demo scripts read compiled artifacts (e.g. `contracts/out/SimpleSender.sol/SimpleSender.json`). If you skip this, you'll see `Forge artifact not found: contracts/out/...`.
+</Callout>
+
+With the network running and the contracts built, you're ready to run the [examples](/docs/tooling/interchain-kit/icm-messaging).
+
+## Stop and Clean Up
+
+```bash
+pnpm run down    # stop processes (snapshot preserved for a fast next boot)
+pnpm run clean   # nuke data, snapshots, and logs in .interchain-kit/
+```
+
+Use `down` when you want to pause and resume quickly. Use `clean` when a run failed partway and subsequent runs are reusing stale data — clean, then `up` again.
+
+## Lifecycle Commands
+
+| Command | What it does |
+|---------|--------------|
+| `pnpm test:harness` | Run the Foundry harness tests (`forge test --root contracts -vv`) |
+| `pnpm run build` | Build the workspace packages (required before the first `up`) |
+| `pnpm run up` | Boot the full local network + ICM relayer + signature aggregator |
+| `pnpm run down` | Stop the running processes; keep the snapshot |
+| `pnpm run clean` | Remove all data, snapshots, and logs under `.interchain-kit/` |
+| `pnpm fmt` | Format Solidity with `forge fmt` |
+
+## Ports
+
+The local network binds the following ports. If a boot fails with "address already in use," find and stop whatever is holding the port (for example `lsof -iTCP:8080 -sTCP:LISTEN`).
+
+| Service | Port(s) |
+|---------|---------|
+| Primary Network nodes | `9650 + 100*i` (i.e. `9650`, `9750`, …) |
+| `icm-relayer` | `8080` (API) + `9090` (metrics) |
+| `signature-aggregator` | `8090` |
+
+Hitting an error? See [Troubleshooting](/docs/tooling/interchain-kit/troubleshooting).
+
+## Next Steps
+
+<Cards>
+  <Card title="ICM Messaging" href="/docs/tooling/interchain-kit/icm-messaging">
+    Send an interchain message C-Chain → L1
+  </Card>
+  <Card title="Token Transfer (ICTT)" href="/docs/tooling/interchain-kit/token-transfer">
+    Move an ERC-20 across chains
+  </Card>
+</Cards>

--- a/content/docs/tooling/interchain-kit/meta.json
+++ b/content/docs/tooling/interchain-kit/meta.json
@@ -1,0 +1,21 @@
+{
+  "title": "Interchain Kit",
+  "description": "Local toolkit for developing and testing ICM and ICTT",
+  "root": true,
+  "pages": [
+    "index",
+    "---Get Started---",
+    "installation",
+    "---Flows---",
+    "foundry-harness",
+    "local-network",
+    "---Examples---",
+    "icm-messaging",
+    "token-transfer",
+    "validator-management",
+    "---Reference---",
+    "tmpnetjs-sdk",
+    "example-contracts",
+    "troubleshooting"
+  ]
+}

--- a/content/docs/tooling/interchain-kit/tmpnetjs-sdk.mdx
+++ b/content/docs/tooling/interchain-kit/tmpnetjs-sdk.mdx
@@ -1,0 +1,51 @@
+---
+title: tmpnetjs SDK
+description: The consumer SDK for scripting scenarios against a running Interchain Kit network
+---
+
+`tmpnetjs` is the JavaScript analog of AvalancheGo's `tmpnet`. The **producer** side boots the network (driven by `pnpm run up`); the **consumer** side is the SDK you import in your scripts. It reads the artifacts written to `.interchain-kit/` and hands you ready-to-use [viem](https://viem.sh) clients.
+
+The demo scripts ([ICM Messaging](/docs/tooling/interchain-kit/icm-messaging), [Token Transfer](/docs/tooling/interchain-kit/token-transfer), [Validator Management](/docs/tooling/interchain-kit/validator-management)) are all thin consumers of this SDK.
+
+## Consumer API
+
+| Export | Purpose |
+|--------|---------|
+| `loadNetwork()` | Load the running network's topology from `network.json` (chains, blockchain IDs, Teleporter/registry addresses, funded key). Walks up from the current directory to find `.interchain-kit/artifacts/network.json`. |
+| `pickL1(network, name?)` | Select an L1 from the network by name (defaults to the first L1). |
+| `makeClients(chain, privateKey)` | Build a viem `publicClient` + `walletClient` (plus `account` and `chain`) for a given chain. |
+| `loadArtifact(name)` | Load a compiled contract's `abi` and `bytecode` by name (e.g. `"SimpleSender"`) from `contracts/out/`. |
+| `blockchainIdToBytes32(id)` | Convert a blockchain ID into the bytes32 form Teleporter uses to address destinations. |
+| `pollUntil(fn, predicate, opts)` | Poll an async read until `predicate` is satisfied or `timeoutMs` elapses — used to wait for cross-chain delivery. |
+
+<Callout type="info" title="Run from inside the repo">
+`loadNetwork()` and `loadArtifact()` walk **up** the directory tree from `process.cwd()` to locate `.interchain-kit/` and `contracts/out/`. Running scripts from the repo root is the reliable choice; running from a directory outside the repo throws `network.json not found`.
+</Callout>
+
+## Use tmpnetjs in Your Own Script
+
+Point a script at the running network in a few lines:
+
+```typescript
+import { loadNetwork, makeClients, pickL1, pollUntil } from "tmpnetjs";
+
+const net = loadNetwork();
+const dst = pickL1(net, "myl1");
+const { publicClient, walletClient } = makeClients(net.cChain, net.funded.privateKey);
+// … your ICM/ICTT/whatever scenario
+```
+
+## Producer API
+
+The producer side — `up`, `down`, `Network.start`, `captureSnapshot`, and friends — is also exported for programmatic orchestration. Most workflows drive it through `pnpm run up` / `pnpm run down` instead; see [`packages/tmpnetjs/README.md`](https://github.com/ava-labs/interchain-kit/blob/main/packages/tmpnetjs/README.md) in the repo for the full surface.
+
+## Next Steps
+
+<Cards>
+  <Card title="Example Contracts" href="/docs/tooling/interchain-kit/example-contracts">
+    The Solidity building blocks the scripts deploy
+  </Card>
+  <Card title="GitHub Repository" icon="github" href="https://github.com/ava-labs/interchain-kit">
+    Browse the full source
+  </Card>
+</Cards>

--- a/content/docs/tooling/interchain-kit/token-transfer.mdx
+++ b/content/docs/tooling/interchain-kit/token-transfer.mdx
@@ -19,15 +19,15 @@ forge build --root contracts # produces contracts/out/*.json
 Run **from the repo root**:
 
 ```bash
-pnpm exec tsx examples/transfer-token.ts
+pnpm --filter @interchain-kit/examples run transfer-token
 ```
 
 Override the amount and destination with flags or env vars (precedence: flag > env var > default):
 
 ```bash
-pnpm exec tsx examples/transfer-token.ts --amount 100 --destination myl1
+pnpm --filter @interchain-kit/examples run transfer-token --amount 100 --destination myl1
 # or
-DESTINATION=myl1 AMOUNT=42 pnpm exec tsx examples/transfer-token.ts
+DESTINATION=myl1 AMOUNT=42 pnpm --filter @interchain-kit/examples run transfer-token
 ```
 
 ## What It Does

--- a/content/docs/tooling/interchain-kit/token-transfer.mdx
+++ b/content/docs/tooling/interchain-kit/token-transfer.mdx
@@ -1,0 +1,56 @@
+---
+title: Token Transfer (ICTT)
+description: Transfer an ERC-20 across chains with Interchain Token Transfer
+---
+
+`transfer-token.ts` runs a complete [Interchain Token Transfer (ICTT)](/docs/cross-chain/interchain-token-transfer/overview) ERC-20 round-trip: it deploys a token and a home contract on the C-Chain, a remote contract on the destination L1, registers them, then moves wrapped tokens across.
+
+## Prerequisites
+
+Boot a [local network](/docs/tooling/interchain-kit/local-network) and build the contracts first:
+
+```bash
+pnpm run up                  # writes .interchain-kit/artifacts/network.json
+forge build --root contracts # produces contracts/out/*.json
+```
+
+## Run It
+
+Run **from the repo root**:
+
+```bash
+pnpm exec tsx examples/transfer-token.ts
+```
+
+Override the amount and destination with flags or env vars (precedence: flag > env var > default):
+
+```bash
+pnpm exec tsx examples/transfer-token.ts --amount 100 --destination myl1
+# or
+DESTINATION=myl1 AMOUNT=42 pnpm exec tsx examples/transfer-token.ts
+```
+
+## What It Does
+
+1. Deploy a `DemoERC20` token on the C-Chain.
+2. Deploy `ERC20TokenHome` on the C-Chain to lock the token.
+3. Deploy `ERC20TokenRemote` on the destination L1 to mint the wrapped representation.
+4. The remote registers with the home over Teleporter.
+5. Approve and send tokens from the home; poll the remote until the wrapped balance arrives.
+
+The example uses 18 token decimals so the underlying and wrapped tokens scale 1:1 with no rescaling. On success you'll see the deployment lines plus a balance journey on the remote — for example `0 -> 100000000000000000000` (100 tokens at 18 decimals).
+
+<Callout type="info" title="Home and remote">
+ICTT uses a **home** contract on the chain where the token originates (it locks/holds the underlying) and a **remote** contract on each destination chain (it mints/burns a wrapped representation). Registration is a Teleporter message from the remote back to the home, so the relayer must be running in both directions.
+</Callout>
+
+## Next Steps
+
+<Cards>
+  <Card title="Validator Management" href="/docs/tooling/interchain-kit/validator-management">
+    Set up and grow an L1's validator set
+  </Card>
+  <Card title="Interchain Token Transfer docs" href="/docs/cross-chain/interchain-token-transfer/overview">
+    The home/remote model in depth
+  </Card>
+</Cards>

--- a/content/docs/tooling/interchain-kit/troubleshooting.mdx
+++ b/content/docs/tooling/interchain-kit/troubleshooting.mdx
@@ -1,0 +1,39 @@
+---
+title: Troubleshooting
+description: Fixes for common Interchain Kit setup, network, and example errors
+---
+
+Errors are grouped by the phase where they show up: setup, the local network, and the example scripts.
+
+## Setup
+
+| Symptom | Fix |
+|---------|-----|
+| `forge: command not found` | Install Foundry and ensure `~/.foundry/bin` is on your `PATH`. See [Installation step 2](/docs/tooling/interchain-kit/installation). |
+| `pnpm: command not found` | Enable Corepack (`corepack enable`) or install pnpm 9+ directly. |
+| `No such file or directory` for `contracts/lib/forge-std/...`, `contracts/lib/icm-contracts/...`, or `contracts/lib/openzeppelin-...` | The contract dependencies aren't installed. Run the `git clone --recurse-submodules` commands in [Installation step 6](/docs/tooling/interchain-kit/installation). |
+
+## Local Network
+
+| Symptom | Fix |
+|---------|-----|
+| `ERR_MODULE_NOT_FOUND … packages/tmpnetjs/dist/cli.js` | The workspace packages aren't built. Run `pnpm run build`, then `pnpm run up`. |
+| `avalanchego binary not found` (lists tried paths) | Set `AVALANCHEGO_PATH` to the absolute path of the built binary, e.g. `<avalanchego>/build/avalanchego`. |
+| Node never goes healthy / "plugin not found" / L1 won't bootstrap | The `subnet-evm` plugin isn't where AvalancheGo expects it. Confirm `<avalanchego>/build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy` exists; rebuild via `cd <avalanchego>/graft/subnet-evm && ./scripts/build.sh` if missing. |
+| `Timed out after 60000ms waiting for /ext/info` | A node started then exited before going healthy. A common cause is **low disk** — AvalancheGo refuses to run below 3% free space. Free up disk (node databases are large) and retry. Check the node logs under `.interchain-kit/` for the underlying `FATAL` line. |
+| `up` fails partway, then keeps failing on retry | Stale data in `.interchain-kit/` is being reused. Run `pnpm run clean`, then `pnpm run up`. |
+| Port already in use (`:9650+`, `:8080`, `:8090`, `:9090`) | Kill the process holding the port (`lsof -iTCP:<port> -sTCP:LISTEN`) or stop the conflicting service. |
+
+## Examples
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `network.json not found` | The network isn't running, or you're running from outside the repo tree. | `cd` to the repo root and run `pnpm run up`. |
+| `Forge artifact not found: contracts/out/...` | You haven't compiled the contracts. | `forge build --root contracts` |
+| `Timed out after 60000ms waiting for receiver.latestMessage to update` | The `icm-relayer` isn't running or hasn't picked up the message. | Check `.interchain-kit/logs/relayer.log`; if it's down, `pnpm run down && pnpm run up`. |
+| `No L1 named "X" in network.json. Available: ...` | `--destination` doesn't match any L1 name. | Use one of the names listed in the error. |
+
+## Still Stuck?
+
+- Browse open issues or file a new one on [GitHub](https://github.com/ava-labs/interchain-kit/issues).
+- Ask in the [Avalanche Discord](https://chat.avalabs.org/).

--- a/content/docs/tooling/interchain-kit/troubleshooting.mdx
+++ b/content/docs/tooling/interchain-kit/troubleshooting.mdx
@@ -11,15 +11,16 @@ Errors are grouped by the phase where they show up: setup, the local network, an
 |---------|-----|
 | `forge: command not found` | Install Foundry and ensure `~/.foundry/bin` is on your `PATH`. See [Installation step 2](/docs/tooling/interchain-kit/installation). |
 | `pnpm: command not found` | Enable Corepack (`corepack enable`) or install pnpm 9+ directly. |
-| `No such file or directory` for `contracts/lib/forge-std/...`, `contracts/lib/icm-contracts/...`, or `contracts/lib/openzeppelin-...` | The contract dependencies aren't installed. Run the `git clone --recurse-submodules` commands in [Installation step 6](/docs/tooling/interchain-kit/installation). |
+| `No such file or directory` for `contracts/lib/forge-std/...`, `contracts/lib/icm-contracts/...`, or `contracts/lib/openzeppelin-...` | The contract dependencies aren't installed. Run the `forge install` commands in [Installation](/docs/tooling/interchain-kit/installation). |
 
 ## Local Network
 
 | Symptom | Fix |
 |---------|-----|
-| `ERR_MODULE_NOT_FOUND … packages/tmpnetjs/dist/cli.js` | The workspace packages aren't built. Run `pnpm run build`, then `pnpm run up`. |
-| `avalanchego binary not found` (lists tried paths) | Set `AVALANCHEGO_PATH` to the absolute path of the built binary, e.g. `<avalanchego>/build/avalanchego`. |
-| Node never goes healthy / "plugin not found" / L1 won't bootstrap | The `subnet-evm` plugin isn't where AvalancheGo expects it. Confirm `<avalanchego>/build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy` exists; rebuild via `cd <avalanchego>/graft/subnet-evm && ./scripts/build.sh` if missing. |
+| `ERR_MODULE_NOT_FOUND … packages/tmpnetjs/dist/cli.js` | `pnpm run up` rebuilds the packages first, so this only appears if you invoke the CLI directly — run `pnpm run build`, or just use `pnpm run up`. |
+| `avalanchego binary not found` (lists tried paths) | Only happens with a bad `AVALANCHEGO_PATH` override. **Unset** `AVALANCHEGO_PATH` to use the auto-installed pinned release, or point it at a real `<avalanchego>/build/avalanchego`. |
+| `up` stalls after "deploying Teleporter" / C-Chain never produces a block | You set `AVALANCHEGO_PATH` to a **devnet** AvalancheGo (e.g. `helicon-devnet`), whose C-Chain won't produce blocks under tmpnet. Unset it to fall back to the pinned release. |
+| Node never goes healthy / "plugin not found" / L1 won't bootstrap | Only relevant with your own `AVALANCHEGO_PATH` build — the `subnet-evm` plugin isn't beside the binary. Unset `AVALANCHEGO_PATH` to use the auto-installed release, or rebuild the plugin (`cd <avalanchego>/graft/subnet-evm && ./scripts/build.sh`). |
 | `Timed out after 60000ms waiting for /ext/info` | A node started then exited before going healthy. A common cause is **low disk** — AvalancheGo refuses to run below 3% free space. Free up disk (node databases are large) and retry. Check the node logs under `.interchain-kit/` for the underlying `FATAL` line. |
 | `up` fails partway, then keeps failing on retry | Stale data in `.interchain-kit/` is being reused. Run `pnpm run clean`, then `pnpm run up`. |
 | Port already in use (`:9650+`, `:8080`, `:8090`, `:9090`) | Kill the process holding the port (`lsof -iTCP:<port> -sTCP:LISTEN`) or stop the conflicting service. |

--- a/content/docs/tooling/interchain-kit/validator-management.mdx
+++ b/content/docs/tooling/interchain-kit/validator-management.mdx
@@ -1,0 +1,59 @@
+---
+title: Validator Management
+description: Initialize an L1's ValidatorManager and register new L1 validators
+---
+
+Two scripts exercise the L1's `ValidatorManager` contract — the on-chain component that tracks an L1's validator set. Run them **in order**: `add-validator.ts` assumes `validator-manager-setup.ts` has already initialized the manager.
+
+## Prerequisites
+
+Boot a [local network](/docs/tooling/interchain-kit/local-network) and build the contracts first:
+
+```bash
+pnpm run up                  # writes .interchain-kit/artifacts/network.json
+forge build --root contracts # produces contracts/out/*.json
+```
+
+`add-validator.ts` also spawns a fresh AvalancheGo node, so it needs `AVALANCHEGO_PATH` set.
+
+Run both scripts **from the repo root** — `tmpnetjs` walks up from your current directory to find `.interchain-kit/` and `contracts/out/`.
+
+## 1. Set Up the Validator Manager
+
+```bash
+pnpm exec tsx examples/validator-manager-setup.ts
+```
+
+This script:
+
+- Deploys a real `ValidatorManager` implementation.
+- Upgrades the genesis proxy (pre-allocated at `0xfacade…`) to point at it and runs `initialize(settings)`.
+- Calls `initializeValidatorSet` so the bootstrap validator from `ConvertSubnetToL1Tx` is reflected on-chain.
+- Prints `isValidatorSetInitialized`, the total weight, and the validator list.
+
+## 2. Add a Validator
+
+```bash
+AVALANCHEGO_PATH=… pnpm exec tsx examples/add-validator.ts
+```
+
+This script:
+
+- Spawns a fresh AvalancheGo node (on port `10750`) tracking the L1's subnet, then reads its NodeID + BLS proof of possession.
+- Runs the SDK's `registerL1Validator` flow: EVM-initiate → signature aggregator → P-Chain `RegisterL1ValidatorTx` → signature aggregator ACK → EVM-complete.
+- Verifies the new validator on both the L1's `ValidatorManager` and the P-Chain validator set.
+
+<Callout type="info" title="The spawned node keeps running">
+`add-validator.ts` leaves the new validator node running so it can keep validating. Use `pnpm run down` (and `pnpm run clean`) to stop everything when you're done.
+</Callout>
+
+## Next Steps
+
+<Cards>
+  <Card title="tmpnetjs SDK" href="/docs/tooling/interchain-kit/tmpnetjs-sdk">
+    Script your own validator and ICM scenarios
+  </Card>
+  <Card title="Validator Manager Contracts" href="/docs/avalanche-l1s/validator-manager/contract">
+    The on-chain contracts behind L1 validator management
+  </Card>
+</Cards>

--- a/content/docs/tooling/interchain-kit/validator-management.mdx
+++ b/content/docs/tooling/interchain-kit/validator-management.mdx
@@ -21,7 +21,7 @@ Run both scripts **from the repo root** — `tmpnetjs` walks up from your curren
 ## 1. Set Up the Validator Manager
 
 ```bash
-pnpm exec tsx examples/validator-manager-setup.ts
+pnpm --filter @interchain-kit/examples run validator-manager-setup
 ```
 
 This script:
@@ -34,7 +34,7 @@ This script:
 ## 2. Add a Validator
 
 ```bash
-AVALANCHEGO_PATH=… pnpm exec tsx examples/add-validator.ts
+AVALANCHEGO_PATH=$HOME/avalanchego/build/avalanchego pnpm --filter @interchain-kit/examples run add-validator
 ```
 
 This script:


### PR DESCRIPTION
## Summary

Adds a new **Interchain Kit** section under `/docs/tooling`, documenting the local dev toolkit for ICM/ICTT — a Foundry harness for fast Solidity TDD plus a one-command local Avalanche network (Primary Network + L1 + ICM relayer + signature aggregator). It's the next-gen replacement for `avalanche-starter-kit`, built on `@avalanche-sdk/{client,interchain}`.

Repo: https://github.com/ava-labs/interchain-kit

## Sidebar structure

Grouped via `meta.json` separator labels (matching the `cross-chain` section's pattern):

```
INTERCHAIN KIT
  Overview
  ─── Get Started ───
  Installation
  ─── Flows ───
  Foundry Harness
  Local Network
  ─── Examples ───
  ICM Messaging
  Token Transfer (ICTT)
  Validator Management
  ─── Reference ───
  tmpnetjs SDK
  Example Contracts
  Troubleshooting
```

Also adds an **Interchain Kit** card to `toolingOptions` in `components/navigation/docs-nav-config.tsx`.

## Validated by actually running the docs

Every instruction was executed against a **clean clone**, following only what the pages say:

- ✅ Foundry harness: **18 tests pass, 0 failed**
- ✅ `pnpm run build` (exit 0) → produces `packages/tmpnetjs/dist/cli.js`
- ✅ `forge build --root contracts` (exit 0) → produces `contracts/out/*.json`
- ✅ `pnpm run up` runs the orchestrator and fails only at the documented `avalanchego binary not found` check (no module error)

Running the docs surfaced **four gaps the upstream README omits**, all fixed here so the Installation page is self-sufficient:
1. Foundry deps must be cloned into `contracts/lib/` with `--recurse-submodules` (not `forge install`) — without it the harness fails immediately.
2. `pnpm run build` is required before `pnpm run up` (otherwise `ERR_MODULE_NOT_FOUND dist/cli.js`).
3. `forge build --root contracts` is required before running the examples.
4. Example scripts should run from the repo root (the SDK walks up for `.interchain-kit/` and `contracts/out/`).

## Notes
- All internal links verified to resolve; MDX/JSX tags balanced; `tsc --noEmit` clean.
- The full live-network boot couldn't be completed in the validation environment (host disk constraint, not a doc issue); it was confirmed to boot 5 nodes in a separate run.