### PR TITLE
fix(hackathons): issue 4275 follow-ups for submission and team UX

### DIFF
--- a/components/hackathons/project-submission/components/GeneralSecure.tsx
+++ b/components/hackathons/project-submission/components/GeneralSecure.tsx
@@ -471,12 +471,10 @@ export default function GeneralSecureComponent({
           {submissionStatus === "closed" && (
             <div className="rounded-md border border-zinc-500/40 bg-zinc-500/10 p-4">
               <h3 className="font-semibold mb-1">
-                {lang === "es" ? "Las entregas están cerradas" : "Submissions are closed"}
+                {t(lang, "submission.status.closedTitle")}
               </h3>
               <p className="text-sm text-zinc-300">
-                {lang === "es"
-                  ? "Tu última versión guardada es la final. Ya no puedes editarla."
-                  : "Your last saved version is final. Edits are no longer accepted."}
+                {t(lang, "submission.status.closedDesc")}
               </p>
             </div>
           )}

--- a/components/hackathons/project-submission/components/SubmissionStep2.tsx
+++ b/components/hackathons/project-submission/components/SubmissionStep2.tsx
@@ -93,6 +93,7 @@ export default function SubmitStep2({ lang = "en", availableTechStack }: SubmitS
                   onChange={field.onChange}
                   placeholder={t(lang, "submission.step2.techStackTags.placeholder")}
                   searchPlaceholder={t(lang, "submission.step2.techStackTags.placeholder")}
+                  allowCreate
                 />
               </FormControl>
               <p className="text-zinc-400 text-[14px] leading-[100%] tracking-[0%] font-aeonik">

--- a/components/hackathons/registration-form/TeamFormation.tsx
+++ b/components/hackathons/registration-form/TeamFormation.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Plus, Send, Trash, Check, Copy } from "lucide-react";
+import { Check, Copy } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { EmailListInput } from "@/components/common/EmailListInput";
 import { createReferralLink } from "@/lib/referrals/client";
 import { type EventsLang, t } from "@/lib/events/i18n";
 import {
@@ -38,26 +39,22 @@ export function TeamFormation({
   const [linkError, setLinkError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
+  // Drafts saved before the tag input existed may still carry empty slots.
+  const emails = useMemo(
+    () => teammates.filter((email) => email.trim().length > 0),
+    [teammates],
+  );
+
   useEffect(() => {
     const cap = Math.max(0, (range.max ?? selectedSize) - 1);
-    const slots = Math.min(cap, Math.max(0, selectedSize - 1));
-    if (teammates.length === slots) return;
-    if (teammates.length > slots) {
-      let end = teammates.length;
-      while (end > slots && teammates[end - 1].trim() === "") end--;
-      if (end !== teammates.length) {
-        onTeammatesChange(teammates.slice(0, end));
-      }
-      const keptNonEmpty = Math.min(cap, end);
-      if (keptNonEmpty + 1 > selectedSize) {
-        onSizeChange(keptNonEmpty + 1);
-      }
-    } else {
-      const next = [...teammates];
-      while (next.length < slots) next.push("");
-      onTeammatesChange(next);
+    if (emails.length > cap) {
+      onTeammatesChange(emails.slice(0, cap));
+      return;
     }
-  }, [selectedSize, teammates, onTeammatesChange, onSizeChange, range.max]);
+    if (emails.length + 1 > selectedSize) {
+      onSizeChange(Math.min(range.max ?? emails.length + 1, emails.length + 1));
+    }
+  }, [emails, selectedSize, onTeammatesChange, onSizeChange, range.max]);
 
   useEffect(() => {
     if (selectedSize <= 1 || referralLink) return;
@@ -91,41 +88,21 @@ export function TeamFormation({
     }
   };
 
-  const updateTeammate = (index: number, value: string) => {
-    const next = [...teammates];
-    next[index] = value;
-    onTeammatesChange(next);
-  };
-
   if (!hasTeamPicker(range)) {
     return null;
   }
 
   const max = range.max as number;
   const sizes = Array.from({ length: max }, (_, i) => i + 1);
-  const teammateLabel = (i: number) =>
-    sizes.length === 2
-      ? lang === "es"
-        ? "Email del compañero"
-        : "Teammate email"
-      : lang === "es"
-      ? `Email del compañero ${i + 1}`
-      : `Teammate ${i + 1} email`;
 
   return (
     <section className="space-y-4 rounded-md border border-input bg-card/50 p-4">
       <div>
-        <h3 className="text-lg font-semibold">
-          {lang === "es" ? "Equipo" : "Team"}
-        </h3>
+        <h3 className="text-lg font-semibold">{t(lang, "reg.team.title")}</h3>
         <p className="text-sm text-muted-foreground">
           {range.min > 1
-            ? lang === "es"
-              ? `Equipos de ${range.min} a ${max} personas.`
-              : `Teams of ${range.min}–${max}.`
-            : lang === "es"
-            ? `Hasta ${max} personas por equipo. Tu compañero se registra al confirmar el correo.`
-            : `Up to ${max} per team. Your teammate confirms by signing in via Builder Hub.`}
+            ? t(lang, "reg.team.sizeRange", { min: range.min, max })
+            : t(lang, "reg.team.sizeUpTo", { max })}
         </p>
       </div>
 
@@ -148,13 +125,9 @@ export function TeamFormation({
               } ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
             >
               {s === 1
-                ? lang === "es"
-                  ? "Solo"
-                  : "Solo"
+                ? t(lang, "reg.team.solo")
                 : s === 2
-                ? lang === "es"
-                  ? "Dúo"
-                  : "Duo"
+                ? t(lang, "reg.team.duo")
                 : s}
             </button>
           );
@@ -163,33 +136,17 @@ export function TeamFormation({
 
       {selectedSize > 1 && (
         <div className="space-y-3 pt-2">
-          {teammates.map((email, i) => (
-            <div key={i} className="space-y-1">
-              <label className="text-sm font-medium" htmlFor={`teammate-${i}`}>
-                {teammateLabel(i)}
-              </label>
-              <Input
-                id={`teammate-${i}`}
-                type="email"
-                inputMode="email"
-                autoComplete="off"
-                placeholder="teammate@example.com"
-                value={email}
-                onChange={(e) => updateTeammate(i, e.target.value)}
-              />
-            </div>
-          ))}
+          <EmailListInput
+            value={emails}
+            onChange={onTeammatesChange}
+            label={t(lang, "reg.team.emailsLabel")}
+            placeholder={t(lang, "reg.team.emailsPlaceholder")}
+          />
 
           <div className="rounded-md border border-dashed border-input p-3 text-sm">
-            <p className="font-medium mb-2">
-              {lang === "es"
-                ? "Tu compañero aún no tiene cuenta?"
-                : "Teammate doesn't have an account yet?"}
-            </p>
+            <p className="font-medium mb-2">{t(lang, "reg.team.inviteTitle")}</p>
             <p className="text-muted-foreground mb-3">
-              {lang === "es"
-                ? "Comparte este enlace para que se registren en el evento. Cuando inicien sesión, podrás verlos como confirmados."
-                : "Share this link so they can sign up for this event. They'll show as confirmed once they sign in."}
+              {t(lang, "reg.team.inviteDesc")}
             </p>
             {referralLink ? (
               <div className="flex items-center gap-2">
@@ -202,13 +159,7 @@ export function TeamFormation({
                 <Button type="button" variant="outline" size="sm" onClick={handleCopy}>
                   {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
                   <span className="ml-1">
-                    {copied
-                      ? lang === "es"
-                        ? "Copiado"
-                        : "Copied"
-                      : lang === "es"
-                      ? "Copiar"
-                      : "Copy"}
+                    {copied ? t(lang, "reg.team.copied") : t(lang, "reg.team.copy")}
                   </span>
                 </Button>
               </div>
@@ -216,7 +167,7 @@ export function TeamFormation({
               <p className="text-sm text-red-500">{linkError}</p>
             ) : (
               <p className="text-sm text-muted-foreground">
-                {lang === "es" ? "Generando enlace…" : "Generating link…"}
+                {t(lang, "reg.team.generatingLink")}
               </p>
             )}
           </div>

--- a/components/ui/multi-select.tsx
+++ b/components/ui/multi-select.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
-import { X, ChevronDown } from 'lucide-react';
+import { X, ChevronDown, Plus } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import {
   Command,
@@ -24,6 +24,12 @@ interface MultiSelectProps {
   onChange: (values: string[]) => void;
   placeholder?: string;
   searchPlaceholder?: string;
+  /**
+   * When true, lets the user add a value that isn't in `options` by typing it
+   * and confirming (Enter or the "Create" row). Used for free-form tag inputs
+   * like tech-stack tags. Space is left typable so multi-word tags work.
+   */
+  allowCreate?: boolean;
 }
 
 export function MultiSelect({
@@ -31,7 +37,8 @@ export function MultiSelect({
   selected = [],
   onChange,
   placeholder = 'Select options',
-  searchPlaceholder = 'Search framework'
+  searchPlaceholder = 'Search framework',
+  allowCreate = false,
 }: MultiSelectProps) {
   const [open, setOpen] = React.useState(false);
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -116,6 +123,27 @@ export function MultiSelect({
     );
   }, [selected, onChange]);
 
+  const trimmedQuery = searchQuery.trim();
+  const canCreate =
+    allowCreate &&
+    trimmedQuery.length > 0 &&
+    !options.some(
+      (o) =>
+        o.label.toLowerCase() === trimmedQuery.toLowerCase() ||
+        o.value.toLowerCase() === trimmedQuery.toLowerCase()
+    ) &&
+    !(selected || []).some((s) => s.toLowerCase() === trimmedQuery.toLowerCase());
+
+  const handleCreate = React.useCallback((value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    const already = (selected || []).some(
+      (s) => s.toLowerCase() === trimmed.toLowerCase()
+    );
+    if (!already) onChange([...(selected || []), trimmed]);
+    setSearchQuery('');
+  }, [selected, onChange]);
+
   const handleKeyDown = React.useCallback((e: React.KeyboardEvent) => {
     if (!open && e.key.length === 1 && !e.ctrlKey && !e.altKey && !e.metaKey) {
       e.preventDefault();
@@ -144,10 +172,22 @@ export function MultiSelect({
         setFocusedIndex((prev) => (prev > 0 ? prev - 1 : prev));
         break;
       case 'Enter':
-      case ' ':
         e.preventDefault();
         if (focusedIndex >= 0) {
           handleSelect(filteredOptions[focusedIndex].value);
+        } else if (canCreate) {
+          handleCreate(trimmedQuery);
+        }
+        break;
+      case ' ':
+        // When creating free-form tags, let the space character be typed into
+        // the search input so multi-word tags work. Otherwise keep the legacy
+        // behaviour where space toggles the focused option.
+        if (!allowCreate) {
+          e.preventDefault();
+          if (focusedIndex >= 0) {
+            handleSelect(filteredOptions[focusedIndex].value);
+          }
         }
         break;
       case 'Escape':
@@ -162,7 +202,7 @@ export function MultiSelect({
         setSearchQuery('');
         break;
     }
-  }, [open, focusedIndex, filteredOptions, handleSelect]);
+  }, [open, focusedIndex, filteredOptions, handleSelect, allowCreate, canCreate, trimmedQuery, handleCreate]);
 
   React.useEffect(() => {
     if (focusedIndex >= 0 && listRef.current) {
@@ -254,8 +294,22 @@ export function MultiSelect({
               onValueChange={setSearchQuery}
               onKeyDown={handleKeyDown}
             />
-            <CommandEmpty>No results found.</CommandEmpty>
+            <CommandEmpty>
+              {canCreate ? null : 'No results found.'}
+            </CommandEmpty>
             <CommandGroup className="max-h-[200px] overflow-auto p-1">
+              {canCreate && (
+                <CommandItem
+                  key={`__create__${trimmedQuery}`}
+                  value={trimmedQuery}
+                  onSelect={() => handleCreate(trimmedQuery)}
+                  className="cursor-pointer dark:focus:!bg-red-500 focus:text-foreground"
+                  role="option"
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  <span>Create &ldquo;{trimmedQuery}&rdquo;</span>
+                </CommandItem>
+              )}
               {filteredOptions.map((option, index) => {
                 const isSelected = (selected || []).some(
                   (s) => s.toLowerCase() === option.value.toLowerCase()

--- a/lib/events/i18n.ts
+++ b/lib/events/i18n.ts
@@ -419,6 +419,20 @@ const dict: Record<EventsLang, Dict> = {
     "reg.step3.prohibited.label": "I agree not to bring any of the following prohibited items. *",
     "reg.step3.prohibited.hint": "Review the list of restricted items before attending in-person events.",
 
+    // Team formation
+    "reg.team.title": "Team",
+    "reg.team.sizeRange": "Teams of {min}–{max}.",
+    "reg.team.sizeUpTo": "Up to {max} per team. Your teammate confirms by signing in via Builder Hub.",
+    "reg.team.solo": "Solo",
+    "reg.team.duo": "Duo",
+    "reg.team.emailsLabel": "Teammate emails",
+    "reg.team.emailsPlaceholder": "teammate@example.com",
+    "reg.team.inviteTitle": "Teammate doesn't have an account yet?",
+    "reg.team.inviteDesc": "Share this link so they can sign up for this event. They'll show as confirmed once they sign in.",
+    "reg.team.copy": "Copy",
+    "reg.team.copied": "Copied",
+    "reg.team.generatingLink": "Generating link…",
+
     // Grouped User-level consents (used in account creation and event registration)
     "consents.group.label": "Stay connected with Avalanche",
     "consents.notifications.label":
@@ -499,6 +513,8 @@ const dict: Record<EventsLang, Dict> = {
     "submission.status.complete": "Your project is submitted!",
     "submission.status.completeSub": "All required fields are complete. You can still edit before the deadline.",
     "submission.status.editCta": "Edit submission",
+    "submission.status.closedTitle": "Submissions are closed",
+    "submission.status.closedDesc": "Your last saved version is final. Edits are no longer accepted.",
 
     // Invitation email
     "invitation.email.subject": "You're invited to collaborate on \"{projectName}\"",
@@ -948,6 +964,20 @@ const dict: Record<EventsLang, Dict> = {
     "reg.step3.prohibited.label": "Acepto no traer ninguno de los artículos prohibidos. *",
     "reg.step3.prohibited.hint": "Revisa la lista de artículos restringidos antes de asistir a eventos presenciales.",
 
+    // Formación de equipo
+    "reg.team.title": "Equipo",
+    "reg.team.sizeRange": "Equipos de {min} a {max} personas.",
+    "reg.team.sizeUpTo": "Hasta {max} personas por equipo. Tu compañero se registra al confirmar el correo.",
+    "reg.team.solo": "Solo",
+    "reg.team.duo": "Dúo",
+    "reg.team.emailsLabel": "Correos de tus compañeros",
+    "reg.team.emailsPlaceholder": "compañero@ejemplo.com",
+    "reg.team.inviteTitle": "¿Tu compañero aún no tiene cuenta?",
+    "reg.team.inviteDesc": "Comparte este enlace para que se registren en el evento. Cuando inicien sesión, podrás verlos como confirmados.",
+    "reg.team.copy": "Copiar",
+    "reg.team.copied": "Copiado",
+    "reg.team.generatingLink": "Generando enlace…",
+
     // Consentimientos a nivel usuario (creación de cuenta y registro a eventos)
     "consents.group.label": "Mantente conectado con Avalanche",
     "consents.notifications.label":
@@ -1028,6 +1058,8 @@ const dict: Record<EventsLang, Dict> = {
     "submission.status.complete": "¡Tu proyecto está enviado!",
     "submission.status.completeSub": "Todos los campos obligatorios están completos. Aún puedes editar antes de la fecha límite.",
     "submission.status.editCta": "Editar envío",
+    "submission.status.closedTitle": "Las entregas están cerradas",
+    "submission.status.closedDesc": "Tu última versión guardada es la final. Ya no puedes editarla.",
 
     // Invitation email
     "invitation.email.subject": "Te invitaron a colaborar en \"{projectName}\"",

--- a/server/services/SendInvitationProjectMember.ts
+++ b/server/services/SendInvitationProjectMember.ts
@@ -10,13 +10,32 @@ interface HackathonContext {
 const DEFAULT_BANNER_URL =
   'https://qizat5l3bwvomkny.public.blob.vercel-storage.com/builders-hub/hackathon-images/main_banner_img-crBsoLT7R07pdstPKvRQkH65yAbpFX.png';
 
+// Minimal escaping for values interpolated into HTML attributes/text below —
+// hackathon title and banner come from the DB, not from the email recipient,
+// but they must not be able to break out of the markup.
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 // Only hosted images render reliably in email: data-URI banners are blocked
 // by most clients and can push the HTML past Gmail's ~102KB clipping limit,
-// so anything that isn't an absolute http(s) URL falls back to the generic
-// banner.
+// so anything that isn't a well-formed absolute http(s) URL falls back to the
+// generic banner.
 function resolveBannerUrl(banner?: string): string {
   const trimmed = (banner ?? '').trim();
-  return /^https?:\/\//i.test(trimmed) ? trimmed : DEFAULT_BANNER_URL;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return DEFAULT_BANNER_URL;
+    }
+  } catch {
+    return DEFAULT_BANNER_URL;
+  }
+  return escapeHtml(trimmed);
 }
 
 export async function sendInvitation(
@@ -49,7 +68,7 @@ export async function sendInvitation(
 
   const text = `${body} "${headline}" — ${inviteLink}`;
   const bannerHtml = useHackathonCopy
-    ? `<img src="${resolveBannerUrl(hackathon?.banner)}" alt="${hackathon!.title}" style="width: 100%; max-height: 160px; object-fit: cover; border-radius: 8px 8px 0 0; margin-bottom: 0;">`
+    ? `<img src="${resolveBannerUrl(hackathon?.banner)}" alt="${escapeHtml(hackathon!.title)}" style="width: 100%; max-height: 160px; object-fit: cover; border-radius: 8px 8px 0 0; margin-bottom: 0;">`
     : "";
   const html = `
     <div style="background-color: #18181B; color: white; font-family: Arial, sans-serif; max-width: 500px; margin: 0 auto; padding: 20px; border-radius: 8px; border: 1px solid #EF4444; text-align: center;">
@@ -58,9 +77,9 @@ export async function sendInvitation(
 
       <div style="background-color: #27272A; border: 1px solid #EF4444; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
         <p style="font-size: 16px; color: #F87171; margin-bottom: 10px;">
-          <strong>${inviterName}</strong> ${body.replace(`${inviterName} `, '')}
+          <strong>${escapeHtml(inviterName)}</strong> ${escapeHtml(body.replace(`${inviterName} `, ''))}
         </p>
-        <p style="font-size: 20px; font-weight: bold; color: #EF4444; margin: 8px 0;">"${headline}"</p>
+        <p style="font-size: 20px; font-weight: bold; color: #EF4444; margin: 8px 0;">"${escapeHtml(headline)}"</p>
         <a href="${inviteLink}" target="_blank" style="display: inline-block; margin-top: 20px; padding: 10px 20px; background-color: #EF4444; color: white; text-decoration: none; border-radius: 4px; font-weight: bold;">
           ${cta}
         </a>

--- a/server/services/SendInvitationProjectMember.ts
+++ b/server/services/SendInvitationProjectMember.ts
@@ -6,6 +6,19 @@ interface HackathonContext {
   banner?: string;
 }
 
+// Generic hosted hackathon banner (same fallback the event page uses).
+const DEFAULT_BANNER_URL =
+  'https://qizat5l3bwvomkny.public.blob.vercel-storage.com/builders-hub/hackathon-images/main_banner_img-crBsoLT7R07pdstPKvRQkH65yAbpFX.png';
+
+// Only hosted images render reliably in email: data-URI banners are blocked
+// by most clients and can push the HTML past Gmail's ~102KB clipping limit,
+// so anything that isn't an absolute http(s) URL falls back to the generic
+// banner.
+function resolveBannerUrl(banner?: string): string {
+  const trimmed = (banner ?? '').trim();
+  return /^https?:\/\//i.test(trimmed) ? trimmed : DEFAULT_BANNER_URL;
+}
+
 export async function sendInvitation(
   email: string,
   projectName: string,
@@ -35,8 +48,8 @@ export async function sendInvitation(
   const footer = t(lang, "invitation.email.footer");
 
   const text = `${body} "${headline}" — ${inviteLink}`;
-  const bannerHtml = hackathon?.banner
-    ? `<img src="${hackathon.banner}" alt="${hackathon.title}" style="width: 100%; max-height: 160px; object-fit: cover; border-radius: 8px 8px 0 0; margin-bottom: 0;">`
+  const bannerHtml = useHackathonCopy
+    ? `<img src="${resolveBannerUrl(hackathon?.banner)}" alt="${hackathon!.title}" style="width: 100%; max-height: 160px; object-fit: cover; border-radius: 8px 8px 0 0; margin-bottom: 0;">`
     : "";
   const html = `
     <div style="background-color: #18181B; color: white; font-family: Arial, sans-serif; max-width: 500px; margin: 0 auto; padding: 20px; border-radius: 8px; border: 1px solid #EF4444; text-align: center;">


### PR DESCRIPTION
Follow-up fixes from #4275 (everything except the staged-hackathon items, which went into #4243). The country lock is intentionally kept as requested.

## Changelog

- **Tech stack tags allow non-listed options** — `MultiSelect` gains an `allowCreate` prop (taken verbatim from the `feat/events-stages` branch so the two PRs merge cleanly): typing a value that isn't in the list shows a *Create "…"* row, and Enter adds it as a free-form tag. Enabled on the `tech_stack_tags` field in the submission form, mirroring how the skills picker allows custom entries. The Zod schemas already accept free strings, so no server change.
- **Translations via i18n** — the hardcoded es/en ternaries in `GeneralSecure` (closed-submissions banner) and `TeamFormation` (all copy) now go through the existing `t()` dictionary in `lib/events/i18n.ts`, with new `submission.status.closed*` and `reg.team.*` keys in both languages.
- **Teammate emails reuse `EmailListInput`** — `TeamFormation` drops its per-slot email inputs for the shared tag-style `EmailListInput` component (added in #4241 but never wired up). Emails are validated/deduped on entry, team size auto-bumps as emails are added, and the count stays capped at `team_size_max − 1`.
- **Invitation email banner validation** — `SendInvitationProjectMember` no longer embeds whatever is in `hackathon.banner`: only absolute `http(s)` URLs are used. Base64 data-URIs (which most clients block and which push the HTML past Gmail's ~102KB clipping limit, causing "[Message clipped]" + an empty black box), relative paths, or missing banners fall back to the generic hosted hackathon banner already used by the event page. The banner URL is parsed with `new URL()` and attribute-escaped, and the title/inviter/project-name interpolations into the email HTML are now escaped too (security review).

## Test plan

1. **Custom tech tags** — open a hackathon submission → step 2 → Tech Stack Tags: type a value not in the list → *Create "…"* row appears, Enter adds the tag; saving persists it.
2. **i18n** — view a Spanish-language event: closed-submissions banner and the whole Team section render in Spanish (no English leakage), English events unchanged.
3. **Team emails** — registration form with team size > 1: emails are entered as tags in a single input (Enter/Space/Tab adds, ✕ removes); invalid emails are rejected; adding a 3rd email auto-selects team size 4 (capped at max); submit still validates count/duplicates/self-invite as before.
4. **Invitation email** — invite a teammate on a hackathon whose banner is a base64 data-URI → the email arrives un-clipped with the generic hosted banner; a hackathon with a hosted banner URL still shows its own banner.

Refs #4275
