### PR TITLE
fix(console): allow custom devnet faucet amounts

### DIFF
--- a/app/api/devnet-faucet/route.ts
+++ b/app/api/devnet-faucet/route.ts
@@ -5,7 +5,9 @@ import { getAuthSession } from '@/lib/auth/authSession';
 
 const DEVNET_RPC_URL = 'https://api.avax-dev.network/ext/bc/C/rpc';
 const DEVNET_CHAIN_ID = 43117;
-const DRIP_AMOUNT = '2';
+const DEFAULT_DRIP_AMOUNT = 2;
+const MIN_DRIP_AMOUNT = 1;
+const MAX_DRIP_AMOUNT = 2000;
 
 const SERVER_PRIVATE_KEY = process.env.FAUCET_C_CHAIN_PRIVATE_KEY;
 const FAUCET_ADDRESS = process.env.FAUCET_C_CHAIN_ADDRESS;
@@ -20,6 +22,20 @@ const devnetCChain = defineChain({
 });
 
 const account = SERVER_PRIVATE_KEY ? privateKeyToAccount(SERVER_PRIVATE_KEY as `0x${string}`) : null;
+
+function parseDripAmount(amountParam: string | null): number | null {
+  const amount = amountParam?.trim() || DEFAULT_DRIP_AMOUNT.toString();
+  if (!/^[1-9]\d*$/.test(amount)) {
+    return null;
+  }
+
+  const parsedAmount = Number(amount);
+  if (!Number.isSafeInteger(parsedAmount) || parsedAmount < MIN_DRIP_AMOUNT || parsedAmount > MAX_DRIP_AMOUNT) {
+    return null;
+  }
+
+  return parsedAmount;
+}
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
@@ -62,6 +78,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       );
     }
 
+    const dripAmount = parseDripAmount(request.nextUrl.searchParams.get('amount'));
+    if (dripAmount === null) {
+      return NextResponse.json(
+        { success: false, message: `Amount must be a whole number from ${MIN_DRIP_AMOUNT} to ${MAX_DRIP_AMOUNT} AVAX` },
+        { status: 400 }
+      );
+    }
+
     const walletClient = createWalletClient({
       account,
       chain: devnetCChain,
@@ -75,7 +99,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     // Check faucet balance
     const balance = await publicClient.getBalance({ address: FAUCET_ADDRESS as `0x${string}` });
-    const amountToSend = parseEther(DRIP_AMOUNT);
+    const amountToSend = parseEther(dripAmount.toString());
 
     if (balance < amountToSend) {
       return NextResponse.json(
@@ -103,7 +127,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       txHash,
       sourceAddress: FAUCET_ADDRESS,
       destinationAddress,
-      amount: DRIP_AMOUNT,
+      amount: dripAmount.toString(),
       chainId: DEVNET_CHAIN_ID,
     });
   } catch (error) {

--- a/components/toolbox/console/primary-network/DevnetFaucet.tsx
+++ b/components/toolbox/console/primary-network/DevnetFaucet.tsx
@@ -17,6 +17,9 @@ import { useWalletStore } from '@/components/toolbox/stores/walletStore';
 const DEVNET_RPC_URL = 'https://api.avax-dev.network/ext/bc/C/rpc';
 const DEVNET_CHAIN_ID = 43117;
 const DEVNET_CHAIN_ID_HEX = '0xa86d';
+const DEFAULT_DRIP_AMOUNT = '2';
+const MIN_DRIP_AMOUNT = 1;
+const MAX_DRIP_AMOUNT = 2000;
 
 const devnetCChain = defineChain({
   id: DEVNET_CHAIN_ID,
@@ -38,6 +41,16 @@ const metadata: ConsoleToolMetadata = {
   toolRequirements: [AccountRequirementsConfigKey.UserLoggedIn],
   githubUrl: generateConsoleToolGitHubUrl(import.meta.url),
 };
+
+function isValidDripAmount(amount: string) {
+  const trimmedAmount = amount.trim();
+  if (!/^[1-9]\d*$/.test(trimmedAmount)) {
+    return false;
+  }
+
+  const parsedAmount = Number(trimmedAmount);
+  return Number.isSafeInteger(parsedAmount) && parsedAmount >= MIN_DRIP_AMOUNT && parsedAmount <= MAX_DRIP_AMOUNT;
+}
 
 function CopyButton({ text, label }: { text: string; label?: string }) {
   const [copied, setCopied] = useState(false);
@@ -73,6 +86,8 @@ function DevnetFaucet({ onSuccess: _onSuccess }: BaseConsoleToolProps) {
   const [recipientAddress, setRecipientAddress] = useState('');
   const [recipientError, setRecipientError] = useState<string | null>(null);
   const [hasEditedRecipientAddress, setHasEditedRecipientAddress] = useState(false);
+  const [dripAmount, setDripAmount] = useState(DEFAULT_DRIP_AMOUNT);
+  const [amountError, setAmountError] = useState<string | null>(null);
 
   const [faucetBalance, setFaucetBalance] = useState<string | null>(null);
   const [faucetAddress, setFaucetAddress] = useState<string | null>(null);
@@ -178,12 +193,21 @@ function DevnetFaucet({ onSuccess: _onSuccess }: BaseConsoleToolProps) {
       return;
     }
 
+    const requestedAmount = dripAmount.trim();
+    if (!isValidDripAmount(requestedAmount)) {
+      setAmountError(`Enter a whole number from ${MIN_DRIP_AMOUNT} to ${MAX_DRIP_AMOUNT}`);
+      return;
+    }
+
     setIsDripping(true);
     setResult(null);
     setRecipientError(null);
+    setAmountError(null);
 
     try {
-      const response = await fetch(`/api/devnet-faucet?address=${encodeURIComponent(destinationAddress)}`);
+      const response = await fetch(
+        `/api/devnet-faucet?address=${encodeURIComponent(destinationAddress)}&amount=${encodeURIComponent(requestedAmount)}`
+      );
       const data = await response.json();
 
       if (!response.ok) {
@@ -328,7 +352,9 @@ function DevnetFaucet({ onSuccess: _onSuccess }: BaseConsoleToolProps) {
               <div className="flex items-baseline justify-between gap-2">
                 <h3 className="font-medium text-zinc-900 dark:text-white leading-tight">C-Chain</h3>
                 <span className="shrink-0">
-                  <span className="font-mono font-semibold text-zinc-900 dark:text-white">2</span>
+                  <span className="font-mono font-semibold text-zinc-900 dark:text-white">
+                    {isValidDripAmount(dripAmount) ? dripAmount.trim() : DEFAULT_DRIP_AMOUNT}
+                  </span>
                   <span className="text-sm text-zinc-500 ml-1">AVAX</span>
                 </span>
               </div>
@@ -402,6 +428,35 @@ function DevnetFaucet({ onSuccess: _onSuccess }: BaseConsoleToolProps) {
               />
               {recipientError && <p className="text-xs text-red-500">{recipientError}</p>}
             </div>
+            <div className="space-y-1.5">
+              <label
+                htmlFor="devnet-faucet-amount"
+                className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
+              >
+                Amount
+              </label>
+              <div className="relative">
+                <input
+                  id="devnet-faucet-amount"
+                  type="number"
+                  min={MIN_DRIP_AMOUNT}
+                  max={MAX_DRIP_AMOUNT}
+                  step={1}
+                  value={dripAmount}
+                  onChange={(event) => {
+                    setDripAmount(event.target.value);
+                    setAmountError(null);
+                    setResult(null);
+                  }}
+                  className="w-full px-3 py-2 pr-16 text-sm font-mono bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 rounded text-zinc-900 dark:text-white placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500"
+                />
+                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-medium text-zinc-500">
+                  AVAX
+                </span>
+              </div>
+              <p className="text-xs text-zinc-500">Whole AVAX only, up to {MAX_DRIP_AMOUNT.toLocaleString()}.</p>
+              {amountError && <p className="text-xs text-red-500">{amountError}</p>}
+            </div>
             {walletEVMAddress && (
               <p className="text-xs text-zinc-500 truncate">
                 Connected wallet: <span className="font-mono">{walletEVMAddress}</span>
@@ -409,11 +464,13 @@ function DevnetFaucet({ onSuccess: _onSuccess }: BaseConsoleToolProps) {
             )}
             <button
               onClick={handleDrip}
-              disabled={isDripping || !recipientAddress.trim()}
+              disabled={isDripping || !recipientAddress.trim() || !dripAmount.trim()}
               className="w-full px-4 py-2 text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 transition-colors disabled:bg-zinc-400 disabled:cursor-not-allowed rounded flex items-center justify-center gap-2"
             >
               <Droplets className="w-4 h-4" />
-              {isDripping ? 'Dripping...' : 'Drip 2 AVAX'}
+              {isDripping
+                ? 'Dripping...'
+                : `Drip ${isValidDripAmount(dripAmount) ? dripAmount.trim() : DEFAULT_DRIP_AMOUNT} AVAX`}
             </button>
           </div>
 


### PR DESCRIPTION
## Summary
- add a devnet faucet amount input with a 1 to 2,000 AVAX whole-number range
- pass the requested amount through the existing devnet faucet endpoint
- enforce the same 1 to 2,000 AVAX guardrails server-side before sending tokens

## Testing
- ./node_modules/.bin/eslint components/toolbox/console/primary-network/DevnetFaucet.tsx
- git diff --check

Note: app/api/devnet-faucet/route.ts is outside the current ESLint config and is ignored by that command when passed explicitly.