### PR TITLE
fix: events, timezone visibility

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -49,7 +49,12 @@ const createHackathonSchema = z.object({
   location: z.string().min(1),
   total_prizes: z.number().nonnegative().optional(),
   participants: z.number().nonnegative().optional(),
-  tags: z.array(z.string()).min(1),
+  tags: z
+    .array(z.string())
+    .transform((arr) => arr.map((t) => t.trim()).filter((t) => t.length > 0))
+    .refine((arr) => arr.length >= 1, {
+      message: 'Please add at least one category or tag.',
+    }),
   timezone: z.string().optional(),
   cohosts: z.array(z.string().email()).optional(),
   organizers: z.string().max(200).optional(),
@@ -211,8 +216,16 @@ export const POST = withAuth(async (req: NextRequest, context: any, session: any
       { status: 201 }
     );
   } catch (error: any) {
-    console.error('Error POST /api/events:', error.message);
     const wrappedError = error as Error;
+    if (wrappedError.cause === 'ValidationError') {
+      const details = (wrappedError as any).details as Array<{ field: string; message: string }> | undefined;
+      console.error(
+        'Error POST /api/events: Validation failed',
+        details?.map((d) => `${d.field}: ${d.message}`)
+      );
+    } else {
+      console.error('Error POST /api/events:', error.message);
+    }
     return NextResponse.json(
       { error: wrappedError },
       { status: wrappedError.cause == 'ValidationError' ? 400 : 500 }

--- a/components/events/TimezoneCombobox.tsx
+++ b/components/events/TimezoneCombobox.tsx
@@ -50,6 +50,7 @@ const CURATED_TIMEZONES: TimezoneOption[] = [
   { value: "America/Sao_Paulo", label: "São Paulo, Brazil (BRT) - GMT-3", offset: -3 },
   { value: "America/Santiago", label: "Santiago, Chile (CLT) - GMT-3", offset: -3 },
   { value: "America/Buenos_Aires", label: "Buenos Aires, Argentina (ART) - GMT-3", offset: -3 },
+  { value: "UTC", label: "UTC (Coordinated Universal Time) - GMT+0", offset: 0 },
   { value: "Europe/London", label: "London (GMT/BST) - GMT+0/+1", offset: 0 },
   { value: "Europe/Paris", label: "Paris (CET/CEST) - GMT+1/+2", offset: 1 },
   { value: "Europe/Berlin", label: "Berlin (CET/CEST) - GMT+1/+2", offset: 1 },

--- a/components/hackathons/event-layouts/ModernEventLayout.tsx
+++ b/components/hackathons/event-layouts/ModernEventLayout.tsx
@@ -67,6 +67,24 @@ export default function ModernEventLayout({
     validStartDate.getMonth() === validEndDate.getMonth() &&
     validStartDate.getDate() === validEndDate.getDate();
 
+  // Short timezone offset label (e.g. "UTC+2"); full zone name shown on hover.
+  const timeZone = hackathon.timezone || "UTC";
+  const shortTimeZone = (() => {
+    try {
+      const offset = new Intl.DateTimeFormat("en-US", {
+        timeZone,
+        timeZoneName: "shortOffset",
+      })
+        .formatToParts(validStartDate)
+        .find((part) => part.type === "timeZoneName")?.value;
+      if (!offset) return timeZone;
+      const label = offset.replace("GMT", "UTC");
+      return label === "UTC+0" || label === "UTC-0" ? "UTC" : label;
+    } catch {
+      return timeZone;
+    }
+  })();
+
   const formattedDate =
     isSameDay
       ? `${format(validStartDate, "MMMM d, h:mm a")} - ${format(
@@ -217,6 +235,12 @@ export default function ModernEventLayout({
                 <Calendar className="w-5 h-5 text-zinc-600 dark:text-zinc-400 flex-shrink-0" />
                 <span className="text-base sm:text-lg font-medium text-zinc-900 dark:text-zinc-100">
                   {formattedDate}
+                  {isSameDay && (
+                    <>
+                      {" "}
+                      <span title={timeZone}>{shortTimeZone}</span>
+                    </>
+                  )}
                 </span>
               </div>
 

--- a/lib/events/i18n.ts
+++ b/lib/events/i18n.ts
@@ -97,7 +97,7 @@ const dict: Record<EventsLang, Dict> = {
     // Buttons / misc
     "join.registered": "You're In",
     "join.chat": "Join the Hackathon Chat",
-    "join.default": "Join now",
+    "join.default": "Register / Join",
     "join.editRegistration": "Edit registration",
     "overview.learnMore": "LEARN MORE",
     "overview.hackathonTitleFallback": "Hackathon Title",
@@ -623,7 +623,7 @@ const dict: Record<EventsLang, Dict> = {
     // Buttons / misc
     "join.registered": "Ya estás dentro",
     "join.chat": "Únete al chat del hackathon",
-    "join.default": "Unirse ahora",
+    "join.default": "Registrarse / Unirse",
     "join.editRegistration": "Editar registro",
     "overview.learnMore": "SABER MÁS",
     "overview.hackathonTitleFallback": "Título del hackathon",


### PR DESCRIPTION
- add zod validation for tags, which are mandatory, but were not validated
- add UTC to timezone dropdown at events/edit 
- rename "Join" button to "Register / Join" to avoid confusion for future events
- show timezone at /events/[id] page if a time is set