### PR TITLE
fix(console): Rules-of-Hooks crash in toolbox stores — TestSend dead on 3 Academy pages

### DIFF
--- a/components/toolbox/console/icm/network/hooks/useIcmMigrationOnce.ts
+++ b/components/toolbox/console/icm/network/hooks/useIcmMigrationOnce.ts
@@ -30,7 +30,9 @@ export function useIcmMigrationOnce(): MigrationState {
     for (const l1 of l1List as L1ListItem[]) {
       const existing = chains[l1.id];
       try {
-        const slice = getToolboxStore(l1.id)();
+        // Inside an effect: read store state imperatively — calling the
+        // bound store hook here would violate the Rules of Hooks.
+        const slice = getToolboxStore(l1.id).getState();
         const registryFromToolbox = (slice.teleporterRegistryAddress ?? '') as string;
         const demoFromToolbox = (slice.icmReceiverAddress ?? '') as string;
         const registryFromL1 = (l1.wellKnownTeleporterRegistryAddress ?? '') as string;

--- a/components/toolbox/console/icm/network/inspectors/DemoInspector.tsx
+++ b/components/toolbox/console/icm/network/inspectors/DemoInspector.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import DeployICMDemo from '@/components/toolbox/console/icm/test-connection/DeployICMDemo';
 import { useIcmSetupStore } from '@/components/toolbox/stores/icmSetupStore';
 import { useL1List, useSelectedL1, type L1ListItem } from '@/components/toolbox/stores/l1ListStore';
-import { getToolboxStore } from '@/components/toolbox/stores/toolboxStore';
+import { getToolboxStore, NO_CHAIN_SELECTED } from '@/components/toolbox/stores/toolboxStore';
 import { Note } from '@/components/toolbox/components/Note';
 import type { Address } from '@/components/toolbox/console/icm/network/types';
 
@@ -28,14 +28,14 @@ export function DemoInspector() {
     selectedL1 ? (s.chains[selectedL1.id]?.demoAddress ?? null) : null,
   );
 
-  const toolboxDemo = useMemo(() => {
-    if (!selectedL1) return null;
-    try {
-      return (getToolboxStore(selectedL1.id)().icmReceiverAddress ?? null) as Address | null;
-    } catch {
-      return null;
-    }
-  }, [selectedL1]);
+  // Store hooks can't live inside useMemo (Rules of Hooks) — subscribe
+  // unconditionally (sentinel store when nothing is selected). This also
+  // makes the value reactive: the memo version only refreshed when
+  // selectedL1 changed, not when the demo address landed in the store.
+  const toolboxDemoRaw = getToolboxStore(selectedL1?.id ?? NO_CHAIN_SELECTED)(
+    (s) => (s.icmReceiverAddress ?? null) as Address | null,
+  );
+  const toolboxDemo = selectedL1 ? toolboxDemoRaw : null;
 
   useEffect(() => {
     if (!selectedL1) return;

--- a/components/toolbox/console/ictt/bridge/inspectors/RemoteInspector.tsx
+++ b/components/toolbox/console/ictt/bridge/inspectors/RemoteInspector.tsx
@@ -9,7 +9,7 @@ import {
   useSetTeleporterRegistryAddress,
   type L1ListItem,
 } from '@/components/toolbox/stores/l1ListStore';
-import { getToolboxStore } from '@/components/toolbox/stores/toolboxStore';
+import { getToolboxStore, NO_CHAIN_SELECTED } from '@/components/toolbox/stores/toolboxStore';
 import { useWalletStore } from '@/components/toolbox/stores/walletStore';
 import { useWallet } from '@/components/toolbox/hooks/useWallet';
 import { Note } from '@/components/toolbox/components/Note';
@@ -60,9 +60,12 @@ export function RemoteInspector({ onPhaseChange, bridge, remote }: RemoteInspect
   // Heals user-created destination L1s where ICM was deployed but the
   // address never propagated to l1ListStore. The fallback chain matches
   // HomeInspector: toolbox > well-known > empty.
-  const destinationToolboxRegistry = destinationL1Id
-    ? getToolboxStore(destinationL1Id)((s: { teleporterRegistryAddress: string }) => s.teleporterRegistryAddress)
-    : '';
+  // The store hook must run unconditionally (Rules of Hooks): select from
+  // the sentinel store when no destination is chosen, discard the value.
+  const destinationToolboxRegistryRaw = getToolboxStore(destinationL1Id || NO_CHAIN_SELECTED)(
+    (s: { teleporterRegistryAddress: string }) => s.teleporterRegistryAddress,
+  );
+  const destinationToolboxRegistry = destinationL1Id ? destinationToolboxRegistryRaw : '';
   const defaultRegistry = (destinationToolboxRegistry || wellKnownRegistry || '') as Address;
   const setTeleporterRegistryOnDestinationL1 = useSetTeleporterRegistryAddress();
 

--- a/components/toolbox/console/ictt/token-transfer/TestSend.tsx
+++ b/components/toolbox/console/ictt/token-transfer/TestSend.tsx
@@ -21,13 +21,23 @@ import { EVMAddressInput } from '@/components/toolbox/components/EVMAddressInput
 import { Token, TokenInput } from '@/components/toolbox/components/TokenInputToolbox';
 import SelectBlockchain, { type BlockchainSelection } from '@/components/toolbox/components/SelectBlockchain';
 import { CB58ToHex } from '@avalanche-sdk/client/utils';
-import { Container } from '@/components/toolbox/components/Container';
 import { Toggle } from '@/components/toolbox/components/Toggle';
 import { Ellipsis } from 'lucide-react';
+import { NO_CHAIN_SELECTED } from '@/components/toolbox/stores/toolboxStore';
+import { WalletRequirementsConfigKey } from '@/components/toolbox/hooks/useWalletRequirements';
+import { ConsoleToolMetadata, withConsoleToolMetadata } from '@/components/toolbox/components/WithConsoleToolMetadata';
+import { generateConsoleToolGitHubUrl } from '@/components/toolbox/utils/githubUrl';
 
 const DEFAULT_GAS_LIMIT = 250000n;
 
-export default function TokenBridge() {
+const metadata: ConsoleToolMetadata = {
+  title: 'Cross-Chain Token Bridge',
+  description: 'Send tokens from the connected chain to another chain',
+  toolRequirements: [WalletRequirementsConfigKey.WalletConnected],
+  githubUrl: generateConsoleToolGitHubUrl(import.meta.url),
+};
+
+function TokenBridge() {
   const [criticalError, setCriticalError] = useState<Error | null>(null);
   const { walletEVMAddress } = useWalletStore();
   const walletClient = useResolvedWalletClient();
@@ -82,7 +92,7 @@ export default function TokenBridge() {
 
   // Get chain info - source is current chain, destination is selected
   const destL1 = useL1ByChainId(destinationSelection.blockchainId);
-  const destToolboxStore = getToolboxStore(destinationSelection.blockchainId)();
+  const destToolboxStore = getToolboxStore(destinationSelection.blockchainId || NO_CHAIN_SELECTED)();
 
   const { erc20TokenHomeAddress, nativeTokenHomeAddress } = useToolboxStore();
 
@@ -627,11 +637,7 @@ export default function TokenBridge() {
   const [isGasLimitEditing, setIsGasLimitEditing] = useState(false);
 
   return (
-    <Container
-      title="Cross-Chain Token Bridge"
-      description={`Send tokens from the current chain (${selectedL1?.name}) to another chain.`}
-      githubUrl="https://github.com/ava-labs/builders-hub/edit/master/components/toolbox/console/ictt/token-transfer/TestSend.tsx"
-    >
+    <div className="space-y-6">
       <SelectBlockchain
         label="Destination Blockchain"
         value={destinationSelection.blockchainId}
@@ -825,6 +831,8 @@ export default function TokenBridge() {
           </div>
         </div>
       )}
-    </Container>
+    </div>
   );
 }
+
+export default withConsoleToolMetadata(TokenBridge, metadata);

--- a/components/toolbox/console/permissioned-l1s/ChangeWeight.tsx
+++ b/components/toolbox/console/permissioned-l1s/ChangeWeight.tsx
@@ -5,8 +5,18 @@ import StepFlow from '@/components/console/step-flow';
 import { steps } from '@/app/console/permissioned-l1s/change-validator-weight/steps';
 import { useChangeWeightStore } from '@/components/toolbox/stores/changeWeightStore';
 import ValidatorManagerLayout from '@/components/toolbox/contexts/ValidatorManagerLayout';
+import { WalletRequirementsConfigKey } from '@/components/toolbox/hooks/useWalletRequirements';
+import { ConsoleToolMetadata, withConsoleToolMetadata } from '@/components/toolbox/components/WithConsoleToolMetadata';
+import { generateConsoleToolGitHubUrl } from '@/components/toolbox/utils/githubUrl';
 
-export default function ChangeWeight() {
+const metadata: ConsoleToolMetadata = {
+  title: 'Change Validator Weight',
+  description: "Change a validator's consensus weight on your L1 via the Validator Manager",
+  toolRequirements: [WalletRequirementsConfigKey.WalletConnected],
+  githubUrl: generateConsoleToolGitHubUrl(import.meta.url),
+};
+
+function ChangeWeight() {
   const { subnetIdL1, globalError } = useChangeWeightStore();
   const firstKey = steps[0].type === 'single' ? steps[0].key : steps[0].options[0].key;
   const [currentStepKey, setCurrentStepKey] = useState(firstKey);
@@ -28,3 +38,5 @@ export default function ChangeWeight() {
     </ValidatorManagerLayout>
   );
 }
+
+export default withConsoleToolMetadata(ChangeWeight, metadata);

--- a/components/toolbox/stores/toolboxStore.ts
+++ b/components/toolbox/stores/toolboxStore.ts
@@ -23,7 +23,7 @@ const toolboxInitialState = {
   poaManagerAddress: '',
 };
 
-export const getToolboxStore = (chainId: string) =>
+const createToolboxStore = (chainId: string) =>
   create(
     persist(
       combine(toolboxInitialState, (set, _get) => ({
@@ -55,6 +55,20 @@ export const getToolboxStore = (chainId: string) =>
     ),
   );
 
+// Singleton store per chain, mirroring getL1ListStore. Creating a fresh
+// store (and persist subscription) on every call re-subscribed components
+// each render and made hook identity unstable for anything keyed off it.
+const toolboxStoreSingletons = new Map<string, ReturnType<typeof createToolboxStore>>();
+
+export const getToolboxStore = (chainId: string) => {
+  let store = toolboxStoreSingletons.get(chainId);
+  if (!store) {
+    store = createToolboxStore(chainId);
+    toolboxStoreSingletons.set(chainId, store);
+  }
+  return store;
+};
+
 const noopSetter = () => {};
 
 const emptyToolboxState = {
@@ -75,13 +89,23 @@ const emptyToolboxState = {
   reset: noopSetter,
 };
 
+// Sentinel store key for "no chain selected (yet)". The store hook must be
+// called unconditionally — an early return that skips it means that when
+// the wallet connects (or a selection is made) while a component is
+// mounted, the extra subscription shifts React's hook order and crashes
+// the component (Rules of Hooks). The sentinel store is never written to,
+// so it never touches localStorage. Callers selecting from a maybe-empty
+// chain id should use `getToolboxStore(id || NO_CHAIN_SELECTED)` and
+// discard the result when the id is empty.
+export const NO_CHAIN_SELECTED = '__no-chain-selected__';
+
 export const useToolboxStore = () => {
   const selectedL1 = useSelectedL1();
   const chainId = selectedL1?.id;
-  // During bootstrap (no L1 selected), return an inert default state
-  // so we never create a store keyed by "".
+  const state = getToolboxStore(chainId ?? NO_CHAIN_SELECTED)();
+  // During bootstrap, expose inert state (noop setters) instead.
   if (!chainId) return emptyToolboxState;
-  return getToolboxStore(chainId)();
+  return state;
 };
 
 export function useViemChainStore() {


### PR DESCRIPTION
Fixes #4284.

## Root cause

Two compounding problems in `toolboxStore.ts`:

1. `getToolboxStore(chainId)` created a **brand-new persisted zustand store on every call** — unlike `getL1ListStore`, which uses singletons.
2. `useToolboxStore()` **early-returned before calling the store hook** when no L1 was selected. When the wallet connected while a tool was mounted (selectedL1 appears), the store subscription appeared mid-lifecycle → React hook order shifted → `TypeError ... at areHookInputsEqual` → component dead behind the ErrorBoundary.

This killed `TestSend` ("Try Again" fallback instead of the exercise) on three live Academy pages:
- `/academy/avalanche-l1/native-token-bridge/01-erc20-to-native/07-bridge-tokens`
- `/academy/avalanche-l1/native-token-bridge/02-native-to-erc20/08-bridge-tokens`
- `/academy/avalanche-l1/native-token-bridge/03-native-to-native/07-bridge-native-tokens`

Only unwrapped tools were exposed: tools behind `CheckRequirements` don't mount until *after* the wallet connects, so they never see the transition.

## Fix

- `getToolboxStore` → per-chainId singletons (mirrors `getL1ListStore`)
- `useToolboxStore` → always calls the store hook; sentinel `NO_CHAIN_SELECTED` store during bootstrap (never written to → no localStorage pollution); still returns inert state pre-selection
- Fixed the same latent bug class at three more sites found by audit:
  - `RemoteInspector` — store hook inside a ternary
  - `DemoInspector` — store hook inside `useMemo` (someone had try/caught the crash; now also properly reactive)
  - `useIcmMigrationOnce` — store hook inside a `useEffect` loop → imperative `getState()`
- Wrapped `TestSend` + `ChangeWeight` in `withConsoleToolMetadata` (standard chrome, Report Issue/Edit links, `WalletConnected` gating). `TestSend`'s inline `Container` moved into tool metadata.

## Verification

Probed all four affected Academy pages with the QA harness wallet shim (auto-connected wallet, the exact crash trigger): tool titles render, zero hook errors, zero page exceptions, no "Try Again". Regression-probed two previously-passing pages (deploy-icm-demo, deploy-native-token-remote): unchanged. `tsc --noEmit`, eslint (toolbox, --max-warnings 0), check-console-design, check-render-safety all green.

Found by the QA harness from #4283 on its first sweep — with that PR's suite, these three pages flip from fail to pass.