### PR TITLE
feat: show event registrations for team1-admins

### DIFF
--- a/app/(home)/events/[id]/registrations/page.tsx
+++ b/app/(home)/events/[id]/registrations/page.tsx
@@ -1,0 +1,112 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { prisma } from "@/prisma/prisma";
+import { getAuthSession } from "@/lib/auth/authSession";
+import { canViewEventRegistrations } from "@/lib/auth/permissions";
+import { getRegistrationsByHackathon } from "@/server/services/registerForms";
+import { formatTeamLabel } from "@/lib/referrals/team-labels";
+
+const dateFormat = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeZone: "UTC",
+});
+
+export default async function EventRegistrationsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await getAuthSession();
+  if (!session || !(await canViewEventRegistrations(session, id))) {
+    redirect("/");
+  }
+
+  const hackathon = await prisma.hackathon.findUnique({
+    where: { id },
+    select: { title: true },
+  });
+  if (!hackathon) redirect("/events");
+
+  const registrations = await getRegistrationsByHackathon(id);
+
+  return (
+    <main className="container relative px-2 py-4 lg:py-16">
+      <Link
+        href={`/events/${id}`}
+        className="mb-4 inline-flex items-center gap-2 text-sm text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+      >
+        <ArrowLeft size={16} />
+        Back to the event
+      </Link>
+      <h1 className="text-2xl font-semibold">Registrations</h1>
+      <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+        {hackathon.title} — {registrations.length} registered
+      </p>
+
+      {registrations.length === 0 ? (
+        <p className="mt-8 text-sm text-zinc-500 dark:text-zinc-400">
+          No registrations yet.
+        </p>
+      ) : (
+        <div className="mt-6 overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-zinc-200 bg-zinc-50 text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
+              <tr>
+                <th className="px-4 py-3 font-medium">Name</th>
+                <th className="px-4 py-3 font-medium">Email</th>
+                <th className="px-4 py-3 font-medium">City</th>
+                <th className="px-4 py-3 font-medium">Company</th>
+                <th className="px-4 py-3 font-medium">Role</th>
+                <th className="px-4 py-3 font-medium">Telegram</th>
+                <th className="px-4 py-3 font-medium">Referrer</th>
+                <th className="px-4 py-3 font-medium">Referrer team</th>
+                <th className="px-4 py-3 font-medium">Registered</th>
+              </tr>
+            </thead>
+            <tbody>
+              {registrations.map((registration) => (
+                <tr
+                  key={registration.id}
+                  className="border-b border-zinc-200 last:border-0 dark:border-zinc-800"
+                >
+                  <td className="max-w-48 truncate px-4 py-3">
+                    {registration.name}
+                  </td>
+                  <td className="max-w-64 truncate px-4 py-3">
+                    {registration.email}
+                  </td>
+                  <td className="max-w-40 truncate px-4 py-3">
+                    {registration.city}
+                  </td>
+                  <td className="max-w-40 truncate px-4 py-3">
+                    {registration.company_name ?? "—"}
+                  </td>
+                  <td className="max-w-40 truncate px-4 py-3">
+                    {registration.role}
+                  </td>
+                  <td className="max-w-40 truncate px-4 py-3">
+                    {registration.telegram_account ?? "—"}
+                  </td>
+                  <td className="max-w-48 truncate px-4 py-3">
+                    {registration.referrer_name ?? "—"}
+                  </td>
+                  <td className="max-w-40 truncate px-4 py-3">
+                    {formatTeamLabel(
+                      registration.referrer_team,
+                      registration.referrer_team_other,
+                    ) ?? "—"}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3">
+                    {dateFormat.format(registration.created_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/components/evaluate/HostNavButtons.tsx
+++ b/components/evaluate/HostNavButtons.tsx
@@ -3,8 +3,9 @@ import { getAuthSession } from "@/lib/auth/authSession";
 import {
   canEvaluateHackathon,
   canManageHackathonJudges,
+  canViewEventRegistrations,
 } from "@/lib/auth/permissions";
-import { Gavel, ClipboardCheck } from "lucide-react";
+import { Gavel, ClipboardCheck, Users } from "lucide-react";
 
 type Props = {
   hackathonId: string;
@@ -17,15 +18,25 @@ export async function HostNavButtons({ hackathonId }: Props) {
   const session = await getAuthSession();
   if (!session?.user) return null;
 
-  const [canManage, canEvaluate] = await Promise.all([
+  const [canManage, canEvaluate, canViewRegistrations] = await Promise.all([
     Promise.resolve(canManageHackathonJudges(session)),
     canEvaluateHackathon(session, hackathonId),
+    canViewEventRegistrations(session, hackathonId),
   ]);
 
-  if (!canManage && !canEvaluate) return null;
+  if (!canManage && !canEvaluate && !canViewRegistrations) return null;
 
   return (
     <div className="flex flex-wrap items-center gap-2">
+      {canViewRegistrations && (
+        <Link
+          href={`/events/${hackathonId}/registrations`}
+          className={BUTTON_CLASS}
+        >
+          <Users size={16} />
+          Registrations
+        </Link>
+      )}
       {canManage && (
         <Link
           href={`/events/${hackathonId}/admin-panel/judges`}

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -1,6 +1,7 @@
 import { timingSafeEqual } from "node:crypto";
 import { prisma } from "../../prisma/prisma";
 import { MINI_GRANT_HACKATHON_ID } from "@/lib/grants/programs";
+import { isTeam1Event } from "@/lib/events/team1";
 
 export function hasAnyAttribute(
   attributes: string[] | undefined | null,
@@ -73,6 +74,40 @@ export function canManageEvaluationPhase(
 ): boolean {
   if (!session?.user) return false;
   return hasAnyAttribute(session.user.custom_attributes, ["devrel"]);
+}
+
+/**
+ * True when the user may view an event's registrations (registrant PII):
+ * - devrel: all events (global event admins).
+ * - team1-admin: all Team1 events (full access to everything Team1).
+ * - team1-event-admin: only events they created or where they are a
+ *   listed cohost (creators are NOT auto-added to cohosts).
+ * Cohosts without one of these roles are intentionally excluded —
+ * registrants only consent to sharing their contact data with Avalanche
+ * Team1, not with arbitrary external co-organizers.
+ */
+export async function canViewEventRegistrations(
+  session:
+    | { user?: { id?: string; email?: string; custom_attributes?: string[] } }
+    | null
+    | undefined,
+  hackathonId: string,
+): Promise<boolean> {
+  if (!session?.user) return false;
+  const attributes = session.user.custom_attributes;
+  if (hasAnyAttribute(attributes, ["devrel"])) return true;
+  const isTeam1Admin = hasAnyAttribute(attributes, ["team1-admin"]);
+  const isTeam1EventAdmin = hasAnyAttribute(attributes, ["team1-event-admin"]);
+  if (!isTeam1Admin && !isTeam1EventAdmin) return false;
+  const hackathon = await prisma.hackathon.findUnique({
+    where: { id: hackathonId },
+    select: { organizers: true, cohosts: true, created_by: true },
+  });
+  if (!hackathon) return false;
+  if (isTeam1Admin && isTeam1Event(hackathon)) return true;
+  if (!isTeam1EventAdmin) return false;
+  if (session.user.id && hackathon.created_by === session.user.id) return true;
+  return !!session.user.email && hackathon.cohosts.includes(session.user.email);
 }
 
 /**

--- a/server/services/registerForms.ts
+++ b/server/services/registerForms.ts
@@ -410,6 +410,51 @@ export async function createRegisterForm(
     failedInvites: string[];
   };
 }
+export async function getRegistrationsByHackathon(hackathon_id: string) {
+  const [registrations, attributions] = await Promise.all([
+    prisma.registerForm.findMany({
+      where: { hackathon_id },
+      orderBy: { created_at: "desc" },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        city: true,
+        company_name: true,
+        role: true,
+        telegram_account: true,
+        created_at: true,
+      },
+    }),
+    prisma.referralAttribution.findMany({
+      where: { target_type: "hackathon_registration", target_id: hackathon_id },
+      select: {
+        team_id_referrer: true,
+        team_id_referrer_other: true,
+        user: { select: { email: true } },
+        referrer: { select: { name: true, email: true } },
+      },
+    }),
+  ]);
+
+  const attributionByEmail = new Map(
+    attributions
+      .filter((a) => a.user?.email)
+      .map((a) => [a.user!.email, a]),
+  );
+
+  return registrations.map((registration) => {
+    const attribution = attributionByEmail.get(registration.email);
+    return {
+      ...registration,
+      referrer_name:
+        attribution?.referrer?.name ?? attribution?.referrer?.email ?? null,
+      referrer_team: attribution?.team_id_referrer ?? null,
+      referrer_team_other: attribution?.team_id_referrer_other ?? null,
+    };
+  });
+}
+
 export async function getRegisterForm(email: string, hackathon_id: string) {
   const [registeredData, attribution] = await Promise.all([
     prisma.registerForm.findFirst({

--- a/tests/unit/auth/canViewEventRegistrations.test.ts
+++ b/tests/unit/auth/canViewEventRegistrations.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { findUniqueMock } = vi.hoisted(() => ({ findUniqueMock: vi.fn() }));
+
+vi.mock("@/prisma/prisma", () => ({
+  prisma: { hackathon: { findUnique: findUniqueMock } },
+}));
+
+import { canViewEventRegistrations } from "@/lib/auth/permissions";
+
+const EVENT_ID = "evt-1";
+
+beforeEach(() => {
+  findUniqueMock.mockReset();
+});
+
+describe("canViewEventRegistrations", () => {
+  it("denies anonymous users without touching the database", async () => {
+    expect(await canViewEventRegistrations(null, EVENT_ID)).toBe(false);
+    expect(await canViewEventRegistrations(undefined, EVENT_ID)).toBe(false);
+    expect(await canViewEventRegistrations({}, EVENT_ID)).toBe(false);
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("allows devrel for any event without a lookup", async () => {
+    const allowed = await canViewEventRegistrations(
+      { user: { id: "u1", custom_attributes: ["devrel"] } },
+      EVENT_ID,
+    );
+    expect(allowed).toBe(true);
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("denies a plain cohost without a privileged role, without a lookup", async () => {
+    const allowed = await canViewEventRegistrations(
+      { user: { id: "u2", email: "cohost@example.com", custom_attributes: [] } },
+      EVENT_ID,
+    );
+    expect(allowed).toBe(false);
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("allows team1-admin for a Team1 event", async () => {
+    findUniqueMock.mockResolvedValue({
+      organizers: "team1-india",
+      cohosts: [],
+      created_by: "someone-else",
+    });
+    const allowed = await canViewEventRegistrations(
+      { user: { id: "u3", custom_attributes: ["team1-admin"] } },
+      EVENT_ID,
+    );
+    expect(allowed).toBe(true);
+  });
+
+  it("denies team1-admin for a non-Team1 event, even as cohost", async () => {
+    findUniqueMock.mockResolvedValue({
+      organizers: "acme",
+      cohosts: ["admin@example.com"],
+      created_by: "someone-else",
+    });
+    const allowed = await canViewEventRegistrations(
+      {
+        user: {
+          id: "u4",
+          email: "admin@example.com",
+          custom_attributes: ["team1-admin"],
+        },
+      },
+      EVENT_ID,
+    );
+    expect(allowed).toBe(false);
+  });
+
+  it("allows team1-event-admin only where they are a cohost", async () => {
+    findUniqueMock.mockResolvedValue({
+      organizers: "team1-latam",
+      cohosts: ["organizer@example.com"],
+      created_by: "someone-else",
+    });
+    const session = (email: string) => ({
+      user: { id: "u5", email, custom_attributes: ["team1-event-admin"] },
+    });
+    expect(
+      await canViewEventRegistrations(session("organizer@example.com"), EVENT_ID),
+    ).toBe(true);
+    expect(
+      await canViewEventRegistrations(session("stranger@example.com"), EVENT_ID),
+    ).toBe(false);
+  });
+
+  it("allows team1-event-admin for events they created, even without a cohost entry", async () => {
+    findUniqueMock.mockResolvedValue({
+      organizers: "team1-latam",
+      cohosts: [],
+      created_by: "u5",
+    });
+    const allowed = await canViewEventRegistrations(
+      {
+        user: {
+          id: "u5",
+          email: "creator@example.com",
+          custom_attributes: ["team1-event-admin"],
+        },
+      },
+      EVENT_ID,
+    );
+    expect(allowed).toBe(true);
+  });
+
+  it("denies when the event does not exist", async () => {
+    findUniqueMock.mockResolvedValue(null);
+    const allowed = await canViewEventRegistrations(
+      { user: { id: "u6", custom_attributes: ["team1-admin"] } },
+      EVENT_ID,
+    );
+    expect(allowed).toBe(false);
+  });
+});


### PR DESCRIPTION
adds new page/events/[id]/registrations, which:
- is always visible for users with role devrel
- is visible for users with role "team1-admin" if organizer is Team1
- is visible for users with role "team1-event-admin" if organizer is Team1 and the user is one of the hosts (creator or cohost)