### PR TITLE
docs(academy): clarify proxy vs. implementation in PoA Manager setup

### DIFF
--- a/content/academy/avalanche-l1/permissioned-l1s/06-multisig-setup/01-poa-manager.mdx
+++ b/content/academy/avalanche-l1/permissioned-l1s/06-multisig-setup/01-poa-manager.mdx
@@ -1,7 +1,7 @@
 ---
 title: PoA Manager Contract
 description: Understanding the PoA Manager contract and why it simplifies multi-sig governance
-updated: 2025-03-19
+updated: 2026-06-17
 authors: [nicolasarnedo]
 icon: BookOpen
 ---
@@ -94,6 +94,35 @@ contract PoAManager is Ownable {
 **Is PoA Manager Required?**
 
 No! You can absolutely transfer Validator Manager ownership directly to a multi-sig. The PoA Manager just makes the multi-sig experience smoother. For simple setups or if you're comfortable building complex transactions, direct ownership works fine.
+</Callout>
+
+## Proxy vs. Implementation: The Address That Trips Everyone Up
+
+<Callout type="info">
+**This section applies only if your Validator Manager is deployed behind a proxy** — which is the default path in this course. The genesis ships an OpenZeppelin `TransparentUpgradeableProxy` (commonly at `0xfacade...`, though some templates use a different address such as `0xFEEDC0DE...`) and [Upgrade Proxy](/academy/avalanche-l1/permissioned-l1s/04-validator-manager-deployment/03-upgrade-proxy) pointed it at your implementation. If you deployed the Validator Manager **directly, with no proxy**, it is a single address — skip the distinction below and use that one address everywhere.
+</Callout>
+
+When you deploy behind a proxy, "the Validator Manager" is really **three** contracts — and almost every PoA setup failure comes from confusing them:
+
+| Contract | Example address | What it holds | When you use it |
+|----------|-----------------|---------------|-----------------|
+| **Implementation** | the address you deployed | Logic only — **no state** | **Never directly.** It is just the code the proxy borrows. |
+| **Proxy** | `0xfacade...` (or `0xFEEDC0DE...`) | All state: `owner`, validator set, settings | **Everywhere.** Initialization, `transferOwnership`, reads, and the PoA Manager's constructor all target this. |
+| **ProxyAdmin** | `0xdad0...` | The proxy's upgrade admin | **Only** to upgrade the implementation. |
+
+<Callout type="warning">
+**The rule: when your manager is behind a proxy, whenever a step asks for "the Validator Manager address," use the proxy address (e.g. `0xfacade...`) — never the implementation.**
+
+The proxy `delegatecall`s into the implementation, so all state (including `owner`) lives at the **proxy** address. If you point the PoA Manager at the implementation, or call `transferOwnership` on the implementation, you are operating on a stateless contract: the transactions "succeed" but change nothing the proxy uses, and later validator operations revert.
+</Callout>
+
+Concretely, this governs the next two steps:
+
+- **Deploying the PoA Manager** — its constructor stores `validatorManager` and forwards every call there, so pass the **proxy**.
+- **Transferring ownership** — `transferOwnership` updates the **proxy's** `owner` storage, so call it on the **proxy**.
+
+<Callout type="info">
+The Console tools in this course resolve the proxy address for you automatically from your L1. You'll mainly hit this pitfall when scripting the setup by hand — for example a private L1 that can't use the Console — so there, double-check that every "Validator Manager" address is `0xfacade...`, not the implementation you just deployed.
 </Callout>
 
 ## Architecture Overview

--- a/content/academy/avalanche-l1/permissioned-l1s/06-multisig-setup/04-deploy-poa-manager.mdx
+++ b/content/academy/avalanche-l1/permissioned-l1s/06-multisig-setup/04-deploy-poa-manager.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy PoA Manager
 description: Deploy the PoA Manager contract with your multi-sig wallet as the owner
-updated: 2025-03-19
+updated: 2026-06-17
 authors: [nicolasarnedo]
 icon: Terminal
 ---
@@ -17,7 +17,7 @@ Now that you have your Safe/Ash wallet set up, it's time to deploy the PoA Manag
 The PoA Manager is initialized with two key addresses:
 
 1. **Owner**: Your Safe/Ash multi-sig wallet address
-2. **Validator Manager**: The VMC address on C-Chain (from the previous section)
+2. **Validator Manager**: if your Validator Manager is behind a proxy (the default here), its **proxy** address (e.g. `0xfacade...`) — **not** the implementation you deployed earlier. (Deployed without a proxy? Use the Validator Manager address directly.)
 
 ```solidity
 constructor(address _owner, address _validatorManager) {
@@ -25,6 +25,10 @@ constructor(address _owner, address _validatorManager) {
     validatorManager = IValidatorManager(_validatorManager);
 }
 ```
+
+<Callout type="warning">
+If your Validator Manager is behind a proxy, pass the **proxy** address (e.g. `0xfacade...`) as `_validatorManager`, never the implementation. The PoA Manager stores this address and forwards every validator call to it; pointed at the stateless implementation, those calls revert with `OwnableUnauthorizedAccount` once the multi-sig tries to use them (a Safe surfaces this as `GS013`). See [Proxy vs. Implementation](/academy/avalanche-l1/permissioned-l1s/06-multisig-setup/01-poa-manager). The Console tool below resolves the proxy automatically; this bites manual/scripted deployments.
+</Callout>
 
 ## Deployment Architecture
 
@@ -80,7 +84,7 @@ After deployment, verify:
 
 - ✅ **Contract Deployed**: You have a valid PoA Manager address
 - ✅ **Owner Set**: The `owner()` function returns your Safe address
-- ✅ **Validator Manager Linked**: The `validatorManager()` function returns the correct VMC address
+- ✅ **Validator Manager Linked**: The `validatorManager()` function returns the **proxy** address (`0xfacade...`), not the implementation
 
 ## Current Ownership State
 

--- a/content/academy/avalanche-l1/permissioned-l1s/06-multisig-setup/05-transfer-vmc-ownership.mdx
+++ b/content/academy/avalanche-l1/permissioned-l1s/06-multisig-setup/05-transfer-vmc-ownership.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transfer VMC Ownership to PoA Manager
 description: Transfer the Validator Manager Contract ownership to your PoA Manager
-updated: 2025-03-19
+updated: 2026-06-17
 authors: [nicolasarnedo]
 icon: Terminal
 ---
@@ -69,6 +69,10 @@ Before transferring ownership, verify:
 
 Use the tool below to transfer Validator Manager ownership to your PoA Manager:
 
+<Callout type="warning">
+If your Validator Manager is behind a proxy, call `transferOwnership` on the **proxy** (e.g. `0xfacade...`), not the implementation. Ownership lives in the proxy's storage; transferring it on the implementation leaves the proxy still owned by your EOA, and the PoA Manager's calls will later revert with `OwnableUnauthorizedAccount` / `GS013`. The Console tool below targets the proxy automatically; if you script this, use your proxy address.
+</Callout>
+
 <ToolboxMdxWrapper walletMode="c-chain">
     <TransferOwnership />
 </ToolboxMdxWrapper>
@@ -98,10 +102,28 @@ function _transferOwnership(address newOwner) internal {
 
 ## Verification
 
-After the transfer completes:
+After the transfer completes, calling `owner()` on the **proxy** (e.g. `0xfacade...`) should return the PoA Manager address:
 
-1. **Check VMC Owner**: The Validator Manager's `owner()` should return the PoA Manager address
-2. **Test Access**: Your EOA should no longer be able to call owner-restricted functions
+```bash
+cast call <PROXY> "owner()(address)" --rpc-url <YOUR_L1_RPC>   # → your PoA Manager
+```
+
+Also confirm your EOA can no longer call owner-restricted functions directly.
+
+## Troubleshooting: `GS013` / `OwnableUnauthorizedAccount`
+
+If a validator operation from the multi-sig fails — the Safe shows `GS013` / "cannot estimate gas" / "this transaction will most likely fail," or a direct call reverts with selector `0x118cdaa7` (`OwnableUnauthorizedAccount`) — the ownership chain is wired to the wrong address. Check it end to end:
+
+1. **PoA Manager → proxy?** `cast call <PoAManager> "validatorManager()(address)"` must return the proxy (`0xfacade...`), not the implementation. If it points at the implementation, redeploy the PoA Manager with the proxy address.
+2. **Proxy → PoA Manager?** `cast call <PROXY> "owner()(address)"` (your proxy, e.g. `0xfacade...`) must return the PoA Manager. If it still returns your EOA, the transfer was run against the implementation — re-run it on the proxy. (No proxy? This is just the Validator Manager address.)
+3. **Multi-sig → PoA Manager?** `cast call <PoAManager> "owner()(address)"` must return your Safe.
+
+A preflight that mirrors exactly what the Safe will execute (it reverts `0x118cdaa7` if mis-wired and succeeds once correct), so you can confirm before collecting signatures:
+
+```bash
+cast call <PoAManager> "initiateValidatorWeightUpdate(bytes32,uint64)" <VALIDATION_ID> <NEW_WEIGHT> \
+  --from <SAFE_ADDRESS> --rpc-url <YOUR_L1_RPC>
+```
 
 ## Complete Ownership Chain
 


### PR DESCRIPTION
## Why

A client (manual/scripted PoA setup on a private L1) hit **`GS013` / "cannot estimate gas"** from the Safe Transaction Builder when calling `PoAManager.initiateValidatorWeightUpdate()`. Root cause: their **Validator Manager is deployed behind an OZ `TransparentUpgradeableProxy`**, but they (a) gave the PoA Manager the **implementation** address instead of the proxy, and (b) ran `transferOwnership` on the **implementation**. Both leave the proxy's `owner` unchanged, so calls revert `OwnableUnauthorizedAccount` (`0x118cdaa7`) → the Safe surfaces this as `GS013`.

The `06-multisig-setup` chapter never made the proxy-vs-implementation distinction explicit (the Console auto-resolves the proxy, so only manual/scripted users hit it).

## Changes

- **`01-poa-manager.mdx`** — new **"Proxy vs. Implementation: The Address That Trips Everyone Up"** section: the three-address model (implementation / proxy / ProxyAdmin) as a table, and the rule *"whenever a step asks for the Validator Manager address, use the proxy — never the implementation."* Gated on the conditional that the manager is **deployed behind a proxy** (the course default; the proxy may be `0xfacade...` or e.g. `0xFEEDC0DE...`). Proxy-less deployments use a single address and skip the section.
- **`04-deploy-poa-manager.mdx`** — the constructor's `_validatorManager` must be the **proxy**; added a warning callout (explains the `OwnableUnauthorizedAccount`/`GS013` failure mode) and updated the verification bullet.
- **`05-transfer-vmc-ownership.mdx`** — `transferOwnership` must target the **proxy**; added a `cast call <PROXY> "owner()"` verification and a **"Troubleshooting: GS013 / OwnableUnauthorizedAccount"** section (3-step ownership check + a `--from <safe>` preflight that mirrors what the Safe executes).

No new components/imports (reuses `Callout`); MDX tag/fence balance verified. Did not run the full `next build`.