### PR TITLE
fix: events/edit - timezone handling

### DIFF
--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -50,6 +50,15 @@ export const PUT = withAuthRole('devrel', async (req: NextRequest, context: any,
       return NextResponse.json(updatedHackathon);
     }
   } catch (error) {
+    const wrappedError = error as Error;
+    if (wrappedError.cause === 'ValidationError') {
+      const details = (wrappedError as any).details as Array<{ field: string; message: string }> | undefined;
+      console.error(
+        "Error in PUT /api/events/[id]: Validation failed",
+        details?.map((d) => `${d.field}: ${d.message}`)
+      );
+      return NextResponse.json({ error: 'Invalid request body', details }, { status: 400 });
+    }
     console.error("Error in PUT /api/events/[id]:", error);
     return NextResponse.json({ error: `Internal Server Error: ${error}` }, { status: 500 });
   }

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -177,8 +177,15 @@ export const POST = withAuth(async (req: NextRequest, context: any, session: any
     // the service layer.  This prevents mass-assignment / schema injection.
     const parseResult = createHackathonSchema.safeParse(rawBody);
     if (!parseResult.success) {
+      // Emit details as an array of { field, message } so the client's error
+      // renderer (see app/events/edit/page.tsx) can surface the specific
+      // validation message instead of falling back to the generic error string.
+      const details = parseResult.error.issues.map((issue) => ({
+        field: issue.path.join('.') || '(body)',
+        message: issue.message,
+      }));
       return NextResponse.json(
-        { error: 'Invalid request body', details: parseResult.error.flatten() },
+        { error: 'Invalid request body', details },
         { status: 400 }
       );
     }

--- a/app/events/edit/initials.ts
+++ b/app/events/edit/initials.ts
@@ -142,7 +142,7 @@ export const initialData: {
   latest: {
     start_date: "",
     end_date: "",
-    timezone: "",
+    timezone: "UTC",
     banner: "https://qizat5l3bwvomkny.public.blob.vercel-storage.com/Hackathon_assets/Template/main_banner_template.png",
     icon: "https://qizat5l3bwvomkny.public.blob.vercel-storage.com/Hackathon_assets/Template/icon_template.png",
     small_banner: "https://qizat5l3bwvomkny.public.blob.vercel-storage.com/Hackathon_assets/Template/small_banner_template.png",

--- a/app/events/edit/page.tsx
+++ b/app/events/edit/page.tsx
@@ -101,6 +101,57 @@ function toIso8601(datetimeLocal: string) {
   return date.toISOString();
 }
 
+function isSupportedTimeZone(timeZone: string) {
+  if (!timeZone) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Render a stored absolute instant (`isoString`, UTC) as the `datetime-local`
+ * wall clock in the event's own `timeZone` — NOT the browser's timezone. This
+ * is the inverse of how the server persists the value (a naive wall clock in
+ * `timeZone`, see server/services/date-parser.ts), so what the organiser typed
+ * is what they see again on reload, regardless of where they open the editor.
+ */
+function toEventDatetimeString(isoString: string, timeZone: string) {
+  if (!isoString) return '';
+  const date = new Date(isoString);
+  if (isNaN(date.getTime())) return '';
+  const tz = isSupportedTimeZone(timeZone) ? timeZone : 'UTC';
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+  const map: Record<string, string> = Object.fromEntries(
+    fmt.formatToParts(date).map((p) => [p.type, p.value])
+  );
+  const hour = map.hour === '24' ? '00' : map.hour;
+  return `${map.year}-${map.month}-${map.day}T${hour}:${map.minute}`;
+}
+
+/**
+ * Strip any timezone suffix from a `datetime-local` value WITHOUT shifting the
+ * clock, yielding the naive wall clock ("YYYY-MM-DDTHH:MM") the user sees. The
+ * server interprets this in the event's selected timezone. We deliberately do
+ * not convert via `new Date().toISOString()` here (that would re-introduce the
+ * browser-timezone shift bug).
+ */
+function toNaiveDatetime(value: string) {
+  if (!value) return '';
+  const m = value.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2})/);
+  return m ? m[1] : value;
+}
+
 type ChangedField = { key: string; oldValue: unknown; newValue: unknown };
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -1457,8 +1508,8 @@ const HackathonsEdit = () => {
     });
     setRawTrackDescriptions(trackDescriptions);
     setFormDataLatest({
-      start_date: toLocalDatetimeString(hackathon.start_date ?? ''),
-      end_date: toLocalDatetimeString(hackathon.end_date ?? ''),
+      start_date: toEventDatetimeString(hackathon.start_date ?? '', hackathon.timezone ?? ''),
+      end_date: toEventDatetimeString(hackathon.end_date ?? '', hackathon.timezone ?? ''),
       timezone: hackathon.timezone ?? '',
       banner: hackathon.banner ?? '',
       icon: hackathon.icon ?? '',
@@ -1882,8 +1933,9 @@ const HackathonsEdit = () => {
     content.registration_deadline = toIso8601(content.registration_deadline);
     content.schedule = content.schedule.map(ev => ({ ...ev, date: toIso8601(ev.date) }));
     const latest = { ...formDataLatest };
-    latest.start_date = toIso8601(latest.start_date);
-    latest.end_date = toIso8601(latest.end_date);
+    // Send the naive wall clock; the server interprets it in `latest.timezone`.
+    latest.start_date = toNaiveDatetime(latest.start_date);
+    latest.end_date = toNaiveDatetime(latest.end_date);
     latest.google_calendar_id = formDataLatest.google_calendar_id?.trim() || null;
     const { icon, ...latestWithoutIcon } = latest;
     return {

--- a/lib/hackathons/hackathon-edit.schema.ts
+++ b/lib/hackathons/hackathon-edit.schema.ts
@@ -131,7 +131,12 @@ export const hackathonEditSchema = z.object({
     description: z.string().trim().min(10).max(540),
     location: z.string().trim().min(2).max(100),
     total_prizes: z.number().min(0).max(100_000_000),
-    tags: z.array(z.string().max(30)).min(1).max(10),
+    tags: z
+      .array(z.string().max(30))
+      .max(10)
+      .refine((arr) => arr.some((t) => t.trim().length > 0), {
+        message: 'Please add at least one category or tag.',
+      }),
     participants: z.number().min(0).max(1_000_000).optional(),
     organizers: z.string().max(200).optional(),
     is_public: z.boolean().optional(),

--- a/server/services/date-parser.ts
+++ b/server/services/date-parser.ts
@@ -10,14 +10,79 @@ function isSupportedTimeZone(timeZone: string): boolean {
     }
 }
 
+/**
+ * Offset (in ms) of `timeZone` at the given absolute `instant`.
+ *
+ * Computed as (the instant's wall clock in `timeZone`, read as if it were UTC)
+ * minus the instant itself. Positive east of UTC. Relies only on `Intl` and
+ * `Date.UTC`, so the result does NOT depend on the timezone of the host
+ * process — critical, since this runs on servers configured to UTC while
+ * clients pick arbitrary event timezones.
+ */
+function timeZoneOffsetMs(instant: Date, timeZone: string): number {
+    const fmt = new Intl.DateTimeFormat('en-US', {
+        timeZone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+    });
+    const map: Record<string, string> = Object.fromEntries(
+        fmt.formatToParts(instant).map(p => [p.type, p.value])
+    );
+    let hour = Number(map.hour);
+    if (hour === 24) hour = 0; // Intl can emit "24" at midnight in some engines
+    const asUTC = Date.UTC(
+        Number(map.year),
+        Number(map.month) - 1,
+        Number(map.day),
+        hour,
+        Number(map.minute),
+        Number(map.second)
+    );
+    return asUTC - instant.getTime();
+}
+
+/**
+ * Convert a naive wall-clock (Y-M-D H:M:S with no zone) that is understood to
+ * be in `timeZone` into the corresponding absolute UTC instant.
+ *
+ * Uses one refinement pass so DST transitions resolve correctly (the offset at
+ * the naive time differs from the offset at the resulting instant near a DST
+ * boundary).
+ */
+function zonedWallClockToUtc(
+    year: number,
+    month: number,
+    day: number,
+    hour: number,
+    minute: number,
+    second: number,
+    timeZone: string
+): Date {
+    const utcGuess = Date.UTC(year, month - 1, day, hour, minute, second);
+    let offset = timeZoneOffsetMs(new Date(utcGuess), timeZone);
+    // Refine using the offset at the first approximation of the true instant.
+    offset = timeZoneOffsetMs(new Date(utcGuess - offset), timeZone);
+    return new Date(utcGuess - offset);
+}
+
 export function getDateWithTimezone(dateStr: string, timeZone: string): Date {
     if (!dateStr) {
         throw new Error(`Invalid date string: "${dateStr}"`);
     }
     const s: string = dateStr.trim();
     const endsWithZ: boolean = /[zZ]$/.test(s);
-  
-    // Case 1: ends with 'Z' (UTC instant) → project to target TZ wall time
+
+    // Case 1: ends with 'Z' (UTC instant) → project to target TZ wall time.
+    //
+    // LEGACY PATH: the event schedule still submits browser-converted 'Z'
+    // strings through this branch. Its behavior is intentionally preserved as-is
+    // — do NOT "simplify" it to a pass-through without also migrating the
+    // schedule load/save code, or existing schedule times will shift.
     if (endsWithZ) {
       const utcDate: Date = new Date(s);
       if (isNaN(utcDate.getTime())) throw new Error(`Invalid date string: "${dateStr}"`);
@@ -37,7 +102,7 @@ export function getDateWithTimezone(dateStr: string, timeZone: string): Date {
       });
       const parts: Intl.DateTimeFormatPart[] = fmt.formatToParts(utcDate);
       const map: Record<string, string> = Object.fromEntries(parts.map(p => [p.type, p.value]));
-  
+
       const year: number = Number(map.year);
       const month: number = Number(map.month);
       const day: number = Number(map.day);
@@ -45,14 +110,33 @@ export function getDateWithTimezone(dateStr: string, timeZone: string): Date {
       const minute: number = Number(map.minute ?? '0');
       const second: number = Number(map.second ?? '0');
       const ms: number = utcDate.getUTCMilliseconds();
-  
+
       // Build a Date using those wall-clock numbers (this "freezes" the TZ wall time).
       return new Date(year, month - 1, day, hour, minute, second, ms);
     }
-  
-    // Case 2: any other format → ignore timeZone and parse as-is (preserve the instant)
+
+    // Case 2: a naive wall-clock ("YYYY-MM-DDTHH:MM[:SS]") with no zone info is
+    // interpreted as a wall-clock time in `timeZone` and converted to the true
+    // absolute UTC instant. This is the path used by the event start/end
+    // date pickers: e.g. "11:00" in "UTC" → 11:00Z, "11:00" in "Europe/Moscow"
+    // (UTC+3) → 08:00Z. It is independent of the host process timezone.
+    const naive = s.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?$/);
+    if (naive) {
+      const safeTimeZone: string = isSupportedTimeZone(timeZone) ? timeZone : 'UTC';
+      return zonedWallClockToUtc(
+        Number(naive[1]),
+        Number(naive[2]),
+        Number(naive[3]),
+        Number(naive[4]),
+        Number(naive[5]),
+        Number(naive[6] ?? '0'),
+        safeTimeZone
+      );
+    }
+
+    // Case 3: any other format (e.g. an explicit numeric offset like
+    // "…+03:00") already denotes an absolute instant → parse as-is.
     const d: Date = new Date(s);
     if (isNaN(d.getTime())) throw new Error(`Invalid date string: "${dateStr}"`);
     return d;
   }
-  

--- a/tests/unit/services/date-parser.test.ts
+++ b/tests/unit/services/date-parser.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { getDateWithTimezone } from '@/server/services/date-parser';
+
+/**
+ * A naive wall-clock string ("YYYY-MM-DDTHH:MM") entered in the event editor
+ * represents a wall-clock time in the event's selected timezone. Persisting it
+ * must produce the correct absolute UTC instant, and the result must NOT depend
+ * on the timezone of the server process running this code.
+ */
+describe('getDateWithTimezone — naive wall-clock in a timezone', () => {
+  it('interprets a UTC wall-clock verbatim', () => {
+    expect(getDateWithTimezone('2026-07-01T11:00', 'UTC').toISOString()).toBe(
+      '2026-07-01T11:00:00.000Z'
+    );
+  });
+
+  it('interprets a fixed-offset (+3) zone', () => {
+    // Europe/Moscow is UTC+3 year-round → 11:00 local == 08:00 UTC.
+    expect(
+      getDateWithTimezone('2026-07-01T11:00', 'Europe/Moscow').toISOString()
+    ).toBe('2026-07-01T08:00:00.000Z');
+  });
+
+  it('honours daylight saving (summer, New York = UTC-4)', () => {
+    expect(
+      getDateWithTimezone('2026-07-01T15:00', 'America/New_York').toISOString()
+    ).toBe('2026-07-01T19:00:00.000Z');
+  });
+
+  it('honours standard time (winter, New York = UTC-5)', () => {
+    expect(
+      getDateWithTimezone('2026-01-15T15:00', 'America/New_York').toISOString()
+    ).toBe('2026-01-15T20:00:00.000Z');
+  });
+
+  it('handles half-hour offsets (Kolkata = UTC+5:30)', () => {
+    expect(
+      getDateWithTimezone('2026-07-01T11:00', 'Asia/Kolkata').toISOString()
+    ).toBe('2026-07-01T05:30:00.000Z');
+  });
+
+  it('falls back to UTC for an unknown/empty timezone', () => {
+    expect(getDateWithTimezone('2026-07-01T11:00', '').toISOString()).toBe(
+      '2026-07-01T11:00:00.000Z'
+    );
+  });
+
+  it('treats an explicit numeric offset as an absolute instant', () => {
+    // "+03:00" already pins the instant → timezone arg is irrelevant.
+    expect(
+      getDateWithTimezone('2026-07-01T11:00:00+03:00', 'America/New_York').toISOString()
+    ).toBe('2026-07-01T08:00:00.000Z');
+  });
+});


### PR DESCRIPTION
1. Fixes event start/end dates shifting when the editor is opened from a browser in a different timezone than the event.
2. show validation error on event edit page for empty tags
3. Surfaces Zod validation errors (e.g missing tags) to ui on event edit page