### PR TITLE
fix: Rules-of-Hooks crash in TestSend on bridge-tokens course pages

### DIFF
--- a/components/toolbox/console/icm/network/hooks/useIcmMigrationOnce.ts
+++ b/components/toolbox/console/icm/network/hooks/useIcmMigrationOnce.ts
@@ -30,7 +30,10 @@ export function useIcmMigrationOnce(): MigrationState {
     for (const l1 of l1List as L1ListItem[]) {
       const existing = chains[l1.id];
       try {
-        const slice = getToolboxStore(l1.id)();
+        // Plain state read — calling the store hook here (inside an
+        // effect) was an invalid hook call that threw, and the catch
+        // below silently skipped the migration for every chain.
+        const slice = getToolboxStore(l1.id).getState();
         const registryFromToolbox = (slice.teleporterRegistryAddress ?? '') as string;
         const demoFromToolbox = (slice.icmReceiverAddress ?? '') as string;
         const registryFromL1 = (l1.wellKnownTeleporterRegistryAddress ?? '') as string;

--- a/components/toolbox/console/icm/network/inspectors/DemoInspector.tsx
+++ b/components/toolbox/console/icm/network/inspectors/DemoInspector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import DeployICMDemo from '@/components/toolbox/console/icm/test-connection/DeployICMDemo';
 import { useIcmSetupStore } from '@/components/toolbox/stores/icmSetupStore';
 import { useL1List, useSelectedL1, type L1ListItem } from '@/components/toolbox/stores/l1ListStore';
@@ -28,14 +28,13 @@ export function DemoInspector() {
     selectedL1 ? (s.chains[selectedL1.id]?.demoAddress ?? null) : null,
   );
 
-  const toolboxDemo = useMemo(() => {
-    if (!selectedL1) return null;
-    try {
-      return (getToolboxStore(selectedL1.id)().icmReceiverAddress ?? null) as Address | null;
-    } catch {
-      return null;
-    }
-  }, [selectedL1]);
+  // Subscribe to the active L1's toolbox slice directly. The previous
+  // version called the store hook inside useMemo — an invalid hook call
+  // that threw on every render; the catch returned null, silently
+  // disabling this mirror. '' maps to the inert bootstrap store.
+  const toolboxDemo = getToolboxStore(selectedL1?.id ?? '')(
+    (s: { icmReceiverAddress: string }) => (s.icmReceiverAddress || null) as Address | null,
+  );
 
   useEffect(() => {
     if (!selectedL1) return;

--- a/components/toolbox/console/ictt/bridge/inspectors/RemoteInspector.tsx
+++ b/components/toolbox/console/ictt/bridge/inspectors/RemoteInspector.tsx
@@ -60,9 +60,14 @@ export function RemoteInspector({ onPhaseChange, bridge, remote }: RemoteInspect
   // Heals user-created destination L1s where ICM was deployed but the
   // address never propagated to l1ListStore. The fallback chain matches
   // HomeInspector: toolbox > well-known > empty.
-  const destinationToolboxRegistry = destinationL1Id
-    ? getToolboxStore(destinationL1Id)((s: { teleporterRegistryAddress: string }) => s.teleporterRegistryAddress)
-    : '';
+  // Subscribe unconditionally (Rules of Hooks): the previous ternary only
+  // called the store hook when a destination was selected, so the hook
+  // count changed when destinationL1Id flipped and React crashed with a
+  // hook-order error. '' maps to the inert bootstrap store, whose
+  // teleporterRegistryAddress is always ''.
+  const destinationToolboxRegistry = getToolboxStore(destinationL1Id || '')(
+    (s: { teleporterRegistryAddress: string }) => s.teleporterRegistryAddress,
+  );
   const defaultRegistry = (destinationToolboxRegistry || wellKnownRegistry || '') as Address;
   const setTeleporterRegistryOnDestinationL1 = useSetTeleporterRegistryAddress();
 

--- a/components/toolbox/console/ictt/token-transfer/TestSend.tsx
+++ b/components/toolbox/console/ictt/token-transfer/TestSend.tsx
@@ -21,13 +21,22 @@ import { EVMAddressInput } from '@/components/toolbox/components/EVMAddressInput
 import { Token, TokenInput } from '@/components/toolbox/components/TokenInputToolbox';
 import SelectBlockchain, { type BlockchainSelection } from '@/components/toolbox/components/SelectBlockchain';
 import { CB58ToHex } from '@avalanche-sdk/client/utils';
-import { Container } from '@/components/toolbox/components/Container';
 import { Toggle } from '@/components/toolbox/components/Toggle';
 import { Ellipsis } from 'lucide-react';
+import { WalletRequirementsConfigKey } from '@/components/toolbox/hooks/useWalletRequirements';
+import { ConsoleToolMetadata, withConsoleToolMetadata } from '@/components/toolbox/components/WithConsoleToolMetadata';
+import { generateConsoleToolGitHubUrl } from '@/components/toolbox/utils/githubUrl';
 
 const DEFAULT_GAS_LIMIT = 250000n;
 
-export default function TokenBridge() {
+const metadata: ConsoleToolMetadata = {
+  title: 'Cross-Chain Token Bridge',
+  description: 'Send tokens from the connected chain to another chain over ICTT',
+  toolRequirements: [WalletRequirementsConfigKey.EVMChainBalance],
+  githubUrl: generateConsoleToolGitHubUrl(import.meta.url),
+};
+
+function TokenBridge() {
   const [criticalError, setCriticalError] = useState<Error | null>(null);
   const { walletEVMAddress } = useWalletStore();
   const walletClient = useResolvedWalletClient();
@@ -80,7 +89,9 @@ export default function TokenBridge() {
   const [tokenBalance, setTokenBalance] = useState<bigint | null>(null);
   const [tokenAllowance, setTokenAllowance] = useState<bigint | null>(null);
 
-  // Get chain info - source is current chain, destination is selected
+  // Get chain info - source is current chain, destination is selected.
+  // getToolboxStore memoizes one store per chain id ('' = inert bootstrap
+  // store), so subscribing by a runtime-changing key is hook-safe here.
   const destL1 = useL1ByChainId(destinationSelection.blockchainId);
   const destToolboxStore = getToolboxStore(destinationSelection.blockchainId)();
 
@@ -627,11 +638,7 @@ export default function TokenBridge() {
   const [isGasLimitEditing, setIsGasLimitEditing] = useState(false);
 
   return (
-    <Container
-      title="Cross-Chain Token Bridge"
-      description={`Send tokens from the current chain (${selectedL1?.name}) to another chain.`}
-      githubUrl="https://github.com/ava-labs/builders-hub/edit/master/components/toolbox/console/ictt/token-transfer/TestSend.tsx"
-    >
+    <>
       <SelectBlockchain
         label="Destination Blockchain"
         value={destinationSelection.blockchainId}
@@ -825,6 +832,8 @@ export default function TokenBridge() {
           </div>
         </div>
       )}
-    </Container>
+    </>
   );
 }
+
+export default withConsoleToolMetadata(TokenBridge, metadata);

--- a/components/toolbox/console/permissioned-l1s/ChangeWeight.tsx
+++ b/components/toolbox/console/permissioned-l1s/ChangeWeight.tsx
@@ -5,8 +5,18 @@ import StepFlow from '@/components/console/step-flow';
 import { steps } from '@/app/console/permissioned-l1s/change-validator-weight/steps';
 import { useChangeWeightStore } from '@/components/toolbox/stores/changeWeightStore';
 import ValidatorManagerLayout from '@/components/toolbox/contexts/ValidatorManagerLayout';
+import { WalletRequirementsConfigKey } from '@/components/toolbox/hooks/useWalletRequirements';
+import { ConsoleToolMetadata, withConsoleToolMetadata } from '@/components/toolbox/components/WithConsoleToolMetadata';
+import { generateConsoleToolGitHubUrl } from '@/components/toolbox/utils/githubUrl';
 
-export default function ChangeWeight() {
+const metadata: ConsoleToolMetadata = {
+  title: 'Change Validator Weight',
+  description: "Change the consensus weight of a validator through the L1's Validator Manager",
+  toolRequirements: [WalletRequirementsConfigKey.EVMChainBalance],
+  githubUrl: generateConsoleToolGitHubUrl(import.meta.url),
+};
+
+function ChangeWeight() {
   const { subnetIdL1, globalError } = useChangeWeightStore();
   const firstKey = steps[0].type === 'single' ? steps[0].key : steps[0].options[0].key;
   const [currentStepKey, setCurrentStepKey] = useState(firstKey);
@@ -28,3 +38,5 @@ export default function ChangeWeight() {
     </ValidatorManagerLayout>
   );
 }
+
+export default withConsoleToolMetadata(ChangeWeight, metadata);

--- a/components/toolbox/stores/toolboxStore.ts
+++ b/components/toolbox/stores/toolboxStore.ts
@@ -23,7 +23,15 @@ const toolboxInitialState = {
   poaManagerAddress: '',
 };
 
-export const getToolboxStore = (chainId: string) =>
+// In-memory storage for the bootstrap ('' chainId) store so nothing is
+// persisted under an empty key while no L1 is selected.
+const noopStateStorage = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+};
+
+const createToolboxStore = (chainId: string) =>
   create(
     persist(
       combine(toolboxInitialState, (set, _get) => ({
@@ -50,38 +58,35 @@ export const getToolboxStore = (chainId: string) =>
       })),
       {
         name: `${STORE_VERSION}-toolbox-storage-${chainId}`,
-        storage: createJSONStorage(localStorageComp),
+        storage: createJSONStorage(chainId ? localStorageComp : () => noopStateStorage),
       },
     ),
   );
 
-const noopSetter = () => {};
+// One store instance per chain id. getToolboxStore used to call zustand's
+// create() on EVERY invocation, so components calling it during render
+// subscribed to a brand-new store (and re-ran persist rehydration) each
+// render, and imperative callers (e.g. stores/reset.ts) mutated throwaway
+// instances that live components never observed.
+const toolboxStores = new Map<string, ReturnType<typeof createToolboxStore>>();
 
-const emptyToolboxState = {
-  ...toolboxInitialState,
-  setValidatorMessagesLibAddress: noopSetter,
-  setValidatorManagerAddress: noopSetter,
-  setRewardCalculatorAddress: noopSetter,
-  setNativeStakingManagerAddress: noopSetter,
-  setErc20StakingManagerAddress: noopSetter,
-  setTeleporterRegistryAddress: noopSetter,
-  setIcmReceiverAddress: noopSetter,
-  setExampleErc20Address: noopSetter,
-  setErc20TokenHomeAddress: noopSetter,
-  setNativeTokenHomeAddress: noopSetter,
-  setErc20TokenRemoteAddress: noopSetter,
-  setNativeTokenRemoteAddress: noopSetter,
-  setPoaManagerAddress: noopSetter,
-  reset: noopSetter,
+export const getToolboxStore = (chainId: string) => {
+  let store = toolboxStores.get(chainId);
+  if (!store) {
+    store = createToolboxStore(chainId);
+    toolboxStores.set(chainId, store);
+  }
+  return store;
 };
 
 export const useToolboxStore = () => {
   const selectedL1 = useSelectedL1();
-  const chainId = selectedL1?.id;
-  // During bootstrap (no L1 selected), return an inert default state
-  // so we never create a store keyed by "".
-  if (!chainId) return emptyToolboxState;
-  return getToolboxStore(chainId)();
+  // Rules of Hooks: always subscribe to a store. During bootstrap (no L1
+  // selected yet) this is an inert, non-persisted store keyed by ''.
+  // The previous version returned early without calling the store hook,
+  // so the hook count changed when selectedL1 resolved mid-hydration and
+  // React crashed with a hook-order error (#4284).
+  return getToolboxStore(selectedL1?.id ?? '')();
 };
 
 export function useViemChainStore() {


### PR DESCRIPTION
Fixes #4284

## Root cause

Two compounding defects in `components/toolbox/stores/toolboxStore.ts`:

1. **`useToolboxStore()` violated the Rules of Hooks.** It returned an inert object early while no L1 was selected — zero store hooks on the bootstrap path, N hooks once `selectedL1` resolved. When wallet hydration flipped `selectedL1` undefined→defined, the hook count changed mid-component and React threw the hook-order error from the issue.
2. **`getToolboxStore(chainId)` was never memoized** — it ran zustand's `create(persist(...))` on every call. Render-time callers (TestSend line 85 et al.) subscribed to a brand-new store every render, and imperative callers (`stores/reset.ts`) mutated throwaway instances that live components never observed (reset wiped localStorage but on-screen state stayed stale).

Why only the TestSend pages crashed: every other console tool is wrapped in `withConsoleToolMetadata`, whose `CheckRequirements` gate delays mounting until wallet/chain state is stable — accidentally masking the flip. TestSend and ChangeWeight mounted raw during hydration.

## Fix

- One memoized store per chain id (module-level `Map`), with an inert **non-persisted** store for the bootstrap `''` key so `useToolboxStore` subscribes unconditionally — stable hook count in every render path.
- Wrap `TestSend` and `ChangeWeight` in `withConsoleToolMetadata` (Container chrome + requirements gating), matching every other console tool. TestSend's hand-rolled `Container` props moved into tool metadata.

## Verification

Ran the #4283 QA harness locally against a dev server (harness merged into a throwaway branch, not part of this PR):

- **Red on master code**: `renders /academy/.../01-erc20-to-native/07-bridge-tokens` fails with the hook-order crash
- **Green with this fix**: all three native-token-bridge pages + `06-change-weight-demo` pass
- `tsc --noEmit` clean

Note: TestSend is embedded on **5** course pages (the three in the issue plus `erc20-bridge/.../06-transfer-tokens` and `.../04-multihop`) — all covered by this fix. The erc20-bridge course is currently absent from the harness's `qa-manifest.json`, so those two pages aren't swept (flagged separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)