### PR TITLE
docs: update Primary Network validator instances i4i → i7i

### DIFF
--- a/content/docs/nodes/system-requirements.mdx
+++ b/content/docs/nodes/system-requirements.mdx
@@ -10,7 +10,7 @@ Running a Primary Network validator requires careful consideration of your stake
 ### Storage Requirements
 
 <Callout type="error" title="SSD Required - No Cloud Block Storage">
-You **must** use a local NVMe SSD attached directly to your hardware with **minimum 3000 IOPS**. Cloud block storage (AWS EBS, GCP Persistent Disk, Azure Managed Disks) introduces latency that causes poor performance, missed blocks, and potential benching. If running in the cloud, use instance types with local NVMe storage (e.g., AWS i3/i4i instances, GCP N2 with local SSD).
+You **must** use a local NVMe SSD attached directly to your hardware with **minimum 3000 IOPS**. Cloud block storage (AWS EBS, GCP Persistent Disk, Azure Managed Disks) introduces latency that causes poor performance, missed blocks, and potential benching. If running in the cloud, use instance types with local NVMe storage (e.g., AWS i7i/i7ie instances, GCP N2 with local SSD).
 </Callout>
 
 <Callout title="State Sync Recommended">

--- a/content/docs/tooling/avalanche-deploy/deploy-primary-network.mdx
+++ b/content/docs/tooling/avalanche-deploy/deploy-primary-network.mdx
@@ -5,7 +5,7 @@ description: Operate production Avalanche Primary Network validators on AWS with
 
 This guide covers deploying and operating Avalanche Primary Network validators — the nodes that validate the P-Chain, X-Chain, and C-Chain. These validators participate in Avalanche consensus and earn staking rewards.
 
-**AWS only**. **Staking minimum**: 2,000 AVAX (mainnet), 1 AVAX (Fuji). **Bootstrap time**: 2–4 hours via state-sync. **Cost**: ~$326/month per validator.
+**AWS only**. **Staking minimum**: 2,000 AVAX (mainnet), 1 AVAX (Fuji). **Bootstrap time**: 2–4 hours via state-sync. **Cost**: ~$292/month per validator.
 
 <Callout type="warn">
 Primary Network workflows are currently supported on **AWS only**. The instances require high-performance NVMe storage for the full chain database.
@@ -23,8 +23,8 @@ flowchart TB
     subgraph AWS["AWS Cloud"]
         subgraph VPC["VPC"]
             subgraph Validators["Primary Validators"]
-                PV1[Validator 1 i4i.xlarge 937GB NVMe]
-                PV2[Validator 2 i4i.xlarge 937GB NVMe]
+                PV1[Validator 1 i7i.xlarge 937GB NVMe]
+                PV2[Validator 2 i7i.xlarge 937GB NVMe]
             end
 
             subgraph Monitoring["Monitoring"]
@@ -59,7 +59,7 @@ flowchart TB
 | Aspect | L1 Deployment | Primary Network |
 |--------|---------------|-----------------|
 | Chain sync | Partial P-Chain headers only | Full P/X/C chain data |
-| Instance type | c6a.xlarge (general compute) | i4i.xlarge (NVMe-optimized) |
+| Instance type | c6a.xlarge (general compute) | i7i.xlarge (NVMe-optimized) |
 | Storage | EBS gp3 volumes | 937GB local NVMe |
 | Bootstrap time | Minutes (partial sync) | 2–4 hours (state-sync) |
 | Cloud support | AWS, GCP, Azure | AWS only |
@@ -76,7 +76,7 @@ flowchart TB
 make primary-infra CLOUD=aws
 ```
 
-This uses a **separate Terraform state** from the L1 deployment (`terraform/primary-network/aws/`), creating i4i.xlarge instances with 937GB NVMe drives.
+This uses a **separate Terraform state** from the L1 deployment (`terraform/primary-network/aws/`), creating i7i.xlarge instances with 937GB NVMe drives.
 
 Edit `terraform/primary-network/aws/terraform.tfvars` before running:
 
@@ -230,10 +230,10 @@ make migrate-validator CLOUD=aws SOURCE=primary-validator-1 TARGET=migration-tar
 
 | Component | Instance | Storage | Monthly Estimate |
 |-----------|----------|---------|-----------------|
-| Primary Validator | i4i.xlarge | 937GB NVMe (included) | ~$310 |
+| Primary Validator | i7i.xlarge | 937GB NVMe (included) | ~$276 |
 | S3 + KMS (keys + snapshots) | — | ~1GB | ~$1 |
 | Monitoring | t3.small | 50GB EBS | ~$15 |
-| **Per validator total** | | | **~$326/mo** |
+| **Per validator total** | | | **~$292/mo** |
 
 ## Terraform Configuration Reference
 


### PR DESCRIPTION
## What
Updates the Primary Network validator docs to reference the current-gen
storage-optimized instance family: `i4i`/`i3` → `i7i` (and `i7ie` as the
dense-storage example).

- `nodes/system-requirements.mdx`: cite `i7i/i7ie` as the local-NVMe examples
- `tooling/avalanche-deploy/deploy-primary-network.mdx`: `i7i.xlarge` in the
  topology diagram, the L1-vs-Primary comparison table, and the deploy/cost
  sections; per-validator estimate refreshed to ~$276/mo → ~$292/mo total.

## Why
`i7i.xlarge` is a clean drop-in for `i4i.xlarge`: same **4 vCPU / 32 GiB /
937 GiB local NVMe**, on 5th-gen Intel (Emerald Rapids) with PCIe Gen5
Nitro SSDs — ~50% better real-time storage performance and lower I/O latency
than i4i. Storage perf is the binding constraint for Primary Network
validators, so the newer family is the right default to document.

Cost: i7i.xlarge on-demand ≈ $0.3775/hr ≈ $275.58/mo (us-east-1), so the
~$276/validator + $1 (S3/KMS) + $15 (t3.small monitoring) = ~$292/mo total.
