### PR TITLE
feat(profile): normalize social account input formats

### DIFF
--- a/app/(home)/projects/new/page.client.tsx
+++ b/app/(home)/projects/new/page.client.tsx
@@ -9,6 +9,14 @@ import {
   LINKEDIN_ACCOUNT_PATTERN,
   X_ACCOUNT_PATTERN,
 } from '@/lib/profile/socialAccountValidation';
+import {
+  extractGithubUsername,
+  extractLinkedInSlug,
+  extractXUsername,
+  normalizeGithubUrl,
+  normalizeLinkedInUrl,
+  normalizeXUrl,
+} from '@/lib/profile/socialAccountFormat';
 import { LogoUploader } from '@/components/common/LogoUploader';
 import {
   UserSearchPicker,
@@ -41,23 +49,10 @@ export function NewProjectForm({ userId, currentUserName, currentUserImage }: Pr
     setValues((prev) => ({ ...prev, [k]: v }));
 
   // Mono-prefix social inputs: store the full URL but show only the handle/slug.
-  function stripPrefix(value: string, prefix: RegExp): string {
-    return value.replace(prefix, '').replace(/\/+$/, '');
-  }
-  const xHandle = stripPrefix(values.x_account, /^https?:\/\/(?:www\.)?x\.com\//i);
-  const linkedinSlug = stripPrefix(
-    values.linkedin_account,
-    /^https?:\/\/(?:www\.)?linkedin\.com\/company\//i,
-  );
-  const githubHandle = stripPrefix(
-    values.github_account,
-    /^https?:\/\/(?:www\.)?github\.com\//i,
-  );
-
-  const setUrlField = (key: 'x_account' | 'linkedin_account' | 'github_account', base: string, slug: string) => {
-    const cleaned = slug.trim().replace(/^\/+|\/+$/g, '');
-    update(key, cleaned ? `${base}${cleaned}` : '');
-  };
+  // Parsing/building is delegated to the shared social-format helper.
+  const xHandle = extractXUsername(values.x_account);
+  const linkedinSlug = extractLinkedInSlug(values.linkedin_account);
+  const githubHandle = extractGithubUsername(values.github_account);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -269,7 +264,7 @@ export function NewProjectForm({ userId, currentUserName, currentUserImage }: Pr
                   id="np-x"
                   type="text"
                   value={xHandle}
-                  onChange={(e) => setUrlField('x_account', 'https://x.com/', e.target.value)}
+                  onChange={(e) => update('x_account', normalizeXUrl(e.target.value))}
                   placeholder="yourcompany"
                 />
               </div>
@@ -285,7 +280,7 @@ export function NewProjectForm({ userId, currentUserName, currentUserImage }: Pr
                   type="text"
                   value={linkedinSlug}
                   onChange={(e) =>
-                    setUrlField('linkedin_account', 'https://linkedin.com/company/', e.target.value)
+                    update('linkedin_account', normalizeLinkedInUrl(e.target.value, 'company'))
                   }
                   placeholder="yourcompany"
                 />
@@ -303,7 +298,7 @@ export function NewProjectForm({ userId, currentUserName, currentUserImage }: Pr
                 id="np-gh"
                 type="text"
                 value={githubHandle}
-                onChange={(e) => setUrlField('github_account', 'https://github.com/', e.target.value)}
+                onChange={(e) => update('github_account', normalizeGithubUrl(e.target.value))}
                 placeholder="yourorg"
               />
             </div>

--- a/components/hackathons/registration-form/RegisterFormStep1.tsx
+++ b/components/hackathons/registration-form/RegisterFormStep1.tsx
@@ -21,6 +21,7 @@ import { User } from "next-auth";
 import { countries } from "@/constants/countries";
 import { hsEmploymentRoles } from "@/constants/hs_employment_role";
 import { EventsLang, t } from "@/lib/events/i18n";
+import { formatTelegramDisplay } from "@/lib/profile/socialAccountFormat";
 
 const hackathonParticipationOptions = [
   { value: "yes", label: "Yes" },
@@ -130,6 +131,10 @@ export default function RegisterFormStep1({ user, lang = "en" }: Step1Props) {
                     placeholder={t(lang, "reg.step1.telegram.placeholder")}
                     className="bg-transparent placeholder-zinc-600"
                     {...field}
+                    onBlur={(e) => {
+                      field.onChange(formatTelegramDisplay(e.target.value));
+                      field.onBlur();
+                    }}
                   />
                 </FormControl>
                 <FormMessage className="text-zinc-600" />

--- a/components/hackathons/registration-form/RegistrationForm.tsx
+++ b/components/hackathons/registration-form/RegistrationForm.tsx
@@ -38,6 +38,7 @@ import {
   GITHUB_ACCOUNT_PATTERN,
   TELEGRAM_ACCOUNT_PATTERN,
 } from "@/lib/profile/socialAccountValidation";
+import { normalizeTelegram } from "@/lib/profile/socialAccountFormat";
 
 const optionalSocial = (pattern: RegExp, message: string) =>
   z
@@ -277,7 +278,7 @@ export function RegisterForm({
         name: step1.name ?? existing.name,
         email: step1.email ?? existing.email,
         country: (step1.city ?? "").trim() || existing.country,
-        telegram_account: (step1.telegram_account ?? "").trim() || existing.telegram_account,
+        telegram_account: normalizeTelegram(step1.telegram_account) || existing.telegram_account,
         user_type: {
           ...userType,
           is_student: Boolean(step1.is_student),
@@ -512,6 +513,7 @@ export function RegisterForm({
 
       const finalData = {
         ...data,
+        telegram_account: normalizeTelegram(data.telegram_account),
         hackathon_id: hackathon_id,
         ...buildReferralAttributionPayload(referrer),
         interests: data.interests ?? [],

--- a/components/login/BasicProfileSetup.tsx
+++ b/components/login/BasicProfileSetup.tsx
@@ -37,6 +37,10 @@ import {
   TELEGRAM_ACCOUNT_PATTERN,
   X_ACCOUNT_PATTERN,
 } from '@/lib/profile/socialAccountValidation';
+import {
+  formatTelegramDisplay,
+  normalizeLinkedInUrl,
+} from '@/lib/profile/socialAccountFormat';
 
 // Form schema. Social fields are optional; only name + country + at least
 // one role are required to complete the basic setup. When a social field is
@@ -354,6 +358,10 @@ export function BasicProfileSetup({ userId, onCompleteProfile }: BasicProfileSet
                       <Input
                         placeholder="https://www.linkedin.com/in/username"
                         {...field}
+                        onBlur={(e) => {
+                          field.onChange(normalizeLinkedInUrl(e.target.value, "in"));
+                          field.onBlur();
+                        }}
                         className="bg-zinc-50 dark:bg-zinc-950 text-sm sm:text-base"
                       />
                     </FormControl>
@@ -455,8 +463,12 @@ export function BasicProfileSetup({ userId, onCompleteProfile }: BasicProfileSet
                     <FormLabel className="text-sm sm:text-base">Telegram</FormLabel>
                     <FormControl>
                       <Input
-                        placeholder="Enter your Telegram username (without @)"
+                        placeholder="@username"
                         {...field}
+                        onBlur={(e) => {
+                          field.onChange(formatTelegramDisplay(e.target.value));
+                          field.onBlur();
+                        }}
                         className="bg-zinc-50 dark:bg-zinc-950 text-sm sm:text-base"
                       />
                     </FormControl>

--- a/components/profile/shell/PersonalCard.tsx
+++ b/components/profile/shell/PersonalCard.tsx
@@ -14,6 +14,10 @@ import {
   extractXUsername,
   extractLinkedInSlug,
 } from "./adapter";
+import {
+  normalizeTelegram,
+  normalizeLinkedInUrl,
+} from "@/lib/profile/socialAccountFormat";
 import type { ProfileLink, ProfileRole, ProfileWallet } from "./types";
 import { hsEmploymentRoles } from "@/constants/hs_employment_role";
 
@@ -249,7 +253,7 @@ export const PersonalCard = React.forwardRef<HTMLDivElement, Props>(function Per
                 <input
                   id="pr-github"
                   value={githubDisplay}
-                  onChange={(e) => onGithubChange(e.target.value.trim())}
+                  onChange={(e) => onGithubChange(extractGithubUsername(e.target.value))}
                   placeholder="username"
                   disabled={githubConnected}
                 />
@@ -320,8 +324,9 @@ export const PersonalCard = React.forwardRef<HTMLDivElement, Props>(function Per
               <span className="pr-pre">@</span>
               <input
                 id="pr-telegram"
-                value={telegram}
+                value={telegram.replace(/^@+/, "")}
                 onChange={(e) => onTelegramChange(e.target.value)}
+                onBlur={(e) => onTelegramChange(normalizeTelegram(e.target.value))}
                 placeholder="username"
               />
             </div>
@@ -336,10 +341,7 @@ export const PersonalCard = React.forwardRef<HTMLDivElement, Props>(function Per
               <input
                 id="pr-linkedin"
                 value={linkedinDisplay}
-                onChange={(e) => {
-                  const slug = e.target.value.trim().replace(/^\/+|\/+$/g, "");
-                  onLinkedinChange(slug ? `https://linkedin.com/in/${slug}` : "");
-                }}
+                onChange={(e) => onLinkedinChange(normalizeLinkedInUrl(e.target.value, "in"))}
                 placeholder="username"
               />
             </div>

--- a/components/profile/shell/adapter.ts
+++ b/components/profile/shell/adapter.ts
@@ -1,4 +1,15 @@
+import {
+  ensureUrl,
+  extractGithubUsername,
+  extractXUsername,
+  extractLinkedInSlug,
+} from "@/lib/profile/socialAccountFormat";
 import type { ProfileLink, ProfileRole, ProfileWallet } from "./types";
+
+// Re-exported from the shared social-format helper so existing
+// `from "./adapter"` imports keep working while the parsing logic lives in
+// one place (`lib/profile/socialAccountFormat.ts`).
+export { ensureUrl, extractGithubUsername, extractXUsername, extractLinkedInSlug };
 
 interface RawProfileValues {
   name?: string;
@@ -19,37 +30,6 @@ interface RawProfileValues {
   wallet?: string[];
   additional_social_accounts?: string[];
   skills?: string[];
-}
-
-const URL_PROTOCOL_RE = /^https?:\/\//i;
-
-export function ensureUrl(value: string): string {
-  if (!value) return value;
-  return URL_PROTOCOL_RE.test(value) ? value : `https://${value}`;
-}
-
-export function extractGithubUsername(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) return "";
-  const match = trimmed.match(/github\.com\/([^/?#\s]+)/i);
-  if (match) return match[1];
-  return trimmed.replace(/^@/, "");
-}
-
-export function extractXUsername(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) return "";
-  const match = trimmed.match(/(?:x|twitter)\.com\/([^/?#\s]+)/i);
-  if (match) return match[1];
-  return trimmed.replace(/^@/, "");
-}
-
-export function extractLinkedInSlug(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) return "";
-  const match = trimmed.match(/linkedin\.com\/(?:in|pub)\/([^/?#\s]+)/i);
-  if (match) return match[1];
-  return trimmed;
 }
 
 export function rolesFromValues(v: RawProfileValues): ProfileRole[] {

--- a/lib/profile/socialAccountFormat.ts
+++ b/lib/profile/socialAccountFormat.ts
@@ -1,0 +1,123 @@
+/**
+ * Social-account input formatting helpers.
+ *
+ * The `*_ACCOUNT_PATTERN`s in `./socialAccountValidation` only *validate* —
+ * they accept or reject. These helpers *normalize* (auto-complete) loose user
+ * input into the canonical stored form, so a handle like `username` or a pasted
+ * `https://t.me/username` collapse to the same value instead of being rejected.
+ *
+ * Canonical stored forms:
+ *   - Telegram → bare handle (no `@`); the `@` is presentation-only.
+ *   - X        → `https://x.com/<handle>`
+ *   - LinkedIn → `https://www.linkedin.com/<kind>/<slug>`
+ *   - GitHub   → `https://github.com/<handle>` (URL form, used by project socials)
+ *
+ * Every output satisfies the matching `*_ACCOUNT_PATTERN`, so validation still
+ * passes after normalization. Empty / whitespace input always returns "".
+ *
+ * This module is the single source of truth: `components/profile/shell/adapter.ts`
+ * and the project-creation form delegate to it instead of re-implementing
+ * handle/URL parsing.
+ */
+
+import { normalizeUrl } from "@/lib/url-validation";
+
+const safe = (input: string | null | undefined): string => (input ?? "").trim();
+
+// ---------------------------------------------------------------------------
+// Telegram — canonical: bare handle (no leading @)
+// ---------------------------------------------------------------------------
+
+/** Strips a leading `@`, any `t.me/` / `telegram.me/` wrapper, and trailing slashes. */
+export function normalizeTelegram(input: string | null | undefined): string {
+  const trimmed = safe(input);
+  if (!trimmed) return "";
+  const fromUrl = trimmed.match(/(?:t|telegram)\.me\/([^/?#\s]+)/i);
+  const handle = (fromUrl ? fromUrl[1] : trimmed).replace(/^@+/, "");
+  return handle.replace(/\/+$/, "");
+}
+
+/** Presentation form for a Telegram handle: `@handle` (or "" when empty). */
+export function formatTelegramDisplay(input: string | null | undefined): string {
+  const handle = normalizeTelegram(input);
+  return handle ? `@${handle}` : "";
+}
+
+// ---------------------------------------------------------------------------
+// X / Twitter — canonical: https://x.com/<handle>
+// ---------------------------------------------------------------------------
+
+/** Returns the bare X/Twitter handle from a URL, `@handle`, or bare handle. */
+export function extractXUsername(input: string | null | undefined): string {
+  const trimmed = safe(input);
+  if (!trimmed) return "";
+  const match = trimmed.match(/(?:twitter|x)\.com\/([^/?#\s]+)/i);
+  return (match ? match[1] : trimmed).replace(/^@+/, "").replace(/\/+$/, "");
+}
+
+/** Builds the canonical X profile URL, normalizing twitter.com → x.com. */
+export function normalizeXUrl(input: string | null | undefined): string {
+  const handle = extractXUsername(input);
+  return handle ? `https://x.com/${handle}` : "";
+}
+
+// ---------------------------------------------------------------------------
+// LinkedIn — canonical: https://www.linkedin.com/<kind>/<slug>
+// ---------------------------------------------------------------------------
+
+export type LinkedInKind = "in" | "company" | "pub" | "school";
+
+/** Returns the slug after `/in/`, `/company/`, etc., or the cleaned input. */
+export function extractLinkedInSlug(input: string | null | undefined): string {
+  const trimmed = safe(input);
+  if (!trimmed) return "";
+  const match = trimmed.match(/linkedin\.com\/(?:in|pub|company|school)\/([^/?#\s]+)/i);
+  return (match ? match[1] : trimmed).replace(/^\/+|\/+$/g, "");
+}
+
+/**
+ * Builds the canonical LinkedIn URL. When the input already names a path kind
+ * (`/company/`, `/school/`, …) that kind is preserved; bare slugs fall back to
+ * `defaultKind` (personal profiles use "in", company pages use "company").
+ */
+export function normalizeLinkedInUrl(
+  input: string | null | undefined,
+  defaultKind: LinkedInKind = "in",
+): string {
+  const trimmed = safe(input);
+  if (!trimmed) return "";
+  const match = trimmed.match(/linkedin\.com\/(in|pub|company|school)\/([^/?#\s]+)/i);
+  if (match) {
+    return `https://www.linkedin.com/${match[1].toLowerCase()}/${match[2].replace(/\/+$/, "")}`;
+  }
+  const slug = trimmed.replace(/^\/+|\/+$/g, "");
+  return slug ? `https://www.linkedin.com/${defaultKind}/${slug}` : "";
+}
+
+// ---------------------------------------------------------------------------
+// GitHub
+// ---------------------------------------------------------------------------
+
+/** Returns the bare GitHub username/org from a URL, `@handle`, or bare handle. */
+export function extractGithubUsername(input: string | null | undefined): string {
+  const trimmed = safe(input);
+  if (!trimmed) return "";
+  const match = trimmed.match(/github\.com\/([^/?#\s]+)/i);
+  return (match ? match[1] : trimmed).replace(/^@+/, "").replace(/\/+$/, "");
+}
+
+/** Builds the canonical GitHub profile URL. */
+export function normalizeGithubUrl(input: string | null | undefined): string {
+  const handle = extractGithubUsername(input);
+  return handle ? `https://github.com/${handle}` : "";
+}
+
+// ---------------------------------------------------------------------------
+// Generic site URL
+// ---------------------------------------------------------------------------
+
+/** Prepends `https://` when a scheme is missing; passes empty values through. */
+export function ensureUrl(input: string | null | undefined): string {
+  const value = input ?? "";
+  return value ? normalizeUrl(value) : value;
+}

--- a/lib/schemas/extended-profile.ts
+++ b/lib/schemas/extended-profile.ts
@@ -3,6 +3,10 @@ import {
   LINKEDIN_ACCOUNT_PATTERN,
   TELEGRAM_ACCOUNT_PATTERN,
 } from "@/lib/profile/socialAccountValidation";
+import {
+  normalizeLinkedInUrl,
+  normalizeTelegram,
+} from "@/lib/profile/socialAccountFormat";
 
 /**
  * Shared Zod schemas for the extended user profile.
@@ -12,11 +16,26 @@ import {
  * route and the frontend forms.
  */
 
-const nullableProfileAccount = (pattern: RegExp, message: string) =>
+/**
+ * Normalizes a social account on the way in (auto-completing loose handles
+ * into the canonical stored form) and then validates the result against its
+ * platform pattern. Normalizing *before* validating means fixable input (e.g.
+ * a bare `username`) is accepted instead of rejected, and every persisted value
+ * is canonical regardless of which client sent it (manual save, auto-save, API).
+ */
+const normalizedProfileAccount = (
+  normalize: (value: string) => string,
+  pattern: RegExp,
+  message: string,
+) =>
   z
-    .union([z.string().trim().regex(pattern, message), z.literal("")])
+    .string()
     .nullable()
-    .optional();
+    .optional()
+    .transform((value) => (typeof value === "string" ? normalize(value) : value))
+    .refine((value) => value == null || value === "" || pattern.test(value), {
+      message,
+    });
 
 /** User type data stored as JSON in the database (nested form). */
 export const UserTypeSchema = z.object({
@@ -60,7 +79,8 @@ export const UpdateExtendedProfileSchema = z
       .optional(),
     image: z.string().nullable().optional(),
     country: z.string().nullable().optional(),
-    linkedin_account: nullableProfileAccount(
+    linkedin_account: normalizedProfileAccount(
+      (value) => normalizeLinkedInUrl(value, "in"),
       LINKEDIN_ACCOUNT_PATTERN,
       "Invalid LinkedIn URL.",
     ),
@@ -70,7 +90,8 @@ export const UpdateExtendedProfileSchema = z
     notifications: z.boolean().nullable().optional(),
     consent_sharing: z.boolean().nullable().optional(),
     profile_privacy: z.string().nullable().optional(),
-    telegram_account: nullableProfileAccount(
+    telegram_account: normalizedProfileAccount(
+      normalizeTelegram,
       TELEGRAM_ACCOUNT_PATTERN,
       "Invalid Telegram username.",
     ),

--- a/tests/unit/profile/socialAccountFormat.test.ts
+++ b/tests/unit/profile/socialAccountFormat.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  normalizeTelegram,
+  formatTelegramDisplay,
+  extractXUsername,
+  normalizeXUrl,
+  extractLinkedInSlug,
+  normalizeLinkedInUrl,
+  extractGithubUsername,
+  normalizeGithubUrl,
+  ensureUrl,
+} from '@/lib/profile/socialAccountFormat'
+import {
+  TELEGRAM_ACCOUNT_PATTERN,
+  X_ACCOUNT_PATTERN,
+  LINKEDIN_ACCOUNT_PATTERN,
+  GITHUB_ACCOUNT_PATTERN,
+} from '@/lib/profile/socialAccountValidation'
+
+describe('normalizeTelegram', () => {
+  it('strips a leading @', () => {
+    expect(normalizeTelegram('@username')).toBe('username')
+  })
+
+  it('passes a bare handle through unchanged', () => {
+    expect(normalizeTelegram('username')).toBe('username')
+  })
+
+  it('unwraps t.me and https://t.me/ URLs', () => {
+    expect(normalizeTelegram('t.me/username')).toBe('username')
+    expect(normalizeTelegram('https://t.me/username')).toBe('username')
+    expect(normalizeTelegram('https://telegram.me/username/')).toBe('username')
+  })
+
+  it('collapses a doubled @@ (the profile-editor display bug)', () => {
+    expect(normalizeTelegram('@@username')).toBe('username')
+  })
+
+  it('trims whitespace and returns "" for empty input', () => {
+    expect(normalizeTelegram('  @username  ')).toBe('username')
+    expect(normalizeTelegram('')).toBe('')
+    expect(normalizeTelegram('   ')).toBe('')
+    expect(normalizeTelegram(null)).toBe('')
+    expect(normalizeTelegram(undefined)).toBe('')
+  })
+
+  it('produces a value that satisfies TELEGRAM_ACCOUNT_PATTERN', () => {
+    expect(TELEGRAM_ACCOUNT_PATTERN.test(normalizeTelegram('@andyvargtz'))).toBe(true)
+    expect(TELEGRAM_ACCOUNT_PATTERN.test(normalizeTelegram('https://t.me/andyvargtz'))).toBe(true)
+  })
+})
+
+describe('formatTelegramDisplay', () => {
+  it('prefixes a single @ and never doubles it', () => {
+    expect(formatTelegramDisplay('username')).toBe('@username')
+    expect(formatTelegramDisplay('@username')).toBe('@username')
+    expect(formatTelegramDisplay('@@username')).toBe('@username')
+  })
+
+  it('returns "" for empty input', () => {
+    expect(formatTelegramDisplay('')).toBe('')
+    expect(formatTelegramDisplay(null)).toBe('')
+  })
+})
+
+describe('extractXUsername', () => {
+  it('reads the handle from x.com / twitter.com URLs and @handles', () => {
+    expect(extractXUsername('https://x.com/jack')).toBe('jack')
+    expect(extractXUsername('https://www.twitter.com/jack/')).toBe('jack')
+    expect(extractXUsername('@jack')).toBe('jack')
+    expect(extractXUsername('jack')).toBe('jack')
+  })
+})
+
+describe('normalizeXUrl', () => {
+  it('builds a canonical x.com URL from any form, twitter.com → x.com', () => {
+    expect(normalizeXUrl('jack')).toBe('https://x.com/jack')
+    expect(normalizeXUrl('@jack')).toBe('https://x.com/jack')
+    expect(normalizeXUrl('https://twitter.com/jack')).toBe('https://x.com/jack')
+    expect(normalizeXUrl('')).toBe('')
+  })
+
+  it('produces a value that satisfies X_ACCOUNT_PATTERN', () => {
+    expect(X_ACCOUNT_PATTERN.test(normalizeXUrl('jack'))).toBe(true)
+    expect(X_ACCOUNT_PATTERN.test(normalizeXUrl('https://twitter.com/jack'))).toBe(true)
+  })
+})
+
+describe('extractLinkedInSlug', () => {
+  it('reads the slug from in/pub/company/school paths', () => {
+    expect(extractLinkedInSlug('https://www.linkedin.com/in/jane-doe')).toBe('jane-doe')
+    expect(extractLinkedInSlug('https://linkedin.com/company/ava-labs/')).toBe('ava-labs')
+    expect(extractLinkedInSlug('jane-doe')).toBe('jane-doe')
+  })
+})
+
+describe('normalizeLinkedInUrl', () => {
+  it('builds a canonical /in/ URL from a bare slug by default', () => {
+    expect(normalizeLinkedInUrl('jane-doe')).toBe('https://www.linkedin.com/in/jane-doe')
+  })
+
+  it('uses the provided default kind for bare slugs', () => {
+    expect(normalizeLinkedInUrl('ava-labs', 'company')).toBe(
+      'https://www.linkedin.com/company/ava-labs',
+    )
+  })
+
+  it('preserves an explicit kind present in the input', () => {
+    expect(normalizeLinkedInUrl('https://linkedin.com/company/ava-labs', 'in')).toBe(
+      'https://www.linkedin.com/company/ava-labs',
+    )
+    expect(normalizeLinkedInUrl('https://www.linkedin.com/in/jane', 'company')).toBe(
+      'https://www.linkedin.com/in/jane',
+    )
+  })
+
+  it('returns "" for empty input', () => {
+    expect(normalizeLinkedInUrl('')).toBe('')
+  })
+
+  it('produces a value that satisfies LINKEDIN_ACCOUNT_PATTERN', () => {
+    expect(LINKEDIN_ACCOUNT_PATTERN.test(normalizeLinkedInUrl('jane-doe'))).toBe(true)
+    expect(LINKEDIN_ACCOUNT_PATTERN.test(normalizeLinkedInUrl('ava-labs', 'company'))).toBe(true)
+  })
+})
+
+describe('extractGithubUsername / normalizeGithubUrl', () => {
+  it('reads the handle from URLs, @handles, and bare handles', () => {
+    expect(extractGithubUsername('https://github.com/ava-labs')).toBe('ava-labs')
+    expect(extractGithubUsername('@ava-labs')).toBe('ava-labs')
+    expect(extractGithubUsername('ava-labs')).toBe('ava-labs')
+  })
+
+  it('builds a canonical github.com URL', () => {
+    expect(normalizeGithubUrl('ava-labs')).toBe('https://github.com/ava-labs')
+    expect(normalizeGithubUrl('https://github.com/ava-labs/')).toBe('https://github.com/ava-labs')
+    expect(normalizeGithubUrl('')).toBe('')
+  })
+
+  it('produces a value that satisfies GITHUB_ACCOUNT_PATTERN', () => {
+    expect(GITHUB_ACCOUNT_PATTERN.test(normalizeGithubUrl('ava-labs'))).toBe(true)
+    expect(GITHUB_ACCOUNT_PATTERN.test(extractGithubUsername('ava-labs'))).toBe(true)
+  })
+})
+
+describe('ensureUrl', () => {
+  it('prepends https:// when a scheme is missing', () => {
+    expect(ensureUrl('example.com')).toBe('https://example.com')
+    expect(ensureUrl('https://example.com')).toBe('https://example.com')
+  })
+
+  it('passes empty values through', () => {
+    expect(ensureUrl('')).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #4189

Adds an input-formatting helper so loose social-account input is auto-completed into the canonical stored form instead of being rejected — e.g. typing `username` becomes `@username`, and pasted URLs like `https://t.me/username` or `twitter.com/handle` collapse to the same canonical value.

- New `lib/profile/socialAccountFormat.ts`: single source of truth for parsing/normalizing Telegram, X, LinkedIn, and GitHub input (replaces duplicated logic in `components/profile/shell/adapter.ts` and the project-creation form).
- Wired into all free-form social inputs: profile editor, basic profile setup, hackathon registration, and project creation. Inputs normalize on blur (not per keystroke) so typing/pasting URLs isn't mangled mid-edit.
- `UpdateExtendedProfileSchema` now normalizes **before** validating, so fixable input is accepted and every persisted value is canonical regardless of which client sent it. Every normalized output still satisfies the existing `*_ACCOUNT_PATTERN` validators — nothing new gets past validation.

## Test plan

- 22 unit tests in `tests/unit/profile/socialAccountFormat.test.ts`, including round-trips asserting normalized output passes the validation patterns
- `tsc --noEmit` clean
