### PR TITLE
docs(nodes): Docs/l1 key metrics and alerts

### DIFF
--- a/content/docs/nodes/maintain/meta.json
+++ b/content/docs/nodes/maintain/meta.json
@@ -1,0 +1,8 @@
+{
+  "title": "Maintain",
+  "pages": [
+    "monitoring",
+    "recommended-metrics",
+    "..."
+  ]
+}

--- a/content/docs/nodes/maintain/monitoring.mdx
+++ b/content/docs/nodes/maintain/monitoring.mdx
@@ -11,6 +11,10 @@ This tutorial demonstrates how to set up infrastructure to monitor an instance o
 - [Grafana](https://grafana.com/) to visualize data on a dashboard.
 - A set of pre-made [Avalanche dashboards](https://github.com/ava-labs/avalanche-monitoring/tree/main/grafana/dashboards)
 
+<Callout type="info">
+This page covers how to *collect* metrics. Once you're set up, see [Key Metrics & Alerts](/docs/nodes/maintain/recommended-metrics) for *which* metrics matter most and the recommended healthy ranges and alert thresholds.
+</Callout>
+
 ## Prerequisites:
 
 - A running AvalancheGo node
@@ -353,5 +357,7 @@ Summary[​](#summary "Direct link to heading")
 ---------------------------------------------
 
 Using the script to install node monitoring is easy, and it gives you insight into how your node is behaving and what's going on under the hood. Also, pretty graphs!
+
+Now that data is flowing, head to [Key Metrics & Alerts](/docs/nodes/maintain/recommended-metrics) to set up alerts on the metrics that matter most for L1 health.
 
 If you have feedback on this tutorial, problems with the script or following the steps, send us a message on [Discord](https://chat.avalabs.org/).

--- a/content/docs/nodes/maintain/recommended-metrics.mdx
+++ b/content/docs/nodes/maintain/recommended-metrics.mdx
@@ -1,122 +1,97 @@
 ---
 title: Key Metrics & Alerts
-description: The most important AvalancheGo metrics to watch when running an Avalanche L1, with recommended healthy ranges and alert thresholds.
+description: The two metrics that tell you whether your Avalanche L1 is healthy, with recommended healthy, warning, and paging thresholds.
 ---
 
-Once you have [monitoring set up](/docs/nodes/maintain/monitoring), the next question is *what to actually watch*. AvalancheGo exposes hundreds of Prometheus metrics — this page narrows them to the handful that tell you whether your L1 is healthy, and the thresholds at which you should be warned or paged.
+Once you have [monitoring set up](/docs/nodes/maintain/monitoring), the question is *what to actually alert on*. AvalancheGo exposes hundreds of Prometheus metrics, but you only need **two** to know whether your L1 is healthy:
+
+1. **Query failure rate** — covers almost every consensus, networking, and validator problem.
+2. **Disk space remaining** — the one critical failure that the query failure rate cannot see.
+
+Everything else is downstream of these. A misbehaving validator, a network partition, bad blocks, a stalled chain — they all surface as a rise in the query failure rate. So you page on these two, and use the secondary metrics below only to diagnose *why* the failure rate moved.
 
 <Callout type="info">
-These are guidelines, not hard rules. The thresholds below are portable across L1s (they're ratios and percentages, not absolute counts), but you should still validate them against your own chain's baseline and tune alert windows to your tolerance for noise.
+Thresholds are guidelines. Validate them against your own chain's baseline before paging on them. Throughout, `<chainID>` is your L1's blockchain ID.
 </Callout>
-
-## How to read this page
-
-Metrics fall into two groups:
-
-- **Critical metrics** are *symptoms*. They describe independent failure domains, so each one can degrade without the others moving. These are the metrics you alert and page on.
-- **Explanatory metrics** are *causes*. You generally don't page on them directly; you look at them to find out *why* a critical metric moved. For example, a CPU spike doesn't need its own page — it will show up as a drop in **Successful Queries**, and that's what you investigate.
-
-Throughout, `<chainID>` is your L1's blockchain ID. Most consensus and networking metrics carry a `chain` label; the EVM (VM-level) metric embeds the chain ID in its name. All metrics are scraped from a node's `/ext/metrics` endpoint — see [Monitoring](/docs/nodes/maintain/monitoring) for setup.
 
 ---
 
 ## Critical metrics
 
-### 1. Successful queries
+### 1. Query failure rate
 
-This is the single most sensitive indicator of L1 health.
+The single most sensitive indicator of L1 health. A *poll* is a round of voting where the node asks a sample of validators whether they prefer a block; it succeeds when enough validators respond in time. Because each validator carries a share of stake, the success rate drops by roughly an offline validator's stake share whenever one stops responding — so this one number catches networking faults, down validators, and finalization problems together.
 
 | | |
 |---|---|
-| **Metric** | `avalanche_snowman_polls_successful` / `avalanche_snowman_polls_failed` |
-| **Healthy** | ~100% |
-| **Warn** | < 95% over 5 min |
-| **Page** | < 90% over 5 min |
+| **Healthy** | ~100% successful |
+| **Warning** | < 95% successful |
+| **Paging** | < 90% successful |
 
-AvalancheGo does not expose a success *percentage* directly — it exposes two counters, so you compute the ratio:
+Below ~80% the chain can no longer finalize and effectively halts. This is the metric FIFA mainnet pages on; the underlying signal is the `chits` (query response) message rate:
 
 ```text
-rate(avalanche_snowman_polls_successful{chain="<chainID>"}[5m])
-/
-(
-  rate(avalanche_snowman_polls_successful{chain="<chainID>"}[5m])
-  + rate(avalanche_snowman_polls_failed{chain="<chainID>"}[5m])
+max_over_time(
+  avg by (pod, namespace, region, cluster) (
+    rate(avalanche_handler_messages{op="chits", chain="<chainID>"}[5m]) * 60
+  )[5m:1m]
 )
 ```
 
-A *poll* is a round of voting in which a node asks a sample of validators whether they prefer a block. It succeeds when enough validators respond to record a preference, and fails when responses don't arrive in time. Because every validator carries a share of the total stake, this ratio drops by roughly the offline validator's stake share whenever a validator stops responding — so it catches networking faults *and* down validators in a single number.
+When this degrades, check the secondary metrics below to find the cause.
 
-On a healthy network this sits at 100%. As it falls, finalization time degrades; **below ~80% the chain can no longer finalize and effectively halts.** That makes it both your earliest warning and your most important alert.
+### 2. Disk space remaining
 
-**If this drops, check the explanatory metrics below** — connected stake, CPU, benched validators, clock skew, and block processing all surface the underlying cause.
-
-### 2. Available disk space
-
-Disk is a completely independent failure domain. A node will keep participating in consensus — with **Successful Queries** looking perfectly healthy — right up until it runs out of disk and shuts itself down. The query metric gives you *no warning* of a disk problem, which is exactly why disk needs its own alert.
+A completely independent failure. The node keeps participating in consensus — with the query failure rate looking perfectly healthy — right up until it runs out of disk and shuts itself down. The failure rate gives you *no warning* of a disk problem, which is exactly why disk needs its own alert.
 
 | | |
 |---|---|
-| **Metric** | `avalanche_resource_tracker_disk_available_percentage` |
-| **Healthy** | > 25% free |
-| **Warn** | < 25% free |
-| **Page** | < 15% free |
+| **Healthy** | > 10% free |
+| **Warning** | < 10% free |
+| **Paging** | < 5% free |
 
 ```text
 avalanche_resource_tracker_disk_available_percentage
 ```
 
-AvalancheGo tracks free space on its database volume natively and self-governs on it: by default the node reports **unhealthy below 10% free** and performs a **fatal shutdown below 3% free** (configurable via `--system-tracker-disk-warning-available-space-percentage` and `--system-tracker-disk-required-available-space-percentage`). The thresholds above are intentionally set *above* the node's own 10% warning so you have runway to add storage or prune before the node degrades.
+AvalancheGo tracks free space on its database volume natively and self-governs on it: by default it reports itself **unhealthy below 10% free** and performs a **fatal shutdown below 3% free** (`--system-tracker-disk-warning-available-space-percentage` and `--system-tracker-disk-required-available-space-percentage`). Page before the node degrades so you have time to add storage or prune. If you run in Kubernetes or on a managed host, alert on the equivalent volume-usage metric too, since the node's own metric stops reporting once the process is down.
 
-You should also watch host-level disk usage (e.g. via `node_exporter`) as a redundant signal, since the node's own metric stops being reported once the process is down.
+---
 
-### 3. Bad blocks (EVM L1s)
+## Secondary metrics
 
-A third independent domain: *correctness*. A node can be diverging from the rest of the network — building or accepting blocks the network rejects — while both its query success and disk look fine.
+You don't need to page on these — a real problem already shows up in the query failure rate. They exist to tell you *why* the failure rate dropped. The thresholds below match the FIFA mainnet alert configuration.
+
+### Bad blocks (EVM L1s)
 
 | | |
 |---|---|
 | **Metric** | `avalanche_<chainID>_vm_eth_chain_block_bad_count` |
-| **Healthy** | 0 (no increase) |
-| **Page** | any sustained increase over 5 min |
+| **Healthy** | 0 |
+| **Paging** | > 10 over 5 min |
 
-```text
-increase(avalanche_<chainID>_vm_eth_chain_block_bad_count[5m]) > 0
-```
-
-This counter (exposed by Subnet-EVM / Coreth) increments when the node encounters a block that fails validation — a state-root mismatch, invalid transactions, or similar. A rising count signals consensus divergence or local database corruption, and usually precedes the node falling out of agreement with the rest of the validators. Any sustained increase warrants investigation.
-
----
-
-## Explanatory metrics
-
-You don't normally page on these. When a critical metric — almost always **Successful Queries** — degrades, these tell you *why*.
+Blocks that failed validation (state-root mismatch, invalid transactions). A rising count means this node is diverging from the network — which also drives its failure rate up.
 
 ### Connected stake
 
 | | |
 |---|---|
 | **Metric** | `avalanche_stake_percent_connected` |
-| **Healthy** | ≥ the node's `MinPercentConnectedHealthy` threshold |
+| **Healthy** | ≥ 80% |
+| **Paging** | < 80% |
 
-```text
-avalanche_stake_percent_connected{chain="<chainID>"} * 100
-```
+Percentage of total validator stake the node has live connections to. When it falls, the node cannot reach enough stake to complete polls — a direct cause of failure-rate drops.
 
-The percentage of total validator *stake* this node currently has live connections to. The node's own health check fails when this drops below a threshold derived from your consensus parameters — `alpha/k × 0.8 + 0.2`, which is **80% at the defaults** (`k=20`, `alpha=15`). If you run non-default snow parameters, recompute accordingly. A drop here directly explains a drop in Successful Queries: the node literally cannot reach enough stake to complete polls.
-
-### Number of validators
+### Processing blocks
 
 | | |
 |---|---|
-| **Metric** | `avalanche_stake_num_validators` |
-| **Healthy** | your expected validator count |
-| **Page** | `< 1` |
+| **Metric** | `avalanche_snowman_blks_processing` |
+| **Healthy** | low and stable |
+| **Warning** | > 6 over 5 min |
+| **Paging** | > 15 over 5 min |
 
-```text
-avalanche_stake_num_validators{chain="<chainID>"}
-```
-
-The size of the validator set the node currently sees. Dropping to `0` means the node has lost its view of the validator set entirely (a P-Chain sync or L1 manager problem) — catastrophic for an L1, since it can no longer run consensus.
+Blocks in consensus but not yet finalized. A sustained climb means finalization is stalling — the same condition that raises the failure rate.
 
 ### Benched validators
 
@@ -124,75 +99,39 @@ The size of the validator set the node currently sees. Dropping to `0` means the
 |---|---|
 | **Metric** | `avalanche_benchlist_benched_num` |
 | **Healthy** | 0 |
+| **Paging** | > 1 over 10 min |
 
-```text
-avalanche_benchlist_benched_num{chain="<chainID>"}
-```
+Peers the node has temporarily stopped querying because they keep failing. Points at a specific misbehaving validator.
 
-The number of peers the node has temporarily stopped querying because they keep failing or timing out. A non-zero value points at a specific misbehaving validator. Note: on very small validator sets a single dead validator holding a large stake share may *not* be benchlisted (benchlisting is capped to protect liveness), so a reading of `0` does not by itself prove every validator is healthy — cross-check against connected stake.
-
-### Block processing backlog
+### Number of validators
 
 | | |
 |---|---|
-| **Metric** | `avalanche_snowman_blks_processing` |
-| **Healthy** | low and stable (typically near 0) |
+| **Metric** | `avalanche_stake_num_validators` |
+| **Healthy** | your expected validator count |
+| **Paging** | < 1 |
 
-```text
-avalanche_snowman_blks_processing{chain="<chainID>"}
-```
+The validator set the node currently sees. Dropping to 0 means it has lost its view of the set entirely (a P-Chain or L1 manager problem).
 
-The number of blocks that have entered consensus but are not yet finalized. In steady state this stays low. A sustained climb means finalization is stalling — votes aren't coming back fast enough — which is the same condition that drops Successful Queries. The "right" ceiling depends on your chain's block rate and load, so treat a *sustained upward trend* as the signal rather than a fixed number.
-
-### Chain progress / liveness
+### Health check failures
 
 | | |
 |---|---|
-| **Metric** | `avalanche_snowman_last_accepted_height` |
-| **Healthy** | continuously increasing |
-
-```text
-increase(avalanche_snowman_last_accepted_height{chain="<chainID>"}[5m]) == 0
-```
-
-The height of the most recently accepted block. The most direct confirmation of a halt: if this stops increasing while transactions are being submitted, the chain is not finalizing. Use it to distinguish a genuine halt from transient query noise.
-
-### CPU usage
-
-| | |
-|---|---|
-| **Metric** | `avalanche_resource_tracker_cpu_usage` |
-| **Healthy** | well below your core count |
-
-```text
-avalanche_resource_tracker_cpu_usage
-```
-
-CPU consumed by the node, expressed in cores (a value of `2.0` means two full cores). Sustained saturation slows block verification and message handling, which shows up downstream as a drop in Successful Queries. This is the canonical example of an explanatory metric: you don't page on CPU itself, you page on the query degradation it causes and check CPU to confirm the cause.
-
-### Clock skew
-
-AvalancheGo does not page on clock skew, but it is a real liveness cliff worth a low-threshold warning from your time-sync tooling (NTP/PTP):
-
-- Beyond **~10s** of drift, peers reject this node's proposed blocks (it stays connected but stops contributing as a proposer).
-- Beyond the configured handshake tolerance (**60s** by default), peer connections drop and the node becomes isolated.
-
-There is no graceful degradation past these points, so keep validators within ~1s of UTC and alert on offsets of 2–3s.
-
----
-
-## Node health rollup
-
-| | |
-|---|---|
-| **Metric** | `avalanche_health_checks_failing` |
+| **Metric** | `avalanche_health_checks_failing{check="health"}` |
 | **Healthy** | 0 |
+| **Paging** | > 2 over 5 min |
 
-```text
-avalanche_health_checks_failing{check="health"}
-```
+A catch-all count of failing checks in the node's aggregate health endpoint (networking, router, database, disk, BLS key, pending upgrades, bootstrap status, validation). Coarse, but a useful safety net.
 
-A convenient catch-all: the count of currently failing checks in the node's aggregate health endpoint (`/ext/health/liveness`). It rolls up the individual checks AvalancheGo runs — networking, router, database, disk space, BLS key correctness, pending upgrades, bootstrap status, and validation. Any non-zero value means the node is reporting itself unhealthy. It's coarse (it won't tell you *which* domain failed without drilling in), but it's a cheap safety net behind the specific metrics above.
+### CPU usage (host)
+
+| | |
+|---|---|
+| **Metric** | host / container CPU |
+| **Healthy** | well below your core count |
+| **Paging** | > 90% sustained |
+
+Sustained saturation slows block verification and message handling, which shows up downstream as a higher failure rate.
 
 ---
 
@@ -200,16 +139,14 @@ A convenient catch-all: the count of currently failing checks in the node's aggr
 
 | Metric | Type | Page when |
 |---|---|---|
-| Successful queries (`polls_successful` / `polls_failed`) | Critical | < 90% over 5 min |
-| Available disk (`disk_available_percentage`) | Critical | < 15% free |
-| Bad blocks (`vm_eth_chain_block_bad_count`) | Critical | any sustained increase |
-| Connected stake (`stake_percent_connected`) | Explanatory | — (diagnose) |
-| Number of validators (`stake_num_validators`) | Explanatory | < 1 |
-| Benched validators (`benchlist_benched_num`) | Explanatory | — (diagnose) |
-| Block processing (`blks_processing`) | Explanatory | — (diagnose) |
-| Chain progress (`last_accepted_height`) | Explanatory | not increasing |
-| CPU usage (`cpu_usage`) | Explanatory | — (diagnose) |
-| Clock skew (NTP/PTP) | Explanatory | offset > 2–3s |
-| Health rollup (`health_checks_failing`) | Safety net | > 0 |
+| Query failure rate (`handler_messages{op="chits"}`) | **Critical** | < 90% successful |
+| Disk space remaining (`disk_available_percentage`) | **Critical** | < 5% free |
+| Bad blocks (`vm_eth_chain_block_bad_count`) | Secondary | > 10 / 5 min |
+| Connected stake (`stake_percent_connected`) | Secondary | < 80% |
+| Processing blocks (`blks_processing`) | Secondary | > 15 / 5 min |
+| Benched validators (`benchlist_benched_num`) | Secondary | > 1 / 10 min |
+| Number of validators (`stake_num_validators`) | Secondary | < 1 |
+| Health check failures (`health_checks_failing`) | Secondary | > 2 / 5 min |
+| CPU usage (host) | Secondary | > 90% sustained |
 
-Start with the three critical alerts — successful queries, disk, and bad blocks — and add the explanatory metrics to your dashboards so you can quickly diagnose the cause when a critical alert fires.
+Start with the two critical alerts — query failure rate and disk. Add the secondary metrics to your dashboards so you can quickly find the cause when the failure rate moves.

--- a/content/docs/nodes/maintain/recommended-metrics.mdx
+++ b/content/docs/nodes/maintain/recommended-metrics.mdx
@@ -1,0 +1,215 @@
+---
+title: Key Metrics & Alerts
+description: The most important AvalancheGo metrics to watch when running an Avalanche L1, with recommended healthy ranges and alert thresholds.
+---
+
+Once you have [monitoring set up](/docs/nodes/maintain/monitoring), the next question is *what to actually watch*. AvalancheGo exposes hundreds of Prometheus metrics — this page narrows them to the handful that tell you whether your L1 is healthy, and the thresholds at which you should be warned or paged.
+
+<Callout type="info">
+These are guidelines, not hard rules. The thresholds below are portable across L1s (they're ratios and percentages, not absolute counts), but you should still validate them against your own chain's baseline and tune alert windows to your tolerance for noise.
+</Callout>
+
+## How to read this page
+
+Metrics fall into two groups:
+
+- **Critical metrics** are *symptoms*. They describe independent failure domains, so each one can degrade without the others moving. These are the metrics you alert and page on.
+- **Explanatory metrics** are *causes*. You generally don't page on them directly; you look at them to find out *why* a critical metric moved. For example, a CPU spike doesn't need its own page — it will show up as a drop in **Successful Queries**, and that's what you investigate.
+
+Throughout, `<chainID>` is your L1's blockchain ID. Most consensus and networking metrics carry a `chain` label; the EVM (VM-level) metric embeds the chain ID in its name. All metrics are scraped from a node's `/ext/metrics` endpoint — see [Monitoring](/docs/nodes/maintain/monitoring) for setup.
+
+---
+
+## Critical metrics
+
+### 1. Successful queries
+
+This is the single most sensitive indicator of L1 health.
+
+| | |
+|---|---|
+| **Metric** | `avalanche_snowman_polls_successful` / `avalanche_snowman_polls_failed` |
+| **Healthy** | ~100% |
+| **Warn** | < 95% over 5 min |
+| **Page** | < 90% over 5 min |
+
+AvalancheGo does not expose a success *percentage* directly — it exposes two counters, so you compute the ratio:
+
+```promql
+rate(avalanche_snowman_polls_successful{chain="<chainID>"}[5m])
+/
+(
+  rate(avalanche_snowman_polls_successful{chain="<chainID>"}[5m])
+  + rate(avalanche_snowman_polls_failed{chain="<chainID>"}[5m])
+)
+```
+
+A *poll* is a round of voting in which a node asks a sample of validators whether they prefer a block. It succeeds when enough validators respond to record a preference, and fails when responses don't arrive in time. Because every validator carries a share of the total stake, this ratio drops by roughly the offline validator's stake share whenever a validator stops responding — so it catches networking faults *and* down validators in a single number.
+
+On a healthy network this sits at 100%. As it falls, finalization time degrades; **below ~80% the chain can no longer finalize and effectively halts.** That makes it both your earliest warning and your most important alert.
+
+**If this drops, check the explanatory metrics below** — connected stake, CPU, benched validators, clock skew, and block processing all surface the underlying cause.
+
+### 2. Available disk space
+
+Disk is a completely independent failure domain. A node will keep participating in consensus — with **Successful Queries** looking perfectly healthy — right up until it runs out of disk and shuts itself down. The query metric gives you *no warning* of a disk problem, which is exactly why disk needs its own alert.
+
+| | |
+|---|---|
+| **Metric** | `avalanche_resource_tracker_disk_available_percentage` |
+| **Healthy** | > 25% free |
+| **Warn** | < 25% free |
+| **Page** | < 15% free |
+
+```promql
+avalanche_resource_tracker_disk_available_percentage
+```
+
+AvalancheGo tracks free space on its database volume natively and self-governs on it: by default the node reports **unhealthy below 10% free** and performs a **fatal shutdown below 3% free** (configurable via `--system-tracker-disk-warning-available-space-percentage` and `--system-tracker-disk-required-available-space-percentage`). The thresholds above are intentionally set *above* the node's own 10% warning so you have runway to add storage or prune before the node degrades.
+
+You should also watch host-level disk usage (e.g. via `node_exporter`) as a redundant signal, since the node's own metric stops being reported once the process is down.
+
+### 3. Bad blocks (EVM L1s)
+
+A third independent domain: *correctness*. A node can be diverging from the rest of the network — building or accepting blocks the network rejects — while both its query success and disk look fine.
+
+| | |
+|---|---|
+| **Metric** | `avalanche_<chainID>_vm_eth_chain_block_bad_count` |
+| **Healthy** | 0 (no increase) |
+| **Page** | any sustained increase over 5 min |
+
+```promql
+increase(avalanche_<chainID>_vm_eth_chain_block_bad_count[5m]) > 0
+```
+
+This counter (exposed by Subnet-EVM / Coreth) increments when the node encounters a block that fails validation — a state-root mismatch, invalid transactions, or similar. A rising count signals consensus divergence or local database corruption, and usually precedes the node falling out of agreement with the rest of the validators. Any sustained increase warrants investigation.
+
+---
+
+## Explanatory metrics
+
+You don't normally page on these. When a critical metric — almost always **Successful Queries** — degrades, these tell you *why*.
+
+### Connected stake
+
+| | |
+|---|---|
+| **Metric** | `avalanche_stake_percent_connected` |
+| **Healthy** | ≥ the node's `MinPercentConnectedHealthy` threshold |
+
+```promql
+avalanche_stake_percent_connected{chain="<chainID>"} * 100
+```
+
+The percentage of total validator *stake* this node currently has live connections to. The node's own health check fails when this drops below a threshold derived from your consensus parameters — `alpha/k × 0.8 + 0.2`, which is **80% at the defaults** (`k=20`, `alpha=15`). If you run non-default snow parameters, recompute accordingly. A drop here directly explains a drop in Successful Queries: the node literally cannot reach enough stake to complete polls.
+
+### Number of validators
+
+| | |
+|---|---|
+| **Metric** | `avalanche_stake_num_validators` |
+| **Healthy** | your expected validator count |
+| **Page** | `< 1` |
+
+```promql
+avalanche_stake_num_validators{chain="<chainID>"}
+```
+
+The size of the validator set the node currently sees. Dropping to `0` means the node has lost its view of the validator set entirely (a P-Chain sync or L1 manager problem) — catastrophic for an L1, since it can no longer run consensus.
+
+### Benched validators
+
+| | |
+|---|---|
+| **Metric** | `avalanche_benchlist_benched_num` |
+| **Healthy** | 0 |
+
+```promql
+avalanche_benchlist_benched_num{chain="<chainID>"}
+```
+
+The number of peers the node has temporarily stopped querying because they keep failing or timing out. A non-zero value points at a specific misbehaving validator. Note: on very small validator sets a single dead validator holding a large stake share may *not* be benchlisted (benchlisting is capped to protect liveness), so a reading of `0` does not by itself prove every validator is healthy — cross-check against connected stake.
+
+### Block processing backlog
+
+| | |
+|---|---|
+| **Metric** | `avalanche_snowman_blks_processing` |
+| **Healthy** | low and stable (typically near 0) |
+
+```promql
+avalanche_snowman_blks_processing{chain="<chainID>"}
+```
+
+The number of blocks that have entered consensus but are not yet finalized. In steady state this stays low. A sustained climb means finalization is stalling — votes aren't coming back fast enough — which is the same condition that drops Successful Queries. The "right" ceiling depends on your chain's block rate and load, so treat a *sustained upward trend* as the signal rather than a fixed number.
+
+### Chain progress / liveness
+
+| | |
+|---|---|
+| **Metric** | `avalanche_snowman_last_accepted_height` |
+| **Healthy** | continuously increasing |
+
+```promql
+increase(avalanche_snowman_last_accepted_height{chain="<chainID>"}[5m]) == 0
+```
+
+The height of the most recently accepted block. The most direct confirmation of a halt: if this stops increasing while transactions are being submitted, the chain is not finalizing. Use it to distinguish a genuine halt from transient query noise.
+
+### CPU usage
+
+| | |
+|---|---|
+| **Metric** | `avalanche_resource_tracker_cpu_usage` |
+| **Healthy** | well below your core count |
+
+```promql
+avalanche_resource_tracker_cpu_usage
+```
+
+CPU consumed by the node, expressed in cores (a value of `2.0` means two full cores). Sustained saturation slows block verification and message handling, which shows up downstream as a drop in Successful Queries. This is the canonical example of an explanatory metric: you don't page on CPU itself, you page on the query degradation it causes and check CPU to confirm the cause.
+
+### Clock skew
+
+AvalancheGo does not page on clock skew, but it is a real liveness cliff worth a low-threshold warning from your time-sync tooling (NTP/PTP):
+
+- Beyond **~10s** of drift, peers reject this node's proposed blocks (it stays connected but stops contributing as a proposer).
+- Beyond the configured handshake tolerance (**60s** by default), peer connections drop and the node becomes isolated.
+
+There is no graceful degradation past these points, so keep validators within ~1s of UTC and alert on offsets of 2–3s.
+
+---
+
+## Node health rollup
+
+| | |
+|---|---|
+| **Metric** | `avalanche_health_checks_failing` |
+| **Healthy** | 0 |
+
+```promql
+avalanche_health_checks_failing{check="health"}
+```
+
+A convenient catch-all: the count of currently failing checks in the node's aggregate health endpoint (`/ext/health/liveness`). It rolls up the individual checks AvalancheGo runs — networking, router, database, disk space, BLS key correctness, pending upgrades, bootstrap status, and validation. Any non-zero value means the node is reporting itself unhealthy. It's coarse (it won't tell you *which* domain failed without drilling in), but it's a cheap safety net behind the specific metrics above.
+
+---
+
+## Summary
+
+| Metric | Type | Page when |
+|---|---|---|
+| Successful queries (`polls_successful` / `polls_failed`) | Critical | < 90% over 5 min |
+| Available disk (`disk_available_percentage`) | Critical | < 15% free |
+| Bad blocks (`vm_eth_chain_block_bad_count`) | Critical | any sustained increase |
+| Connected stake (`stake_percent_connected`) | Explanatory | — (diagnose) |
+| Number of validators (`stake_num_validators`) | Explanatory | < 1 |
+| Benched validators (`benchlist_benched_num`) | Explanatory | — (diagnose) |
+| Block processing (`blks_processing`) | Explanatory | — (diagnose) |
+| Chain progress (`last_accepted_height`) | Explanatory | not increasing |
+| CPU usage (`cpu_usage`) | Explanatory | — (diagnose) |
+| Clock skew (NTP/PTP) | Explanatory | offset > 2–3s |
+| Health rollup (`health_checks_failing`) | Safety net | > 0 |
+
+Start with the three critical alerts — successful queries, disk, and bad blocks — and add the explanatory metrics to your dashboards so you can quickly diagnose the cause when a critical alert fires.

--- a/content/docs/nodes/maintain/recommended-metrics.mdx
+++ b/content/docs/nodes/maintain/recommended-metrics.mdx
@@ -61,7 +61,7 @@ AvalancheGo tracks free space on its database volume natively and self-governs o
 
 ## Secondary metrics
 
-You don't need to page on these — a real problem already shows up in the query failure rate. They exist to tell you *why* the failure rate dropped. The thresholds below match the alert configuration we run for production mainnet L1s.
+The query failure rate usually moves first, so these are your main tools for diagnosing *why* it dropped — but several are still worth paging on in their own right (the paging thresholds are noted per metric), because some failures can occur without the failure rate reacting. The thresholds below match the alert configuration we run for production mainnet L1s.
 
 ### Bad blocks (EVM L1s)
 
@@ -120,11 +120,11 @@ The validator set the node currently sees. Dropping to 0 means it has lost its v
 
 | | |
 |---|---|
-| **Metric** | `avalanche_health_checks_failing{check="health",tag="application"}` |
+| **Metric** | `avalanche_health_checks_failing{check="health",tag="all"}` |
 | **Healthy** | 0 |
 | **Paging** | > 0 (sustained) |
 
-A catch-all gauge of how many checks are *currently* failing in the node's health endpoint (networking, router, database, disk, BLS key, pending upgrades, bootstrap status, validation). It carries two labels: `check` (one of `health`, `liveness`, `readiness`) and `tag` (`all`, `application`, or a specific subnet ID). Use `{check="health",tag="application"}` for the application-level health rollup. Because it reports the current count rather than an event total, **any non-zero value already means the node is unhealthy** — page on `> 0`, optionally requiring it to persist a minute or two to avoid flapping on transient checks.
+A catch-all gauge of how many checks are *currently* failing in the node's health endpoint (networking, router, database, disk, BLS key, pending upgrades, bootstrap status, validation). It carries two labels: `check` (one of `health`, `liveness`, `readiness`) and `tag` (`all`, `application`, or a specific subnet ID). Use `tag="all"` for the complete rollup — `tag="application"` covers only node-wide checks and excludes per-subnet ones, so it is not a true catch-all. To watch one L1 specifically, select that subnet's ID as the `tag`. Because the gauge reports the current count rather than an event total, **any non-zero value already means the node is unhealthy** — page on `> 0`, optionally requiring it to persist a minute or two to avoid flapping on transient checks.
 
 ### CPU usage
 

--- a/content/docs/nodes/maintain/recommended-metrics.mdx
+++ b/content/docs/nodes/maintain/recommended-metrics.mdx
@@ -35,7 +35,7 @@ This is the single most sensitive indicator of L1 health.
 
 AvalancheGo does not expose a success *percentage* directly — it exposes two counters, so you compute the ratio:
 
-```promql
+```text
 rate(avalanche_snowman_polls_successful{chain="<chainID>"}[5m])
 /
 (
@@ -61,7 +61,7 @@ Disk is a completely independent failure domain. A node will keep participating 
 | **Warn** | < 25% free |
 | **Page** | < 15% free |
 
-```promql
+```text
 avalanche_resource_tracker_disk_available_percentage
 ```
 
@@ -79,7 +79,7 @@ A third independent domain: *correctness*. A node can be diverging from the rest
 | **Healthy** | 0 (no increase) |
 | **Page** | any sustained increase over 5 min |
 
-```promql
+```text
 increase(avalanche_<chainID>_vm_eth_chain_block_bad_count[5m]) > 0
 ```
 
@@ -98,7 +98,7 @@ You don't normally page on these. When a critical metric — almost always **Suc
 | **Metric** | `avalanche_stake_percent_connected` |
 | **Healthy** | ≥ the node's `MinPercentConnectedHealthy` threshold |
 
-```promql
+```text
 avalanche_stake_percent_connected{chain="<chainID>"} * 100
 ```
 
@@ -112,7 +112,7 @@ The percentage of total validator *stake* this node currently has live connectio
 | **Healthy** | your expected validator count |
 | **Page** | `< 1` |
 
-```promql
+```text
 avalanche_stake_num_validators{chain="<chainID>"}
 ```
 
@@ -125,7 +125,7 @@ The size of the validator set the node currently sees. Dropping to `0` means the
 | **Metric** | `avalanche_benchlist_benched_num` |
 | **Healthy** | 0 |
 
-```promql
+```text
 avalanche_benchlist_benched_num{chain="<chainID>"}
 ```
 
@@ -138,7 +138,7 @@ The number of peers the node has temporarily stopped querying because they keep 
 | **Metric** | `avalanche_snowman_blks_processing` |
 | **Healthy** | low and stable (typically near 0) |
 
-```promql
+```text
 avalanche_snowman_blks_processing{chain="<chainID>"}
 ```
 
@@ -151,7 +151,7 @@ The number of blocks that have entered consensus but are not yet finalized. In s
 | **Metric** | `avalanche_snowman_last_accepted_height` |
 | **Healthy** | continuously increasing |
 
-```promql
+```text
 increase(avalanche_snowman_last_accepted_height{chain="<chainID>"}[5m]) == 0
 ```
 
@@ -164,7 +164,7 @@ The height of the most recently accepted block. The most direct confirmation of 
 | **Metric** | `avalanche_resource_tracker_cpu_usage` |
 | **Healthy** | well below your core count |
 
-```promql
+```text
 avalanche_resource_tracker_cpu_usage
 ```
 
@@ -188,7 +188,7 @@ There is no graceful degradation past these points, so keep validators within ~1
 | **Metric** | `avalanche_health_checks_failing` |
 | **Healthy** | 0 |
 
-```promql
+```text
 avalanche_health_checks_failing{check="health"}
 ```
 

--- a/content/docs/nodes/maintain/recommended-metrics.mdx
+++ b/content/docs/nodes/maintain/recommended-metrics.mdx
@@ -3,15 +3,15 @@ title: Key Metrics & Alerts
 description: The two metrics that tell you whether your Avalanche L1 is healthy, with recommended healthy, warning, and paging thresholds.
 ---
 
-Once you have [monitoring set up](/docs/nodes/maintain/monitoring), the question is *what to actually alert on*. AvalancheGo exposes hundreds of Prometheus metrics, but you only need **two** to know whether your L1 is healthy:
+Once you have [monitoring set up](/docs/nodes/maintain/monitoring), the question is *what to actually alert on*. AvalancheGo exposes hundreds of Prometheus metrics, but two of them carry most of the signal:
 
-1. **Query failure rate** — covers almost every consensus, networking, and validator problem.
-2. **Disk space remaining** — the one critical failure that the query failure rate cannot see.
+1. **Query failure rate** — covers almost every consensus, networking, and validator problem; most issues surface here first.
+2. **Disk space remaining** — an independent failure the query failure rate cannot see.
 
-Everything else is downstream of these. A misbehaving validator, a network partition, bad blocks, a stalled chain — they all surface as a rise in the query failure rate. So you page on these two, and use the secondary metrics below only to diagnose *why* the failure rate moved.
+Page on these two. Most other problems (a misbehaving validator, a network partition, a stalled chain) show up as a rise in the query failure rate, so the secondary metrics below are mainly for diagnosing *why* it moved. The exception is correctness failures such as bad blocks, which can occur independently and are worth their own alert.
 
 <Callout type="info">
-Thresholds are guidelines. Validate them against your own chain's baseline before paging on them. Throughout, `<chainID>` is your L1's blockchain ID.
+Thresholds are guidelines — most of the secondary values below reflect operational policy, not hard limits in the code. Validate them against your own chain's baseline before paging. Throughout, `<chain>` is your L1's blockchain ID (or its primary alias), which appears as the `chain` label on per-chain metrics.
 </Callout>
 
 ---
@@ -28,13 +28,14 @@ The single most sensitive indicator of L1 health. A *poll* is a round of voting 
 | **Warning** | < 95% successful |
 | **Paging** | < 90% successful |
 
-Below ~80% the chain can no longer finalize and effectively halts. The underlying signal is the `chits` (query response) message rate:
+As it falls, finalization slows. Once a node's connected stake drops below `AlphaConfidence/K` (75% at the defaults), it stops sending queries and the chain stalls for that node. AvalancheGo does not expose a success *percentage* directly — compute it from the Snowman poll counters (`polls_successful`, `polls_failed`):
 
 ```text
-max_over_time(
-  avg by (pod, namespace, region, cluster) (
-    rate(avalanche_handler_messages{op="chits", chain="<chainID>"}[5m]) * 60
-  )[5m:1m]
+rate(avalanche_snowman_polls_successful{chain="<chain>"}[5m])
+/
+(
+  rate(avalanche_snowman_polls_successful{chain="<chain>"}[5m])
++ rate(avalanche_snowman_polls_failed{chain="<chain>"}[5m])
 )
 ```
 
@@ -46,15 +47,15 @@ A completely independent failure. The node keeps participating in consensus — 
 
 | | |
 |---|---|
-| **Healthy** | > 10% free |
-| **Warning** | < 10% free |
-| **Paging** | < 5% free |
+| **Healthy** | > 20% free |
+| **Warning** | < 20% free |
+| **Paging** | < 10% free |
 
 ```text
 avalanche_resource_tracker_disk_available_percentage
 ```
 
-AvalancheGo tracks free space on its database volume natively and self-governs on it: by default it reports itself **unhealthy below 10% free** and performs a **fatal shutdown below 3% free** (`--system-tracker-disk-warning-available-space-percentage` and `--system-tracker-disk-required-available-space-percentage`). Page before the node degrades so you have time to add storage or prune. If you run in Kubernetes or on a managed host, alert on the equivalent volume-usage metric too, since the node's own metric stops reporting once the process is down.
+AvalancheGo tracks free space on its database volume natively and self-governs on it: by default it reports itself **unhealthy below 10% free** and performs a **fatal shutdown below 3% free** (`--system-tracker-disk-warning-available-space-percentage` defaults to 10, `--system-tracker-disk-required-available-space-percentage` defaults to 3). Page at the 10% mark — the point the node itself flags unhealthy — so you have runway to add storage or prune well before the 3% shutdown. If you run in Kubernetes or on a managed host, alert on the equivalent volume-usage metric too, since the node's own metric stops reporting once the process is down.
 
 ---
 
@@ -66,48 +67,50 @@ You don't need to page on these — a real problem already shows up in the query
 
 | | |
 |---|---|
-| **Metric** | `avalanche_<chainID>_vm_eth_chain_block_bad_count` |
+| **Metric** | `avalanche_subnetevm_eth_chain_block_bad_count{chain="<chain>"}` |
 | **Healthy** | 0 |
-| **Paging** | > 10 over 5 min |
+| **Paging** | any sustained increase |
 
-Blocks that failed validation (state-root mismatch, invalid transactions). A rising count means this node is diverging from the network — which also drives its failure rate up.
+Blocks that failed validation (state-root mismatch, invalid transactions). A rising count means this node is diverging from the network. It is an independent signal — the counter increments separately from the consensus poll counters, so a node can accumulate bad blocks without the failure rate moving, which is exactly why it gets its own alert.
+
+The metric is namespaced by VM: `avalanche_subnetevm_…` for Subnet-EVM L1s and `avalanche_evm_…` for the C-Chain (Coreth). Nodes that run the VM as an external plugin add a `vm_` segment (e.g. `avalanche_subnetevm_vm_eth_chain_block_bad_count`). There is no built-in alert threshold — `badBlockLimit` (10) in the source is just an in-memory cache size, so alert on any sustained increase rather than a fixed count.
 
 ### Connected stake
 
 | | |
 |---|---|
-| **Metric** | `avalanche_stake_percent_connected` |
-| **Healthy** | ≥ 80% |
-| **Paging** | < 80% |
+| **Metric** | `avalanche_stake_percent_connected{chain="<chain>"}` |
+| **Healthy** | ≥ 0.8 (80%) |
+| **Paging** | < 0.8 (80%) |
 
-Percentage of total validator stake the node has live connections to. When it falls, the node cannot reach enough stake to complete polls — a direct cause of failure-rate drops.
+The fraction of total validator stake the node has live connections to. Note this is a fraction in `[0, 1]`, not a 0–100 value — compare against `0.8`, or multiply by 100 to display a percentage. When it falls, the node cannot reach enough stake to complete polls — a direct cause of failure-rate drops. The node's own health check fails below ~80% (`alpha/k` plus a buffer, at the defaults); query sending stops below 75% (`AlphaConfidence/K`).
 
 ### Processing blocks
 
 | | |
 |---|---|
-| **Metric** | `avalanche_snowman_blks_processing` |
+| **Metric** | `avalanche_snowman_blks_processing{chain="<chain>"}` |
 | **Healthy** | low and stable |
-| **Warning** | > 6 over 5 min |
-| **Paging** | > 15 over 5 min |
+| **Warning** | sustained climb (e.g. > 6 over 5 min) |
+| **Paging** | sustained spike (e.g. > 15 over 5 min) |
 
-Blocks in consensus but not yet finalized. A sustained climb means finalization is stalling — the same condition that raises the failure rate.
+Blocks in consensus but not yet finalized. A sustained climb usually means finalization is stalling. The thresholds above are operational policy, not code defaults — AvalancheGo's own consensus health check trips on `MaxOutstandingItems` (256) and `MaxItemProcessingTime` (30s), so tune the numbers to your chain's block rate and watch the *trend*. To confirm whether the chain is genuinely stuck (versus just busy), check that `avalanche_snowman_last_accepted_height{chain="<chain>"}` is still increasing.
 
 ### Benched validators
 
 | | |
 |---|---|
-| **Metric** | `avalanche_benchlist_benched_num` |
+| **Metric** | `avalanche_benchlist_benched_num{chain="<chain>"}` |
 | **Healthy** | 0 |
 | **Paging** | > 1 over 10 min |
 
-Peers the node has temporarily stopped querying because they keep failing. Points at a specific misbehaving validator.
+The *count* of peers the node has temporarily stopped querying because they keep failing. A non-zero value means at least one validator is unreachable, but the gauge doesn't name which one — you'll need the node's logs to identify it. Also note benchlisting is capped by stake: a high-stake validator can keep failing without ever being benched, so `0` doesn't guarantee every validator is healthy.
 
 ### Number of validators
 
 | | |
 |---|---|
-| **Metric** | `avalanche_stake_num_validators` |
+| **Metric** | `avalanche_stake_num_validators{chain="<chain>"}` |
 | **Healthy** | your expected validator count |
 | **Paging** | < 1 |
 
@@ -117,21 +120,21 @@ The validator set the node currently sees. Dropping to 0 means it has lost its v
 
 | | |
 |---|---|
-| **Metric** | `avalanche_health_checks_failing{check="health"}` |
+| **Metric** | `avalanche_health_checks_failing{tag="application"}` |
 | **Healthy** | 0 |
-| **Paging** | > 2 over 5 min |
+| **Paging** | > 0 (sustained) |
 
-A catch-all count of failing checks in the node's aggregate health endpoint (networking, router, database, disk, BLS key, pending upgrades, bootstrap status, validation). Coarse, but a useful safety net.
+A catch-all gauge of how many checks are *currently* failing in the node's health endpoint (networking, router, database, disk, BLS key, pending upgrades, bootstrap status, validation). The labels are `check` (per-check name) and `tag`; use `tag="application"` for the application-level rollup, or `tag="all"` for every registered check. Because it reports the current count rather than an event total, **any non-zero value already means the node is unhealthy** — page on `> 0`, optionally requiring it to persist a minute or two to avoid flapping on transient checks.
 
-### CPU usage (host)
+### CPU usage
 
 | | |
 |---|---|
-| **Metric** | host / container CPU |
+| **Metric** | `avalanche_resource_tracker_cpu_usage` (and host/container CPU) |
 | **Healthy** | well below your core count |
-| **Paging** | > 90% sustained |
+| **Paging** | sustained saturation |
 
-Sustained saturation slows block verification and message handling, which shows up downstream as a higher failure rate.
+AvalancheGo exposes its own CPU usage as `avalanche_resource_tracker_cpu_usage`, measured in **cores** (a value of `2.0` means two full cores), not a percentage. Watch this alongside host- or container-level CPU (which comes from your infrastructure, not AvalancheGo). Sustained saturation slows block verification and message handling, which shows up downstream as a higher failure rate.
 
 ---
 
@@ -139,14 +142,14 @@ Sustained saturation slows block verification and message handling, which shows 
 
 | Metric | Type | Page when |
 |---|---|---|
-| Query failure rate (`handler_messages{op="chits"}`) | **Critical** | < 90% successful |
-| Disk space remaining (`disk_available_percentage`) | **Critical** | < 5% free |
-| Bad blocks (`vm_eth_chain_block_bad_count`) | Secondary | > 10 / 5 min |
-| Connected stake (`stake_percent_connected`) | Secondary | < 80% |
-| Processing blocks (`blks_processing`) | Secondary | > 15 / 5 min |
+| Query failure rate (`polls_successful` / `polls_failed`) | **Critical** | < 90% successful |
+| Disk space remaining (`disk_available_percentage`) | **Critical** | < 10% free |
+| Bad blocks (`subnetevm_eth_chain_block_bad_count`) | Secondary | any sustained increase |
+| Connected stake (`stake_percent_connected`) | Secondary | < 0.8 |
+| Processing blocks (`blks_processing`) | Secondary | sustained spike |
 | Benched validators (`benchlist_benched_num`) | Secondary | > 1 / 10 min |
 | Number of validators (`stake_num_validators`) | Secondary | < 1 |
-| Health check failures (`health_checks_failing`) | Secondary | > 2 / 5 min |
-| CPU usage (host) | Secondary | > 90% sustained |
+| Health check failures (`health_checks_failing`) | Secondary | > 0 sustained |
+| CPU usage (`resource_tracker_cpu_usage`) | Secondary | sustained saturation |
 
 Start with the two critical alerts — query failure rate and disk. Add the secondary metrics to your dashboards so you can quickly find the cause when the failure rate moves.

--- a/content/docs/nodes/maintain/recommended-metrics.mdx
+++ b/content/docs/nodes/maintain/recommended-metrics.mdx
@@ -67,13 +67,13 @@ You don't need to page on these — a real problem already shows up in the query
 
 | | |
 |---|---|
-| **Metric** | `avalanche_subnetevm_eth_chain_block_bad_count{chain="<chain>"}` |
+| **Metric** | `avalanche_subnetevm_vm_eth_chain_block_bad_count{chain="<chain>"}` |
 | **Healthy** | 0 |
 | **Paging** | any sustained increase |
 
 Blocks that failed validation (state-root mismatch, invalid transactions). A rising count means this node is diverging from the network. It is an independent signal — the counter increments separately from the consensus poll counters, so a node can accumulate bad blocks without the failure rate moving, which is exactly why it gets its own alert.
 
-The metric is namespaced by VM: `avalanche_subnetevm_…` for Subnet-EVM L1s and `avalanche_evm_…` for the C-Chain (Coreth). Nodes that run the VM as an external plugin add a `vm_` segment (e.g. `avalanche_subnetevm_vm_eth_chain_block_bad_count`). There is no built-in alert threshold — `badBlockLimit` (10) in the source is just an in-memory cache size, so alert on any sustained increase rather than a fixed count.
+The metric is namespaced by VM. A Subnet-EVM L1 runs the VM as an out-of-process plugin, so its metric carries a `vm_` segment: `avalanche_subnetevm_vm_eth_chain_block_bad_count`. The in-process C-Chain (Coreth) has no `vm_` segment: `avalanche_evm_eth_chain_block_bad_count{chain="C"}`. There is no built-in alert threshold — `badBlockLimit` (10) in the source is just an in-memory cache size, so alert on any sustained increase rather than a fixed count.
 
 ### Connected stake
 
@@ -120,11 +120,11 @@ The validator set the node currently sees. Dropping to 0 means it has lost its v
 
 | | |
 |---|---|
-| **Metric** | `avalanche_health_checks_failing{tag="application"}` |
+| **Metric** | `avalanche_health_checks_failing{check="health",tag="application"}` |
 | **Healthy** | 0 |
 | **Paging** | > 0 (sustained) |
 
-A catch-all gauge of how many checks are *currently* failing in the node's health endpoint (networking, router, database, disk, BLS key, pending upgrades, bootstrap status, validation). The labels are `check` (per-check name) and `tag`; use `tag="application"` for the application-level rollup, or `tag="all"` for every registered check. Because it reports the current count rather than an event total, **any non-zero value already means the node is unhealthy** — page on `> 0`, optionally requiring it to persist a minute or two to avoid flapping on transient checks.
+A catch-all gauge of how many checks are *currently* failing in the node's health endpoint (networking, router, database, disk, BLS key, pending upgrades, bootstrap status, validation). It carries two labels: `check` (one of `health`, `liveness`, `readiness`) and `tag` (`all`, `application`, or a specific subnet ID). Use `{check="health",tag="application"}` for the application-level health rollup. Because it reports the current count rather than an event total, **any non-zero value already means the node is unhealthy** — page on `> 0`, optionally requiring it to persist a minute or two to avoid flapping on transient checks.
 
 ### CPU usage
 
@@ -144,7 +144,7 @@ AvalancheGo exposes its own CPU usage as `avalanche_resource_tracker_cpu_usage`,
 |---|---|---|
 | Query failure rate (`polls_successful` / `polls_failed`) | **Critical** | < 90% successful |
 | Disk space remaining (`disk_available_percentage`) | **Critical** | < 10% free |
-| Bad blocks (`subnetevm_eth_chain_block_bad_count`) | Secondary | any sustained increase |
+| Bad blocks (`subnetevm_vm_eth_chain_block_bad_count`) | Secondary | any sustained increase |
 | Connected stake (`stake_percent_connected`) | Secondary | < 0.8 |
 | Processing blocks (`blks_processing`) | Secondary | sustained spike |
 | Benched validators (`benchlist_benched_num`) | Secondary | > 1 / 10 min |

--- a/content/docs/nodes/maintain/recommended-metrics.mdx
+++ b/content/docs/nodes/maintain/recommended-metrics.mdx
@@ -28,7 +28,7 @@ The single most sensitive indicator of L1 health. A *poll* is a round of voting 
 | **Warning** | < 95% successful |
 | **Paging** | < 90% successful |
 
-Below ~80% the chain can no longer finalize and effectively halts. This is the metric FIFA mainnet pages on; the underlying signal is the `chits` (query response) message rate:
+Below ~80% the chain can no longer finalize and effectively halts. The underlying signal is the `chits` (query response) message rate:
 
 ```text
 max_over_time(
@@ -60,7 +60,7 @@ AvalancheGo tracks free space on its database volume natively and self-governs o
 
 ## Secondary metrics
 
-You don't need to page on these — a real problem already shows up in the query failure rate. They exist to tell you *why* the failure rate dropped. The thresholds below match the FIFA mainnet alert configuration.
+You don't need to page on these — a real problem already shows up in the query failure rate. They exist to tell you *why* the failure rate dropped. The thresholds below match the alert configuration we run for production mainnet L1s.
 
 ### Bad blocks (EVM L1s)
 

--- a/content/docs/nodes/system-requirements.mdx
+++ b/content/docs/nodes/system-requirements.mdx
@@ -97,7 +97,7 @@ A fully connected Avalanche node maintains thousands of live TCP connections. Un
 
 ## Monitoring Thresholds
 
-Set up monitoring and alerts to catch resource issues before they impact your validator:
+Set up monitoring and alerts to catch resource issues before they impact your validator. The table below covers host-level resources; for chain-health metrics (query success, consensus, finalization) and their thresholds, see [Key Metrics & Alerts](/docs/nodes/maintain/recommended-metrics).
 
 | Resource | Warning Threshold | Critical Threshold | Action Required |
 |----------|------------------|-------------------|-----------------|
@@ -117,3 +117,4 @@ Set up monitoring and alerts to catch resource issues before they impact your va
 
 - Learn about [Active State vs Archive State](/docs/nodes/maintain/chain-state-management) to understand storage requirements
 - Set up [node monitoring](/docs/nodes/maintain/monitoring) to track resource usage and configure alerts
+- Review the [Key Metrics & Alerts](/docs/nodes/maintain/recommended-metrics) to learn which AvalancheGo metrics signal L1 health and at what thresholds to page


### PR DESCRIPTION
Adds a new docs page — Key Metrics & Alerts (/docs/nodes/maintain/recommended-metrics) — answering a recurring question from on-prem L1 operators: which Prometheus metrics actually tell me my L1 is healthy, and at what thresholds should I be warned or paged?

Why

monitoring.mdx already explains how to collect metrics (Prometheus, Grafana, node_exporter, dashboards) but never says which metrics matter or what good/bad looks like. This page fills that gap.

What it covers

Based on the production alert schedule we run for mainnet L1s, distilled to what an operator needs:

- Two critical metrics (page on these), each with healthy / warning / paging thresholds:
  - Query failure rate — the most sensitive signal; almost every consensus, networking, or validator problem surfaces here.
  - Disk space remaining — the one critical failure the failure rate can't see (the node runs fine until it fills disk and shuts down).
- Secondary metrics (diagnostics, downstream of failure rate): bad blocks, connected stake, processing blocks, benched validators, validator count, health-check rollup, CPU — each with the thresholds from our production config.

Metrics and thresholds mirror the alerts we actually run; no invented signals.

Changes

- content/docs/nodes/maintain/recommended-metrics.mdx — new page
- content/docs/nodes/maintain/meta.json — orders it after Monitoring in the nav
- content/docs/nodes/maintain/monitoring.mdx — cross-links to the new page
- content/docs/nodes/system-requirements.mdx — cross-links from the Monitoring Thresholds section

Notes

- Verified rendering locally (yarn dev, page returns 200).
- PromQL examples use text code fences — the promql language isn't bundled in the site's Shiki highlighter.
