### PR TITLE
fix(console): use platform-cli binary + v2.0.0 command names in generated CLI commands

### DIFF
--- a/components/console/cli-onboarding-flow.tsx
+++ b/components/console/cli-onboarding-flow.tsx
@@ -11,8 +11,8 @@ interface CliOnboardingFlowProps {
 }
 
 const INSTALL_CMD = "curl -sSfL https://build.avax.network/install/platform-cli | sh";
-const GENERATE_KEY_CMD = "platform keys generate --name mykey";
-const GET_ADDRESS_CMD = "platform wallet address --key-name mykey";
+const GENERATE_KEY_CMD = "platform-cli keys generate --name mykey";
+const GET_ADDRESS_CMD = "platform-cli wallet address --key-name mykey";
 
 function CopyableCommand({ command, label }: { command: string; label?: string }) {
   const [copied, setCopied] = useState(false);
@@ -80,7 +80,7 @@ export function CliOnboardingFlow({
         </div>
         <CopyableCommand command={GENERATE_KEY_CMD} />
         <p className="text-xs text-muted-foreground ml-7">
-          Or import an existing key: <code className="text-xs bg-muted px-1 py-0.5 rounded">platform keys import --name mykey --private-key &quot;PrivateKey-...&quot;</code>
+          Or import an existing key: <code className="text-xs bg-muted px-1 py-0.5 rounded">platform-cli keys import --name mykey --private-key &quot;PrivateKey-...&quot;</code>
         </p>
       </div>
 

--- a/components/toolbox/console/layer-1/BalanceTopup.tsx
+++ b/components/toolbox/console/layer-1/BalanceTopup.tsx
@@ -342,7 +342,7 @@ function ValidatorBalanceIncrease({ onSuccess }: BaseConsoleToolProps) {
                   loadingText="Increasing Balance..."
                   disabled={isDisabled}
                   className="w-full"
-                  cliCommand={`platform l1 add-balance --validation-id ${validatorSelection.validationId || '<validation-id>'} --balance ${amount || '<amount>'} --network ${isTestnet ? 'fuji' : 'mainnet'} --key-name <your-key-name>`}
+                  cliCommand={`platform-cli l1 increase-validator-balance --validation-id ${validatorSelection.validationId || '<validation-id>'} --balance ${amount || '<amount>'} --network ${isTestnet ? 'fuji' : 'mainnet'} --key-name <your-key-name>`}
                 >
                   Increase Balance
                 </CoreWalletTransactionButton>

--- a/components/toolbox/console/layer-1/create/ConvertSubnetToL1.tsx
+++ b/components/toolbox/console/layer-1/create/ConvertSubnetToL1.tsx
@@ -69,7 +69,7 @@ function ConvertToL1({ onSuccess }: BaseConsoleToolProps) {
 
   function buildConvertCliCommand() {
     const parts = [
-      `platform subnet convert-l1`,
+      `platform-cli subnet convert-to-l1`,
       `--subnet-id ${selection.subnetId || '<subnet-id>'}`,
       `--chain-id ${validatorManagerChainID || '<chain-id>'}`,
       `--manager ${validatorManagerAddress || '<address>'}`,

--- a/components/toolbox/console/layer-1/create/CreateChain.tsx
+++ b/components/toolbox/console/layer-1/create/CreateChain.tsx
@@ -292,7 +292,7 @@ function CreateChain({ onSuccess: _onSuccess, embedded = false, preinstallDefaul
               loadingText="Creating Chain..."
               disabled={!canCreateChain}
               className="w-full"
-              cliCommand={`platform chain create --subnet-id ${subnetId || '<subnet-id>'} --genesis ./genesis.json --name "${localChainName}"${vmId !== SUBNET_EVM_VM_ID ? ` --vm-id ${vmId}` : ''} --network ${isTestnet ? 'fuji' : 'mainnet'}`}
+              cliCommand={`platform-cli chain create --subnet-id ${subnetId || '<subnet-id>'} --genesis ./genesis.json --name "${localChainName}"${vmId !== SUBNET_EVM_VM_ID ? ` --vm-id ${vmId}` : ''} --network ${isTestnet ? 'fuji' : 'mainnet'}`}
               downloadFile={genesisData ? { data: genesisData, filename: 'genesis.json' } : undefined}
             >
               Create Chain

--- a/components/toolbox/console/layer-1/create/CreateSubnet.tsx
+++ b/components/toolbox/console/layer-1/create/CreateSubnet.tsx
@@ -81,7 +81,7 @@ function CreateSubnet(_props: BaseConsoleToolProps) {
         loadingText="Creating..."
         variant="primary"
         className="w-full"
-        cliCommand={`platform subnet create --network ${isTestnet ? 'fuji' : 'mainnet'}`}
+        cliCommand={`platform-cli subnet create --network ${isTestnet ? 'fuji' : 'mainnet'}`}
       >
         Create Subnet
       </CoreWalletTransactionButton>

--- a/components/toolbox/console/permissioned-l1s/add-validator/SubmitPChainTxRegisterL1Validator.tsx
+++ b/components/toolbox/console/permissioned-l1s/add-validator/SubmitPChainTxRegisterL1Validator.tsx
@@ -193,7 +193,7 @@ const SubmitPChainTxRegisterL1Validator: React.FC<SubmitPChainTxRegisterL1Valida
     if (!signedWarpMessage) return '';
     const network = isTestnet ? 'fuji' : 'mainnet';
     return [
-      `platform l1 register-validator \\`,
+      `platform-cli l1 register-validator \\`,
       `  --message "${signedWarpMessage}" \\`,
       `  --pop "${blsProofOfPossession || '<BLS_PROOF>'}" \\`,
       `  --balance ${validatorBalance || '<BALANCE_AVAX>'} \\`,

--- a/components/toolbox/console/permissioned-l1s/remove-validator/SubmitPChainTxRemoval.tsx
+++ b/components/toolbox/console/permissioned-l1s/remove-validator/SubmitPChainTxRemoval.tsx
@@ -334,7 +334,7 @@ const SubmitPChainTxRemoval: React.FC<SubmitPChainTxRemovalProps> = ({
     if (!signedWarpMessage) return '';
     const network = isTestnet ? 'fuji' : 'mainnet';
     return [
-      `platform l1 set-weight \\`,
+      `platform-cli l1 set-validator-weight \\`,
       `  --message "${signedWarpMessage}" \\`,
       `  --network ${network} \\`,
       `  --key-name <your-key-name>`,

--- a/components/toolbox/console/primary-network/CrossChainTransfer.tsx
+++ b/components/toolbox/console/primary-network/CrossChainTransfer.tsx
@@ -561,8 +561,8 @@ console.log("Import tx:", txnResponse.txHash);`,
 
   const cliCommand =
     sourceChain === 'c-chain'
-      ? `platform transfer c-to-p --amount ${amount || '<amount>'} --network ${isTestnet ? 'fuji' : 'mainnet'}`
-      : `platform transfer p-to-c --amount ${amount || '<amount>'} --network ${isTestnet ? 'fuji' : 'mainnet'}`;
+      ? `platform-cli transfer c-to-p --amount ${amount || '<amount>'} --network ${isTestnet ? 'fuji' : 'mainnet'}`
+      : `platform-cli transfer p-to-c --amount ${amount || '<amount>'} --network ${isTestnet ? 'fuji' : 'mainnet'}`;
 
   const sourceChainName = sourceChain === 'c-chain' ? 'C-Chain' : 'P-Chain';
   const destChainName = destinationChain === 'c-chain' ? 'C-Chain' : 'P-Chain';

--- a/components/toolbox/console/primary-network/Faucet.tsx
+++ b/components/toolbox/console/primary-network/Faucet.tsx
@@ -186,7 +186,7 @@ function ManualPChainFaucetInput() {
       <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-2">
         Using platform-cli? Paste your address from{' '}
         <code className="bg-zinc-100 dark:bg-zinc-800 px-1 py-0.5 rounded text-[10px] font-mono">
-          platform wallet balance
+          platform-cli wallet balance
         </code>{' '}
         &mdash; the{' '}
         <code className="bg-zinc-100 dark:bg-zinc-800 px-1 py-0.5 rounded text-[10px] font-mono">P-fuji1</code> prefix

--- a/components/toolbox/console/primary-network/Stake.tsx
+++ b/components/toolbox/console/primary-network/Stake.tsx
@@ -251,7 +251,7 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
     }
   };
 
-  const cliCommand = `platform validator add --node-id ${validator?.nodeID || '<node-id>'} --stake ${stakeInAvax || '<amount>'} --duration ${getDurationHours()}h --delegation-fee ${Number(delegationFee) / 100} --network ${onFuji ? 'fuji' : 'mainnet'}`;
+  const cliCommand = `platform-cli validator add-permissionless --node-id ${validator?.nodeID || '<node-id>'} --stake ${stakeInAvax || '<amount>'} --duration ${getDurationHours()}h --delegation-fee ${Number(delegationFee) / 100} --network ${onFuji ? 'fuji' : 'mainnet'}`;
 
   return (
     <SDKCodeViewer sources={SDK_SOURCES} height="auto">

--- a/components/toolbox/console/shared/SubmitPChainTxWeightUpdate.tsx
+++ b/components/toolbox/console/shared/SubmitPChainTxWeightUpdate.tsx
@@ -290,7 +290,7 @@ const SubmitPChainTxWeightUpdate: React.FC<SubmitPChainTxWeightUpdateProps> = ({
     if (!signedWarpMessage) return '';
     const network = isTestnet ? 'fuji' : 'mainnet';
     return [
-      `platform l1 set-weight \\`,
+      `platform-cli l1 set-validator-weight \\`,
       `  --message "${signedWarpMessage}" \\`,
       `  --network ${network} \\`,
       `  --key-name <your-key-name>`,

--- a/components/toolbox/console/shared/pchainCommands.ts
+++ b/components/toolbox/console/shared/pchainCommands.ts
@@ -19,23 +19,23 @@ export const PCHAIN_COMMANDS = {
     network: 'fuji' | 'mainnet';
     keyName?: string;
   }) =>
-    `platform l1 register-validator --message ${opts.signedWarpMessage} --balance ${opts.balance} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
+    `platform-cli l1 register-validator --message ${opts.signedWarpMessage} --balance ${opts.balance} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
 
   /** IssueSetL1ValidatorWeightTx — update validator weight (used for removal, delegation, weight change) */
   setL1ValidatorWeight: (opts: { signedWarpMessage: string; network: 'fuji' | 'mainnet'; keyName?: string }) =>
-    `platform l1 set-weight --message ${opts.signedWarpMessage} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
+    `platform-cli l1 set-validator-weight --message ${opts.signedWarpMessage} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
 
   /** IssueIncreaseL1ValidatorBalanceTx — top up validator balance */
   addBalance: (opts: { validationId: string; balance: string; network: 'fuji' | 'mainnet'; keyName?: string }) =>
-    `platform l1 add-balance --validation-id ${opts.validationId} --balance ${opts.balance} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
+    `platform-cli l1 increase-validator-balance --validation-id ${opts.validationId} --balance ${opts.balance} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
 
   /** IssueDisableL1ValidatorTx — disable a validator */
   disableValidator: (opts: { validationId: string; network: 'fuji' | 'mainnet'; keyName?: string }) =>
-    `platform l1 disable-validator --validation-id ${opts.validationId} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
+    `platform-cli l1 disable-validator --validation-id ${opts.validationId} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
 
   /** IssueCreateSubnetTx */
   createSubnet: (opts: { network: 'fuji' | 'mainnet'; keyName?: string }) =>
-    `platform subnet create --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
+    `platform-cli subnet create --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
 
   /** IssueCreateChainTx */
   createChain: (opts: {
@@ -45,7 +45,7 @@ export const PCHAIN_COMMANDS = {
     network: 'fuji' | 'mainnet';
     keyName?: string;
   }) =>
-    `platform chain create --subnet-id ${opts.subnetId} --genesis ${opts.genesisFile} --name "${opts.name}" --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
+    `platform-cli chain create --subnet-id ${opts.subnetId} --genesis ${opts.genesisFile} --name "${opts.name}" --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
 
   /** IssueConvertSubnetToL1Tx */
   convertToL1: (opts: {
@@ -55,7 +55,7 @@ export const PCHAIN_COMMANDS = {
     network: 'fuji' | 'mainnet';
     keyName?: string;
   }) =>
-    `platform subnet convert-l1 --subnet-id ${opts.subnetId} --chain-id ${opts.chainId} --contract-address ${opts.contractAddress} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
+    `platform-cli subnet convert-to-l1 --subnet-id ${opts.subnetId} --chain-id ${opts.chainId} --contract-address ${opts.contractAddress} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
 
   /** IssueAddPermissionlessValidatorTx (Primary Network) */
   addValidator: (opts: {
@@ -66,7 +66,7 @@ export const PCHAIN_COMMANDS = {
     network: 'fuji' | 'mainnet';
     keyName?: string;
   }) =>
-    `platform validator add --node-id ${opts.nodeId} --stake ${opts.stake} --duration ${opts.duration} --delegation-fee ${opts.delegationFee} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
+    `platform-cli validator add-permissionless --node-id ${opts.nodeId} --stake ${opts.stake} --duration ${opts.duration} --delegation-fee ${opts.delegationFee} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
 
   /** IssueAddPermissionlessDelegatorTx (Primary Network) */
   addDelegator: (opts: {
@@ -76,7 +76,7 @@ export const PCHAIN_COMMANDS = {
     network: 'fuji' | 'mainnet';
     keyName?: string;
   }) =>
-    `platform validator delegate --node-id ${opts.nodeId} --stake ${opts.stake} --duration ${opts.duration} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
+    `platform-cli validator add-permissionless-delegator --node-id ${opts.nodeId} --stake ${opts.stake} --duration ${opts.duration} --network ${opts.network}${opts.keyName ? ` --key-name ${opts.keyName}` : ''}`,
 } as const;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The Builder Console generates copy-paste platform-cli commands (the "Run via CLI" snippets in the staking, L1, subnet, transfer, and onboarding tools). Those strings were stale after platform-cli **v2.0.0** and would fail if a user pasted them:

- **Binary name:** `platform …` → the binary is `platform-cli` (renamed in [platform-cli #34](https://github.com/ava-labs/platform-cli/pull/34)) → `command not found`.
- **Renamed commands (v2.0.0 breaking renames):** the old names now error with `unknown command`.

## Fix

Updated the generated command strings across **12 Console files**:

| Old | New |
|---|---|
| `platform …` | `platform-cli …` |
| `validator add` | `validator add-permissionless` |
| `validator delegate` | `validator add-permissionless-delegator` |
| `subnet convert-l1` | `subnet convert-to-l1` |
| `l1 set-weight` | `l1 set-validator-weight` |
| `l1 add-balance` | `l1 increase-validator-balance` |

Commands that only needed the binary rename (`keys`, `wallet`, `transfer`, `subnet create`, `chain create`, `l1 register-validator`, `l1 disable-validator`) were updated too.

## Notes
- **String-content only** — no logic changes (23 insertions / 23 deletions). Template literals + interpolation preserved.
- False positives deliberately left untouched: the `//platform chain id` test comments and a `// validator add/remove/weight` code comment.
- Companion to docs PRs #4304 (renames) and #4315 (auto-renewed docs + the same `platform`→`platform-cli` rename in docs).