### PR TITLE
feat(console): add auto-renewed staking (ACP-236) option to primary network stake

### DIFF
--- a/components/toolbox/components/ValidatorListInput/AddValidatorControls.tsx
+++ b/components/toolbox/components/ValidatorListInput/AddValidatorControls.tsx
@@ -7,6 +7,7 @@ import { cn } from '../utils';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs';
 import { Input } from '../ui/input';
 import type { ConvertToL1Validator } from '../ValidatorListInput';
+import { validateManagedNodeCredentials, validateNodeCredentials } from './nodeCredentials';
 
 type ManagedTestnetNodeSuggestion = {
   id: string;
@@ -95,12 +96,20 @@ export function AddValidatorControls({
       return;
     }
 
-    const publicKey = (choice.public_key || '').trim();
-    const proof = (choice.proof_of_possession || '').trim();
+    const validated = validateManagedNodeCredentials({
+      nodeID: choice.node_id,
+      publicKey: choice.public_key || '',
+      proofOfPossession: choice.proof_of_possession || '',
+    });
+    if (!validated.ok) {
+      setError(`Hosted node returned invalid credentials. ${validated.error}`);
+      return;
+    }
+    const { nodeID, publicKey, proofOfPossession } = validated.value;
 
     const newValidator: ConvertToL1Validator = {
-      nodeID: choice.node_id,
-      nodePOP: { publicKey, proofOfPossession: proof },
+      nodeID,
+      nodePOP: { publicKey, proofOfPossession },
       validatorWeight: BigInt(100),
       validatorBalance: BigInt(100000000),
       remainingBalanceOwner: {
@@ -128,9 +137,21 @@ export function AddValidatorControls({
         setError('Invalid JSON format. Missing nodeID or nodePOP.');
         return;
       }
-      const validator: ConvertToL1Validator = {
+      const validated = validateNodeCredentials({
         nodeID,
-        nodePOP,
+        publicKey: nodePOP.publicKey,
+        proofOfPossession: nodePOP.proofOfPossession,
+      });
+      if (!validated.ok) {
+        setError(validated.error);
+        return;
+      }
+      const validator: ConvertToL1Validator = {
+        nodeID: validated.value.nodeID,
+        nodePOP: {
+          publicKey: validated.value.publicKey,
+          proofOfPossession: validated.value.proofOfPossession,
+        },
         validatorWeight: BigInt(100),
         validatorBalance: BigInt(100000000),
         remainingBalanceOwner: {
@@ -151,16 +172,25 @@ export function AddValidatorControls({
   };
 
   const handleAddManual = () => {
-    const nodeID = manualNodeID.trim();
-    const publicKey = manualPublicKey.trim();
-    const proofOfPossession = manualProof.trim();
-    if (!nodeID || !publicKey || !proofOfPossession) {
+    if (!manualNodeID.trim() || !manualPublicKey.trim() || !manualProof.trim()) {
       setError('Please provide NodeID, BLS Public Key, and Proof of Possession');
       return;
     }
+    const validated = validateNodeCredentials({
+      nodeID: manualNodeID,
+      publicKey: manualPublicKey,
+      proofOfPossession: manualProof,
+    });
+    if (!validated.ok) {
+      setError(validated.error);
+      return;
+    }
     const validator: ConvertToL1Validator = {
-      nodeID,
-      nodePOP: { publicKey, proofOfPossession },
+      nodeID: validated.value.nodeID,
+      nodePOP: {
+        publicKey: validated.value.publicKey,
+        proofOfPossession: validated.value.proofOfPossession,
+      },
       validatorWeight: BigInt(100),
       validatorBalance: BigInt(100000000),
       remainingBalanceOwner: {

--- a/components/toolbox/components/ValidatorListInput/nodeCredentials.ts
+++ b/components/toolbox/components/ValidatorListInput/nodeCredentials.ts
@@ -1,0 +1,101 @@
+import { utils } from '@avalabs/avalanchejs';
+
+// Pasted node credentials routinely arrive wrapped in JSON punctuation (a terminal
+// drag-copy of info.getNodeID output grabs the closing quote). A stray trailing quote
+// on the BLS public key is exactly what avalanchejs' hexToBuffer turns into the cryptic
+// `hex string expected, got non-hex character "8"" at index 96` seen on the stake page.
+const LEADING_JUNK = /^[\s"',;]+/;
+const TRAILING_JUNK = /[\s"',;]+$/;
+// A real credential is at most 194 chars (0x plus 192 hex). The trailing-junk scan is
+// quadratic on multi-KB garbage, so oversized pastes skip sanitizing and fail validation.
+const MAX_SANITIZE_LENGTH = 256;
+
+export function sanitizeCredentialInput(raw: string): string {
+  // The JSON tab feeds values straight off JSON.parse, so non-strings can arrive at runtime.
+  if (typeof raw !== 'string') return '';
+  if (raw.length > MAX_SANITIZE_LENGTH) return raw;
+  return raw.replace(LEADING_JUNK, '').replace(TRAILING_JUNK, '');
+}
+
+export const BLS_PUBLIC_KEY_REGEX = /^0x[0-9a-fA-F]{96}$/;
+export const BLS_PROOF_OF_POSSESSION_REGEX = /^0x[0-9a-fA-F]{192}$/;
+
+export interface NodeCredentials {
+  nodeID: string;
+  publicKey: string;
+  proofOfPossession: string;
+}
+
+export type NodeCredentialsResult = { ok: true; value: NodeCredentials } | { ok: false; error: string };
+
+const NODE_ID_PREFIX = 'NodeID-';
+
+function isValidNodeID(nodeID: string): boolean {
+  if (!nodeID.startsWith(NODE_ID_PREFIX)) return false;
+  const encoded = nodeID.slice(NODE_ID_PREFIX.length);
+  // Real NodeIDs are ~33 base58 chars; base58 decoding is quadratic, so bound the input.
+  if (encoded.length === 0 || encoded.length > 64) return false;
+  try {
+    // base58check.decode strips the 4-byte CB58 checksum without verifying it,
+    // so re-encode the payload and compare to catch corrupted pastes.
+    const payload = utils.base58check.decode(encoded);
+    return payload.length === 20 && utils.base58check.encode(payload) === encoded;
+  } catch {
+    return false;
+  }
+}
+
+const INVALID_NODE_ID_ERROR =
+  'Invalid NodeID: expected "NodeID-" followed by a valid CB58 string. Re-copy the full value from your node\'s info.getNodeID response.';
+
+function describeHexIssue(value: string, expectedHexChars: number): string {
+  if (!value.startsWith('0x')) return 'the value does not start with 0x';
+  const hexLength = value.length - 2;
+  if (hexLength !== expectedHexChars) return `got ${hexLength}`;
+  return 'it contains non-hex characters';
+}
+
+export function validateNodeCredentials(input: NodeCredentials): NodeCredentialsResult {
+  const nodeID = sanitizeCredentialInput(input.nodeID);
+  const publicKey = sanitizeCredentialInput(input.publicKey);
+  const proofOfPossession = sanitizeCredentialInput(input.proofOfPossession);
+
+  if (!isValidNodeID(nodeID)) {
+    return { ok: false, error: INVALID_NODE_ID_ERROR };
+  }
+
+  if (!BLS_PUBLIC_KEY_REGEX.test(publicKey)) {
+    return {
+      ok: false,
+      error: `Invalid BLS public key: expected 0x plus 96 hex characters (48 bytes), but ${describeHexIssue(
+        publicKey,
+        96,
+      )}. Check for missing or extra characters in the paste.`,
+    };
+  }
+
+  if (!BLS_PROOF_OF_POSSESSION_REGEX.test(proofOfPossession)) {
+    return {
+      ok: false,
+      error: `Invalid BLS proof of possession: expected 0x plus 192 hex characters (96 bytes), but ${describeHexIssue(
+        proofOfPossession,
+        192,
+      )}. Check for missing or extra characters in the paste.`,
+    };
+  }
+
+  return { ok: true, value: { nodeID, publicKey, proofOfPossession } };
+}
+
+// Managed testnet nodes may legitimately omit BLS info (the UI points users to the other
+// tabs for those); the NodeID is still validated. Half-present BLS info is invalid.
+export function validateManagedNodeCredentials(input: NodeCredentials): NodeCredentialsResult {
+  if (!input.publicKey && !input.proofOfPossession) {
+    const nodeID = sanitizeCredentialInput(input.nodeID);
+    if (!isValidNodeID(nodeID)) {
+      return { ok: false, error: INVALID_NODE_ID_ERROR };
+    }
+    return { ok: true, value: { nodeID, publicKey: '', proofOfPossession: '' } };
+  }
+  return validateNodeCredentials(input);
+}

--- a/components/toolbox/console/primary-network/Stake.tsx
+++ b/components/toolbox/console/primary-network/Stake.tsx
@@ -11,7 +11,10 @@ import {
 } from '../../components/WithConsoleToolMetadata';
 import { useWalletStore } from '@/components/toolbox/stores/walletStore';
 import { useWallet } from '@/components/toolbox/hooks/useWallet';
-import { prepareAddPermissionlessValidatorTxn } from '@avalanche-sdk/client/methods/wallet/pChain';
+import {
+  prepareAddPermissionlessValidatorTxn,
+  prepareAddAutoRenewedValidatorTxn,
+} from '@avalanche-sdk/client/methods/wallet/pChain';
 import { sendXPTransaction } from '@avalanche-sdk/client/methods/wallet';
 import { avaxToNanoAvax } from '@avalanche-sdk/client/utils';
 import { networkIDs } from '@avalabs/avalanchejs';
@@ -28,6 +31,7 @@ import Link from 'next/link';
 const STAKE_VALIDATOR_SOURCE = `import type { AvalanchePChainWalletClient } from "@avalanche-sdk/client";
 import { prepareAddPermissionlessValidatorTxn } from "@avalanche-sdk/client/methods/wallet/pChain";
 import { sendXPTransaction } from "@avalanche-sdk/client/methods/wallet";
+import { avaxToNanoAvax } from "@avalanche-sdk/client/utils";
 
 export async function stakeOnPrimaryNetwork(
   pChainClient: AvalanchePChainWalletClient,
@@ -43,13 +47,13 @@ export async function stakeOnPrimaryNetwork(
 ): Promise<string> {
   const { tx } = await prepareAddPermissionlessValidatorTxn(pChainClient, {
     nodeId: params.nodeId,
-    stakeInAvax: params.stakeInAvax,
-    end: params.endTime,
+    stakeInNanoAvax: avaxToNanoAvax(params.stakeInAvax),
+    end: BigInt(params.endTime),
     rewardAddresses: [params.rewardAddress],
     delegatorRewardAddresses: [params.rewardAddress],
     delegatorRewardPercentage: params.delegationFee,
     threshold: 1,
-    locktime: 0,
+    locktime: 0n,
     publicKey: params.publicKey,
     signature: params.signature,
   });
@@ -62,12 +66,63 @@ export async function stakeOnPrimaryNetwork(
   return result.txHash;
 }`;
 
-const SDK_SOURCES: SDKCodeSource[] = [
+const STAKE_AUTO_RENEWED_SOURCE = `import type { AvalanchePChainWalletClient } from "@avalanche-sdk/client";
+import { prepareAddAutoRenewedValidatorTxn } from "@avalanche-sdk/client/methods/wallet/pChain";
+import { sendXPTransaction } from "@avalanche-sdk/client/methods/wallet";
+import { avaxToNanoAvax } from "@avalanche-sdk/client/utils";
+
+// ACP-236 (Helicon upgrade): the stake automatically renews every cycle.
+export async function stakeAutoRenewedOnPrimaryNetwork(
+  pChainClient: AvalanchePChainWalletClient,
+  params: {
+    nodeId: string;
+    stakeInAvax: number;
+    periodSeconds: bigint;
+    rewardAddress: string;
+    delegationFee: number;
+    autoCompoundRewardPercentage: number; // 0 = withdraw all rewards, 100 = restake all
+    publicKey: string;
+    signature: string;
+  }
+): Promise<string> {
+  const { tx } = await prepareAddAutoRenewedValidatorTxn(pChainClient, {
+    nodeId: params.nodeId,
+    stakeInNanoAvax: avaxToNanoAvax(params.stakeInAvax),
+    period: params.periodSeconds,
+    rewardAddresses: [params.rewardAddress],
+    delegatorRewardAddresses: [params.rewardAddress],
+    ownerAddresses: [params.rewardAddress], // authorized to update the config or stop later
+    delegatorRewardPercentage: params.delegationFee,
+    autoCompoundRewardPercentage: params.autoCompoundRewardPercentage,
+    threshold: 1,
+    locktime: 0n,
+    publicKey: params.publicKey,
+    signature: params.signature,
+  });
+
+  const result = await sendXPTransaction(pChainClient, {
+    tx,
+    chainAlias: "P",
+  });
+
+  return result.txHash;
+}`;
+
+const FIXED_SDK_SOURCES: SDKCodeSource[] = [
   {
     name: 'TypeScript',
     filename: 'stakeOnPrimaryNetwork.ts',
     code: STAKE_VALIDATOR_SOURCE,
     description: 'Add a permissionless validator to the Primary Network using the Avalanche SDK.',
+  },
+];
+
+const AUTO_RENEW_SDK_SOURCES: SDKCodeSource[] = [
+  {
+    name: 'TypeScript',
+    filename: 'stakeAutoRenewedOnPrimaryNetwork.ts',
+    code: STAKE_AUTO_RENEWED_SOURCE,
+    description: 'Add an auto-renewed validator (ACP-236) to the Primary Network using the Avalanche SDK.',
   },
 ];
 
@@ -84,6 +139,12 @@ const NETWORK_CONFIG = {
       { label: '1 week', days: 7 },
       { label: '2 weeks', days: 14 },
     ],
+    minPeriodHours: 12,
+    periodPresets: [
+      { label: '1 day', hours: 24 },
+      { label: '1 week', hours: 168 },
+      { label: '2 weeks', hours: 336 },
+    ],
   },
   mainnet: {
     minStakeAvax: 2000,
@@ -95,11 +156,21 @@ const NETWORK_CONFIG = {
       { label: '1 month', days: 30 },
       { label: '3 months', days: 90 },
     ],
+    // TODO(helicon-mainnet): auto-renewed staking is not activated on Mainnet yet;
+    // these become live when the gate in the staking-mode picker is lifted.
+    minPeriodHours: 48,
+    periodPresets: [
+      { label: '2 weeks', hours: 336 },
+      { label: '1 month', hours: 720 },
+      { label: '3 months', hours: 2160 },
+    ],
   },
 };
 
 const MAX_END_SECONDS = 365 * 24 * 60 * 60;
+const MAX_PERIOD_HOURS = 365 * 24;
 const DEFAULT_DELEGATOR_FEE = '2';
+const DEFAULT_AUTO_COMPOUND = '100';
 const BUFFER_MINUTES = 5;
 
 const metadata: ConsoleToolMetadata = {
@@ -121,7 +192,11 @@ const metadata: ConsoleToolMetadata = {
       >
         AddPermissionlessValidatorTx
       </Link>{' '}
-      on the P-Chain.
+      on the P-Chain, or an{' '}
+      <Link href="/docs/acps/236-auto-renewed-staking" className="text-primary hover:underline">
+        AddAutoRenewedValidatorTx
+      </Link>{' '}
+      for auto-renewed staking (ACP-236, Fuji).
     </>
   ),
   toolRequirements: [WalletRequirementsConfigKey.WalletConnected],
@@ -133,8 +208,11 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
   const { avalancheWalletClient } = useWallet();
 
   const [validator, setValidator] = useState<ConvertToL1Validator | null>(null);
+  const [stakingMode, setStakingMode] = useState<'fixed' | 'autoRenew'>('fixed');
   const [stakeInAvax, setStakeInAvax] = useState<string>('');
   const [endTime, setEndTime] = useState<string>('');
+  const [periodHours, setPeriodHours] = useState<string>('336');
+  const [autoCompound, setAutoCompound] = useState<string>(DEFAULT_AUTO_COMPOUND);
   const [delegationFee, setDelegationFee] = useState<string>(DEFAULT_DELEGATOR_FEE);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -146,6 +224,9 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
   const onFuji = isTestnet === true || avalancheNetworkID === networkIDs.FujiID;
   const config = onFuji ? NETWORK_CONFIG.fuji : NETWORK_CONFIG.mainnet;
   const networkName = onFuji ? 'Fuji' : 'Mainnet';
+  const isAutoRenew = stakingMode === 'autoRenew';
+  // TODO(helicon-mainnet): flip to true for all networks once Helicon activates on Mainnet.
+  const autoRenewAvailable = onFuji;
 
   // Initialize defaults
   if (!stakeInAvax) {
@@ -194,11 +275,21 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
       return `Minimum stake is ${config.minStakeAvax.toLocaleString()} AVAX on ${networkName}`;
     }
 
-    if (!endTime) return 'End time is required';
-    const endUnix = Math.floor(new Date(endTime).getTime() / 1000);
-    const duration = endUnix - Math.floor(Date.now() / 1000);
-    if (duration < config.minEndSeconds) return `End time must be at least ${config.minEndLabel} from now`;
-    if (duration > MAX_END_SECONDS) return 'End time must be within 1 year';
+    if (isAutoRenew) {
+      if (!autoRenewAvailable) return 'Auto-renewed staking (ACP-236) is only available on Fuji';
+      const hours = Number(periodHours);
+      if (!Number.isFinite(hours) || hours < config.minPeriodHours || hours > MAX_PERIOD_HOURS) {
+        return `Cycle period must be between ${config.minPeriodHours} hours and 1 year`;
+      }
+      const ac = Number(autoCompound);
+      if (!Number.isFinite(ac) || ac < 0 || ac > 100) return 'Auto-compound must be between 0 and 100';
+    } else {
+      if (!endTime) return 'End time is required';
+      const endUnix = Math.floor(new Date(endTime).getTime() / 1000);
+      const duration = endUnix - Math.floor(Date.now() / 1000);
+      if (duration < config.minEndSeconds) return `End time must be at least ${config.minEndLabel} from now`;
+      if (duration > MAX_END_SECONDS) return 'End time must be within 1 year';
+    }
 
     const fee = Number(delegationFee);
     if (!Number.isFinite(fee) || fee < 2 || fee > 100) return 'Delegation fee must be between 2 and 100';
@@ -224,26 +315,44 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
     try {
       setIsSubmitting(true);
 
-      const endUnix = Math.floor(new Date(endTime).getTime() / 1000);
-      const { tx } = await prepareAddPermissionlessValidatorTxn(avalancheWalletClient.pChain, {
-        nodeId: validator!.nodeID,
-        stakeInNanoAvax: avaxToNanoAvax(Number(stakeInAvax)),
-        end: BigInt(endUnix),
-        rewardAddresses: [pChainAddress!],
-        delegatorRewardAddresses: [pChainAddress!],
-        delegatorRewardPercentage: Number(delegationFee),
-        threshold: 1,
-        locktime: 0n,
-        publicKey: validator!.nodePOP.publicKey,
-        signature: validator!.nodePOP.proofOfPossession,
-      });
+      let tx;
+      if (isAutoRenew) {
+        ({ tx } = await prepareAddAutoRenewedValidatorTxn(avalancheWalletClient.pChain, {
+          nodeId: validator!.nodeID,
+          stakeInNanoAvax: avaxToNanoAvax(Number(stakeInAvax)),
+          period: BigInt(Math.round(Number(periodHours) * 60 * 60)),
+          rewardAddresses: [pChainAddress!],
+          delegatorRewardAddresses: [pChainAddress!],
+          ownerAddresses: [pChainAddress!],
+          delegatorRewardPercentage: Number(delegationFee),
+          autoCompoundRewardPercentage: Number(autoCompound),
+          threshold: 1,
+          locktime: 0n,
+          publicKey: validator!.nodePOP.publicKey,
+          signature: validator!.nodePOP.proofOfPossession,
+        }));
+      } else {
+        const endUnix = Math.floor(new Date(endTime).getTime() / 1000);
+        ({ tx } = await prepareAddPermissionlessValidatorTxn(avalancheWalletClient.pChain, {
+          nodeId: validator!.nodeID,
+          stakeInNanoAvax: avaxToNanoAvax(Number(stakeInAvax)),
+          end: BigInt(endUnix),
+          rewardAddresses: [pChainAddress!],
+          delegatorRewardAddresses: [pChainAddress!],
+          delegatorRewardPercentage: Number(delegationFee),
+          threshold: 1,
+          locktime: 0n,
+          publicKey: validator!.nodePOP.publicKey,
+          signature: validator!.nodePOP.proofOfPossession,
+        }));
+      }
 
       const stakePromise = sendXPTransaction(avalancheWalletClient.pChain, {
         tx,
         chainAlias: 'P',
       }).then((result) => result.txHash);
 
-      notify('addPermissionlessValidator', stakePromise);
+      notify(isAutoRenew ? 'addAutoRenewedValidator' : 'addPermissionlessValidator', stakePromise);
 
       const txHash = await stakePromise;
       setTxId(txHash);
@@ -255,10 +364,12 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
     }
   };
 
-  const cliCommand = `platform-cli validator add-permissionless --node-id ${validator?.nodeID || '<node-id>'} --stake ${stakeInAvax || '<amount>'} --duration ${getDurationHours()}h --delegation-fee ${Number(delegationFee) / 100} --network ${onFuji ? 'fuji' : 'mainnet'}`;
+  const cliCommand = isAutoRenew
+    ? `platform-cli validator add-auto-renewed --node-id ${validator?.nodeID || '<node-id>'} --stake ${stakeInAvax || '<amount>'} --period ${periodHours}h --delegation-fee ${Number(delegationFee) / 100} --auto-compound ${Number(autoCompound) / 100} --network ${onFuji ? 'fuji' : 'mainnet'}`
+    : `platform-cli validator add-permissionless --node-id ${validator?.nodeID || '<node-id>'} --stake ${stakeInAvax || '<amount>'} --duration ${getDurationHours()}h --delegation-fee ${Number(delegationFee) / 100} --network ${onFuji ? 'fuji' : 'mainnet'}`;
 
   return (
-    <SDKCodeViewer sources={SDK_SOURCES} height="auto">
+    <SDKCodeViewer sources={isAutoRenew ? AUTO_RENEW_SDK_SOURCES : FIXED_SDK_SOURCES} height="auto">
       <div>
         {txId ? (
           <div className="space-y-4">
@@ -266,7 +377,10 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
               variant="secondary"
               onClick={() => {
                 setValidator(null);
+                setStakingMode('fixed');
                 setStakeInAvax(String(config.minStakeAvax));
+                setPeriodHours('336');
+                setAutoCompound(DEFAULT_AUTO_COMPOUND);
                 setDelegationFee(DEFAULT_DELEGATOR_FEE);
                 setError(null);
                 setTxId('');
@@ -316,10 +430,56 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
             <Step>
               <h3 className="text-[14px] font-semibold mb-1">Stake Configuration</h3>
               <p className="text-[12px] text-zinc-500 dark:text-zinc-400 mb-3">
-                Set your stake amount, delegation fee, and duration.
+                {isAutoRenew
+                  ? 'Set your stake amount, delegation fee, cycle period, and auto-compounding.'
+                  : 'Set your stake amount, delegation fee, and duration.'}
               </p>
 
               <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">
+                    Staking Mode
+                  </label>
+                  <div className="grid grid-cols-2 gap-2">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setStakingMode('fixed');
+                        setError(null);
+                      }}
+                      className={`p-3 rounded-xl border-2 text-left transition-all ${
+                        !isAutoRenew
+                          ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                          : 'border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600'
+                      }`}
+                    >
+                      <div className="font-medium text-sm">Fixed Duration</div>
+                      <div className="text-xs text-zinc-500">Stake until a set end date</div>
+                    </button>
+                    <button
+                      type="button"
+                      disabled={!autoRenewAvailable}
+                      onClick={() => {
+                        setStakingMode('autoRenew');
+                        setError(null);
+                      }}
+                      className={`p-3 rounded-xl border-2 text-left transition-all ${
+                        isAutoRenew
+                          ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                          : 'border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600'
+                      } ${!autoRenewAvailable ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    >
+                      <div className="font-medium text-sm">Auto-Renewed</div>
+                      <div className="text-xs text-zinc-500">Restakes each cycle (ACP-236)</div>
+                    </button>
+                  </div>
+                  {!autoRenewAvailable && (
+                    <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
+                      Auto-renewed staking (Helicon upgrade) is not yet activated on Mainnet — available on Fuji.
+                    </p>
+                  )}
+                </div>
+
                 <Input
                   label="Stake Amount"
                   value={stakeInAvax}
@@ -353,53 +513,130 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
                   }
                 />
 
-                <div>
-                  <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">Duration</label>
-                  <div className="flex gap-2 mb-2">
-                    {config.presets.map((preset) => (
-                      <button
-                        key={preset.days}
-                        onClick={() => setEndInDays(preset.days)}
-                        className={`flex-1 py-2 rounded-lg border text-xs font-medium transition-colors ${
-                          isDateButtonActive(preset.days)
-                            ? 'bg-zinc-100 dark:bg-zinc-800 border-zinc-400 dark:border-zinc-600 text-zinc-900 dark:text-zinc-100'
-                            : 'border-zinc-200/80 dark:border-zinc-800 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50'
-                        }`}
-                      >
-                        {preset.label}
-                      </button>
-                    ))}
+                {!isAutoRenew && (
+                  <div>
+                    <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">Duration</label>
+                    <div className="flex gap-2 mb-2">
+                      {config.presets.map((preset) => (
+                        <button
+                          key={preset.days}
+                          onClick={() => setEndInDays(preset.days)}
+                          className={`flex-1 py-2 rounded-lg border text-xs font-medium transition-colors ${
+                            isDateButtonActive(preset.days)
+                              ? 'bg-zinc-100 dark:bg-zinc-800 border-zinc-400 dark:border-zinc-600 text-zinc-900 dark:text-zinc-100'
+                              : 'border-zinc-200/80 dark:border-zinc-800 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50'
+                          }`}
+                        >
+                          {preset.label}
+                        </button>
+                      ))}
+                    </div>
+                    <Input
+                      label=""
+                      value={endTime}
+                      onChange={setEndTime}
+                      type="datetime-local"
+                      helperText={`Min: ${config.minEndLabel} · Max: 1 year`}
+                      error={(() => {
+                        if (!endTime || !error) return null;
+                        const d = Math.floor(new Date(endTime).getTime() / 1000) - Math.floor(Date.now() / 1000);
+                        if (d < config.minEndSeconds)
+                          return `Must be at least ${config.minEndLabel} from now`;
+                        if (d > MAX_END_SECONDS) return 'Must be within 1 year';
+                        return null;
+                      })()}
+                    />
                   </div>
-                  <Input
-                    label=""
-                    value={endTime}
-                    onChange={setEndTime}
-                    type="datetime-local"
-                    helperText={`Min: ${config.minEndLabel} · Max: 1 year`}
-                    error={(() => {
-                      if (!endTime || !error) return null;
-                      const d = Math.floor(new Date(endTime).getTime() / 1000) - Math.floor(Date.now() / 1000);
-                      if (d < config.minEndSeconds)
-                        return `Must be at least ${config.minEndLabel} from now`;
-                      if (d > MAX_END_SECONDS) return 'Must be within 1 year';
-                      return null;
-                    })()}
-                  />
-                </div>
+                )}
+
+                {isAutoRenew && (
+                  <>
+                    <div>
+                      <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">
+                        Cycle Period
+                      </label>
+                      <div className="flex gap-2 mb-2">
+                        {config.periodPresets.map((preset) => (
+                          <button
+                            key={preset.hours}
+                            onClick={() => setPeriodHours(String(preset.hours))}
+                            className={`flex-1 py-2 rounded-lg border text-xs font-medium transition-colors ${
+                              Number(periodHours) === preset.hours
+                                ? 'bg-zinc-100 dark:bg-zinc-800 border-zinc-400 dark:border-zinc-600 text-zinc-900 dark:text-zinc-100'
+                                : 'border-zinc-200/80 dark:border-zinc-800 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50'
+                            }`}
+                          >
+                            {preset.label}
+                          </button>
+                        ))}
+                      </div>
+                      <Input
+                        label=""
+                        value={periodHours}
+                        onChange={setPeriodHours}
+                        type="number"
+                        min={config.minPeriodHours}
+                        max={MAX_PERIOD_HOURS}
+                        unit="hours"
+                        helperText={`Stake auto-renews every cycle · Min: ${config.minPeriodHours} hours · Max: 1 year (${networkName})`}
+                        error={
+                          error &&
+                          (Number(periodHours) < config.minPeriodHours || Number(periodHours) > MAX_PERIOD_HOURS)
+                            ? `Must be between ${config.minPeriodHours} hours and 1 year`
+                            : null
+                        }
+                      />
+                    </div>
+
+                    <Input
+                      label="Auto-Compound Rewards"
+                      value={autoCompound}
+                      onChange={setAutoCompound}
+                      type="number"
+                      step="1"
+                      min="0"
+                      max="100"
+                      unit="%"
+                      helperText="Share of each cycle's reward restaked (0 = withdraw all, 100 = restake all)"
+                      error={
+                        error && (Number(autoCompound) < 0 || Number(autoCompound) > 100)
+                          ? 'Must be between 0-100%'
+                          : null
+                      }
+                    />
+
+                    <p className="text-[12px] text-zinc-500 dark:text-zinc-400">
+                      The stake renews automatically at the end of each cycle. Stop anytime — the validator exits at the
+                      end of its current cycle.
+                    </p>
+                  </>
+                )}
               </div>
             </Step>
 
             <Step>
               <h3 className="text-[14px] font-semibold mb-1">Submit</h3>
               <p className="text-[12px] text-zinc-500 dark:text-zinc-400 mb-3">
-                Issues an{' '}
-                <Link
-                  href="/docs/rpcs/p-chain/txn-format#unsigned-add-permissionless-validator-tx"
-                  className="text-primary hover:underline"
-                >
-                  AddPermissionlessValidatorTx
-                </Link>{' '}
-                on the P-Chain.
+                {isAutoRenew ? (
+                  <>
+                    Issues an{' '}
+                    <Link href="/docs/acps/236-auto-renewed-staking" className="text-primary hover:underline">
+                      AddAutoRenewedValidatorTx
+                    </Link>{' '}
+                    on the P-Chain. Your stake automatically renews every cycle.
+                  </>
+                ) : (
+                  <>
+                    Issues an{' '}
+                    <Link
+                      href="/docs/rpcs/p-chain/txn-format#unsigned-add-permissionless-validator-tx"
+                      className="text-primary hover:underline"
+                    >
+                      AddPermissionlessValidatorTx
+                    </Link>{' '}
+                    on the P-Chain.
+                  </>
+                )}
               </p>
 
               {error && <Alert variant="error">{error}</Alert>}

--- a/components/toolbox/console/primary-network/Stake.tsx
+++ b/components/toolbox/console/primary-network/Stake.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/toolbox/components/Button';
 import { Input } from '@/components/toolbox/components/Input';
 import { WalletRequirementsConfigKey } from '@/components/toolbox/hooks/useWalletRequirements';
@@ -14,7 +14,10 @@ import { useWallet } from '@/components/toolbox/hooks/useWallet';
 import {
   prepareAddPermissionlessValidatorTxn,
   prepareAddAutoRenewedValidatorTxn,
+  prepareSetAutoRenewedValidatorConfigTxn,
 } from '@avalanche-sdk/client/methods/wallet/pChain';
+import { createPChainClient } from '@avalanche-sdk/client';
+import { avalanche, avalancheFuji } from '@avalanche-sdk/client/chains';
 import { sendXPTransaction } from '@avalanche-sdk/client/methods/wallet';
 import { avaxToNanoAvax } from '@avalanche-sdk/client/utils';
 import { networkIDs } from '@avalabs/avalanchejs';
@@ -130,6 +133,55 @@ const AUTO_RENEW_SDK_SOURCES: SDKCodeSource[] = [
   },
 ];
 
+const SET_AUTO_RENEW_CONFIG_SOURCE = `import type { AvalanchePChainWalletClient } from "@avalanche-sdk/client";
+import { prepareSetAutoRenewedValidatorConfigTxn } from "@avalanche-sdk/client/methods/wallet/pChain";
+import { sendXPTransaction } from "@avalanche-sdk/client/methods/wallet";
+
+// ACP-236: update an auto-renewed validator's next-cycle config.
+// period = 0n stops auto-renewal — the validator exits at the end of its current cycle.
+export async function setAutoRenewedValidatorConfig(
+  pChainClient: AvalanchePChainWalletClient,
+  params: {
+    validatorTxId: string; // ID of the original AddAutoRenewedValidatorTx
+    periodSeconds: bigint;
+    autoCompoundRewardPercentage: number; // 0 = withdraw all rewards, 100 = restake all
+  }
+): Promise<string> {
+  const { tx } = await prepareSetAutoRenewedValidatorConfigTxn(pChainClient, {
+    validatorTxId: params.validatorTxId,
+    auth: [0], // index into the validator's authority owner set
+    period: params.periodSeconds,
+    autoCompoundRewardPercentage: params.autoCompoundRewardPercentage,
+  });
+
+  const result = await sendXPTransaction(pChainClient, {
+    tx,
+    chainAlias: "P",
+  });
+
+  return result.txHash;
+}`;
+
+const SET_CONFIG_SDK_SOURCES: SDKCodeSource[] = [
+  {
+    name: 'TypeScript',
+    filename: 'setAutoRenewedValidatorConfig.ts',
+    code: SET_AUTO_RENEW_CONFIG_SOURCE,
+    description: "Update or stop an auto-renewed validator's config (ACP-236) using the Avalanche SDK.",
+  },
+];
+
+type ExistingValidatorInfo = {
+  kind: 'autoRenewed' | 'fixed';
+  txID: string;
+  isAuthority: boolean;
+  stakeAvax: string;
+  endTime?: number;
+  periodHours?: number;
+  autoCompoundPct?: number;
+  authorityAddresses: string[];
+};
+
 const NETWORK_CONFIG = {
   fuji: {
     minStakeAvax: 1,
@@ -219,6 +271,12 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
   const [autoCompound, setAutoCompound] = useState<string>(DEFAULT_AUTO_COMPOUND);
   const [delegationFee, setDelegationFee] = useState<string>(DEFAULT_DELEGATOR_FEE);
 
+  const [existingValidator, setExistingValidator] = useState<ExistingValidatorInfo | null>(null);
+  const [checkingExisting, setCheckingExisting] = useState(false);
+  const [updPeriodHours, setUpdPeriodHours] = useState<string>('');
+  const [updAutoCompound, setUpdAutoCompound] = useState<string>('');
+  const [confirmStop, setConfirmStop] = useState(false);
+
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [txId, setTxId] = useState<string>('');
@@ -231,6 +289,70 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
   const isAutoRenew = stakingMode === 'autoRenew';
   // TODO(helicon-mainnet): flip to true for all networks once Helicon activates on Mainnet.
   const autoRenewAvailable = onFuji;
+  const isUpdateMode = existingValidator?.kind === 'autoRenewed' && existingValidator.isAuthority;
+
+  // Once a NodeID is entered, check whether it is already an active validator:
+  // an auto-renewed one owned by this wallet switches the tool to config-update mode.
+  useEffect(() => {
+    const nodeID = validator?.nodeID;
+    setExistingValidator(null);
+    setConfirmStop(false);
+    if (!nodeID?.startsWith('NodeID-')) return;
+
+    let cancelled = false;
+    setCheckingExisting(true);
+    const client = createPChainClient({
+      chain: onFuji ? avalancheFuji : avalanche,
+      transport: { type: 'http' },
+    });
+    client
+      .getCurrentValidators({ nodeIDs: [nodeID] })
+      .then(({ validators }) => {
+        if (cancelled) return;
+        const v = validators?.[0];
+        if (!v) return;
+        const stakeAvax = (Number(v.stakeAmount ?? v.weight ?? 0) / 1e9).toLocaleString();
+        const walletAddr = pChainAddress?.replace(/^P-/, '');
+        if (v.nextPeriod !== undefined || v.validatorAuthority) {
+          const authorityAddresses = (v.validatorAuthority?.addresses ?? []).map((a) =>
+            a.startsWith('P-') ? a : `P-${a}`,
+          );
+          const isAuthority = !!walletAddr && authorityAddresses.some((a) => a.replace(/^P-/, '') === walletAddr);
+          const currentPeriodHours = Math.round(Number(v.nextPeriod ?? 0) / 3600);
+          const autoCompoundPct = Number(v.autoCompoundRewardShares ?? 0) / 10_000;
+          setExistingValidator({
+            kind: 'autoRenewed',
+            txID: v.txID,
+            isAuthority,
+            stakeAvax,
+            periodHours: currentPeriodHours,
+            autoCompoundPct,
+            authorityAddresses,
+          });
+          setUpdPeriodHours(String(currentPeriodHours));
+          setUpdAutoCompound(String(autoCompoundPct));
+        } else {
+          setExistingValidator({
+            kind: 'fixed',
+            txID: v.txID,
+            isAuthority: false,
+            stakeAvax,
+            endTime: Number(v.endTime ?? 0),
+            authorityAddresses: [],
+          });
+        }
+      })
+      .catch(() => {
+        // Lookup is best-effort; the add flow still works without it.
+      })
+      .finally(() => {
+        if (!cancelled) setCheckingExisting(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [validator?.nodeID, onFuji, pChainAddress]);
 
   // Initialize defaults
   if (!stakeInAvax) {
@@ -370,12 +492,72 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
     }
   };
 
-  const cliCommand = isAutoRenew
-    ? `platform-cli validator add-auto-renewed --node-id ${validator?.nodeID || '<node-id>'} --stake ${stakeInAvax || '<amount>'} --period ${periodHours}h --delegation-fee ${Number(delegationFee) / 100} --auto-compound ${Number(autoCompound) / 100} --network ${onFuji ? 'fuji' : 'mainnet'}`
-    : `platform-cli validator add-permissionless --node-id ${validator?.nodeID || '<node-id>'} --stake ${stakeInAvax || '<amount>'} --duration ${getDurationHours()}h --delegation-fee ${Number(delegationFee) / 100} --network ${onFuji ? 'fuji' : 'mainnet'}`;
+  const submitConfigUpdate = async (stop: boolean) => {
+    setError(null);
+    setTxId('');
+    if (!existingValidator) return;
+
+    if (!stop) {
+      const hours = Number(updPeriodHours);
+      if (!Number.isFinite(hours) || hours < config.minPeriodHours || hours > MAX_PERIOD_HOURS) {
+        setError(`Cycle period must be between ${config.minPeriodHours} hours and 1 year`);
+        return;
+      }
+      const ac = Number(updAutoCompound);
+      if (!Number.isFinite(ac) || ac < 0 || ac > 100) {
+        setError('Auto-compound must be between 0 and 100');
+        return;
+      }
+    }
+
+    if (!avalancheWalletClient) {
+      setError('Avalanche client not found');
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+
+      const walletAddr = pChainAddress?.replace(/^P-/, '');
+      const authIndex = Math.max(
+        0,
+        existingValidator.authorityAddresses.findIndex((a) => a.replace(/^P-/, '') === walletAddr),
+      );
+      const { tx } = await prepareSetAutoRenewedValidatorConfigTxn(avalancheWalletClient.pChain, {
+        validatorTxId: existingValidator.txID,
+        auth: [authIndex],
+        period: stop ? 0n : BigInt(Math.round(Number(updPeriodHours) * 60 * 60)),
+        autoCompoundRewardPercentage: stop ? 0 : Number(updAutoCompound),
+      });
+
+      const updatePromise = sendXPTransaction(avalancheWalletClient.pChain, {
+        tx,
+        chainAlias: 'P',
+      }).then((result) => result.txHash);
+
+      notify('setAutoRenewedValidatorConfig', updatePromise);
+
+      const txHash = await updatePromise;
+      setTxId(txHash);
+      onSuccess?.();
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const cliCommand = isUpdateMode
+    ? `platform-cli validator set-auto-renewed-config --tx-id ${existingValidator?.txID || '<tx-id>'} --node-id ${validator?.nodeID || '<node-id>'} --period ${updPeriodHours || '<hours>'}h --auto-compound ${Number(updAutoCompound || 0) / 100} --network ${onFuji ? 'fuji' : 'mainnet'}`
+    : isAutoRenew
+      ? `platform-cli validator add-auto-renewed --node-id ${validator?.nodeID || '<node-id>'} --stake ${stakeInAvax || '<amount>'} --period ${periodHours}h --delegation-fee ${Number(delegationFee) / 100} --auto-compound ${Number(autoCompound) / 100} --network ${onFuji ? 'fuji' : 'mainnet'}`
+      : `platform-cli validator add-permissionless --node-id ${validator?.nodeID || '<node-id>'} --stake ${stakeInAvax || '<amount>'} --duration ${getDurationHours()}h --delegation-fee ${Number(delegationFee) / 100} --network ${onFuji ? 'fuji' : 'mainnet'}`;
 
   return (
-    <SDKCodeViewer sources={isAutoRenew ? AUTO_RENEW_SDK_SOURCES : FIXED_SDK_SOURCES} height="auto">
+    <SDKCodeViewer
+      sources={isUpdateMode ? SET_CONFIG_SDK_SOURCES : isAutoRenew ? AUTO_RENEW_SDK_SOURCES : FIXED_SDK_SOURCES}
+      height="auto"
+    >
       <div>
         {txId ? (
           <div className="space-y-4">
@@ -388,12 +570,16 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
                 setPeriodHours('336');
                 setAutoCompound(DEFAULT_AUTO_COMPOUND);
                 setDelegationFee(DEFAULT_DELEGATOR_FEE);
+                setExistingValidator(null);
+                setUpdPeriodHours('');
+                setUpdAutoCompound('');
+                setConfirmStop(false);
                 setError(null);
                 setTxId('');
               }}
               className="w-full"
             >
-              Stake Another Validator
+              {isUpdateMode ? 'Start Over' : 'Stake Another Validator'}
             </Button>
           </div>
         ) : (
@@ -431,173 +617,139 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
                   </div>
                 </div>
               )}
+
+              {checkingExisting && (
+                <p className="text-[12px] text-zinc-500 dark:text-zinc-400 mt-2">Checking current validator status…</p>
+              )}
+              {isUpdateMode && (
+                <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
+                  This node already has auto-renewed staking — switched to config update mode.
+                </p>
+              )}
             </Step>
 
             <Step>
-              <h3 className="text-[14px] font-semibold mb-1">Stake Configuration</h3>
-              <p className="text-[12px] text-zinc-500 dark:text-zinc-400 mb-3">
-                {isAutoRenew
-                  ? 'Set your stake amount, delegation fee, cycle period, and auto-compounding.'
-                  : 'Set your stake amount, delegation fee, and duration.'}
-              </p>
-
-              <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">
-                    Staking Mode
-                  </label>
-                  <div className="grid grid-cols-2 gap-2">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setStakingMode('fixed');
-                        setError(null);
-                      }}
-                      className={`p-3 rounded-xl border-2 text-left transition-all ${
-                        !isAutoRenew
-                          ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
-                          : 'border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600'
-                      }`}
-                    >
-                      <div className="font-medium text-sm">Fixed Duration</div>
-                      <div className="text-xs text-zinc-500">Stake until a set end date</div>
-                    </button>
-                    <button
-                      type="button"
-                      disabled={!autoRenewAvailable}
-                      onClick={() => {
-                        setStakingMode('autoRenew');
-                        setError(null);
-                      }}
-                      className={`p-3 rounded-xl border-2 text-left transition-all ${
-                        isAutoRenew
-                          ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
-                          : 'border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600'
-                      } ${!autoRenewAvailable ? 'opacity-50 cursor-not-allowed' : ''}`}
-                    >
-                      <div className="font-medium text-sm">Auto-Renewed</div>
-                      <div className="text-xs text-zinc-500">Restakes each cycle (ACP-236)</div>
-                    </button>
-                  </div>
-                  {!autoRenewAvailable && (
-                    <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
-                      Auto-renewed staking (Helicon upgrade) is not yet activated on Mainnet — available on Fuji.
-                    </p>
-                  )}
-                </div>
-
-                <Input
-                  label="Stake Amount"
-                  value={stakeInAvax}
-                  onChange={setStakeInAvax}
-                  type="number"
-                  step="0.001"
-                  min={config.minStakeAvax}
-                  unit="AVAX"
-                  helperText={`Minimum: ${config.minStakeAvax.toLocaleString()} AVAX (${networkName})`}
-                  error={
-                    error && Number(stakeInAvax) < config.minStakeAvax
-                      ? `Minimum stake is ${config.minStakeAvax} AVAX`
-                      : null
-                  }
-                />
-
-                <Input
-                  label="Delegation Fee"
-                  value={delegationFee}
-                  onChange={setDelegationFee}
-                  type="number"
-                  step="0.1"
-                  min="2"
-                  max="100"
-                  unit="%"
-                  helperText="Your fee from delegators (2-100%)"
-                  error={
-                    error && (Number(delegationFee) < 2 || Number(delegationFee) > 100)
-                      ? 'Must be between 2-100%'
-                      : null
-                  }
-                />
-
-                {!isAutoRenew && (
-                  <div>
-                    <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">Duration</label>
-                    <div className="flex gap-2 mb-2">
-                      {config.presets.map((preset) => (
-                        <button
-                          key={preset.days}
-                          onClick={() => setEndInDays(preset.days)}
-                          className={`flex-1 py-2 rounded-lg border text-xs font-medium transition-colors ${
-                            isDateButtonActive(preset.days)
-                              ? 'bg-zinc-100 dark:bg-zinc-800 border-zinc-400 dark:border-zinc-600 text-zinc-900 dark:text-zinc-100'
-                              : 'border-zinc-200/80 dark:border-zinc-800 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50'
-                          }`}
-                        >
-                          {preset.label}
-                        </button>
-                      ))}
-                    </div>
-                    <Input
-                      label=""
-                      value={endTime}
-                      onChange={setEndTime}
-                      type="datetime-local"
-                      helperText={`Min: ${config.minEndLabel} · Max: 1 year`}
-                      error={(() => {
-                        if (!endTime || !error) return null;
-                        const d = Math.floor(new Date(endTime).getTime() / 1000) - Math.floor(Date.now() / 1000);
-                        if (d < config.minEndSeconds)
-                          return `Must be at least ${config.minEndLabel} from now`;
-                        if (d > MAX_END_SECONDS) return 'Must be within 1 year';
-                        return null;
-                      })()}
-                    />
-                  </div>
-                )}
-
-                {isAutoRenew && (
-                  <>
+              {existingValidator?.kind === 'fixed' && (
+                <>
+                  <h3 className="text-[14px] font-semibold mb-1">Existing Validator</h3>
+                  <p className="text-[12px] text-zinc-500 dark:text-zinc-400 mb-3">
+                    This node is already a fixed-duration Primary Network validator.
+                  </p>
+                  <div className="p-3 bg-zinc-50/50 dark:bg-zinc-900/50 border border-zinc-200/50 dark:border-zinc-800/50 rounded-lg space-y-2">
                     <div>
-                      <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">
-                        Cycle Period
-                      </label>
-                      <div className="flex gap-2 mb-2">
-                        {config.periodPresets.map((preset) => (
-                          <button
-                            key={preset.hours}
-                            onClick={() => setPeriodHours(String(preset.hours))}
-                            className={`flex-1 py-2 rounded-lg border text-xs font-medium transition-colors ${
-                              Number(periodHours) === preset.hours
-                                ? 'bg-zinc-100 dark:bg-zinc-800 border-zinc-400 dark:border-zinc-600 text-zinc-900 dark:text-zinc-100'
-                                : 'border-zinc-200/80 dark:border-zinc-800 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50'
-                            }`}
-                          >
-                            {preset.label}
-                          </button>
-                        ))}
+                      <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 mb-0.5">
+                        Stake
                       </div>
-                      <Input
-                        label=""
-                        value={periodHours}
-                        onChange={setPeriodHours}
-                        type="number"
-                        min={config.minPeriodHours}
-                        max={MAX_PERIOD_HOURS}
-                        unit="hours"
-                        helperText={`Stake auto-renews every cycle · Min: ${config.minPeriodHours} hours · Max: 1 year (${networkName})`}
-                        error={
-                          error &&
-                          (Number(periodHours) < config.minPeriodHours || Number(periodHours) > MAX_PERIOD_HOURS)
-                            ? `Must be between ${config.minPeriodHours} hours and 1 year`
-                            : null
-                        }
-                      />
+                      <div className="text-xs text-zinc-700 dark:text-zinc-300">{existingValidator.stakeAvax} AVAX</div>
                     </div>
+                    <div>
+                      <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 mb-0.5">
+                        Validating Until
+                      </div>
+                      <div className="text-xs text-zinc-700 dark:text-zinc-300">
+                        {existingValidator.endTime ? new Date(existingValidator.endTime * 1000).toLocaleString() : '—'}
+                      </div>
+                    </div>
+                  </div>
+                  <Alert variant="info" className="mt-3">
+                    Fixed-duration stake can't be modified. This node can be staked again after its current validation
+                    ends.
+                  </Alert>
+                </>
+              )}
+
+              {existingValidator?.kind === 'autoRenewed' && !existingValidator.isAuthority && (
+                <>
+                  <h3 className="text-[14px] font-semibold mb-1">Auto-Renewed Validator</h3>
+                  <p className="text-[12px] text-zinc-500 dark:text-zinc-400 mb-3">
+                    This node already validates with auto-renewal. Read-only view.
+                  </p>
+                  <div className="p-3 bg-zinc-50/50 dark:bg-zinc-900/50 border border-zinc-200/50 dark:border-zinc-800/50 rounded-lg space-y-2">
+                    <div>
+                      <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 mb-0.5">
+                        Stake
+                      </div>
+                      <div className="text-xs text-zinc-700 dark:text-zinc-300">{existingValidator.stakeAvax} AVAX</div>
+                    </div>
+                    <div>
+                      <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 mb-0.5">
+                        Cycle Period
+                      </div>
+                      <div className="text-xs text-zinc-700 dark:text-zinc-300">
+                        {existingValidator.periodHours} hours
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 mb-0.5">
+                        Auto-Compound
+                      </div>
+                      <div className="text-xs text-zinc-700 dark:text-zinc-300">
+                        {existingValidator.autoCompoundPct}%
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 mb-0.5">
+                        Validator Authority
+                      </div>
+                      <div className="font-mono text-xs text-zinc-700 dark:text-zinc-300 break-all">
+                        {existingValidator.authorityAddresses.join(', ')}
+                      </div>
+                    </div>
+                  </div>
+                  <Alert variant="warning" className="mt-3">
+                    The connected wallet is not this validator's authority — only the authority can update or stop it.
+                  </Alert>
+                </>
+              )}
+
+              {isUpdateMode && existingValidator && (
+                <>
+                  <h3 className="text-[14px] font-semibold mb-1">Auto-Renewal Config</h3>
+                  <p className="text-[12px] text-zinc-500 dark:text-zinc-400 mb-3">
+                    Update the next cycle's period and auto-compounding for this validator.
+                  </p>
+
+                  <div className="space-y-4">
+                    <div className="p-3 bg-zinc-50/50 dark:bg-zinc-900/50 border border-zinc-200/50 dark:border-zinc-800/50 rounded-lg space-y-2">
+                      <div>
+                        <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 mb-0.5">
+                          Stake
+                        </div>
+                        <div className="text-xs text-zinc-700 dark:text-zinc-300">
+                          {existingValidator.stakeAvax} AVAX
+                        </div>
+                      </div>
+                      <div>
+                        <div className="text-[10px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500 mb-0.5">
+                          Current Config
+                        </div>
+                        <div className="text-xs text-zinc-700 dark:text-zinc-300">
+                          {existingValidator.periodHours}h cycle · {existingValidator.autoCompoundPct}% auto-compound
+                        </div>
+                      </div>
+                    </div>
+
+                    <Input
+                      label="Cycle Period"
+                      value={updPeriodHours}
+                      onChange={setUpdPeriodHours}
+                      type="number"
+                      min={config.minPeriodHours}
+                      max={MAX_PERIOD_HOURS}
+                      unit="hours"
+                      helperText={`Min: ${config.minPeriodHours} hours · Max: 1 year (${networkName})`}
+                      error={
+                        error &&
+                        (Number(updPeriodHours) < config.minPeriodHours || Number(updPeriodHours) > MAX_PERIOD_HOURS)
+                          ? `Must be between ${config.minPeriodHours} hours and 1 year`
+                          : null
+                      }
+                    />
 
                     <Input
                       label="Auto-Compound Rewards"
-                      value={autoCompound}
-                      onChange={setAutoCompound}
+                      value={updAutoCompound}
+                      onChange={setUpdAutoCompound}
                       type="number"
                       step="1"
                       min="0"
@@ -605,61 +757,318 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
                       unit="%"
                       helperText="Share of each cycle's reward restaked (0 = withdraw all, 100 = restake all)"
                       error={
-                        error && (Number(autoCompound) < 0 || Number(autoCompound) > 100)
+                        error && (Number(updAutoCompound) < 0 || Number(updAutoCompound) > 100)
                           ? 'Must be between 0-100%'
                           : null
                       }
                     />
 
                     <p className="text-[12px] text-zinc-500 dark:text-zinc-400">
-                      The stake renews automatically at the end of each cycle. Stop anytime — the validator exits at the
-                      end of its current cycle.
+                      Changes take effect from the next cycle.
                     </p>
-                  </>
-                )}
-              </div>
+                  </div>
+                </>
+              )}
+
+              {!existingValidator && (
+                <>
+                  <h3 className="text-[14px] font-semibold mb-1">Stake Configuration</h3>
+                  <p className="text-[12px] text-zinc-500 dark:text-zinc-400 mb-3">
+                    {isAutoRenew
+                      ? 'Set your stake amount, delegation fee, cycle period, and auto-compounding.'
+                      : 'Set your stake amount, delegation fee, and duration.'}
+                  </p>
+
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">
+                        Staking Mode
+                      </label>
+                      <div className="grid grid-cols-2 gap-2">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setStakingMode('fixed');
+                            setError(null);
+                          }}
+                          className={`p-3 rounded-xl border-2 text-left transition-all ${
+                            !isAutoRenew
+                              ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                              : 'border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600'
+                          }`}
+                        >
+                          <div className="font-medium text-sm">Fixed Duration</div>
+                          <div className="text-xs text-zinc-500">Stake until a set end date</div>
+                        </button>
+                        <button
+                          type="button"
+                          disabled={!autoRenewAvailable}
+                          onClick={() => {
+                            setStakingMode('autoRenew');
+                            setError(null);
+                          }}
+                          className={`p-3 rounded-xl border-2 text-left transition-all ${
+                            isAutoRenew
+                              ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                              : 'border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600'
+                          } ${!autoRenewAvailable ? 'opacity-50 cursor-not-allowed' : ''}`}
+                        >
+                          <div className="font-medium text-sm">Auto-Renewed</div>
+                          <div className="text-xs text-zinc-500">Restakes each cycle (ACP-236)</div>
+                        </button>
+                      </div>
+                      {!autoRenewAvailable && (
+                        <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
+                          Auto-renewed staking (Helicon upgrade) is not yet activated on Mainnet — available on Fuji.
+                        </p>
+                      )}
+                    </div>
+
+                    <Input
+                      label="Stake Amount"
+                      value={stakeInAvax}
+                      onChange={setStakeInAvax}
+                      type="number"
+                      step="0.001"
+                      min={config.minStakeAvax}
+                      unit="AVAX"
+                      helperText={`Minimum: ${config.minStakeAvax.toLocaleString()} AVAX (${networkName})`}
+                      error={
+                        error && Number(stakeInAvax) < config.minStakeAvax
+                          ? `Minimum stake is ${config.minStakeAvax} AVAX`
+                          : null
+                      }
+                    />
+
+                    <Input
+                      label="Delegation Fee"
+                      value={delegationFee}
+                      onChange={setDelegationFee}
+                      type="number"
+                      step="0.1"
+                      min="2"
+                      max="100"
+                      unit="%"
+                      helperText="Your fee from delegators (2-100%)"
+                      error={
+                        error && (Number(delegationFee) < 2 || Number(delegationFee) > 100)
+                          ? 'Must be between 2-100%'
+                          : null
+                      }
+                    />
+
+                    {!isAutoRenew && (
+                      <div>
+                        <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">
+                          Duration
+                        </label>
+                        <div className="flex gap-2 mb-2">
+                          {config.presets.map((preset) => (
+                            <button
+                              key={preset.days}
+                              onClick={() => setEndInDays(preset.days)}
+                              className={`flex-1 py-2 rounded-lg border text-xs font-medium transition-colors ${
+                                isDateButtonActive(preset.days)
+                                  ? 'bg-zinc-100 dark:bg-zinc-800 border-zinc-400 dark:border-zinc-600 text-zinc-900 dark:text-zinc-100'
+                                  : 'border-zinc-200/80 dark:border-zinc-800 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50'
+                              }`}
+                            >
+                              {preset.label}
+                            </button>
+                          ))}
+                        </div>
+                        <Input
+                          label=""
+                          value={endTime}
+                          onChange={setEndTime}
+                          type="datetime-local"
+                          helperText={`Min: ${config.minEndLabel} · Max: 1 year`}
+                          error={(() => {
+                            if (!endTime || !error) return null;
+                            const d = Math.floor(new Date(endTime).getTime() / 1000) - Math.floor(Date.now() / 1000);
+                            if (d < config.minEndSeconds)
+                              return `Must be at least ${config.minEndLabel} from now`;
+                            if (d > MAX_END_SECONDS) return 'Must be within 1 year';
+                            return null;
+                          })()}
+                        />
+                      </div>
+                    )}
+
+                    {isAutoRenew && (
+                      <>
+                        <div>
+                          <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">
+                            Cycle Period
+                          </label>
+                          <div className="flex gap-2 mb-2">
+                            {config.periodPresets.map((preset) => (
+                              <button
+                                key={preset.hours}
+                                onClick={() => setPeriodHours(String(preset.hours))}
+                                className={`flex-1 py-2 rounded-lg border text-xs font-medium transition-colors ${
+                                  Number(periodHours) === preset.hours
+                                    ? 'bg-zinc-100 dark:bg-zinc-800 border-zinc-400 dark:border-zinc-600 text-zinc-900 dark:text-zinc-100'
+                                    : 'border-zinc-200/80 dark:border-zinc-800 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50'
+                                }`}
+                              >
+                                {preset.label}
+                              </button>
+                            ))}
+                          </div>
+                          <Input
+                            label=""
+                            value={periodHours}
+                            onChange={setPeriodHours}
+                            type="number"
+                            min={config.minPeriodHours}
+                            max={MAX_PERIOD_HOURS}
+                            unit="hours"
+                            helperText={`Stake auto-renews every cycle · Min: ${config.minPeriodHours} hours · Max: 1 year (${networkName})`}
+                            error={
+                              error &&
+                              (Number(periodHours) < config.minPeriodHours || Number(periodHours) > MAX_PERIOD_HOURS)
+                                ? `Must be between ${config.minPeriodHours} hours and 1 year`
+                                : null
+                            }
+                          />
+                        </div>
+
+                        <Input
+                          label="Auto-Compound Rewards"
+                          value={autoCompound}
+                          onChange={setAutoCompound}
+                          type="number"
+                          step="1"
+                          min="0"
+                          max="100"
+                          unit="%"
+                          helperText="Share of each cycle's reward restaked (0 = withdraw all, 100 = restake all)"
+                          error={
+                            error && (Number(autoCompound) < 0 || Number(autoCompound) > 100)
+                              ? 'Must be between 0-100%'
+                              : null
+                          }
+                        />
+
+                        <p className="text-[12px] text-zinc-500 dark:text-zinc-400">
+                          The stake renews automatically at the end of each cycle. Stop anytime — the validator exits at
+                          the end of its current cycle.
+                        </p>
+                      </>
+                    )}
+                  </div>
+                </>
+              )}
             </Step>
 
-            <Step>
-              <h3 className="text-[14px] font-semibold mb-1">Submit</h3>
-              <p className="text-[12px] text-zinc-500 dark:text-zinc-400 mb-3">
-                {isAutoRenew ? (
+            {(!existingValidator || isUpdateMode) && (
+              <Step>
+                {isUpdateMode ? (
                   <>
-                    Issues an{' '}
-                    <Link href="/docs/acps/236-auto-renewed-staking" className="text-primary hover:underline">
-                      AddAutoRenewedValidatorTx
-                    </Link>{' '}
-                    on the P-Chain. Your stake automatically renews every cycle.
+                    <h3 className="text-[14px] font-semibold mb-1">Submit</h3>
+                    <p className="text-[12px] text-zinc-500 dark:text-zinc-400 mb-3">
+                      Issues a{' '}
+                      <Link href="/docs/acps/236-auto-renewed-staking" className="text-primary hover:underline">
+                        SetAutoRenewedValidatorConfigTx
+                      </Link>{' '}
+                      on the P-Chain.
+                    </p>
+
+                    {error && <Alert variant="error">{error}</Alert>}
+
+                    <Button
+                      onClick={() => submitConfigUpdate(false)}
+                      disabled={!pChainAddress || isSubmitting}
+                      loading={isSubmitting}
+                      loadingText="Processing..."
+                      variant="primary"
+                      className="w-full mt-3"
+                    >
+                      Update Config
+                    </Button>
+
+                    {!confirmStop ? (
+                      <Button
+                        variant="outline-danger"
+                        className="w-full mt-2"
+                        onClick={() => setConfirmStop(true)}
+                        disabled={isSubmitting}
+                      >
+                        Stop Auto-Renewal
+                      </Button>
+                    ) : (
+                      <div className="mt-2 space-y-2">
+                        <Alert variant="warning">
+                          The validator exits at the end of its current cycle and the stake returns to your wallet.
+                        </Alert>
+                        <Button
+                          variant="danger"
+                          className="w-full"
+                          onClick={() => submitConfigUpdate(true)}
+                          disabled={isSubmitting}
+                          loading={isSubmitting}
+                          loadingText="Processing..."
+                        >
+                          Confirm Stop
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          className="w-full"
+                          onClick={() => setConfirmStop(false)}
+                          disabled={isSubmitting}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    )}
+
+                    <CliAlternative command={cliCommand} />
                   </>
                 ) : (
                   <>
-                    Issues an{' '}
-                    <Link
-                      href="/docs/rpcs/p-chain/txn-format#unsigned-add-permissionless-validator-tx"
-                      className="text-primary hover:underline"
+                    <h3 className="text-[14px] font-semibold mb-1">Submit</h3>
+                    <p className="text-[12px] text-zinc-500 dark:text-zinc-400 mb-3">
+                      {isAutoRenew ? (
+                        <>
+                          Issues an{' '}
+                          <Link href="/docs/acps/236-auto-renewed-staking" className="text-primary hover:underline">
+                            AddAutoRenewedValidatorTx
+                          </Link>{' '}
+                          on the P-Chain. Your stake automatically renews every cycle.
+                        </>
+                      ) : (
+                        <>
+                          Issues an{' '}
+                          <Link
+                            href="/docs/rpcs/p-chain/txn-format#unsigned-add-permissionless-validator-tx"
+                            className="text-primary hover:underline"
+                          >
+                            AddPermissionlessValidatorTx
+                          </Link>{' '}
+                          on the P-Chain.
+                        </>
+                      )}
+                    </p>
+
+                    {error && <Alert variant="error">{error}</Alert>}
+
+                    <Button
+                      onClick={submitStake}
+                      disabled={!pChainAddress || isSubmitting || checkingExisting}
+                      loading={isSubmitting}
+                      loadingText="Processing..."
+                      variant="primary"
+                      className="w-full mt-3"
                     >
-                      AddPermissionlessValidatorTx
-                    </Link>{' '}
-                    on the P-Chain.
+                      Stake {networkName} Validator
+                    </Button>
+
+                    <CliAlternative command={cliCommand} />
                   </>
                 )}
-              </p>
-
-              {error && <Alert variant="error">{error}</Alert>}
-
-              <Button
-                onClick={submitStake}
-                disabled={!pChainAddress || isSubmitting}
-                loading={isSubmitting}
-                loadingText="Processing..."
-                variant="primary"
-                className="w-full mt-3"
-              >
-                Stake {networkName} Validator
-              </Button>
-
-              <CliAlternative command={cliCommand} />
-            </Step>
+              </Step>
+            )}
           </Steps>
         )}
       </div>

--- a/components/toolbox/console/primary-network/Stake.tsx
+++ b/components/toolbox/console/primary-network/Stake.tsx
@@ -20,6 +20,10 @@ import { avaxToNanoAvax } from '@avalanche-sdk/client/utils';
 import { networkIDs } from '@avalabs/avalanchejs';
 import { AddValidatorControls } from '@/components/toolbox/components/ValidatorListInput/AddValidatorControls';
 import type { ConvertToL1Validator } from '@/components/toolbox/components/ValidatorListInput';
+import {
+  BLS_PROOF_OF_POSSESSION_REGEX,
+  BLS_PUBLIC_KEY_REGEX,
+} from '@/components/toolbox/components/ValidatorListInput/nodeCredentials';
 import { Steps, Step } from 'fumadocs-ui/components/steps';
 import useConsoleNotifications from '@/hooks/useConsoleNotifications';
 import { generateConsoleToolGitHubUrl } from '@/components/toolbox/utils/githubUrl';
@@ -267,8 +271,10 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
     if (!pChainAddress) return 'Connect Core Wallet to get your P-Chain address';
     if (!validator) return 'Please provide validator credentials';
     if (!validator.nodeID?.startsWith('NodeID-')) return 'Invalid NodeID format';
-    if (!validator.nodePOP.publicKey?.startsWith('0x')) return 'Invalid BLS Public Key format';
-    if (!validator.nodePOP.proofOfPossession?.startsWith('0x')) return 'Invalid BLS Signature format';
+    if (!BLS_PUBLIC_KEY_REGEX.test(validator.nodePOP.publicKey))
+      return 'Invalid BLS public key: expected 0x plus 96 hex characters (48 bytes)';
+    if (!BLS_PROOF_OF_POSSESSION_REGEX.test(validator.nodePOP.proofOfPossession))
+      return 'Invalid BLS proof of possession: expected 0x plus 192 hex characters (96 bytes)';
 
     const stakeNum = Number(stakeInAvax);
     if (!Number.isFinite(stakeNum) || stakeNum < config.minStakeAvax) {

--- a/components/toolbox/console/toolbox/tools.ts
+++ b/components/toolbox/console/toolbox/tools.ts
@@ -75,7 +75,8 @@ const TOOLS_RAW: ToolCard[] = [
   },
   {
     name: 'Stake AVAX',
-    description: 'Stake AVAX on the Primary Network as a validator or delegator.',
+    description:
+      'Stake AVAX on the Primary Network as a validator or delegator, with fixed or auto-renewed (ACP-236) staking.',
     path: '/console/primary-network/stake',
     category: 'Primary Network',
     icon: HandCoins,

--- a/hooks/usePChainNotifications.ts
+++ b/hooks/usePChainNotifications.ts
@@ -18,6 +18,7 @@ export type PChainAction =
   | 'convertToL1'
   | 'addPermissionlessValidator'
   | 'addAutoRenewedValidator'
+  | 'setAutoRenewedValidatorConfig'
   | 'registerL1Validator'
   | 'setL1ValidatorWeight'
   | 'increaseL1ValidatorBalance'
@@ -31,6 +32,7 @@ export const PChainActionList = [
   'convertToL1',
   'addPermissionlessValidator',
   'addAutoRenewedValidator',
+  'setAutoRenewedValidatorConfig',
   'registerL1Validator',
   'setL1ValidatorWeight',
   'increaseL1ValidatorBalance',
@@ -77,6 +79,12 @@ const configs: Record<PChainAction, PChainNotificationConfig> = {
     successMessage: 'Auto-renewed validator added successfully',
     errorMessagePrefix: 'Failed to add auto-renewed validator: ',
     eventType: 'auto_renewed_validator_added',
+  },
+  setAutoRenewedValidatorConfig: {
+    loadingMessage: 'Signing SetAutoRenewedValidatorConfigTx with Core...',
+    successMessage: 'Auto-renewal config updated successfully',
+    errorMessagePrefix: 'Failed to update auto-renewal config: ',
+    eventType: 'auto_renewed_validator_config_set',
   },
   registerL1Validator: {
     loadingMessage: 'Signing RegisterL1ValidatorTx with Core...',

--- a/hooks/usePChainNotifications.ts
+++ b/hooks/usePChainNotifications.ts
@@ -17,6 +17,7 @@ export type PChainAction =
   | 'createChain'
   | 'convertToL1'
   | 'addPermissionlessValidator'
+  | 'addAutoRenewedValidator'
   | 'registerL1Validator'
   | 'setL1ValidatorWeight'
   | 'increaseL1ValidatorBalance'
@@ -29,6 +30,7 @@ export const PChainActionList = [
   'createChain',
   'convertToL1',
   'addPermissionlessValidator',
+  'addAutoRenewedValidator',
   'registerL1Validator',
   'setL1ValidatorWeight',
   'increaseL1ValidatorBalance',
@@ -69,6 +71,12 @@ const configs: Record<PChainAction, PChainNotificationConfig> = {
     successMessage: 'Validator added successfully',
     errorMessagePrefix: 'Failed to add validator: ',
     eventType: 'validator_added',
+  },
+  addAutoRenewedValidator: {
+    loadingMessage: 'Signing AddAutoRenewedValidatorTx with Core...',
+    successMessage: 'Auto-renewed validator added successfully',
+    errorMessagePrefix: 'Failed to add auto-renewed validator: ',
+    eventType: 'auto_renewed_validator_added',
   },
   registerL1Validator: {
     loadingMessage: 'Signing RegisterL1ValidatorTx with Core...',

--- a/lib/chat/tools-search.ts
+++ b/lib/chat/tools-search.ts
@@ -37,7 +37,7 @@ export const consoleTools: ConsoleTool[] = [
     url: '/console/primary-network/stake',
     category: 'Primary Network',
     description: 'Stake AVAX to become a validator or delegate to existing validators, with fixed-duration or auto-renewed (ACP-236) staking',
-    keywords: ['stake', 'staking', 'validator', 'delegate', 'delegation', 'avax', 'rewards', 'earn', 'auto-renew', 'auto-renewed', 'continuous', 'auto-compound', 'acp-236', 'helicon'],
+    keywords: ['stake', 'staking', 'validator', 'delegate', 'delegation', 'avax', 'rewards', 'earn', 'auto-renew', 'auto-renewed', 'continuous', 'auto-compound', 'acp-236', 'helicon', 'update', 'stop', 'set-config'],
   },
   {
     title: 'Testnet Faucet',

--- a/lib/chat/tools-search.ts
+++ b/lib/chat/tools-search.ts
@@ -36,8 +36,8 @@ export const consoleTools: ConsoleTool[] = [
     title: 'Stake AVAX',
     url: '/console/primary-network/stake',
     category: 'Primary Network',
-    description: 'Stake AVAX to become a validator or delegate to existing validators',
-    keywords: ['stake', 'staking', 'validator', 'delegate', 'delegation', 'avax', 'rewards', 'earn'],
+    description: 'Stake AVAX to become a validator or delegate to existing validators, with fixed-duration or auto-renewed (ACP-236) staking',
+    keywords: ['stake', 'staking', 'validator', 'delegate', 'delegation', 'avax', 'rewards', 'earn', 'auto-renew', 'auto-renewed', 'continuous', 'auto-compound', 'acp-236', 'helicon'],
   },
   {
     title: 'Testnet Faucet',

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@avalabs/avacloud-sdk": "^0.13.2",
     "@avalabs/avalanchejs": "^5.0.0",
     "@avalanche-sdk/chainkit": "^0.3.0-alpha.9",
-    "@avalanche-sdk/client": "^0.0.4-alpha.14",
+    "@avalanche-sdk/client": "^0.1.2",
     "@avalanche-sdk/interchain": "^0.2.0-alpha.3",
     "@dicebear/collection": "^9.2.4",
     "@dicebear/core": "^9.4.1",

--- a/tests/unit/console/node-credentials.test.ts
+++ b/tests/unit/console/node-credentials.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BLS_PROOF_OF_POSSESSION_REGEX,
+  BLS_PUBLIC_KEY_REGEX,
+  sanitizeCredentialInput,
+  validateManagedNodeCredentials,
+  validateNodeCredentials,
+} from '@/components/toolbox/components/ValidatorListInput/nodeCredentials';
+
+// 96 hex chars ending in '8' — mirrors the production incident where the pasted
+// key's trailing quote produced noble's `non-hex character "8"" at index 96`.
+const PUBLIC_KEY = `0x${'ab'.repeat(47)}a8`;
+const PROOF = `0x${'cd'.repeat(96)}`;
+const NODE_ID = 'NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg';
+
+describe('sanitizeCredentialInput', () => {
+  it('strips the trailing quote from a terminal drag-copy', () => {
+    expect(sanitizeCredentialInput(`${PUBLIC_KEY}"`)).toBe(PUBLIC_KEY);
+  });
+
+  it('strips wrapping quotes, commas, semicolons, and whitespace', () => {
+    expect(sanitizeCredentialInput(`  "${PUBLIC_KEY}",\n`)).toBe(PUBLIC_KEY);
+    expect(sanitizeCredentialInput(`'${NODE_ID}';`)).toBe(NODE_ID);
+  });
+
+  it('leaves interior characters untouched', () => {
+    expect(sanitizeCredentialInput('0xab cd')).toBe('0xab cd');
+  });
+
+  it('returns oversized pastes unchanged instead of scanning them', () => {
+    // Guards against the quadratic trailing-junk scan on multi-KB garbage pastes.
+    const oversized = `0x${' '.repeat(50_000)}x`;
+    expect(sanitizeCredentialInput(oversized)).toBe(oversized);
+  });
+
+  it('turns non-string values into empty strings instead of throwing', () => {
+    // The JSON tab feeds values straight off JSON.parse, so numbers can arrive here.
+    expect(sanitizeCredentialInput(123 as unknown as string)).toBe('');
+    expect(sanitizeCredentialInput(null as unknown as string)).toBe('');
+  });
+});
+
+describe('BLS regexes', () => {
+  it('accepts exact-length hex only', () => {
+    expect(BLS_PUBLIC_KEY_REGEX.test(PUBLIC_KEY)).toBe(true);
+    expect(BLS_PUBLIC_KEY_REGEX.test(PUBLIC_KEY.slice(0, -1))).toBe(false);
+    expect(BLS_PUBLIC_KEY_REGEX.test(`${PUBLIC_KEY}f`)).toBe(false);
+    expect(BLS_PROOF_OF_POSSESSION_REGEX.test(PROOF)).toBe(true);
+    expect(BLS_PROOF_OF_POSSESSION_REGEX.test(PROOF.slice(0, -1))).toBe(false);
+    expect(BLS_PROOF_OF_POSSESSION_REGEX.test(`${PROOF}0`)).toBe(false);
+  });
+});
+
+describe('validateNodeCredentials', () => {
+  it('regression: accepts the exact paste that broke the stake page (trailing quote)', () => {
+    const result = validateNodeCredentials({
+      nodeID: NODE_ID,
+      publicKey: `${PUBLIC_KEY}"`,
+      proofOfPossession: PROOF,
+    });
+    expect(result).toEqual({
+      ok: true,
+      value: { nodeID: NODE_ID, publicKey: PUBLIC_KEY, proofOfPossession: PROOF },
+    });
+  });
+
+  it('accepts clean values unchanged', () => {
+    const result = validateNodeCredentials({
+      nodeID: NODE_ID,
+      publicKey: PUBLIC_KEY,
+      proofOfPossession: PROOF,
+    });
+    expect(result).toEqual({
+      ok: true,
+      value: { nodeID: NODE_ID, publicKey: PUBLIC_KEY, proofOfPossession: PROOF },
+    });
+  });
+
+  it('accepts a NodeID pasted with wrapping quotes', () => {
+    const result = validateNodeCredentials({
+      nodeID: `"${NODE_ID}"`,
+      publicKey: PUBLIC_KEY,
+      proofOfPossession: PROOF,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.nodeID).toBe(NODE_ID);
+  });
+
+  it('rejects a public key with the wrong length, reporting the hex length', () => {
+    const result = validateNodeCredentials({
+      nodeID: NODE_ID,
+      publicKey: PUBLIC_KEY.slice(0, -1),
+      proofOfPossession: PROOF,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/96 hex characters/);
+      expect(result.error).toMatch(/got 95/);
+    }
+  });
+
+  it('rejects a public key with non-hex characters', () => {
+    const result = validateNodeCredentials({
+      nodeID: NODE_ID,
+      publicKey: `0x${'zz'.repeat(48)}`,
+      proofOfPossession: PROOF,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/non-hex/);
+  });
+
+  it('rejects a public key without the 0x prefix', () => {
+    const result = validateNodeCredentials({
+      nodeID: NODE_ID,
+      publicKey: PUBLIC_KEY.slice(2),
+      proofOfPossession: PROOF,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/start with 0x/);
+  });
+
+  it('rejects a proof of possession with the wrong length', () => {
+    const short = validateNodeCredentials({
+      nodeID: NODE_ID,
+      publicKey: PUBLIC_KEY,
+      proofOfPossession: PROOF.slice(0, -1),
+    });
+    expect(short.ok).toBe(false);
+    if (!short.ok) {
+      expect(short.error).toMatch(/192 hex characters/);
+      expect(short.error).toMatch(/got 191/);
+    }
+
+    const long = validateNodeCredentials({
+      nodeID: NODE_ID,
+      publicKey: PUBLIC_KEY,
+      proofOfPossession: `${PROOF}00`,
+    });
+    expect(long.ok).toBe(false);
+    if (!long.ok) expect(long.error).toMatch(/got 194/);
+  });
+
+  it('rejects a NodeID without the NodeID- prefix', () => {
+    const result = validateNodeCredentials({
+      nodeID: NODE_ID.replace('NodeID-', ''),
+      publicKey: PUBLIC_KEY,
+      proofOfPossession: PROOF,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/NodeID/);
+  });
+
+  it('rejects a NodeID with a tampered checksum', () => {
+    const result = validateNodeCredentials({
+      nodeID: `${NODE_ID.slice(0, -1)}h`,
+      publicKey: PUBLIC_KEY,
+      proofOfPossession: PROOF,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/NodeID/);
+  });
+
+  it('rejects a NodeID with invalid base58 characters', () => {
+    const result = validateNodeCredentials({
+      nodeID: 'NodeID-0OIl0OIl0OIl0OIl0OIl0OIl0OIl0OIl0',
+      publicKey: PUBLIC_KEY,
+      proofOfPossession: PROOF,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/NodeID/);
+  });
+
+  it('rejects non-string JSON values with a friendly error instead of throwing', () => {
+    const result = validateNodeCredentials({
+      nodeID: NODE_ID,
+      publicKey: 123 as unknown as string,
+      proofOfPossession: PROOF,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/BLS public key/);
+  });
+
+  it('rejects an absurdly long NodeID without decoding it', () => {
+    const result = validateNodeCredentials({
+      nodeID: `NodeID-${'1'.repeat(100)}`,
+      publicKey: PUBLIC_KEY,
+      proofOfPossession: PROOF,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/NodeID/);
+  });
+});
+
+describe('validateManagedNodeCredentials', () => {
+  it('accepts a managed node without BLS info, sanitizing the NodeID', () => {
+    const result = validateManagedNodeCredentials({
+      nodeID: ` ${NODE_ID} `,
+      publicKey: '',
+      proofOfPossession: '',
+    });
+    expect(result).toEqual({
+      ok: true,
+      value: { nodeID: NODE_ID, publicKey: '', proofOfPossession: '' },
+    });
+  });
+
+  it('rejects a BLS-less managed node when the NodeID is invalid', () => {
+    const result = validateManagedNodeCredentials({
+      nodeID: `${NODE_ID.slice(0, -1)}h`,
+      publicKey: '',
+      proofOfPossession: '',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/NodeID/);
+  });
+
+  it('fully validates when BLS info is present', () => {
+    const sanitized = validateManagedNodeCredentials({
+      nodeID: NODE_ID,
+      publicKey: `${PUBLIC_KEY}"`,
+      proofOfPossession: PROOF,
+    });
+    expect(sanitized).toEqual({
+      ok: true,
+      value: { nodeID: NODE_ID, publicKey: PUBLIC_KEY, proofOfPossession: PROOF },
+    });
+
+    const bad = validateManagedNodeCredentials({
+      nodeID: NODE_ID,
+      publicKey: PUBLIC_KEY.slice(0, -1),
+      proofOfPossession: PROOF,
+    });
+    expect(bad.ok).toBe(false);
+  });
+
+  it('rejects half-present BLS info', () => {
+    const result = validateManagedNodeCredentials({
+      nodeID: NODE_ID,
+      publicKey: PUBLIC_KEY,
+      proofOfPossession: '',
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -230,6 +230,17 @@
   dependencies:
     json-canonicalize "^1.0.6"
 
+"@avalabs/avalanchejs@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@avalabs/avalanchejs/-/avalanchejs-5.1.0.tgz#384752a9787a2e9a7a2e336a0f955c44c1f42f37"
+  integrity sha512-c29b9p0naOPTRRFqxmLpIS8s4FRf08+fkepOtPnwxpDcuGdRaYEeIjouTiioXUqD0H5h+d30uJO6xqkZm49tvw==
+  dependencies:
+    "@noble/curves" "1.3.0"
+    "@noble/hashes" "1.3.3"
+    "@noble/secp256k1" "2.0.0"
+    "@scure/base" "1.1.5"
+    micro-eth-signer "0.7.2"
+
 "@avalabs/avalanchejs@5.1.0-alpha.1":
   version "5.1.0-alpha.1"
   resolved "https://registry.yarnpkg.com/@avalabs/avalanchejs/-/avalanchejs-5.1.0-alpha.1.tgz#94cc6f72654fb22539835deaa10547d5b1d95e46"
@@ -245,17 +256,6 @@
   version "5.0.0"
   resolved "https://registry.npmjs.org/@avalabs/avalanchejs/-/avalanchejs-5.0.0.tgz"
   integrity sha512-0hJK/Hdf8v+q05c8+5K6arFmzq7o1W4I05/Dmr+Es1XRi8canvTu1Y0RruYd6ea2rrvX3UhKrPs3BzLhCTHDrw==
-  dependencies:
-    "@noble/curves" "1.3.0"
-    "@noble/hashes" "1.3.3"
-    "@noble/secp256k1" "2.0.0"
-    "@scure/base" "1.1.5"
-    micro-eth-signer "0.7.2"
-
-"@avalabs/avalanchejs@^5.1.0-alpha.1":
-  version "5.1.0-fee-output.1"
-  resolved "https://registry.yarnpkg.com/@avalabs/avalanchejs/-/avalanchejs-5.1.0-fee-output.1.tgz#4e4aed0fcdc64bbc1e5db127e8335852ce18ad88"
-  integrity sha512-sOu1CHS0GC7FLaOUYEfqA2NzhMwu02VqjyJ3YWSvnCAOSNQpxGJPKNbrR24tK5uQUBs2QNwmuU4rPRMZNvn8fQ==
   dependencies:
     "@noble/curves" "1.3.0"
     "@noble/hashes" "1.3.3"
@@ -283,12 +283,12 @@
     util "^0.12.5"
     viem "^2.33.3"
 
-"@avalanche-sdk/client@^0.0.4-alpha.14":
-  version "0.0.4-alpha.17"
-  resolved "https://registry.yarnpkg.com/@avalanche-sdk/client/-/client-0.0.4-alpha.17.tgz#c4ff9e63dc72ddb16f8fd2481f7569ae0d557314"
-  integrity sha512-pJW1eEa6SEAe6+1fYyjWfM2bItqNybA9pKvMw/qaDjv7YhsIixybCkE6HQt+XODbm1XohFT+lC73qDrps2oWLw==
+"@avalanche-sdk/client@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@avalanche-sdk/client/-/client-0.1.2.tgz#024e7c5914a479882a694f86470fa2d2ecc85862"
+  integrity sha512-RR8XHbSzOL+SZadmjF078/8UqWi/ut8q3Qb9CDlefCAXlrXG3e6WyaEuKPZFn4r0dKqmP+YoYfmZm4B2VLGADw==
   dependencies:
-    "@avalabs/avalanchejs" "^5.1.0-alpha.1"
+    "@avalabs/avalanchejs" "5.1.0"
     "@noble/hashes" "1.3.3"
     "@noble/secp256k1" "2.0.0"
     util "^0.12.5"


### PR DESCRIPTION
Adds an auto-renewed staking (ACP-236) option to /console/primary-network/stake, Fuji-only — cycle period, auto-compounding, SDK snippet, and platform-cli command included. Hold merge until Helicon activates on Fuji (July 28, 2026, 11 AM ET); a follow-up PR enables Mainnet.
