### PR TITLE
fix(console): stop DeployWrappedNative infinite render loop (stale native-currency cache)

### DIFF
--- a/components/toolbox/stores/l1ListStore.ts
+++ b/components/toolbox/stores/l1ListStore.ts
@@ -293,13 +293,21 @@ export const useSetNativeCurrencyInfo = () => {
 };
 
 export const useNativeCurrencyInfo = (chainId?: number) => {
-  const { walletChainId } = useWalletStore();
-  const l1ListStore = useL1ListStore();
+  const walletChainId = useWalletStore((s) => s.walletChainId);
+  const isTestnet = useWalletStore((s) => s.isTestnet);
   const effectiveChainId = chainId || walletChainId;
-
+  // Subscribe to l1List (nativeCurrency is stored on the L1 item), mirroring
+  // useSelectedL1, so writes via setNativeCurrencyInfo are reflected. The old
+  // version read store.getState() inside a useMemo whose deps never changed on
+  // write, so it returned a STALE value forever — which made consumers that
+  // "cache it once" (DeployWrappedNative) re-fire their write every render and
+  // spin into a setState loop ("Maximum update depth exceeded").
+  const testnetL1List = getL1ListStore(true)((state: { l1List: L1ListItem[] }) => state.l1List);
+  const mainnetL1List = getL1ListStore(false)((state: { l1List: L1ListItem[] }) => state.l1List);
   return useMemo(() => {
-    return l1ListStore.getState().getNativeCurrencyInfo(effectiveChainId);
-  }, [l1ListStore, effectiveChainId]);
+    const activeFirstLists = isTestnet ? [testnetL1List, mainnetL1List] : [mainnetL1List, testnetL1List];
+    return activeFirstLists.flat().find((l1: L1ListItem) => l1.evmChainId === effectiveChainId)?.nativeCurrency;
+  }, [effectiveChainId, isTestnet, testnetL1List, mainnetL1List]);
 };
 
 // Wrapped native token hooks


### PR DESCRIPTION
## The bug

On the wrapped-native-token tool (e.g. academy `native-token-bridge/.../deploy-wrapped-token`, or the ICTT console), with a **funded wallet**, the tool never renders — React throws `Maximum update depth exceeded` and the panel stays blank. It only reproduces with a balance: without funds, the requirements gate renders and masks it.

## Root cause

`useNativeCurrencyInfo` read its value as:

```ts
useMemo(() => l1ListStore.getState().getNativeCurrencyInfo(id), [l1ListStore, id])
```

`getState()` doesn't subscribe, and the memo deps never change when `nativeCurrency` is written — so the hook returns a **stale `undefined` forever**. `DeployWrappedNative`'s "cache the currency info once" guard (`if (!cachedNativeCurrency) setNativeCurrencyInfo(...)`) therefore fires on **every** render. Each write mutates `l1List`, which re-fires `useSelectedL1` (a subscriber); its new reference re-runs the effect (it depends on `selectedL1`) → which writes again → an infinite `setState` loop.

## The fix

Rewrite `useNativeCurrencyInfo` to **subscribe to `l1List`** (where `nativeCurrency` lives), mirroring the existing `useSelectedL1` pattern in the same file. Now a write is reflected on the next render, the guard settles after a single write, and the loop never starts. One-file change.

## Scope / risk

- `nativeCurrency` is stored on the L1 item; the write path (`setNativeCurrencyInfo`) is unchanged — only the read is fixed, so persistence and everything downstream are untouched.
- 5 consumers use this hook (all in the wrapped-native feature); the other 4 only *read* it for the token symbol and already fall back to the chain's native symbol, so they get correct-or-identical data and can't loop.
- Separate from #4285 (Owen's TestSend Rules-of-Hooks fix): that's `toolboxStore`; this is `l1ListStore`. Confirmed empirically that #4285 does **not** resolve this loop.

## How it was found / tested

Surfaced by the Academy QA harness's funded-key render pass (invisible to ephemeral-key testing). Verified via that harness: `deploy-wrapped-token` went from a deterministic fail to **passing**, with no regressions across the `native-token-bridge` page set. Type-checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)