### PR TITLE
docs(platform-cli): align with v2.0.0 command renames + add subnet add-validator

### DIFF
--- a/content/docs/primary-network/validate/node-validator.mdx
+++ b/content/docs/primary-network/validate/node-validator.mdx
@@ -141,14 +141,14 @@ Or import an existing private key:
 platform keys import --name mykey --private-key <PRIVATE_KEY>
 ```
 
-You can also use a **Ledger hardware wallet** instead of a stored key. Pass `--ledger` in place of `--key-name` when running `platform validator add`.
+You can also use a **Ledger hardware wallet** instead of a stored key. Pass `--ledger` in place of `--key-name` when running `platform validator add-permissionless`.
 
 ### Add Validator
 
 **Fuji Testnet — manual BLS:**
 
 ```bash
-platform validator add \
+platform validator add-permissionless \
   --node-id <YOUR_NODE_ID> \
   --stake 1 \
   --duration 336h \
@@ -162,7 +162,7 @@ platform validator add \
 **Fuji Testnet — auto-fetch BLS from running node:**
 
 ```bash
-platform validator add \
+platform validator add-permissionless \
   --node-id <YOUR_NODE_ID> \
   --stake 1 \
   --duration 336h \
@@ -175,7 +175,7 @@ platform validator add \
 **Mainnet:**
 
 ```bash
-platform validator add \
+platform validator add-permissionless \
   --node-id <YOUR_NODE_ID> \
   --stake 2000 \
   --duration 336h \
@@ -188,7 +188,7 @@ platform validator add \
 **Mainnet with Ledger:**
 
 ```bash
-platform validator add \
+platform validator add-permissionless \
   --node-id <YOUR_NODE_ID> \
   --stake 2000 \
   --duration 336h \

--- a/content/docs/tooling/platform-cli/command-reference.mdx
+++ b/content/docs/tooling/platform-cli/command-reference.mdx
@@ -190,7 +190,7 @@ platform validator add-permissionless --node-id <id> --stake <avax>
 | `--node-id` | Node ID (required) | |
 | `--stake` | Stake in AVAX (required) | |
 | `--duration` | Validation duration | `336h` |
-| `--start` | Start time (RFC3339 or `now`) | `now` |
+| `--start` | Start time (RFC3339 or `now`). Ignored post-Durango; validation starts at tx acceptance | `now` |
 | `--delegation-fee` | Fee percentage (0.02 = 2%) | `0.02` |
 | `--reward-address` | Reward address | own address |
 | `--bls-public-key` | BLS public key hex (recommended) | |
@@ -208,7 +208,7 @@ platform validator add-permissionless-delegator --node-id <id> --stake <avax>
 | `--node-id` | Node ID to delegate to (required) | |
 | `--stake` | Stake in AVAX (required) | |
 | `--duration` | Delegation duration | `336h` |
-| `--start` | Start time (RFC3339 or `now`) | `now` |
+| `--start` | Start time (RFC3339 or `now`). Ignored post-Durango; validation starts at tx acceptance | `now` |
 | `--reward-address` | Reward address | own address |
 
 ## subnet
@@ -264,7 +264,7 @@ Adds a validator to a permissioned subnet (`AddSubnetValidatorTx`). The node mus
 | `--subnet-id` | Subnet ID (required) | |
 | `--node-id` | Validator node ID, must already validate the primary network (required) | |
 | `--weight` | Validator sampling weight on the subnet (required, > 0) | |
-| `--start` | Start time (RFC3339 or `now`) | `now` |
+| `--start` | Start time (RFC3339 or `now`). Ignored post-Durango; validation starts at tx acceptance | `now` |
 | `--duration` | Validation duration (must fall within the node's primary network validation period) | `336h` |
 
 ## l1

--- a/content/docs/tooling/platform-cli/command-reference.mdx
+++ b/content/docs/tooling/platform-cli/command-reference.mdx
@@ -179,10 +179,10 @@ Manual import step for two-step transfers.
 
 ## validator
 
-### validator add
+### validator add-permissionless
 
 ```bash
-platform validator add --node-id <id> --stake <avax>
+platform validator add-permissionless --node-id <id> --stake <avax>
 ```
 
 | Flag | Description | Default |
@@ -197,10 +197,10 @@ platform validator add --node-id <id> --stake <avax>
 | `--bls-pop` | BLS proof of possession hex (recommended) | |
 | `--node-endpoint` | Node endpoint to auto-fetch BLS | |
 
-### validator delegate
+### validator add-permissionless-delegator
 
 ```bash
-platform validator delegate --node-id <id> --stake <avax>
+platform validator add-permissionless-delegator --node-id <id> --stake <avax>
 ```
 
 | Flag | Description | Default |
@@ -232,10 +232,10 @@ platform subnet transfer-ownership --subnet-id <id> --new-owner <address>
 | `--subnet-id` | Subnet ID (required) |
 | `--new-owner` | New owner P-Chain address (required) |
 
-### subnet convert-l1
+### subnet convert-to-l1
 
 ```bash
-platform subnet convert-l1 --subnet-id <id> --chain-id <id>
+platform subnet convert-to-l1 --subnet-id <id> --chain-id <id>
 ```
 
 | Flag | Description | Default |
@@ -251,6 +251,22 @@ platform subnet convert-l1 --subnet-id <id> --chain-id <id>
 | `--validator-balance` | Balance per validator in AVAX | `1.0` |
 | `--mock-validator` | Use mock validator for testing | `false` |
 
+### subnet add-validator
+
+```bash
+platform subnet add-validator --subnet-id <id> --node-id <id> --weight <uint>
+```
+
+Adds a validator to a permissioned subnet (`AddSubnetValidatorTx`). The node must already be a primary network validator.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--subnet-id` | Subnet ID (required) | |
+| `--node-id` | Validator node ID, must already validate the primary network (required) | |
+| `--weight` | Validator sampling weight on the subnet (required, > 0) | |
+| `--start` | Start time (RFC3339 or `now`) | `now` |
+| `--duration` | Validation duration (must fall within the node's primary network validation period) | `336h` |
+
 ## l1
 
 ### l1 register-validator
@@ -265,20 +281,20 @@ platform l1 register-validator --balance <avax> --pop <hex> --message <hex>
 | `--pop` | BLS proof of possession hex (required) |
 | `--message` | Warp message hex (required) |
 
-### l1 set-weight
+### l1 set-validator-weight
 
 ```bash
-platform l1 set-weight --message <hex>
+platform l1 set-validator-weight --message <hex>
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--message` | Warp message authorizing weight change (required) |
 
-### l1 add-balance
+### l1 increase-validator-balance
 
 ```bash
-platform l1 add-balance --validation-id <id> --balance <avax>
+platform l1 increase-validator-balance --validation-id <id> --balance <avax>
 ```
 
 | Flag | Description |

--- a/content/docs/tooling/platform-cli/l1-validators.mdx
+++ b/content/docs/tooling/platform-cli/l1-validators.mdx
@@ -24,7 +24,7 @@ platform l1 register-validator \
 ## Set Validator Weight
 
 ```bash
-platform l1 set-weight \
+platform l1 set-validator-weight \
   --message 0xabc123... \
   --key-name mykey
 ```
@@ -33,12 +33,12 @@ platform l1 set-weight \
 |------|-------------|
 | `--message` | Warp message authorizing weight change (required) |
 
-## Add Validator Balance
+## Increase Validator Balance
 
 Top up a validator's balance for continuous fee payments:
 
 ```bash
-platform l1 add-balance \
+platform l1 increase-validator-balance \
   --validation-id 2QYfFcfZ9... \
   --balance 5.0 \
   --key-name mykey

--- a/content/docs/tooling/platform-cli/staking.mdx
+++ b/content/docs/tooling/platform-cli/staking.mdx
@@ -90,6 +90,10 @@ Validators charge a fee as a percentage of delegator rewards:
 --start 2026-02-01T00:00:00Z   # RFC3339 format
 ```
 
+<Callout type="info">
+Post-Durango, the P-Chain ignores the transaction start time — validation begins when the transaction is accepted. `--start` is retained for compatibility but has no on-chain effect on current networks.
+</Callout>
+
 ### Duration
 
 Duration uses Go format (hours):

--- a/content/docs/tooling/platform-cli/staking.mdx
+++ b/content/docs/tooling/platform-cli/staking.mdx
@@ -20,7 +20,7 @@ All validators require a BLS proof of possession. You can provide this manually 
 ### Manual BLS Mode (Recommended)
 
 ```bash
-platform validator add \
+platform validator add-permissionless \
   --node-id NodeID-BFa1paAAAA... \
   --stake 2000 \
   --duration 336h \
@@ -34,7 +34,7 @@ platform validator add \
 ### Auto-Fetch BLS from Node
 
 ```bash
-platform validator add \
+platform validator add-permissionless \
   --node-id NodeID-BFa1paAAAA... \
   --stake 2000 \
   --duration 336h \
@@ -63,7 +63,7 @@ BLS PoP:        0xfedcba0987654321...
 Delegate AVAX to an existing validator:
 
 ```bash
-platform validator delegate \
+platform validator add-permissionless-delegator \
   --node-id NodeID-BFa1paAAAA... \
   --stake 100 \
   --duration 336h \

--- a/content/docs/tooling/platform-cli/subnets.mdx
+++ b/content/docs/tooling/platform-cli/subnets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Subnets
-description: Create subnets, transfer ownership, and convert to L1 blockchains
+description: Create subnets, add validators, transfer ownership, and convert to L1 blockchains
 ---
 
 Platform CLI supports creating subnets, transferring ownership, and converting them to L1 blockchains.
@@ -32,6 +32,21 @@ platform subnet transfer-ownership \
   --key-name mykey
 ```
 
+## Add a Validator (Permissioned Subnet)
+
+Add a validator to a permissioned subnet (`AddSubnetValidatorTx`). The node must **already be a primary network validator**, and the subnet owner key authorizes the transaction.
+
+```bash
+platform subnet add-validator \
+  --subnet-id 2QYfFcfZ9... \
+  --node-id NodeID-BFa1paAAAA... \
+  --weight 100 \
+  --duration 336h \
+  --key-name mykey
+```
+
+The validation period must fall within the node's primary network validation window. `--weight` is the validator's sampling weight on the subnet (not a stake amount). To add validators to a subnet that has already been converted to an L1, use [`l1 register-validator`](/docs/tooling/platform-cli/l1-validators) instead.
+
 ## Convert Subnet to L1
 
 Convert a permissioned subnet to an L1 blockchain. This operation is **irreversible**.
@@ -41,7 +56,7 @@ Convert a permissioned subnet to an L1 blockchain. This operation is **irreversi
 Provide validator node addresses and let the CLI fetch NodeID and BLS credentials:
 
 ```bash
-platform subnet convert-l1 \
+platform subnet convert-to-l1 \
   --subnet-id 2QYfFcfZ9... \
   --chain-id 3RZgGdaH1... \
   --manager 0x1234567890abcdef1234567890abcdef12345678 \
@@ -55,7 +70,7 @@ platform subnet convert-l1 \
 Provide validator data explicitly (all lists must be comma-separated and aligned by index):
 
 ```bash
-platform subnet convert-l1 \
+platform subnet convert-to-l1 \
   --subnet-id 2QYfFcfZ9... \
   --chain-id 3RZgGdaH1... \
   --manager 0x1234... \
@@ -71,7 +86,7 @@ platform subnet convert-l1 \
 For local testing, generate a mock validator with random BLS credentials:
 
 ```bash
-platform subnet convert-l1 \
+platform subnet convert-to-l1 \
   --subnet-id 2QYfFcfZ9... \
   --chain-id 3RZgGdaH1... \
   --mock-validator \


### PR DESCRIPTION
## What

Updates the Platform CLI docs to match the upcoming **v2.0.0** release, which renames P-Chain commands to mirror the avalanchego transaction types (breaking — old names removed, no aliases). Also documents the new `subnet add-validator` command.

Companion to platform-cli PR #33 (ava-labs/platform-cli).

## Command renames

| Old | New |
|---|---|
| `validator add` | `validator add-permissionless` |
| `validator delegate` | `validator add-permissionless-delegator` |
| `subnet convert-l1` | `subnet convert-to-l1` |
| `l1 set-weight` | `l1 set-validator-weight` |
| `l1 add-balance` | `l1 increase-validator-balance` |

## New command documented

`subnet add-validator` (`AddSubnetValidatorTx`) — add a validator to a permissioned subnet. Added to `subnets.mdx` and `command-reference.mdx`.

## Files changed (5)
- `tooling/platform-cli/subnets.mdx` — rename `convert-l1`; new "Add a Validator (Permissioned Subnet)" section; frontmatter
- `tooling/platform-cli/staking.mdx` — rename validator add/delegate
- `tooling/platform-cli/l1-validators.mdx` — rename set-weight/add-balance (+ heading)
- `tooling/platform-cli/command-reference.mdx` — rename headings + commands; new `subnet add-validator` entry
- `primary-network/validate/node-validator.mdx` — rename `validator add` (4 code blocks + prose)

## Verification
- Repo-wide sweep confirms **no** old platform-cli command strings remain in `content/`
- No broken cross-doc anchor links to the renamed headings

> Note: this documents v2.0.0 behavior; should merge in coordination with the platform-cli v2.0.0 release.