### PR TITLE
fix(academy): restore subnet creation step in Create a Blockchain lesson

### DIFF
--- a/app/academy/[...slug]/page.tsx
+++ b/app/academy/[...slug]/page.tsx
@@ -35,6 +35,7 @@ import ToolboxMdxWrapper from "@/components/toolbox/academy/wrapper/ToolboxMdxWr
 import CrossChainTransfer from "@/components/toolbox/console/primary-network/CrossChainTransfer";
 import AvalancheGoDocker from "@/components/toolbox/console/layer-1/AvalancheGoDockerL1";
 import CreateChain from "@/components/toolbox/console/layer-1/create/CreateChain";
+import CreateSubnet from "@/components/toolbox/console/layer-1/create/CreateSubnet";
 import ConvertSubnetToL1 from "@/components/toolbox/console/layer-1/create/ConvertSubnetToL1";
 import GenesisBuilder from "@/components/toolbox/console/layer-1/create/GenesisBuilder";
 import DeployExampleERC20 from "@/components/toolbox/console/ictt/setup/DeployExampleERC20";
@@ -61,6 +62,7 @@ const toolboxComponents = {
   CrossChainTransfer,
   GenesisBuilder,
   CreateChain,
+  CreateSubnet,
   AvalancheGoDocker,
   CreateManagedTestnetNode,
   ConvertToL1: ConvertSubnetToL1,

--- a/components/toolbox/console/layer-1/create/CreateChain.tsx
+++ b/components/toolbox/console/layer-1/create/CreateChain.tsx
@@ -18,6 +18,7 @@ import { AlertTriangle } from 'lucide-react';
 import Link from 'next/link';
 import { CoreWalletTransactionButton } from '@/components/toolbox/components/CoreWalletTransactionButton';
 import { useSubmitPChainTx } from '@/components/toolbox/hooks/useSubmitPChainTx';
+import { Success } from '@/components/toolbox/components/Success';
 
 // Import Genesis Wizard components
 import { GenesisWizard } from '@/components/toolbox/components/genesis/GenesisWizard';
@@ -74,6 +75,8 @@ interface CreateChainProps extends BaseConsoleToolProps {
 function CreateChain({ onSuccess: _onSuccess, embedded = false, preinstallDefaults, warpEnabled }: CreateChainProps) {
   const store = useCreateChainStore();
   const subnetId = store((state) => state.subnetId);
+  const chainID = store((state) => state.chainID);
+  const chainName = store((state) => state.chainName);
   const setChainID = store((state) => state.setChainID);
   const genesisData = store((state) => state.genesisData);
   const setGenesisData = store((state) => state.setGenesisData);
@@ -151,7 +154,7 @@ function CreateChain({ onSuccess: _onSuccess, embedded = false, preinstallDefaul
         </div>
         <h3 className="text-sm font-semibold text-center mb-2">No Subnet Selected</h3>
         <p className="text-sm text-muted-foreground text-center max-w-md">
-          Please go back to the previous step and create or select a subnet before configuring your chain.
+          Please create or select a subnet with the Create Subnet tool before configuring your chain.
         </p>
       </div>
     );
@@ -297,6 +300,17 @@ function CreateChain({ onSuccess: _onSuccess, embedded = false, preinstallDefaul
             >
               Create Chain
             </CoreWalletTransactionButton>
+          )}
+
+          {chainID && (
+            <div className="mt-4">
+              <Success
+                label={`Chain${chainName ? ` "${chainName}"` : ''} created (CreateChainTx ID)`}
+                value={chainID}
+                isTestnet={Boolean(isTestnet)}
+                confirmed={true}
+              />
+            </div>
           )}
         </Step>
       </Steps>

--- a/components/toolbox/console/layer-1/create/CreateSubnet.tsx
+++ b/components/toolbox/console/layer-1/create/CreateSubnet.tsx
@@ -15,6 +15,7 @@ import { generateConsoleToolGitHubUrl } from '@/components/toolbox/utils/githubU
 import Link from 'next/link';
 import { CoreWalletTransactionButton } from '@/components/toolbox/components/CoreWalletTransactionButton';
 import { useSubmitPChainTx } from '@/components/toolbox/hooks/useSubmitPChainTx';
+import { Success } from '@/components/toolbox/components/Success';
 
 const metadata: ConsoleToolMetadata = {
   title: 'Create Subnet',
@@ -85,6 +86,10 @@ function CreateSubnet(_props: BaseConsoleToolProps) {
       >
         Create Subnet
       </CoreWalletTransactionButton>
+
+      {subnetId && (
+        <Success label="Subnet ID (CreateSubnetTx)" value={subnetId} isTestnet={Boolean(isTestnet)} confirmed={true} />
+      )}
 
       {/* "or" divider */}
       <div className="relative">

--- a/content/academy/avalanche-l1/avalanche-fundamentals/04-creating-an-l1/05-create-blockchain.mdx
+++ b/content/academy/avalanche-l1/avalanche-fundamentals/04-creating-an-l1/05-create-blockchain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Create a Blockchain
-description: Learn how to configure a blockchain and create a record for it on the P-Chain by issuing a CreateChainTx transaction using the Builder Tooling.
-updated: 2025-03-13
+description: Learn how to create a Subnet and a blockchain record on the P-Chain by issuing the CreateSubnetTx and CreateChainTx transactions using the Builder Tooling.
+updated: 2026-07-13
 authors: [owenwahlgren]
 icon: SquareMousePointer
 ---
@@ -11,29 +11,41 @@ do this by issuing a `CreateSubnetTx` transaction. This will create a Subnet tha
 identified by the transaction hash of the `CreateSubnetTx` transaction.
 
 The `CreateSubnetTx` transaction only has a single parameter: The owner of the Subnet. The owner can
-add blockchains to the Subnet and convert it to an L1. With the conversion to an L1 the owner will loose it's
+add blockchains to the Subnet and convert it to an L1. With the conversion to an L1 the owner will lose its
 privileges. Therefore, the owner is only relevant during the creation time and does not have to be
-secured by a mulit-sig if a immediate conversion to an L1 is planned. We will just use your P-Chain
+secured by a multi-sig if an immediate conversion to an L1 is planned. We will just use your P-Chain
 address as the owner.
 
-Then you will issue the `CreateChainTx` on the P-Chain to create the blockchain record. The
-`CreateChainTx` transaction as the following parameters:
+Click `Create Subnet` below to issue the `CreateSubnetTx` transaction:
+
+<ToolboxMdxWrapper walletMode="c-chain">
+    <CreateSubnet />
+</ToolboxMdxWrapper>
+
+Next you will issue the `CreateChainTx` on the P-Chain to create the blockchain record. The
+`CreateChainTx` transaction has the following parameters:
 
 - `name`: The name of the chain
 - `subnetID`: The ID of the Subnet you want to add the chain to
 - `vmID`: The ID of the Virtual Machine that will be used to run the chain.
 - `genesisData`: The genesis configuration of the chain
 
+The tool below will use the Subnet you just created. Give your chain a name (or keep the suggested
+one) and leave the Virtual Machine set to Subnet EVM.
+
 The Genesis Builder tool allows us to configure many aspects of the blockchain like permissioning,
-it's tokenonomics and the transaction fee mechanism. 
+its tokenomics and the transaction fee mechanism. Feel free to browse through the different
+configuration options, but for now don't change any of the defaults.
 
-Feel free to browse through the different configuration options, but for now don't change any of the
-defaults and just click the `View Genesis JSON` button.
-
-Then click `Create Chain` This will create the P-Chain record for your blockchain and associate it
-with the Subnet created in the previous step. 
+Finally, click `Create Chain`. This will create the P-Chain record for your blockchain and associate it
+with the Subnet created in the step above.
 
 The blockchain will be uniquely identified by the transaction hash of the `CreateChainTx` transaction.
+
+<Callout type="info">
+If Core shows an "internal error" when you click `Create Chain` right after creating your Subnet,
+the Subnet may not have been indexed yet. Wait a minute and try again.
+</Callout>
 
 <ToolboxMdxWrapper walletMode="c-chain">
     <CreateChain embedded={true} />


### PR DESCRIPTION
Fixes #4338 — the lesson embedded CreateChain but subnet creation was split into a separate CreateSubnet tool in the console rework, leaving learners stuck at 'No Subnet Selected' with no way to create one. Also adds visible success confirmations for both transactions and a callout for the transient Core 'internal error' caused by Data API indexing lag on freshly created subnets.