### PR TITLE
fix(managed-nodes): update prod service IP to 43.207.73.245

### DIFF
--- a/app/api/managed-testnet-nodes/constants.ts
+++ b/app/api/managed-testnet-nodes/constants.ts
@@ -1,7 +1,7 @@
 
 export let MANAGED_TESTNET_NODES_SERVICE_URL = process.env.MANAGED_NODES_OVERRIDE ||
   (process.env.VERCEL_ENV === "production"
-    ? 'https://nodes-prod.18.182.4.86.sslip.io'
+    ? 'https://nodes-prod.43.207.73.245.sslip.io'
     : 'https://nodes-staging.35.74.237.34.sslip.io');
 
 if (MANAGED_TESTNET_NODES_SERVICE_URL.endsWith('/')) {


### PR DESCRIPTION
The prod managed-testnet-nodes box moved; the old hardcoded IP (18.182.4.86) no longer resolves to a live service. Point the prod fallback URL at the new instance.