### PR TITLE
fix(docs): use mcp-remote for Claude Desktop MCP setup

### DIFF
--- a/content/docs/tooling/ai-llm/mcp-server.mdx
+++ b/content/docs/tooling/ai-llm/mcp-server.mdx
@@ -79,14 +79,14 @@ Add this to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 {
   "mcpServers": {
     "avalanche-mcp": {
-      "transport": {
-        "type": "http",
-        "url": "https://build.avax.network/api/mcp"
-      }
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://build.avax.network/api/mcp"]
     }
   }
 }
 ```
+
+Claude Desktop uses stdio transport and does not support HTTP MCP servers natively. [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) acts as a bridge from stdio to the HTTP endpoint. Node.js must be installed for `npx` to work.
 
 ## JSON-RPC Examples
 


### PR DESCRIPTION
## Summary

- Replaces the broken `transport: { type: "http" }` config in the Claude Desktop setup section with the working `mcp-remote` approach
- Adds a note explaining why: Claude Desktop uses stdio transport and doesn't support HTTP MCP servers natively
- The `transport` object format causes Claude Desktop to skip the entry entirely with the error: *"The following entries in claude_desktop_config.json are not valid MCP server configurations and were skipped: avalanche-mcp"*

## Working config

```json
{
  "mcpServers": {
    "avalanche-mcp": {
      "command": "npx",
      "args": ["-y", "mcp-remote", "https://build.avax.network/api/mcp"]
    }
  }
}
```

The Claude Code setup section (which uses `--transport http`) is unaffected — that format works correctly in Claude Code CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)