### PR TITLE
docs: rebrand ACP-194 to Continuous Execution

### DIFF
--- a/components/firewood/PipelineIntegration.tsx
+++ b/components/firewood/PipelineIntegration.tsx
@@ -104,7 +104,7 @@ export function PipelineIntegration({ colors }: { colors: Colors }) {
         Where Firewood fits.
       </h3>
       <p className={`text-xs ${colors.textMuted} font-mono mb-6`}>
-        Firewood is the storage layer for StreVM, Avalanche&apos;s Streaming Async Execution engine.
+        Firewood is the storage layer for StreVM, Avalanche&apos;s Continuous Execution engine.
       </p>
 
       {/* Pipeline diagram */}

--- a/components/landing-v2/pillars.ts
+++ b/components/landing-v2/pillars.ts
@@ -174,7 +174,7 @@ export const PILLARS: Pillar[] = [
         heading: "DOCUMENTATION",
         links: [
           { text: "Avalanche consensus", href: "/docs/primary-network/avalanche-consensus" },
-          { text: "Streaming async execution", href: "/docs/primary-network/streaming-async-execution" },
+          { text: "Continuous execution", href: "/docs/primary-network/continuous-execution" },
           { text: "The Primary Network", href: "/docs/primary-network" },
           { text: "Customize your EVM", href: "/docs/avalanche-l1s/evm-configuration/customize-avalanche-l1" },
         ],

--- a/components/navigation/docs-nav-config.tsx
+++ b/components/navigation/docs-nav-config.tsx
@@ -174,10 +174,10 @@ export const toolingOptions: NavOption[] = [
 
 export const acpsOptions: NavOption[] = [
   {
-    title: 'Streaming Asynchronous Execution',
+    title: 'Continuous Execution',
     description: 'ACP-194',
     icon: <Book className="w-5 h-5" />,
-    url: '/docs/acps/194-streaming-asynchronous-execution',
+    url: '/docs/acps/194-continuous-execution',
   },
   {
     title: 'Auto-Renewed Staking',

--- a/components/sae/FAQ.tsx
+++ b/components/sae/FAQ.tsx
@@ -69,27 +69,27 @@ export function FAQ({ colors }: { colors: Colors }) {
 
   const faqItems: FAQItem[] = [
     {
-      question: "Is finality slower with SAE?",
+      question: "Is finality slower with Continuous Execution?",
       answer: "No — it's technically instant. As soon as consensus accepts a transaction, finality is locked. The key insight: ordering determines the truth, execution reveals it. We have finality the moment a block is accepted — we just won't know the outcome until execution completes. Consensus determines what will happen; execution shows us what happened."
     },
     {
-      question: "What problem does SAE solve?",
-      answer: "Traditional blockchains bottleneck because consensus waits for execution. SAE will run them in parallel — consensus will accept transactions into a queue while execution drains it independently. More throughput, lower latency."
+      question: "What problem does Continuous Execution solve?",
+      answer: "Traditional blockchains bottleneck because consensus waits for execution. Continuous Execution will run them in parallel — consensus will accept transactions into a queue while execution drains it independently. More throughput, lower latency."
     },
     {
-      question: "What will consensus verify in SAE?",
-      answer: "Consensus will verify you can pay for the worst-case cost — gas limit × maximum possible gas price — without running the VM. In synchronous execution, validators execute every transaction to verify it. In SAE, they will only check signatures, nonces, and that senders can afford the maximum fee. Lightweight validation, same security."
+      question: "What will consensus verify in Continuous Execution?",
+      answer: "Consensus will verify you can pay for the worst-case cost — gas limit × maximum possible gas price — without running the VM. In synchronous execution, validators execute every transaction to verify it. With Continuous Execution, they will only check signatures, nonces, and that senders can afford the maximum fee. Lightweight validation, same security."
     },
     {
       question: "How will transaction ordering work?",
       answer: "Order will be locked at consensus, before execution. Once a block is accepted, transaction sequence will be final. Execution will process them in that order. If Alice's swap is ordered before Bob's, Alice executes first — regardless of when execution actually runs."
     },
     {
-      question: "How will a swap or DeFi transaction work in SAE?",
+      question: "How will a swap or DeFi transaction work in Continuous Execution?",
       answer: "Same as before, just faster. Your swap will be ordered by consensus, queued, then executed. You'll get the receipt immediately after execution — not after settlement. The 5-second settlement delay won't affect your experience; your tokens will move as soon as execution completes."
     },
     {
-      question: "How will SAE prevent malicious actors?",
+      question: "How will Continuous Execution prevent malicious actors?",
       answer: "Worst-case fee validation. Attackers won't be able to spam the queue with high gas-limit transactions that use minimal gas — you'll be charged at least half your gas limit. The maximum queue DoS impact will be ~12% fee inflation. If you can't afford the worst-case cost, your transaction will be rejected before it enters the queue."
     },
     {
@@ -98,7 +98,7 @@ export function FAQ({ colors }: { colors: Colors }) {
     },
     {
       question: "Can transactions still fail?",
-      answer: "Yes. SAE will guarantee execution and payment — not success. Reverts, out-of-gas, and contract errors will still happen. The difference: you'll know the outcome faster."
+      answer: "Yes. Continuous Execution will guarantee execution and payment — not success. Reverts, out-of-gas, and contract errors will still happen. The difference: you'll know the outcome faster."
     },
     {
       question: "How fast will users see transaction results?",
@@ -110,11 +110,11 @@ export function FAQ({ colors }: { colors: Colors }) {
     },
     {
       question: "What future capabilities does this unlock?",
-      answer: "Executing after consensus sequencing will enable features like real-time VRF and encrypted mempools for MEV protection. SAE is foundational infrastructure for the next generation of onchain applications."
+      answer: "Executing after consensus sequencing will enable features like real-time VRF and encrypted mempools for MEV protection. Continuous Execution is foundational infrastructure for the next generation of onchain applications."
     },
     {
-      question: "Will SAE be available for just the C-Chain or also L1s?",
-      answer: "SAE will be available for all Avalanche L1s. Every chain in the ecosystem will benefit from parallel consensus and execution."
+      question: "Will Continuous Execution be available for just the C-Chain or also L1s?",
+      answer: "Continuous Execution will be available for all Avalanche L1s. Every chain in the ecosystem will benefit from parallel consensus and execution."
     },
   ]
 

--- a/components/sae/GasClockCard.tsx
+++ b/components/sae/GasClockCard.tsx
@@ -40,7 +40,7 @@ export function GasClockCard({ colors }: { colors: Colors }) {
           >
             ACP-176
           </Link>
-          {" "}introduced the gas rate R = 30M gas/sec. SAE uses R to convert gas consumed into elapsed time.
+          {" "}introduced the gas rate R = 30M gas/sec. Continuous Execution uses R to convert gas consumed into elapsed time.
         </p>
       </div>
       

--- a/components/sae/Payoff.tsx
+++ b/components/sae/Payoff.tsx
@@ -290,7 +290,7 @@ export function Payoff({ colors }: { colors: Colors }) {
       </div>
       
       <p className={`text-xs ${colors.textMuted} font-mono font-medium`}>
-        *Streaming async execution is required to implement these features.
+        *Continuous Execution is required to implement these features.
       </p>
     </div>
   )

--- a/components/sae/TransactionLifecycle.tsx
+++ b/components/sae/TransactionLifecycle.tsx
@@ -72,7 +72,7 @@ export function TransactionLifecycle() {
         <h1
           className={`text-base sm:text-xl md:text-3xl font-medium ${colors.text} uppercase tracking-[0.1em] sm:tracking-[0.2em] mb-4 md:mb-6 font-mono`}
         >
-          Streaming Asynchronous Execution
+          Continuous Execution
         </h1>
         <p className={`text-[10px] sm:text-xs md:text-sm ${colors.textMuted} font-mono uppercase tracking-[0.1em] mb-4 md:mb-6`}>
           ACP-194: Decoupling Consensus and Execution
@@ -81,7 +81,7 @@ export function TransactionLifecycle() {
         {/* Learn More links */}
         <div className="flex flex-row gap-2 sm:gap-3 justify-center items-center">
           <Link 
-            href="/docs/acps/194-streaming-asynchronous-execution"
+            href="/docs/acps/194-continuous-execution"
             className={`group flex items-center gap-1.5 sm:gap-2 px-2.5 sm:px-4 py-2 border ${colors.border} ${colors.blockBg} hover:${colors.blockBgStrong} transition-all`}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={colors.stroke} strokeWidth="1.5" className="opacity-50 group-hover:opacity-100 transition-opacity shrink-0 sm:w-4 sm:h-4">
@@ -234,7 +234,7 @@ export function TransactionLifecycle() {
           
           <div className="flex flex-row gap-2 sm:gap-4 justify-center items-stretch">
             <Link 
-              href="/docs/acps/194-streaming-asynchronous-execution"
+              href="/docs/acps/194-continuous-execution"
               className={`group flex items-center gap-2 sm:gap-3 px-3 sm:px-6 py-3 sm:py-4 border ${colors.border} ${colors.blockBg} hover:${colors.blockBgStrong} transition-all`}
             >
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={colors.stroke} strokeWidth="1.5" className="opacity-50 group-hover:opacity-100 transition-opacity shrink-0 sm:w-5 sm:h-5">

--- a/components/sae/UnderTheHood.tsx
+++ b/components/sae/UnderTheHood.tsx
@@ -79,7 +79,7 @@ function GasClock({ colors }: { colors: Colors }) {
       {/* Explanation text */}
       <div className="mt-4 md:mt-6">
         <p className={`text-base sm:text-sm ${colors.textMuted} leading-relaxed`}>
-          <a href="/docs/acps/176-dynamic-evm-gas-limit-and-price-discovery-updates" className="font-semibold text-red-400 hover:underline">ACP-176</a> gave us <span className="italic font-mono text-red-400">R</span> — how much gas the network can process per second. If you know the gas consumed, you know how much time passed. SAE builds on this: <span className="italic font-mono text-red-400">R</span> shows up in the equations for block size limits, queue bounds, and when blocks settle.
+          <a href="/docs/acps/176-dynamic-evm-gas-limit-and-price-discovery-updates" className="font-semibold text-red-400 hover:underline">ACP-176</a> gave us <span className="italic font-mono text-red-400">R</span> — how much gas the network can process per second. If you know the gas consumed, you know how much time passed. Continuous Execution builds on this: <span className="italic font-mono text-red-400">R</span> shows up in the equations for block size limits, queue bounds, and when blocks settle.
         </p>
       </div>
     </div>
@@ -146,7 +146,7 @@ export function BlockRelationship({ colors }: { colors: Colors }) {
       {/* Section header */}
       <div className="flex items-center gap-2 mb-3 px-1">
         <span className={`text-sm sm:text-xs md:text-[11px] uppercase tracking-[0.15em] ${colors.text} font-semibold`}>
-          Streaming Asynchronous Execution (SAE)
+          Continuous Execution
         </span>
       </div>
 

--- a/content/blog/226-min-block-times.mdx
+++ b/content/blog/226-min-block-times.mdx
@@ -33,7 +33,7 @@ higher gas targets and smoother UX.
 
 ## Looking Ahead
 
-As gas targets climb, expect smaller, more frequent blocks and a snappier user experience. Streaming Asynchronous Execution (a.k.a. SAE, a.k.a. ACP-194) and ongoing
+As gas targets climb, expect smaller, more frequent blocks and a snappier user experience. Continuous Execution (a.k.a. ACP-194, formerly known as SAE) and ongoing
 performance work make lower delays practical. We'll also share visuals that show how ACP-226 and ACP-176 fit together in practice.
 
 ## Want to Learn More?

--- a/content/blog/gas-target-increase.mdx
+++ b/content/blog/gas-target-increase.mdx
@@ -3,7 +3,7 @@ title: Avalanche C-Chain Throughput Increases as Validators Signal Higher Gas Ta
 description: Avalanche validators increase the C-Chain's target gas consumption by 30% thanks to the Octane upgrade, paving the way for higher throughput and future scaling optimizations.
 date: 2025-08-21
 authors: [AvaxDevelopers]
-topics: [Validators, Gas Target, Octane Upgrade, SAE, Firewood]
+topics: [Validators, Gas Target, Octane Upgrade, Continuous Execution, Firewood]
 comments: true
 ---
 
@@ -18,7 +18,7 @@ _Originally published by [@AvaxDevelopers](https://x.com/AvaxDevelopers/status/1
 - Avalanche validators increased the C-Chain's target gas consumption by 30 % from 1.6 M to 2.1 M gas/sec.  
 - The dynamic adjustments were enabled by the Octane upgrade, activated on April 6, 2025.  
 - The Avalanche Foundation plans to continue signaling incremental increases as network metrics allow.  
-- Future improvements like Streaming Asynchronous Execution (SAE) and Firewood Database integration aim to enable even larger increases.
+- Future improvements like Continuous Execution (formerly SAE) and Firewood Database integration aim to enable even larger increases.
 
 Avalanche's C-Chain has seen its throughput capacity increase by over 30% following validator action to raise the target gas
 consumption from 1.6 million to 2.1 million gas per second. The increase was made possible by the Octane upgrade that went live
@@ -29,7 +29,7 @@ and smart contract operations can be executed. For users of the chain, higher ga
 and also lower transaction fees. For validators and node operations, higher gas targets can mean increased demands on hardware and network
 infrastructure, which is closely monitored to ensure stability and reliability.
 The dynamic adjustments were enabled by the Octane upgrade, activated on April 6, 2025.
-Future improvements like Streaming Asynchronous Execution (SAE) and Firewood Database integration aim to enable even larger increases.
+Future improvements like Continuous Execution and Firewood Database integration aim to enable even larger increases.
 
 ---
 
@@ -50,8 +50,7 @@ Since the upgrade's activation, validators run by the Avalanche Foundation have 
 ![](https://qizat5l3bwvomkny.public.blob.vercel-storage.com/1.jpeg)
 
 The Avalanche Foundation plans to continue gradually increasing their validator preferences while monitoring network performance metrics.
-This approach aims to maximize C-Chain utilization within current infrastructure constraints. Upcoming optimizations like Streaming Asynchronous
-Execution and the Firewood Database integration are expected to enable further increases.
+This approach aims to maximize C-Chain utilization within current infrastructure constraints. Upcoming optimizations like Continuous Execution and the Firewood Database integration are expected to enable further increases.
 
 Other validator operators can set their gas target preferences to participate in determining the network's effective throughput capacity.
 This allows scaling decisions to reflect the technical assessment of the broader validator community.
@@ -105,9 +104,9 @@ These metrics remained within acceptable parameters throughout the increase, ind
 The 30% increase represents just the beginning of Avalanche's throughput expansion plans. Two major technical upgrades are in development that could
 enable even more significant capacity improvements:
 
-### Streaming Asynchronous Execution (SAE)  
+### Continuous Execution  
 
-As outlined in Avalanche Community Proposal ACP-194, SAE introduces a fundamental architectural change by separating block execution from the consensus
+As outlined in Avalanche Community Proposal ACP-194, Continuous Execution introduces a fundamental architectural change by separating block execution from the consensus
 process. This allows for a continuous execution thread that operates independently of consensus, enabling gas targets to align with average-case execution
 times rather than being constrained by worst-case scenarios.
 

--- a/content/blog/granite-upgrade.mdx
+++ b/content/blog/granite-upgrade.mdx
@@ -100,7 +100,7 @@ This upgrade activates **ACP-226**, introducing a dynamic adjustment mechanism f
 
 ### How It Works
 
-ACP-226 allows validators to dynamically adjust block times in response to network improvements, such as the upcoming Streaming Asynchronous Execution (SAE) and Firewood features. This flexibility enables:
+ACP-226 allows validators to dynamically adjust block times in response to network improvements, such as the upcoming Continuous Execution (formerly SAE) and Firewood features. This flexibility enables:
 
 - **Sub-second block times** - Significantly faster than the previous fixed intervals
 - **Continuous optimization** - Validators can adjust block times without network upgrades
@@ -125,7 +125,7 @@ This upgrade ensures that users benefit from:
 
 The Granite upgrade represents another significant step forward in Avalanche's evolution as a high-performance blockchain platform. By improving ICM reliability, enabling biometric authentication, and allowing dynamic block time adjustments, Avalanche continues to deliver the speed, flexibility, and scalability that developers need.
 
-As the network continues to evolve with upcoming features like Streaming Asynchronous Execution (SAE) and Firewood Database integration, these Granite improvements lay the foundation for even greater performance enhancements.
+As the network continues to evolve with upcoming features like Continuous Execution and Firewood Database integration, these Granite improvements lay the foundation for even greater performance enhancements.
 
 ---
 

--- a/content/blog/helicon-upgrade.mdx
+++ b/content/blog/helicon-upgrade.mdx
@@ -12,11 +12,11 @@ import { StakingRewardCurveChart } from "@/components/content-design/staking-rew
 
 ## Introducing the Helicon Upgrade
 
-Helicon is coming to the Fuji Testnet. Building on [Octane](https://build.avax.network/blog/octane-optimizing-c-chain-gas-fees) and [Granite](https://build.avax.network/blog/granite-upgrade), this upgrade brings Streaming Asynchronous Execution (SAE) to the C-Chain, along with changes to Avalanche's staking economics.
+Helicon is coming to the Fuji Testnet. Building on [Octane](https://build.avax.network/blog/octane-optimizing-c-chain-gas-fees) and [Granite](https://build.avax.network/blog/granite-upgrade), this upgrade brings Continuous Execution (formerly known as Streaming Asynchronous Execution, or SAE) to the C-Chain, along with changes to Avalanche's staking economics.
 
 The upgrade is driven by six Avalanche Community Proposals:
 
-- [ACP-194: Streaming Asynchronous Execution](/docs/acps/194-streaming-asynchronous-execution)
+- [ACP-194: Continuous Execution](/docs/acps/194-continuous-execution)
 - [ACP-236: Auto-Renewed Staking](/docs/acps/236-auto-renewed-staking)
 - [ACP-267: Increase Validator Uptime Requirement](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/267-uptime-requirement-increase)
 - [ACP-273: Reduce Minimum Staking Duration](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/273-reduce-minimum-staking-duration)
@@ -114,7 +114,7 @@ A 2.5-point cut to the mean consumption rate is not a 2.5-point cut to yield. Th
 
 The staking changes address who validates and how. The next two proposals address what the chain can actually do with that validator set. ACP-194 and ACP-283 both target the C-Chain directly: one restructures how blocks execute, the other closes a long-standing spam vector.
 
-### Streaming Asynchronous Execution (ACP-194)
+### Continuous Execution (ACP-194)
 
 <Callout type="info">
 The C-Chain's current architecture forces consensus and execution to take turns.
@@ -128,7 +128,7 @@ Today the C-Chain executes a block's transactions before consensus can move on, 
 
 <HeliconSaeDiagram diagram="parallel-streams" />
 
-One nuance relevant to a narrow slice of tooling: a transaction's effects finalize a moment after its block is accepted rather than at the instant of acceptance. For the full picture, including the interactive transaction-lifecycle walkthrough, the Streaming Asynchronous Execution doc is the best resource.
+One nuance relevant to a narrow slice of tooling: a transaction's effects finalize a moment after its block is accepted rather than at the instant of acceptance. For the full picture, including the interactive transaction-lifecycle walkthrough, the [Continuous Execution doc](/docs/primary-network/continuous-execution) is the best resource.
 
 ---
 
@@ -162,7 +162,7 @@ The concrete changes for developers and node operators, ordered by ACP.
 ## Resources
 
 - [Join the discussion on GitHub](https://github.com/avalanche-foundation/ACPs/discussions)
-- [ACP-194: Streaming Asynchronous Execution](/docs/acps/194-streaming-asynchronous-execution)
+- [ACP-194: Continuous Execution](/docs/acps/194-continuous-execution)
 - [ACP-236: Auto-Renewed Staking](/docs/acps/236-auto-renewed-staking)
 - [ACP-267: Increase Validator Uptime Requirement](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/267-uptime-requirement-increase)
 - [ACP-273: Reduce Minimum Staking Duration](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/273-reduce-minimum-staking-duration)

--- a/content/docs/acps/meta.json
+++ b/content/docs/acps/meta.json
@@ -13,7 +13,7 @@
     "224-dynamic-gas-limit-in-subnet-evm",
     "209-eip7702-style-account-abstraction",
     "204-precompile-secp256r1",
-    "194-streaming-asynchronous-execution",
+    "194-continuous-execution",
     "191-seamless-l1-creation",
     "181-p-chain-epoched-views",
     "176-dynamic-evm-gas-limit-and-price-discovery-updates",

--- a/content/docs/avalanche-l1s/add-utility/deploy-smart-contract.mdx
+++ b/content/docs/avalanche-l1s/add-utility/deploy-smart-contract.mdx
@@ -5,7 +5,7 @@ description: Deploy a smart contract on your Avalanche L1.
 
 {/*
   EVM Version Warning - TEMPORARY
-  Remove this section when Avalanche adds Pectra support (after SAE implementation)
+  Remove this section when Avalanche adds Pectra support (after Continuous Execution implementation)
   Last reviewed: December 2025
 */}
 

--- a/content/docs/nodes/architecture/execution/continuous-execution.mdx
+++ b/content/docs/nodes/architecture/execution/continuous-execution.mdx
@@ -1,17 +1,17 @@
 ---
-title: Streaming Asynchronous Execution
-description: Learn how Streaming Asynchronous Execution (SAE) decouples consensus from execution to achieve higher throughput and lower latency.
+title: Continuous Execution
+description: Learn how Continuous Execution (ACP-194) decouples consensus from execution to achieve higher throughput and lower latency.
 ---
 
-Streaming Asynchronous Execution (SAE) is a fundamental architectural change that decouples consensus from execution. By allowing these two critical processes to run concurrently, AvalancheGo can achieve significantly higher throughput without sacrificing security guarantees.
+Continuous Execution (formerly known as Streaming Asynchronous Execution, or SAE) is a fundamental architectural change that decouples consensus from execution. By allowing these two critical processes to run concurrently, AvalancheGo can achieve significantly higher throughput without sacrificing security guarantees.
 
 <Callout>
-**Specification**: SAE is defined in [ACP-194](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/194-streaming-asynchronous-execution). The reference implementation is [StreVM](https://github.com/ava-labs/strevm).
+**Specification**: Continuous Execution is defined in [ACP-194](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/194-continuous-execution). The reference implementation is [StreVM](https://github.com/ava-labs/strevm).
 </Callout>
 
 ## Summary
 
-In traditional synchronous execution, a block must be fully executed before it can be accepted by consensus. SAE introduces a queue upon which consensus is performed, with a concurrent execution stream responsible for clearing the queue and reporting state roots to later consensus rounds.
+In traditional synchronous execution, a block must be fully executed before it can be accepted by consensus. Continuous Execution introduces a queue upon which consensus is performed, with a concurrent execution stream responsible for clearing the queue and reporting state roots to later consensus rounds.
 
 Key benefits:
 - **Concurrent processing**: Consensus and execution no longer block each other
@@ -43,9 +43,9 @@ This creates several bottlenecks:
 3. **Resource contention**: CPU-intensive execution competes with network-intensive consensus
 4. **Stop-the-world events**: Database compaction or GC pauses affect both consensus and execution
 
-## How SAE Works
+## How Continuous Execution Works
 
-SAE separates the block lifecycle into distinct phases:
+Continuous Execution separates the block lifecycle into distinct phases:
 
 <Mermaid chart="
 flowchart LR
@@ -114,7 +114,7 @@ A constant time delay ($\tau$ seconds) ensures that sporadic execution slowdowns
 
 ### Gas Charging
 
-SAE introduces a new gas charging formula that accounts for the gas limit:
+Continuous Execution introduces a new gas charging formula that accounts for the gas limit:
 
 $$
 g_C := \max(g_U, g_L / \lambda)
@@ -158,7 +158,7 @@ Blocks that would exceed this queue size are considered invalid.
 
 The primary benefit is that "VM time" more closely aligns with wall time:
 
-| Time | Synchronous | SAE |
+| Time | Synchronous | Continuous Execution |
 |------|-------------|-----|
 | 0-2s | Consensus | Consensus |
 | 1-5s | - | Execution (overlapping) |
@@ -167,11 +167,11 @@ The primary benefit is that "VM time" more closely aligns with wall time:
 | 4-6s | Consensus | - |
 | 6-8s | Execution | - |
 
-In synchronous mode, consensus and execution alternate. In SAE, they overlap, increasing throughput.
+In synchronous mode, consensus and execution alternate. In Continuous Execution, they overlap, increasing throughput.
 
 ### Lean Execution Clients
 
-SAE enables specialized execution-only clients that can:
+Continuous Execution enables specialized execution-only clients that can:
 
 - Rapidly execute the agreed-upon queue
 - Skip expensive Merkle data structure computation
@@ -188,7 +188,7 @@ Irregular events like database compaction are spread across multiple blocks inst
 
 ## Future Features
 
-SAE provides a foundation for additional optimizations:
+Continuous Execution provides a foundation for additional optimizations:
 
 ### Encrypted Mempools
 
@@ -207,14 +207,14 @@ Consensus artifacts become available during execution, enabling:
 - Gaming and lottery applications
 
 <Callout type="warn">
-These features are not yet implemented but require SAE as a prerequisite.
+These features are not yet implemented but require Continuous Execution as a prerequisite.
 </Callout>
 
 ## Implementation
 
 ### StreVM
 
-[StreVM](https://github.com/ava-labs/strevm) is the reference implementation of SAE for EVM blocks:
+[StreVM](https://github.com/ava-labs/strevm) is the reference implementation of Continuous Execution for EVM blocks:
 
 ```bash
 # StreVM is under active development
@@ -227,7 +227,7 @@ StreVM is under active development. There are currently no guarantees about the 
 
 ### Integration with AvalancheGo
 
-SAE integrates with AvalancheGo's existing architecture:
+Continuous Execution integrates with AvalancheGo's existing architecture:
 
 <Mermaid chart="
 flowchart TB
@@ -252,15 +252,15 @@ flowchart TB
 
 <Cards>
   <Card title="Firewood Database" href="/docs/nodes/architecture/execution/firewood">
-    The optimized database designed to work with SAE
+    The optimized database designed to work with Continuous Execution
   </Card>
   <Card title="Consensus Protocols" href="/docs/nodes/architecture/consensus">
-    How Snowman consensus works with SAE
+    How Snowman consensus works with Continuous Execution
   </Card>
 </Cards>
 
 ### External Links
 
-- [ACP-194 Specification](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/194-streaming-asynchronous-execution)
+- [ACP-194 Specification](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/194-continuous-execution)
 - [StreVM Repository](https://github.com/ava-labs/strevm)
 - [ACP-194 Discussion](https://github.com/avalanche-foundation/ACPs/discussions/196)

--- a/content/docs/nodes/architecture/execution/firewood.mdx
+++ b/content/docs/nodes/architecture/execution/firewood.mdx
@@ -353,8 +353,8 @@ Firewood integration with AvalancheGo is under active development. Check the [fi
 ## Related Resources
 
 <Cards>
-  <Card title="Streaming Async Execution" href="/docs/nodes/architecture/execution/streaming-async-execution">
-    How SAE leverages Firewood for efficient execution
+  <Card title="Continuous Execution" href="/docs/nodes/architecture/execution/continuous-execution">
+    How Continuous Execution leverages Firewood for efficient execution
   </Card>
   <Card title="Core Components" href="/docs/nodes/architecture/core-components">
     AvalancheGo's overall architecture

--- a/content/docs/nodes/architecture/execution/index.mdx
+++ b/content/docs/nodes/architecture/execution/index.mdx
@@ -1,19 +1,19 @@
 ---
 title: Execution
-description: Understand how AvalancheGo executes transactions efficiently, including streaming async execution and optimized state storage.
+description: Understand how AvalancheGo executes transactions efficiently, including Continuous Execution and optimized state storage.
 ---
 
 AvalancheGo is evolving its execution model to achieve higher throughput and lower latency. This section covers the advanced execution concepts being developed for Avalanche, including decoupled consensus and execution, and optimized state storage.
 
 <Callout type="info">
-**Active Development**: The concepts described here (Streaming Asynchronous Execution and Firewood) are under active development. Some features may be experimental or not yet deployed to mainnet.
+**Active Development**: The concepts described here (Continuous Execution and Firewood) are under active development. Some features may be experimental or not yet deployed to mainnet.
 </Callout>
 
 ## Execution at a Glance
 
 | Concept | Description |
 |---------|-------------|
-| **Streaming Async Execution** | Decouples consensus from execution, allowing both to proceed concurrently |
+| **Continuous Execution** | Decouples consensus from execution, allowing both to proceed concurrently |
 | **Firewood** | Compaction-less database optimized for Merkleized blockchain state |
 | **Optimistic Parallelism** | Execute multiple transactions concurrently with conflict detection |
 
@@ -21,7 +21,7 @@ AvalancheGo is evolving its execution model to achieve higher throughput and low
 
 ### Decoupled Consensus and Execution
 
-Traditional blockchain execution is synchronous—transactions are executed and their results computed before the block is accepted by consensus. AvalancheGo's Streaming Asynchronous Execution (SAE) breaks this tight coupling:
+Traditional blockchain execution is synchronous—transactions are executed and their results computed before the block is accepted by consensus. AvalancheGo's Continuous Execution (formerly Streaming Asynchronous Execution) breaks this tight coupling:
 
 <Mermaid chart="
 flowchart LR
@@ -29,7 +29,7 @@ flowchart LR
         P1[Proposed] --> E1[Executed] --> A1[Accepted]
     end
 
-    subgraph SAE [Streaming Async Execution]
+    subgraph CE [Continuous Execution]
         P2[Proposed] --> A2[Accepted]
         A2 -->|async| E2[Executed]
         E2 -->|delay| S2[Settled]
@@ -68,8 +68,8 @@ For **the network**:
 ## Explore Further
 
 <Cards>
-  <Card title="Streaming Async Execution" href="/docs/nodes/architecture/execution/streaming-async-execution">
-    Learn how SAE decouples consensus from execution for higher throughput
+  <Card title="Continuous Execution" href="/docs/nodes/architecture/execution/continuous-execution">
+    Learn how Continuous Execution decouples consensus from execution for higher throughput
   </Card>
   <Card title="Firewood Database" href="/docs/nodes/architecture/execution/firewood">
     Discover the compaction-less database optimized for Merkleized state
@@ -78,6 +78,6 @@ For **the network**:
 
 ## Related Resources
 
-- [ACP-194: Streaming Asynchronous Execution](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/194-streaming-asynchronous-execution) - Formal specification
-- [StreVM Repository](https://github.com/ava-labs/strevm) - Reference SAE implementation
+- [ACP-194: Continuous Execution](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/194-continuous-execution) - Formal specification
+- [StreVM Repository](https://github.com/ava-labs/strevm) - Reference Continuous Execution implementation
 - [Firewood Repository](https://github.com/ava-labs/firewood) - Database implementation

--- a/content/docs/nodes/architecture/execution/meta.json
+++ b/content/docs/nodes/architecture/execution/meta.json
@@ -1,9 +1,9 @@
 {
   "title": "Execution",
-  "description": "Advanced execution concepts including streaming async execution and optimized state storage",
+  "description": "Advanced execution concepts including Continuous Execution and optimized state storage",
   "pages": [
     "index",
-    "streaming-async-execution",
+    "continuous-execution",
     "firewood"
   ]
 }

--- a/content/docs/nodes/architecture/index.mdx
+++ b/content/docs/nodes/architecture/index.mdx
@@ -30,7 +30,7 @@ AvalancheGo is written in Go and is designed to be modular, allowing developers 
 - **Chain manager**: Boots P/C/X, creates new chains on request, routes consensus messages.
 - **APIs**: HTTP/WS via `/ext/*`, with health/metrics, admin/info, and per-chain RPCs.
 - **Storage**: LevelDB (default), PebbleDB, or [Firewood](/docs/nodes/architecture/execution/firewood) (experimental), shared atomic UTXO memory for cross-chain transfers.
-- **Execution**: [Streaming Asynchronous Execution](/docs/nodes/architecture/execution/streaming-async-execution) (experimental) decouples consensus from execution for higher throughput.
+- **Execution**: [Continuous Execution](/docs/nodes/architecture/execution/continuous-execution) (experimental) decouples consensus from execution for higher throughput.
 
 ## Core Components
 
@@ -93,6 +93,6 @@ AvalancheGo separates concerns into distinct layers:
     Explore the P2P protocol and peer management system
   </Card>
   <Card title="Execution" href="/docs/nodes/architecture/execution">
-    Explore streaming async execution and the Firewood database
+    Explore Continuous Execution and the Firewood database
   </Card>
 </Cards>

--- a/content/docs/primary-network/continuous-execution.mdx
+++ b/content/docs/primary-network/continuous-execution.mdx
@@ -1,5 +1,5 @@
 ---
-title: Streaming Asynchronous Execution
+title: Continuous Execution
 description: ACP-194 decouples consensus from execution, enabling parallel processing and dramatically improving C-Chain throughput.
 full: true
 ---

--- a/content/docs/primary-network/meta.json
+++ b/content/docs/primary-network/meta.json
@@ -10,7 +10,7 @@
     "virtual-machines",
     "---C-Chain---",
     "coreth-architecture",
-    "streaming-async-execution",
+    "continuous-execution",
     "firewood",
     "verify-contract",
     "---P-Chain---",

--- a/content/docs/primary-network/verify-contract/hardhat.mdx
+++ b/content/docs/primary-network/verify-contract/hardhat.mdx
@@ -5,7 +5,7 @@ description: Learn how to verify a smart contract using Hardhat.
 
 {/*
   EVM Version Warning - TEMPORARY
-  Remove this section when Avalanche adds Pectra support (after SAE implementation)
+  Remove this section when Avalanche adds Pectra support (after Continuous Execution implementation)
   Last reviewed: December 2025
 */}
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -82,6 +82,25 @@ const config = {
         permanent: true,
       },
       {
+        // ACP-194 was renamed upstream (avalanche-foundation/ACPs#295):
+        // "Streaming Asynchronous Execution" (194-streaming-asynchronous-execution) → "Continuous Execution" (194-continuous-execution)
+        source: '/docs/acps/194-streaming-asynchronous-execution',
+        destination: '/docs/acps/194-continuous-execution',
+        permanent: true,
+      },
+      {
+        // Renamed alongside the ACP-194 rebrand to "Continuous Execution"
+        source: '/docs/primary-network/streaming-async-execution',
+        destination: '/docs/primary-network/continuous-execution',
+        permanent: true,
+      },
+      {
+        // Renamed alongside the ACP-194 rebrand to "Continuous Execution"
+        source: '/docs/nodes/architecture/execution/streaming-async-execution',
+        destination: '/docs/nodes/architecture/execution/continuous-execution',
+        permanent: true,
+      },
+      {
         // "Build a Custom VM" landing now lives in the Custom Virtual Machines section
         source: '/docs/avalanche-l1s/build-custom-vm',
         destination: '/docs/avalanche-l1s/virtual-machines-index',


### PR DESCRIPTION
## Summary

ACP-194 (previously SAE / Streaming Asynchronous Execution) is now referred to as **Continuous Execution** externally. Upstream, [avalanche-foundation/ACPs#295](https://github.com/avalanche-foundation/ACPs/pull/295) renames the spec folder to `194-continuous-execution` and retitles it. This PR carries the rename through builders-hub and fixes every link that breaks when #295 merges.

## Changes

**Redirects** (`next.config.mjs`, same pattern as the ACP-236 rename):
- `/docs/acps/194-streaming-asynchronous-execution` → `/docs/acps/194-continuous-execution`
- `/docs/primary-network/streaming-async-execution` → `/docs/primary-network/continuous-execution`
- `/docs/nodes/architecture/execution/streaming-async-execution` → `/docs/nodes/architecture/execution/continuous-execution`

**Page renames**: the two hand-written docs pages above, plus their `meta.json` entries.

**Link fixes**: hardcoded GitHub links to `ACPs/194-streaming-asynchronous-execution` (GitHub does not redirect renamed tree paths), internal `/docs/acps/194-*` links in nav config, the interactive SAE page component, and the Helicon blog post.

**Copy**: user-facing naming updated across docs pages, blog posts (Helicon, Granite, gas-target increase, min-block-times), nav, landing pillars, and the `components/sae` interactive components. First mention per page keeps a "formerly known as Streaming Asynchronous Execution (SAE)" note. Internal code identifiers (`components/sae/`, `SAE_CONFIG`, `StreamingAsyncExecution` component) are intentionally untouched to keep the diff reviewable.

The `/docs/acps/*` page content itself is generated at build time from `avalanche-foundation/ACPs@main` (`utils/remote-content/acps.mts`), so the ACP page body and index regenerate automatically once #295 merges.

## ⚠️ Merge ordering

**Merge this after avalanche-foundation/ACPs#295.** Until #295 is on `main`, the redirect targets (`194-continuous-execution`) don't exist in the generated content and the old slug still does. If this deploys first, the ACP-194 page 404s until #295 lands.

## Testing

- `tsc --noEmit` passes
- Repo-wide sweep: no remaining `194-streaming`/`streaming-async`/user-facing `SAE` references outside redirect sources and intentional "formerly SAE" notes