### PR TITLE
fix: empty ICMDemo source panel in Academy ICM course + missing L1 tx types in PlatformVM docs

### DIFF
--- a/components/console/step-code-viewer.tsx
+++ b/components/console/step-code-viewer.tsx
@@ -157,10 +157,10 @@ export function StepCodeViewer({
       const blocks: CodeBlock[] = [];
 
       try {
-        if (displayStep.codeType === "typescript" && displayStep.code) {
-          // TypeScript: use inline code directly
+        if (displayStep.code) {
+          // Inline code: use directly, regardless of language
           blocks.push({
-            label: displayStep.filename || "code.ts",
+            label: displayStep.filename || (displayStep.codeType === "typescript" ? "code.ts" : "source"),
             code: displayStep.code,
           });
         } else if (displayStep.codeType === "solidity" && displayStep.sourceUrl) {

--- a/content/docs/primary-network/platformvm-architecture.mdx
+++ b/content/docs/primary-network/platformvm-architecture.mdx
@@ -13,7 +13,7 @@ At a glance:
 ## Responsibilities
 
 - **Validator registry & staking**: Tracks Primary Network validators and delegators, uptime, staking rewards, and validator fees.
-- **Subnet/L1 orchestration**: Creates Subnets and chains (`CreateSubnetTx`, `CreateChainTx`), maintains Subnet validator sets (including permissionless add/remove).
+- **Subnet/L1 orchestration**: Creates Subnets and chains (`CreateSubnetTx`, `CreateChainTx`), converts Subnets into L1s (`ConvertSubnetToL1Tx`), and maintains Subnet and L1 validator sets (including permissionless add/remove and warp-authorized L1 validator changes).
 - **Warp messaging**: Signs warp messages for cross-chain communication on Avalanche L1s.
 - **Atomic transfers**: Handles import/export of AVAX to/from other chains via shared memory.
 
@@ -32,6 +32,11 @@ At a glance:
 | `AddPermissionlessValidatorTx` / `AddPermissionlessDelegatorTx` | Permissionless validation on Subnets that allow it |
 | `CreateSubnetTx` | Create a new Subnet and owner controls |
 | `CreateChainTx` | Launch a new blockchain (VM + genesis) on a Subnet |
+| `ConvertSubnetToL1Tx` | Convert a Subnet into an L1 with its initial validator set ([ACP-77](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/77-reinventing-subnets)) |
+| `RegisterL1ValidatorTx` | Add a validator to an L1, authorized by a warp message from the L1's validator manager |
+| `SetL1ValidatorWeightTx` | Change an L1 validator's weight (a weight of 0 removes the validator) |
+| `IncreaseL1ValidatorBalanceTx` | Top up an L1 validator's continuous-fee balance |
+| `DisableL1ValidatorTx` | Deactivate an L1 validator and reclaim its remaining balance |
 | `ImportTx` / `ExportTx` | Move AVAX to/from other chains via atomic UTXOs |
 | `RewardValidatorTx` | Mint rewards after successful staking periods |
 | `TransformSubnetTx` | Legacy subnet transform (disabled post-Etna) |


### PR DESCRIPTION
## Summary

Two quick fixes from Martin's Academy walkthrough (FDE-50):

1. **Empty `ICMDemo.sol` code panel** on the [Deploy ICM Demo step](https://build.avax.network/academy/avalanche-l1/interchain-messaging/05-testing-icm/01-deploy-icm-demo). `StepCodeViewer` only handled `typescript` + inline `code` and `solidity` + remote `sourceUrl` — a `solidity` step with inline `code` (what `DeployICMDemo` passes) fell through both branches and rendered the filename tab over an empty panel. Inline code now renders for any language, with the `sourceUrl` fetch path as fallback. All other `StepCodeViewer` consumers use `sourceUrl` and are unaffected.

2. **Missing post-ACP-77 L1 tx types** on the [PlatformVM architecture page](https://build.avax.network/docs/primary-network/platformvm-architecture). The Key Transaction Types table stopped at the legacy subnet txs; added `ConvertSubnetToL1Tx`, `RegisterL1ValidatorTx`, `SetL1ValidatorWeightTx`, `IncreaseL1ValidatorBalanceTx`, `DisableL1ValidatorTx`, and updated the Subnet/L1 orchestration bullet to match.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Verify the ICMDemo.sol source renders on the Deploy ICM Demo step in preview
- [ ] Verify the tx table renders on the PlatformVM architecture page in preview