### PR TITLE
docs(platform-cli): add auto-renewed staking + fix binary name to platform-cli

### DIFF
--- a/content/docs/primary-network/validate/node-validator.mdx
+++ b/content/docs/primary-network/validate/node-validator.mdx
@@ -122,7 +122,7 @@ For full installation details, see the [platform-cli documentation](/docs/toolin
 You can use the same `info.getNodeID` API call shown in the Core extension section above. Alternatively, platform-cli can fetch BLS credentials directly from a running node:
 
 ```bash
-platform node info --ip <YOUR_NODE_IP>:9650
+platform-cli node info --ip <YOUR_NODE_IP>:9650
 ```
 
 See the [platform-cli command reference](/docs/tooling/platform-cli/command-reference) for all available node commands. You can also look up the full response format in the [Info RPC docs](/docs/rpcs/other/info-rpc#infogetnodeid).
@@ -132,23 +132,23 @@ See the [platform-cli command reference](/docs/tooling/platform-cli/command-refe
 Generate a new key:
 
 ```bash
-platform keys generate --name mykey
+platform-cli keys generate --name mykey
 ```
 
 Or import an existing private key:
 
 ```bash
-platform keys import --name mykey --private-key <PRIVATE_KEY>
+platform-cli keys import --name mykey --private-key <PRIVATE_KEY>
 ```
 
-You can also use a **Ledger hardware wallet** instead of a stored key. Pass `--ledger` in place of `--key-name` when running `platform validator add-permissionless`.
+You can also use a **Ledger hardware wallet** instead of a stored key. Pass `--ledger` in place of `--key-name` when running `platform-cli validator add-permissionless`.
 
 ### Add Validator
 
 **Fuji Testnet — manual BLS:**
 
 ```bash
-platform validator add-permissionless \
+platform-cli validator add-permissionless \
   --node-id <YOUR_NODE_ID> \
   --stake 1 \
   --duration 336h \
@@ -162,7 +162,7 @@ platform validator add-permissionless \
 **Fuji Testnet — auto-fetch BLS from running node:**
 
 ```bash
-platform validator add-permissionless \
+platform-cli validator add-permissionless \
   --node-id <YOUR_NODE_ID> \
   --stake 1 \
   --duration 336h \
@@ -175,7 +175,7 @@ platform validator add-permissionless \
 **Mainnet:**
 
 ```bash
-platform validator add-permissionless \
+platform-cli validator add-permissionless \
   --node-id <YOUR_NODE_ID> \
   --stake 2000 \
   --duration 336h \
@@ -188,7 +188,7 @@ platform validator add-permissionless \
 **Mainnet with Ledger:**
 
 ```bash
-platform validator add-permissionless \
+platform-cli validator add-permissionless \
   --node-id <YOUR_NODE_ID> \
   --stake 2000 \
   --duration 336h \

--- a/content/docs/tooling/avalanche-deploy/deploy-l1-kubernetes.mdx
+++ b/content/docs/tooling/avalanche-deploy/deploy-l1-kubernetes.mdx
@@ -80,8 +80,8 @@ helm upgrade --install l1-rpc ./helm/avalanche-rpc \
 
 ```bash
 # Import or create a deployer key
-platform keys import --name l1-deployer
-platform keys default --name l1-deployer
+platform-cli keys import --name l1-deployer
+platform-cli keys default --name l1-deployer
 
 ./scripts/create-l1.sh \
   --release=l1-validators \

--- a/content/docs/tooling/avalanche-deploy/deploy-l1.mdx
+++ b/content/docs/tooling/avalanche-deploy/deploy-l1.mdx
@@ -162,8 +162,8 @@ Key settings:
 
 ```bash
 # Import or create a deployer key
-platform keys import --name l1-deployer
-platform keys default --name l1-deployer
+platform-cli keys import --name l1-deployer
+platform-cli keys default --name l1-deployer
 
 # Build and run the create-l1 tool
 make create-l1

--- a/content/docs/tooling/platform-cli/chains.mdx
+++ b/content/docs/tooling/platform-cli/chains.mdx
@@ -8,7 +8,7 @@ Deploy a new blockchain on an existing subnet using the `chain create` command.
 ## Create a Chain
 
 ```bash
-platform chain create \
+platform-cli chain create \
   --subnet-id 2QYfFcfZ9... \
   --genesis genesis.json \
   --name mychain \

--- a/content/docs/tooling/platform-cli/command-reference.mdx
+++ b/content/docs/tooling/platform-cli/command-reference.mdx
@@ -21,7 +21,7 @@ Available on all commands:
 ## version
 
 ```bash
-platform version
+platform-cli version
 ```
 
 Prints the CLI version.
@@ -33,7 +33,7 @@ Manage persistent keys stored in `~/.platform/keys/`.
 ### keys generate
 
 ```bash
-platform keys generate --name <name> [--encrypt=false]
+platform-cli keys generate --name <name> [--encrypt=false]
 ```
 
 | Flag | Description | Default |
@@ -44,7 +44,7 @@ platform keys generate --name <name> [--encrypt=false]
 ### keys import
 
 ```bash
-platform keys import --name <name> [--private-key <key>] [--encrypt=false]
+platform-cli keys import --name <name> [--private-key <key>] [--encrypt=false]
 ```
 
 | Flag | Description | Default |
@@ -56,7 +56,7 @@ platform keys import --name <name> [--private-key <key>] [--encrypt=false]
 ### keys list
 
 ```bash
-platform keys list [--show-addresses]
+platform-cli keys list [--show-addresses]
 ```
 
 | Flag | Description |
@@ -66,8 +66,8 @@ platform keys list [--show-addresses]
 ### keys export
 
 ```bash
-platform keys export --name <name> --output-file <path>
-platform keys export --name <name> --unsafe-stdout
+platform-cli keys export --name <name> --output-file <path>
+platform-cli keys export --name <name> --unsafe-stdout
 ```
 
 | Flag | Description | Default |
@@ -80,7 +80,7 @@ platform keys export --name <name> --unsafe-stdout
 ### keys delete
 
 ```bash
-platform keys delete --name <name> [--force]
+platform-cli keys delete --name <name> [--force]
 ```
 
 | Flag | Description |
@@ -91,7 +91,7 @@ platform keys delete --name <name> [--force]
 ### keys default
 
 ```bash
-platform keys default [--name <name>]
+platform-cli keys default [--name <name>]
 ```
 
 Shows current default if `--name` is omitted. Sets default if `--name` is provided.
@@ -101,7 +101,7 @@ Shows current default if `--name` is omitted. Sets default if `--name` is provid
 ### wallet balance
 
 ```bash
-platform wallet balance
+platform-cli wallet balance
 ```
 
 Displays P-Chain address and AVAX balance.
@@ -109,7 +109,7 @@ Displays P-Chain address and AVAX balance.
 ### wallet address
 
 ```bash
-platform wallet address
+platform-cli wallet address
 ```
 
 Displays P-Chain and EVM addresses derived from the key.
@@ -119,7 +119,7 @@ Displays P-Chain and EVM addresses derived from the key.
 ### transfer send
 
 ```bash
-platform transfer send --to <address> --amount <avax>
+platform-cli transfer send --to <address> --amount <avax>
 ```
 
 | Flag | Description |
@@ -131,7 +131,7 @@ platform transfer send --to <address> --amount <avax>
 ### transfer p-to-c
 
 ```bash
-platform transfer p-to-c --amount <avax>
+platform-cli transfer p-to-c --amount <avax>
 ```
 
 One-step P-Chain to C-Chain transfer (export + import).
@@ -144,7 +144,7 @@ One-step P-Chain to C-Chain transfer (export + import).
 ### transfer c-to-p
 
 ```bash
-platform transfer c-to-p --amount <avax>
+platform-cli transfer c-to-p --amount <avax>
 ```
 
 One-step C-Chain to P-Chain transfer (export + import).
@@ -152,7 +152,7 @@ One-step C-Chain to P-Chain transfer (export + import).
 ### transfer export
 
 ```bash
-platform transfer export --from <chain> --to <chain> --amount <avax>
+platform-cli transfer export --from <chain> --to <chain> --amount <avax>
 ```
 
 Manual export step for two-step transfers.
@@ -167,7 +167,7 @@ Manual export step for two-step transfers.
 ### transfer import
 
 ```bash
-platform transfer import --from <chain> --to <chain>
+platform-cli transfer import --from <chain> --to <chain>
 ```
 
 Manual import step for two-step transfers.
@@ -182,7 +182,7 @@ Manual import step for two-step transfers.
 ### validator add-permissionless
 
 ```bash
-platform validator add-permissionless --node-id <id> --stake <avax>
+platform-cli validator add-permissionless --node-id <id> --stake <avax>
 ```
 
 | Flag | Description | Default |
@@ -200,7 +200,7 @@ platform validator add-permissionless --node-id <id> --stake <avax>
 ### validator add-permissionless-delegator
 
 ```bash
-platform validator add-permissionless-delegator --node-id <id> --stake <avax>
+platform-cli validator add-permissionless-delegator --node-id <id> --stake <avax>
 ```
 
 | Flag | Description | Default |
@@ -214,7 +214,7 @@ platform validator add-permissionless-delegator --node-id <id> --stake <avax>
 ### validator add-auto-renewed
 
 ```bash
-platform validator add-auto-renewed --node-id <id> --stake <avax>
+platform-cli validator add-auto-renewed --node-id <id> --stake <avax>
 ```
 
 Adds an auto-renewed validator (`AddAutoRenewedValidatorTx`, ACP-236) that restakes each cycle.
@@ -235,7 +235,7 @@ Adds an auto-renewed validator (`AddAutoRenewedValidatorTx`, ACP-236) that resta
 ### validator set-auto-renewed-config
 
 ```bash
-platform validator set-auto-renewed-config --tx-id <id> --period <dur> --auto-compound <frac>
+platform-cli validator set-auto-renewed-config --tx-id <id> --period <dur> --auto-compound <frac>
 ```
 
 Updates the next-cycle config of an auto-renewed validator (`SetAutoRenewedValidatorConfigTx`). Must be signed by the owner address set at add time.
@@ -252,7 +252,7 @@ Updates the next-cycle config of an auto-renewed validator (`SetAutoRenewedValid
 ### subnet create
 
 ```bash
-platform subnet create
+platform-cli subnet create
 ```
 
 Creates a new subnet owned by the wallet address. No additional flags required.
@@ -260,7 +260,7 @@ Creates a new subnet owned by the wallet address. No additional flags required.
 ### subnet transfer-ownership
 
 ```bash
-platform subnet transfer-ownership --subnet-id <id> --new-owner <address>
+platform-cli subnet transfer-ownership --subnet-id <id> --new-owner <address>
 ```
 
 | Flag | Description |
@@ -271,7 +271,7 @@ platform subnet transfer-ownership --subnet-id <id> --new-owner <address>
 ### subnet convert-to-l1
 
 ```bash
-platform subnet convert-to-l1 --subnet-id <id> --chain-id <id>
+platform-cli subnet convert-to-l1 --subnet-id <id> --chain-id <id>
 ```
 
 | Flag | Description | Default |
@@ -290,7 +290,7 @@ platform subnet convert-to-l1 --subnet-id <id> --chain-id <id>
 ### subnet add-validator
 
 ```bash
-platform subnet add-validator --subnet-id <id> --node-id <id> --weight <uint>
+platform-cli subnet add-validator --subnet-id <id> --node-id <id> --weight <uint>
 ```
 
 Adds a validator to a permissioned subnet (`AddSubnetValidatorTx`). The node must already be a primary network validator.
@@ -308,7 +308,7 @@ Adds a validator to a permissioned subnet (`AddSubnetValidatorTx`). The node mus
 ### l1 register-validator
 
 ```bash
-platform l1 register-validator --balance <avax> --pop <hex> --message <hex>
+platform-cli l1 register-validator --balance <avax> --pop <hex> --message <hex>
 ```
 
 | Flag | Description |
@@ -320,7 +320,7 @@ platform l1 register-validator --balance <avax> --pop <hex> --message <hex>
 ### l1 set-validator-weight
 
 ```bash
-platform l1 set-validator-weight --message <hex>
+platform-cli l1 set-validator-weight --message <hex>
 ```
 
 | Flag | Description |
@@ -330,7 +330,7 @@ platform l1 set-validator-weight --message <hex>
 ### l1 increase-validator-balance
 
 ```bash
-platform l1 increase-validator-balance --validation-id <id> --balance <avax>
+platform-cli l1 increase-validator-balance --validation-id <id> --balance <avax>
 ```
 
 | Flag | Description |
@@ -341,7 +341,7 @@ platform l1 increase-validator-balance --validation-id <id> --balance <avax>
 ### l1 disable-validator
 
 ```bash
-platform l1 disable-validator --validation-id <id>
+platform-cli l1 disable-validator --validation-id <id>
 ```
 
 | Flag | Description |
@@ -353,7 +353,7 @@ platform l1 disable-validator --validation-id <id>
 ### chain create
 
 ```bash
-platform chain create --subnet-id <id> --genesis <file>
+platform-cli chain create --subnet-id <id> --genesis <file>
 ```
 
 | Flag | Description | Default |
@@ -368,7 +368,7 @@ platform chain create --subnet-id <id> --genesis <file>
 ### node info
 
 ```bash
-platform node info --ip <address>
+platform-cli node info --ip <address>
 ```
 
 | Flag | Description |

--- a/content/docs/tooling/platform-cli/command-reference.mdx
+++ b/content/docs/tooling/platform-cli/command-reference.mdx
@@ -211,6 +211,42 @@ platform validator add-permissionless-delegator --node-id <id> --stake <avax>
 | `--start` | Start time (RFC3339 or `now`). Ignored post-Durango; validation starts at tx acceptance | `now` |
 | `--reward-address` | Reward address | own address |
 
+### validator add-auto-renewed
+
+```bash
+platform validator add-auto-renewed --node-id <id> --stake <avax>
+```
+
+Adds an auto-renewed validator (`AddAutoRenewedValidatorTx`, ACP-236) that restakes each cycle.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--node-id` | Node ID to validate (required) | |
+| `--stake` | Stake in AVAX (network minimum applies) | |
+| `--period` | Auto-renewal cycle duration | `336h` |
+| `--auto-compound` | Fraction of rewards to auto-compound (0.3 = 30%, 1 = 100%) | `1` |
+| `--delegation-fee` | Fee percentage (0.02 = 2%) | `0.02` |
+| `--owner-address` | Address authorized to update the auto-renew config | own address |
+| `--reward-address` | Reward address | own address |
+| `--bls-public-key` | BLS public key hex (recommended) | |
+| `--bls-pop` | BLS proof of possession hex (recommended) | |
+| `--node-endpoint` | Node endpoint to auto-fetch BLS | |
+
+### validator set-auto-renewed-config
+
+```bash
+platform validator set-auto-renewed-config --tx-id <id> --period <dur> --auto-compound <frac>
+```
+
+Updates the next-cycle config of an auto-renewed validator (`SetAutoRenewedValidatorConfigTx`). Must be signed by the owner address set at add time.
+
+| Flag | Description |
+|------|-------------|
+| `--tx-id` | Original `AddAutoRenewedValidatorTx` ID (required) |
+| `--period` | Next cycle duration, or `0` to exit after the current cycle (required) |
+| `--auto-compound` | Fraction of rewards to auto-compound (required) |
+| `--node-id` | Validator node ID to narrow the authority lookup (optional, recommended) |
+
 ## subnet
 
 ### subnet create

--- a/content/docs/tooling/platform-cli/installation.mdx
+++ b/content/docs/tooling/platform-cli/installation.mdx
@@ -26,7 +26,7 @@ The script auto-detects your OS (Linux/macOS) and architecture (amd64/arm64), do
 Verify the installation:
 
 ```bash
-platform --help
+platform-cli --help
 ```
 
 ## Build from Source
@@ -85,10 +85,10 @@ When a command needs a private key, Platform CLI checks these sources in order:
 
 ```bash
 # Fuji testnet (default)
-platform wallet balance --key-name mykey
+platform-cli wallet balance --key-name mykey
 
 # Mainnet
-platform wallet balance --key-name mykey --network mainnet
+platform-cli wallet balance --key-name mykey --network mainnet
 ```
 
 ### Custom RPC
@@ -97,10 +97,10 @@ For local networks or custom endpoints:
 
 ```bash
 # Local network
-platform wallet balance --key-name mykey --rpc-url http://127.0.0.1:9650
+platform-cli wallet balance --key-name mykey --rpc-url http://127.0.0.1:9650
 
 # Custom endpoint with explicit network ID
-platform wallet balance --key-name mykey --rpc-url https://my-node.example.com:9650 --network-id 5
+platform-cli wallet balance --key-name mykey --rpc-url https://my-node.example.com:9650 --network-id 5
 ```
 
 When using `--rpc-url`, the network ID is auto-detected from the node unless `--network-id` is specified.

--- a/content/docs/tooling/platform-cli/key-management.mdx
+++ b/content/docs/tooling/platform-cli/key-management.mdx
@@ -11,10 +11,10 @@ Create a new random secp256k1 key:
 
 ```bash
 # Generate an encrypted key (default, prompts for password)
-platform keys generate --name mykey
+platform-cli keys generate --name mykey
 
 # Generate an unencrypted key (unsafe, not recommended)
-platform keys generate --name mykey --encrypt=false
+platform-cli keys generate --name mykey --encrypt=false
 ```
 
 Output:
@@ -27,7 +27,7 @@ Key generated successfully!
   Encrypted:     true
   Default:       yes
 
-WARNING: Back up your key! Use 'platform keys export' to view the private key.
+WARNING: Back up your key! Use 'platform-cli keys export' to view the private key.
 ```
 
 ## Importing Keys
@@ -36,13 +36,13 @@ Import an existing private key:
 
 ```bash
 # Import and encrypt (default)
-platform keys import --name mykey --private-key "PrivateKey-..."
+platform-cli keys import --name mykey --private-key "PrivateKey-..."
 
 # Import with hidden input prompt (encrypted by default)
-platform keys import --name mykey
+platform-cli keys import --name mykey
 
 # Import without encryption (unsafe)
-platform keys import --name mykey --encrypt=false
+platform-cli keys import --name mykey --encrypt=false
 ```
 
 Accepted key formats:
@@ -53,10 +53,10 @@ Accepted key formats:
 
 ```bash
 # Basic listing
-platform keys list
+platform-cli keys list
 
 # Include addresses
-platform keys list --show-addresses
+platform-cli keys list --show-addresses
 ```
 
 Output:
@@ -75,13 +75,13 @@ Export a private key to a file (recommended) or stdout:
 
 ```bash
 # Export to file with secure permissions (0600)
-platform keys export --name mykey --output-file ./mykey.txt
+platform-cli keys export --name mykey --output-file ./mykey.txt
 
 # Export in hex format to file
-platform keys export --name mykey --format hex --output-file ./mykey.hex
+platform-cli keys export --name mykey --format hex --output-file ./mykey.hex
 
 # Export to stdout (requires explicit opt-in)
-platform keys export --name mykey --unsafe-stdout
+platform-cli keys export --name mykey --unsafe-stdout
 ```
 
 If the key is encrypted, you'll be prompted for the password. Set `PLATFORM_CLI_KEY_PASSWORD` to skip the prompt in scripts.
@@ -90,10 +90,10 @@ If the key is encrypted, you'll be prompted for the password. Set `PLATFORM_CLI_
 
 ```bash
 # Delete with confirmation prompt
-platform keys delete --name mykey
+platform-cli keys delete --name mykey
 
 # Delete without confirmation
-platform keys delete --name mykey --force
+platform-cli keys delete --name mykey --force
 ```
 
 Deletion is irreversible. Ensure you have a backup first.
@@ -104,10 +104,10 @@ Set a default key to avoid specifying `--key-name` on every command:
 
 ```bash
 # Set default
-platform keys default --name mykey
+platform-cli keys default --name mykey
 
 # Show current default
-platform keys default
+platform-cli keys default
 ```
 
 ## Built-in Test Key: ewoq
@@ -115,7 +115,7 @@ platform keys default
 Platform CLI includes the well-known `ewoq` test key for local development:
 
 ```bash
-platform wallet address --key-name ewoq
+platform-cli wallet address --key-name ewoq
 ```
 
 The ewoq key is pre-funded on local networks. Platform CLI blocks its use on mainnet for safety.
@@ -128,11 +128,11 @@ Build with Ledger support and use the `--ledger` flag:
 go build -tags ledger -o platform .
 
 # Use Ledger for any command
-platform wallet address --ledger
-platform transfer send --to P-fuji1... --amount 10 --ledger
+platform-cli wallet address --ledger
+platform-cli transfer send --to P-fuji1... --amount 10 --ledger
 
 # Use a different address index
-platform wallet balance --ledger --ledger-index 1
+platform-cli wallet balance --ledger --ledger-index 1
 ```
 
 ## Security Best Practices

--- a/content/docs/tooling/platform-cli/l1-validators.mdx
+++ b/content/docs/tooling/platform-cli/l1-validators.mdx
@@ -8,7 +8,7 @@ Once a subnet is converted to an L1, manage its validators with the `l1` command
 ## Register Validator
 
 ```bash
-platform l1 register-validator \
+platform-cli l1 register-validator \
   --balance 1.0 \
   --pop 0xabc123... \
   --message 0xdef456... \
@@ -24,7 +24,7 @@ platform l1 register-validator \
 ## Set Validator Weight
 
 ```bash
-platform l1 set-validator-weight \
+platform-cli l1 set-validator-weight \
   --message 0xabc123... \
   --key-name mykey
 ```
@@ -38,7 +38,7 @@ platform l1 set-validator-weight \
 Top up a validator's balance for continuous fee payments:
 
 ```bash
-platform l1 increase-validator-balance \
+platform-cli l1 increase-validator-balance \
   --validation-id 2QYfFcfZ9... \
   --balance 5.0 \
   --key-name mykey
@@ -54,7 +54,7 @@ platform l1 increase-validator-balance \
 Disable a validator and return remaining funds:
 
 ```bash
-platform l1 disable-validator \
+platform-cli l1 disable-validator \
   --validation-id 2QYfFcfZ9... \
   --key-name mykey
 ```

--- a/content/docs/tooling/platform-cli/staking.mdx
+++ b/content/docs/tooling/platform-cli/staking.mdx
@@ -113,6 +113,58 @@ By default, rewards go to your P-Chain address. Specify a different address with
 --reward-address P-avax1xyz789...
 ```
 
+## Auto-Renewed Staking (ACP-236)
+
+An auto-renewed validator automatically restakes at the end of each cycle instead of expiring, optionally compounding its rewards. The configuration for the *next* cycle can be updated at any time by the owner address set when the validator was added.
+
+### Add an Auto-Renewed Validator
+
+```bash
+platform validator add-auto-renewed \
+  --node-id NodeID-BFa1paAAAA... \
+  --stake 2000 \
+  --period 336h \
+  --delegation-fee 0.02 \
+  --auto-compound 1 \
+  --bls-public-key 0x1234... \
+  --bls-pop 0x5678... \
+  --owner-address P-avax1xyz789... \
+  --key-name mykey \
+  --network mainnet
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--node-id` | Node ID to validate (required) | |
+| `--stake` | Stake amount in AVAX (network minimum applies) | |
+| `--period` | Auto-renewal cycle duration (e.g. `336h` for 14 days) | `336h` |
+| `--auto-compound` | Fraction of rewards to auto-compound (`0.3` = 30%, `1` = 100%) | `1` |
+| `--delegation-fee` | Delegation fee (`0.02` = 2%) | `0.02` |
+| `--owner-address` | Address authorized to update the auto-renew config | own address |
+| `--reward-address` | Reward address | own address |
+| `--bls-public-key` / `--bls-pop` | BLS credentials (recommended/manual mode) | |
+| `--node-endpoint` | Node endpoint to auto-fetch BLS (fallback mode) | |
+
+### Update the Next-Cycle Config
+
+Change the next cycle's period and auto-compound rate, or stop auto-renewal. Must be signed by the `--owner-address` set at add time, and references the original `add-auto-renewed` transaction ID.
+
+```bash
+platform validator set-auto-renewed-config \
+  --tx-id 2QYfFcfZ9... \
+  --node-id NodeID-BFa1paAAAA... \
+  --period 720h \
+  --auto-compound 0.5 \
+  --key-name mykey
+```
+
+| Flag | Description |
+|------|-------------|
+| `--tx-id` | Original `AddAutoRenewedValidatorTx` ID (required) |
+| `--period` | Next cycle duration, or `0` to exit after the current cycle (required) |
+| `--auto-compound` | Fraction of rewards to auto-compound (required) |
+| `--node-id` | Validator node ID to narrow the authority lookup (optional, recommended) |
+
 ## Next Steps
 
 <Cards>

--- a/content/docs/tooling/platform-cli/staking.mdx
+++ b/content/docs/tooling/platform-cli/staking.mdx
@@ -20,7 +20,7 @@ All validators require a BLS proof of possession. You can provide this manually 
 ### Manual BLS Mode (Recommended)
 
 ```bash
-platform validator add-permissionless \
+platform-cli validator add-permissionless \
   --node-id NodeID-BFa1paAAAA... \
   --stake 2000 \
   --duration 336h \
@@ -34,7 +34,7 @@ platform validator add-permissionless \
 ### Auto-Fetch BLS from Node
 
 ```bash
-platform validator add-permissionless \
+platform-cli validator add-permissionless \
   --node-id NodeID-BFa1paAAAA... \
   --stake 2000 \
   --duration 336h \
@@ -49,7 +49,7 @@ platform validator add-permissionless \
 Use `node info` to retrieve BLS credentials from a running node:
 
 ```bash
-platform node info --ip validator.example.com:9650
+platform-cli node info --ip validator.example.com:9650
 ```
 
 ```
@@ -63,7 +63,7 @@ BLS PoP:        0xfedcba0987654321...
 Delegate AVAX to an existing validator:
 
 ```bash
-platform validator add-permissionless-delegator \
+platform-cli validator add-permissionless-delegator \
   --node-id NodeID-BFa1paAAAA... \
   --stake 100 \
   --duration 336h \
@@ -120,7 +120,7 @@ An auto-renewed validator automatically restakes at the end of each cycle instea
 ### Add an Auto-Renewed Validator
 
 ```bash
-platform validator add-auto-renewed \
+platform-cli validator add-auto-renewed \
   --node-id NodeID-BFa1paAAAA... \
   --stake 2000 \
   --period 336h \
@@ -150,7 +150,7 @@ platform validator add-auto-renewed \
 Change the next cycle's period and auto-compound rate, or stop auto-renewal. Must be signed by the `--owner-address` set at add time, and references the original `add-auto-renewed` transaction ID.
 
 ```bash
-platform validator set-auto-renewed-config \
+platform-cli validator set-auto-renewed-config \
   --tx-id 2QYfFcfZ9... \
   --node-id NodeID-BFa1paAAAA... \
   --period 720h \

--- a/content/docs/tooling/platform-cli/subnets.mdx
+++ b/content/docs/tooling/platform-cli/subnets.mdx
@@ -8,7 +8,7 @@ Platform CLI supports creating subnets, transferring ownership, and converting t
 ## Create a Subnet
 
 ```bash
-platform subnet create --key-name mykey --network fuji
+platform-cli subnet create --key-name mykey --network fuji
 ```
 
 ```
@@ -26,7 +26,7 @@ The subnet owner is the wallet address used to create it. You need P-Chain AVAX 
 Transfer ownership to a new P-Chain address:
 
 ```bash
-platform subnet transfer-ownership \
+platform-cli subnet transfer-ownership \
   --subnet-id 2QYfFcfZ9... \
   --new-owner P-fuji1xyz789... \
   --key-name mykey
@@ -37,7 +37,7 @@ platform subnet transfer-ownership \
 Add a validator to a permissioned subnet (`AddSubnetValidatorTx`). The node must **already be a primary network validator**, and the subnet owner key authorizes the transaction.
 
 ```bash
-platform subnet add-validator \
+platform-cli subnet add-validator \
   --subnet-id 2QYfFcfZ9... \
   --node-id NodeID-BFa1paAAAA... \
   --weight 100 \
@@ -56,7 +56,7 @@ Convert a permissioned subnet to an L1 blockchain. This operation is **irreversi
 Provide validator node addresses and let the CLI fetch NodeID and BLS credentials:
 
 ```bash
-platform subnet convert-to-l1 \
+platform-cli subnet convert-to-l1 \
   --subnet-id 2QYfFcfZ9... \
   --chain-id 3RZgGdaH1... \
   --manager 0x1234567890abcdef1234567890abcdef12345678 \
@@ -70,7 +70,7 @@ platform subnet convert-to-l1 \
 Provide validator data explicitly (all lists must be comma-separated and aligned by index):
 
 ```bash
-platform subnet convert-to-l1 \
+platform-cli subnet convert-to-l1 \
   --subnet-id 2QYfFcfZ9... \
   --chain-id 3RZgGdaH1... \
   --manager 0x1234... \
@@ -86,7 +86,7 @@ platform subnet convert-to-l1 \
 For local testing, generate a mock validator with random BLS credentials:
 
 ```bash
-platform subnet convert-to-l1 \
+platform-cli subnet convert-to-l1 \
   --subnet-id 2QYfFcfZ9... \
   --chain-id 3RZgGdaH1... \
   --mock-validator \

--- a/content/docs/tooling/platform-cli/transfers.mdx
+++ b/content/docs/tooling/platform-cli/transfers.mdx
@@ -19,13 +19,13 @@ These flags are mutually exclusive. Use `--amount-navax` when exact precision ma
 Send AVAX to another P-Chain address:
 
 ```bash
-platform transfer send --to P-fuji1abc123... --amount 10 --key-name mykey
+platform-cli transfer send --to P-fuji1abc123... --amount 10 --key-name mykey
 
 # With exact nAVAX amount
-platform transfer send --to P-fuji1abc123... --amount-navax 10000000000 --key-name mykey
+platform-cli transfer send --to P-fuji1abc123... --amount-navax 10000000000 --key-name mykey
 
 # On mainnet
-platform transfer send --to P-avax1abc123... --amount 100 --network mainnet --key-name mykey
+platform-cli transfer send --to P-avax1abc123... --amount 100 --network mainnet --key-name mykey
 ```
 
 ## Cross-Chain: P-Chain to C-Chain
@@ -33,7 +33,7 @@ platform transfer send --to P-avax1abc123... --amount 100 --network mainnet --ke
 Transfer AVAX from P-Chain to C-Chain in one step (handles export + import automatically):
 
 ```bash
-platform transfer p-to-c --amount 10 --key-name mykey
+platform-cli transfer p-to-c --amount 10 --key-name mykey
 ```
 
 Output:
@@ -52,7 +52,7 @@ Transfer complete!
 ## Cross-Chain: C-Chain to P-Chain
 
 ```bash
-platform transfer c-to-p --amount 5 --key-name mykey
+platform-cli transfer c-to-p --amount 5 --key-name mykey
 ```
 
 ## Manual Two-Step Transfers
@@ -61,10 +61,10 @@ For advanced use cases, perform export and import separately:
 
 ```bash
 # Step 1: Export
-platform transfer export --from p --to c --amount 10 --key-name mykey
+platform-cli transfer export --from p --to c --amount 10 --key-name mykey
 
 # Step 2: Import (after network confirmation)
-platform transfer import --from p --to c --key-name mykey
+platform-cli transfer import --from p --to c --key-name mykey
 ```
 
 The `--from` and `--to` flags accept `p` or `c`.
@@ -72,7 +72,7 @@ The `--from` and `--to` flags accept `p` or `c`.
 ## Checking Balances
 
 ```bash
-platform wallet balance --key-name mykey --network fuji
+platform-cli wallet balance --key-name mykey --network fuji
 ```
 
 ```
@@ -85,7 +85,7 @@ Balance: 100.000000000 AVAX
 The same private key derives different addresses on each chain:
 
 ```bash
-platform wallet address --key-name mykey
+platform-cli wallet address --key-name mykey
 ```
 
 ```


### PR DESCRIPTION
## What

Completes and corrects the v2.0.0 platform-cli docs. Two changes:

### 1. Document ACP-236 auto-renewed staking (was missing)
v2.0.0 shipped auto-renewed staking ([platform-cli #28](https://github.com/ava-labs/platform-cli/pull/28)) but the docs (merged in #4304) didn't cover it.
- `staking.mdx` — new "Auto-Renewed Staking (ACP-236)" section: `validator add-auto-renewed` + `validator set-auto-renewed-config`.
- `command-reference.mdx` — entries + flag tables for both. Flags verified against the v2.0.0 CLI `--help`.

### 2. Fix the binary name `platform` → `platform-cli` (accuracy bug)
The CLI binary is **`platform-cli`** (per `.goreleaser.yaml` `binary: platform-cli`, `install.sh` `BINARY="platform-cli"`, `go.mod` module path, and cobra `Use` after [platform-cli #34](https://github.com/ava-labs/platform-cli/pull/34)). The docs still invoked it as `platform …`, so the documented commands fail with `command not found`. Renamed all command invocations across the platform-cli docs (and the platform-cli usages in `node-validator` + `avalanche-deploy`).

- 91 command invocations renamed across 11 files. Product name "Platform CLI" and the `install/platform-cli` URL are unchanged; no double-renames.

Follow-up to #4304.