### PR TITLE
style(explorer): gas grammar for all stats surfaces + subnav z-order fix

### DIFF
--- a/app/api/cchain-activity/route.ts
+++ b/app/api/cchain-activity/route.ts
@@ -1,18 +1,25 @@
 import { NextResponse } from "next/server";
-import { getCchainDailyActivity } from "@/lib/explorer-clickhouse";
+import { getCchainDailyActivity, type CchainActivityDays } from "@/lib/explorer-clickhouse";
 
 // Daily C-Chain activity by on-chain behavior (DeFi / NFT / tokens /
-// other) for the overview's stacked area chart. Classification runs over
-// the raw log archive in ClickHouse — heavy, so the helper caches for 15
-// minutes and this response rides the CDN for the same window.
+// other) for the overview's stacked area chart, windowed by the page
+// clock (?days=7|30|90; the year view clamps to 90 client-side — the
+// classification runs over the raw log archive and a full year buys
+// nothing but spill). Heavy, so the helper caches per window for 15
+// minutes and this response rides the CDN for the same.
 
-export async function GET() {
-  const days = await getCchainDailyActivity();
-  if (days === null) {
+const WINDOWS: CchainActivityDays[] = [7, 30, 90];
+
+export async function GET(request: Request) {
+  const raw = Number(new URL(request.url).searchParams.get("days") ?? 7);
+  const days = (WINDOWS.includes(raw as CchainActivityDays) ? raw : 7) as CchainActivityDays;
+
+  const points = await getCchainDailyActivity(days);
+  if (points === null) {
     return NextResponse.json({ error: "no activity data" }, { status: 404 });
   }
   return NextResponse.json(
-    { days },
+    { days: points },
     {
       headers: {
         "Cache-Control": "public, max-age=300, s-maxage=900, stale-while-revalidate=3600",

--- a/components/explorer-v2/ExplorerSubnav.tsx
+++ b/components/explorer-v2/ExplorerSubnav.tsx
@@ -194,7 +194,8 @@ function ChainSwitcher({
       </button>
 
       {open && (
-        // z-50: must clear the stats pages' sticky section bar (z-40)
+        // z-50 within the subnav's own stacking context (the z-[35] rail):
+        // only needs to clear siblings inside the rail, not the page
         <div className="absolute left-0 top-full z-50 w-[min(20rem,calc(100vw-2.5rem))] border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950">
           <div className="relative border-b border-zinc-100 dark:border-zinc-900">
             <Search className="pointer-events-none absolute left-4 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-400 dark:text-zinc-500" />
@@ -530,11 +531,12 @@ export function ExplorerSubnav({
     // sticky just below the global navbar (h-14 + banner), riding every
     // shell: only this rail pins — the page header below scrolls away.
     // Negative margins bleed the surface across the shells' px-5/px-6 so
-    // content never peeks past its edges; z-[45] keeps it (and the chain
-    // switcher's dropdown) above the stats pages' sticky bars (z-40).
+    // content never peeks past its edges; z-[35] clears the page-level
+    // sticky bars (z-30) but stays UNDER the global navbar (#nd-nav, z-40)
+    // so its dropdown menus paint over this rail, not behind it.
     <div
       className={cn(
-        "sticky top-[calc(var(--fd-banner-height,0px)+3.5rem)] z-[45] -mx-5 flex items-stretch justify-between gap-x-6 border-b border-zinc-200 bg-white/85 px-5 backdrop-blur-[12px] md:-mx-6 md:px-6 dark:border-zinc-800 dark:bg-zinc-950/85",
+        "sticky top-[calc(var(--fd-banner-height,0px)+3.5rem)] z-[35] -mx-5 flex items-stretch justify-between gap-x-6 border-b border-zinc-200 bg-white/85 px-5 backdrop-blur-[12px] md:-mx-6 md:px-6 dark:border-zinc-800 dark:bg-zinc-950/85",
         className,
       )}
     >

--- a/components/explorer-v2/evm/EvmAccounts.tsx
+++ b/components/explorer-v2/evm/EvmAccounts.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { EvmShell } from "@/components/explorer-v2/EvmShell";
-import { Board, BoardHeader, SectionHeader, StatDash } from "@/components/explorer-v2/ui";
+import { Board, BoardHeader, ChartBoard, StatDash } from "@/components/explorer-v2/ui";
 import { ChartEmpty, Stat } from "@/components/explorer-v2/staking/bits";
 import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import { useContractNames } from "@/lib/sourcify-client";
@@ -12,19 +12,24 @@ import { useChainContext } from "@/app/(home)/explorer/[network]/[chain]/layout.
 import type { AccountsActivity, AccountLeader } from "@/lib/explorer-clickhouse";
 import {
   ChartSection,
+  Delta,
   DualChart,
   OverlayKey,
   fmtCompact,
   metricSeries,
   num,
+  pctOf,
   useChainMetrics,
+  windowPair,
 } from "./metric-charts";
 
-/* The chain's Accounts tab: who is here and who the traffic actually is.
-   The chart half (active/total addresses, contracts deployed) reads the
-   chain-stats indexer; the leaderboard half (most-called addresses,
-   busiest senders) reads ClickHouse through /api/accounts. Chains outside
-   the ClickHouse dataset keep the charts and say so under the boards. */
+/* The chain's Accounts tab in the gas page's grammar: a readings board on
+   the shared clock (each figure against its previous window), outlined
+   chart cards, and the leaderboards framed the same way. The chart half
+   (active/total addresses, contracts deployed) reads the chain-stats
+   indexer; the leaderboard half (most-called addresses, busiest senders)
+   reads ClickHouse through /api/accounts. Chains outside the ClickHouse
+   dataset keep the charts and say so under the boards. */
 
 const METRICS = ["activeAddresses", "activeSenders", "cumulativeAddresses", "contracts", "deployers"].join(",");
 
@@ -68,9 +73,11 @@ function useAccountsActivity(chainId: string, rangeDays: number) {
 }
 
 /* one leaderboard: rank, labelled address, and the three numbers that
-   describe its traffic from this side of the transaction */
+   describe its traffic from this side of the transaction. The card only
+   carries a window chip when it CAN'T follow the page clock. */
 function LeaderBoard({
   label,
+  windowNote,
   leaders,
   loading,
   base,
@@ -80,6 +87,8 @@ function LeaderBoard({
   volume,
 }: {
   label: string;
+  /** the clamp exception, e.g. "90 days · longest computed" */
+  windowNote?: string;
   leaders: AccountLeader[];
   loading: boolean;
   base: string;
@@ -89,9 +98,18 @@ function LeaderBoard({
   volume: (l: AccountLeader) => string;
 }) {
   return (
-    <section className="flex flex-col gap-4">
-      <SectionHeader label={label} />
-      <Board className={cn(loading && leaders.length > 0 && "opacity-60 transition-opacity")}>
+    <ChartBoard
+      label={label}
+      bodyClassName={cn("p-0", loading && leaders.length > 0 && "opacity-60 transition-opacity")}
+      action={
+        windowNote ? (
+          <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+            {windowNote}
+          </span>
+        ) : undefined
+      }
+    >
+      <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
         <div className="grid grid-cols-[2rem_minmax(0,1fr)_5rem_5rem_6rem] gap-3 px-5 py-2.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 md:px-6 dark:text-zinc-500">
           <span>#</span>
           <span>Address</span>
@@ -131,8 +149,8 @@ function LeaderBoard({
         {loading && leaders.length === 0 && (
           <div className="px-5 py-4 font-mono text-[11px] text-zinc-400 md:px-6 dark:text-zinc-500">Loading…</div>
         )}
-      </Board>
-    </section>
+      </div>
+    </ChartBoard>
   );
 }
 
@@ -145,12 +163,15 @@ export function EvmAccounts({ network }: { network: string }) {
   const range = RANGE_DAYS[clock];
   const rangeLabel = RANGE_LABEL[clock];
 
-  const { metrics, failed } = useChainMetrics(c.chainId, range, METRICS);
+  // fetch double the window so every reading can face its previous window
+  const { metrics, failed } = useChainMetrics(c.chainId, Math.min(range * 2, 365), METRICS);
   const { activity, notIndexed, served } = useAccountsActivity(c.chainId, range);
-  const boardsLabel = served < range ? `${served} days` : rangeLabel;
+  // the leaderboards' one exception to the page clock, stated on the card
+  const boardsNote = served < range ? `${served} days · longest computed` : undefined;
 
   const m = metrics ?? {};
   const current = (key: string) => num(m[key]?.current_value);
+  const win = (key: string, mode: "sum" | "avg" = "sum") => windowPair(m[key]?.data, range, mode);
 
   // one Sourcify pass over both boards — the resolved names accumulate,
   // so flipping the clock relabels instantly for repeat leaders
@@ -160,39 +181,69 @@ export function EvmAccounts({ network }: { network: string }) {
   );
   const names = useContractNames(c.chainId, leaderAddresses);
 
-  const strip: { label: string; value: number | null; sub?: string }[] = [
-    {
-      label: "Active Addresses · 24h",
-      value: current("activeAddresses"),
-      sub: current("activeSenders") !== null ? `${fmtCompact(current("activeSenders")!)} senders` : undefined,
-    },
-    { label: "Total Addresses", value: current("cumulativeAddresses"), sub: "all-time" },
-    {
-      label: "Contracts Deployed · 24h",
-      value: current("contracts"),
-      sub: current("deployers") !== null ? `${fmtCompact(current("deployers")!)} deployers` : undefined,
-    },
-  ];
+  // the readings row on the page clock — cells only carry a window label
+  // when they DON'T follow it (the all-time total)
+  const activePair = win("activeAddresses", "avg");
+  const sendersPair = win("activeSenders", "avg");
+  const contractsPair = win("contracts");
+  const deployersPair = win("deployers");
+  const totalAddresses = current("cumulativeAddresses");
 
   return (
     <EvmShell network={network}>
       <div className="flex flex-col gap-10">
-        {/* who's here right now */}
-        <Board divide={false}>
-          <BoardHeader label="Latest Day" />
-          <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 sm:grid-cols-3 sm:divide-y-0 dark:divide-zinc-800">
-            {strip.map((s) => (
-              <Stat key={s.label} label={s.label} sub={s.sub}>
-                {s.value !== null ? fmtCompact(s.value) : metrics || failed ? <StatDash /> : "…"}
-              </Stat>
-            ))}
+        {/* the window is stated once, up here */}
+        <Board divide={false} className="border">
+          <BoardHeader
+            label="Accounts"
+            display
+            action={
+              <span className="shrink-0 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
+                Last {rangeLabel}
+              </span>
+            }
+          />
+          <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-sm:[&>*:nth-child(odd)]:border-l-0 sm:grid-cols-3 sm:divide-y-0 dark:divide-zinc-800">
+            <Stat
+              label="Active Addresses"
+              sub={
+                activePair ? (
+                  <>
+                    {sendersPair
+                      ? `${range > 1 ? "avg " : ""}${fmtCompact(sendersPair.cur)} senders · `
+                      : range > 1
+                        ? "daily avg · "
+                        : null}
+                    <Delta value={pctOf(activePair)} />
+                  </>
+                ) : undefined
+              }
+            >
+              {activePair ? fmtCompact(activePair.cur) : metrics || failed ? <StatDash /> : "…"}
+            </Stat>
+            <Stat label="Total Addresses" sub="all-time">
+              {totalAddresses !== null ? fmtCompact(totalAddresses) : metrics || failed ? <StatDash /> : "…"}
+            </Stat>
+            <Stat
+              label="Contracts Deployed"
+              sub={
+                contractsPair ? (
+                  <>
+                    {deployersPair ? `${fmtCompact(deployersPair.cur)} deployers · ` : null}
+                    <Delta value={pctOf(contractsPair)} />
+                  </>
+                ) : undefined
+              }
+            >
+              {contractsPair ? fmtCompact(contractsPair.cur) : metrics || failed ? <StatDash /> : "…"}
+            </Stat>
           </div>
         </Board>
 
         {/* the population over time */}
         <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
           <ChartSection
-            label={`Active Addresses · ${rangeLabel}`}
+            label="Active Addresses"
             action={<OverlayKey label="senders" />}
           >
             {metricSeries(m, range, "activeAddresses", "activeSenders").length ? (
@@ -208,7 +259,7 @@ export function EvmAccounts({ network }: { network: string }) {
             )}
           </ChartSection>
 
-          <ChartSection label={`Total Addresses · ${rangeLabel}`}>
+          <ChartSection label="Total Addresses">
             {metricSeries(m, range, "cumulativeAddresses").length ? (
               <DualChart
                 data={metricSeries(m, range, "cumulativeAddresses")}
@@ -223,7 +274,7 @@ export function EvmAccounts({ network }: { network: string }) {
         </div>
 
         <ChartSection
-          label={`Contracts Deployed · ${rangeLabel}`}
+          label="Contracts Deployed"
           action={<OverlayKey label="deployers" dashed />}
         >
           {metricSeries(m, range, "contracts", "deployers").length ? (
@@ -242,13 +293,14 @@ export function EvmAccounts({ network }: { network: string }) {
 
         {/* who the traffic actually is */}
         {notIndexed ? (
-          <p className="font-mono text-[11px] text-zinc-400 dark:text-zinc-500">
+          <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
             Leaderboards need indexed transaction history; this chain isn&apos;t in the dataset yet.
           </p>
         ) : (
           <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
             <LeaderBoard
-              label={`Most Called · ${boardsLabel}`}
+              label="Most Called"
+              windowNote={boardsNote}
               leaders={activity?.called ?? []}
               loading={!activity}
               base={base}
@@ -258,7 +310,8 @@ export function EvmAccounts({ network }: { network: string }) {
               volume={(l) => `${fmtCompact(l.feesNative)} ${sym}`}
             />
             <LeaderBoard
-              label={`Top Senders · ${boardsLabel}`}
+              label="Top Senders"
+              windowNote={boardsNote}
               leaders={activity?.senders ?? []}
               loading={!activity}
               base={base}

--- a/components/explorer-v2/evm/EvmActivity.tsx
+++ b/components/explorer-v2/evm/EvmActivity.tsx
@@ -1,16 +1,27 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Area, AreaChart, Line, LineChart, ResponsiveContainer, Tooltip as RechartsTooltip, YAxis } from "recharts";
-import { Board, SectionHeader } from "@/components/explorer-v2/ui";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Area,
+  AreaChart,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { cn } from "@/lib/utils";
+import { ChartBoard } from "@/components/explorer-v2/ui";
+import { TipPlate } from "@/components/explorer-v2/staking/bits";
+import { RANGE_DAYS, useExplorerTimeRange, type ExplorerRange } from "@/components/explorer-v2/time-range";
+import { fmtCompact, metricSeries, useChainMetrics } from "./metric-charts";
 
-/* What the chain is FOR — ported from the pre-EvmHome overview
- * (components/explorer/L1ExplorerPage.tsx). C-Chain: 14 days of activity
- * classified by on-chain behavior (ClickHouse via /api/cchain-activity),
- * stacked areas. Other chains: the plain daily-transactions line
- * (ClickHouse via /api/explorer/{chainId}?historyOnly=true), drawn in the
- * chain's own accent. Either section renders nothing until data exists, so
- * unindexed chains lose no vertical space. */
+/* What the chain is FOR — the overview's activity breakdown, on the page
+ * clock. C-Chain: daily activity classified by on-chain behavior
+ * (ClickHouse via /api/cchain-activity?days=…), stacked areas. Other
+ * chains: the daily-transactions area off the chain-stats indexer, drawn
+ * in the chain's own accent. Either card doors into the Transactions tab.
+ * Both render nothing until data exists, so unindexed chains lose no
+ * vertical space. */
 
 interface CchainActivityDay {
   date: string;
@@ -28,148 +39,183 @@ const ACTIVITY_SERIES: { key: keyof Omit<CchainActivityDay, "date">; label: stri
   { key: "nft", label: "NFT", tone: "#52525b" },
 ];
 
-export function CchainActivityChart() {
+/* the served window per clock tick: the classification can't afford a
+   year (it spills past 90d), and a 1-point day chart says nothing — both
+   ends clamp and the label states the exception */
+const ACTIVITY_DAYS: Record<ExplorerRange, 7 | 30 | 90> = {
+  day: 7,
+  week: 7,
+  month: 30,
+  quarter: 90,
+  year: 90,
+};
+
+const AXIS_TICK = { fontSize: 10, fill: "#a1a1aa", fontFamily: "monospace" } as const;
+
+export function CchainActivityChart({ href }: { href?: string }) {
+  const clock = useExplorerTimeRange();
+  const served = ACTIVITY_DAYS[clock];
+  const exception =
+    clock === "day" ? "· 7 days" : clock === "year" ? "· 90 days · longest computed" : null;
+
   const [activity, setActivity] = useState<CchainActivityDay[] | null>(null);
+  const [servedDays, setServedDays] = useState<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    fetch("/api/cchain-activity")
+    fetch(`/api/cchain-activity?days=${served}`)
       .then((res) => (res.ok ? res.json() : null))
       .then((data: { days: CchainActivityDay[] } | null) => {
-        if (!cancelled && data?.days?.length) setActivity(data.days);
+        if (!cancelled && data?.days?.length) {
+          setActivity(data.days);
+          setServedDays(served);
+        }
       })
       .catch(() => {});
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [served]);
 
   if (!activity) return null;
+  // a window switch keeps the last payload on screen, dimmed, until the
+  // new one lands — same idiom as the gas market
+  const stale = servedDays !== served;
 
   return (
-    <section className="flex flex-col gap-4">
-      <SectionHeader
-        label="Network Activity · 14 days"
-        action={
-          <span className="flex shrink-0 items-center gap-4 font-mono text-[9px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-            {ACTIVITY_SERIES.map((s) => (
-              <span key={s.key} className="flex items-center gap-1.5">
-                <span className="h-2 w-2" style={{ background: s.tone }} />
-                {s.label}
-              </span>
-            ))}
-          </span>
-        }
-      />
-      <Board divide={false} className="px-5 py-5 md:px-6">
-        <div className="h-28">
-          <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={activity}>
-              <YAxis hide domain={[0, "dataMax"]} />
-              <RechartsTooltip
-                cursor={{ stroke: "rgba(161,161,170,0.3)" }}
-                content={({ active: a, payload }) => {
-                  if (!a || !payload?.length) return null;
-                  const d = payload[0].payload as CchainActivityDay;
-                  const total = d.defi + d.nft + d.tokens + d.other;
-                  return (
-                    <div className="bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 px-2.5 py-1.5 shadow-sm">
-                      <p className="text-[10px] text-zinc-500">
-                        {d.date} · {total.toLocaleString()} txns
+    <ChartBoard
+      label={exception ? `Network Activity ${exception}` : "Network Activity"}
+      href={href}
+      className={cn(stale && "opacity-60 transition-opacity")}
+      action={
+        <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 sm:gap-4 dark:text-zinc-500">
+          {ACTIVITY_SERIES.map((s) => (
+            <span key={s.key} className="flex items-center gap-1.5">
+              <span className="h-2 w-2" style={{ background: s.tone }} />
+              {s.label}
+            </span>
+          ))}
+        </span>
+      }
+    >
+      <div className="h-48">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={activity} margin={{ top: 4, right: 0, left: 0, bottom: 0 }}>
+            <XAxis
+              dataKey="date"
+              tickLine={false}
+              axisLine={false}
+              tick={AXIS_TICK}
+              minTickGap={48}
+              interval="preserveStartEnd"
+            />
+            <YAxis hide domain={[0, "dataMax"]} />
+            <RechartsTooltip
+              cursor={{ stroke: "rgba(161,161,170,0.3)" }}
+              content={({ active: a, payload }) => {
+                if (!a || !payload?.length) return null;
+                const d = payload[0].payload as CchainActivityDay;
+                const total = d.defi + d.nft + d.tokens + d.other;
+                return (
+                  <TipPlate>
+                    <p className="text-[10px] text-zinc-500">
+                      {d.date} · {total.toLocaleString()} txns
+                    </p>
+                    {ACTIVITY_SERIES.map((s) => (
+                      <p
+                        key={s.key}
+                        className="flex items-center gap-1.5 text-xs tabular-nums text-zinc-900 dark:text-zinc-100"
+                      >
+                        <span className="h-1.5 w-1.5" style={{ background: s.tone }} />
+                        {d[s.key].toLocaleString()} {s.label.toLowerCase()}
+                        <span className="text-[10px] text-zinc-400">
+                          {total > 0 ? `${((d[s.key] / total) * 100).toFixed(0)}%` : ""}
+                        </span>
                       </p>
-                      {ACTIVITY_SERIES.map((s) => (
-                        <p key={s.key} className="flex items-center gap-1.5 text-xs tabular-nums text-zinc-900 dark:text-zinc-100">
-                          <span className="h-1.5 w-1.5" style={{ background: s.tone }} />
-                          {d[s.key].toLocaleString()} {s.label.toLowerCase()}
-                        </p>
-                      ))}
-                    </div>
-                  );
-                }}
+                    ))}
+                  </TipPlate>
+                );
+              }}
+            />
+            {ACTIVITY_SERIES.map((s) => (
+              <Area
+                key={s.key}
+                dataKey={s.key}
+                stackId="day"
+                stroke={s.tone}
+                strokeWidth={1}
+                fill={s.tone}
+                fillOpacity={0.85}
+                type="monotone"
+                isAnimationActive={false}
               />
-              {ACTIVITY_SERIES.map((s) => (
-                <Area
-                  key={s.key}
-                  dataKey={s.key}
-                  stackId="day"
-                  stroke={s.tone}
-                  strokeWidth={1}
-                  fill={s.tone}
-                  fillOpacity={0.85}
-                  type="monotone"
-                />
-              ))}
-            </AreaChart>
-          </ResponsiveContainer>
-        </div>
-      </Board>
-    </section>
+            ))}
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </ChartBoard>
   );
 }
 
-interface TransactionHistoryPoint {
-  date: string;
-  transactions: number;
-}
+// the history charts ride the chain-stats indexer, which serves any clock
+const TX_METRICS = "txCount";
 
-export function TxHistoryChart({ chainId }: { chainId: number | string }) {
-  const [history, setHistory] = useState<TransactionHistoryPoint[] | null>(null);
+export function TxHistoryChart({ chainId, href }: { chainId: number | string; href?: string }) {
+  const clock = useExplorerTimeRange();
+  const range = RANGE_DAYS[clock];
+  // a 1-point day chart says nothing — floor at a week, label the exception
+  const windowDays = Math.max(7, range);
+  const { metrics } = useChainMetrics(String(chainId), windowDays, TX_METRICS);
 
-  useEffect(() => {
-    let cancelled = false;
-    fetch(`/api/explorer/${chainId}?historyOnly=true`)
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data: { transactionHistory: TransactionHistoryPoint[] } | null) => {
-        if (!cancelled && data?.transactionHistory?.length) setHistory(data.transactionHistory);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [chainId]);
+  const history = useMemo(
+    () => metricSeries(metrics ?? {}, windowDays, "txCount"),
+    [metrics, windowDays],
+  );
 
-  if (!history) return null;
+  if (!history.length) return null;
 
   return (
-    <section className="flex flex-col gap-4">
-      <SectionHeader
-        label="Transactions · 14 days"
-        action={
-          <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-            {history[0]?.date} → {history[history.length - 1]?.date}
-          </span>
-        }
-      />
-      <Board divide={false} className="px-5 py-5 md:px-6">
-        <div className="h-20">
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={history}>
-              <YAxis hide domain={["dataMin", "dataMax"]} />
-              <RechartsTooltip
-                content={({ active, payload }) => {
-                  if (!active || !payload?.[0]) return null;
-                  return (
-                    <div className="bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 px-2 py-1 shadow-sm">
-                      <p className="text-[10px] text-zinc-500">{payload[0].payload.date}</p>
-                      <p className="text-xs font-semibold text-[var(--chain-accent,#E6212F)]">
-                        {payload[0].value?.toLocaleString()} txns
-                      </p>
-                    </div>
-                  );
-                }}
-              />
-              <Line
-                type="monotone"
-                dataKey="transactions"
-                stroke="var(--chain-accent, #E6212F)"
-                strokeWidth={1.5}
-                dot={false}
-                activeDot={{ r: 3, fill: "var(--chain-accent, #E6212F)" }}
-              />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-      </Board>
-    </section>
+    <ChartBoard label={clock === "day" ? "Transactions · 7 days" : "Transactions"} href={href}>
+      <div className="h-40">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={history} margin={{ top: 4, right: 0, left: 0, bottom: 0 }}>
+            <XAxis
+              dataKey="date"
+              tickLine={false}
+              axisLine={false}
+              tick={AXIS_TICK}
+              minTickGap={48}
+              interval="preserveStartEnd"
+            />
+            <YAxis hide domain={[0, "dataMax"]} />
+            <RechartsTooltip
+              cursor={{ stroke: "rgba(161,161,170,0.3)" }}
+              content={({ active, payload }) => {
+                if (!active || !payload?.[0]) return null;
+                const d = payload[0].payload as { date: string; a: number };
+                return (
+                  <TipPlate>
+                    <p className="text-[10px] text-zinc-500">{d.date}</p>
+                    <p className="text-xs font-semibold tabular-nums text-[var(--chain-accent,#E6212F)]">
+                      {fmtCompact(d.a)} txns
+                    </p>
+                  </TipPlate>
+                );
+              }}
+            />
+            <Area
+              type="monotone"
+              dataKey="a"
+              stroke="var(--chain-accent, #E6212F)"
+              strokeWidth={1.5}
+              fill="var(--chain-accent, #E6212F)"
+              fillOpacity={0.08}
+              isAnimationActive={false}
+              activeDot={{ r: 3, fill: "var(--chain-accent, #E6212F)" }}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </ChartBoard>
   );
 }

--- a/components/explorer-v2/evm/EvmAddress.tsx
+++ b/components/explorer-v2/evm/EvmAddress.tsx
@@ -7,7 +7,7 @@ import { EvmShell } from "@/components/explorer-v2/EvmShell";
 import { Board, CellLabel, DetailSkeleton, HashChip, SectionHeader, SpecPlate, SpecRow } from "@/components/explorer-v2/ui";
 import { formatNumber, formatTime, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { formatEther } from "./format";
-import { MethodChip } from "./bits";
+import { FeedDown, MethodChip } from "./bits";
 import { StatusPill } from "./EvmTx";
 import { useEvmData } from "./hooks";
 import { useChainContext } from "@/app/(home)/explorer/[network]/[chain]/layout.client";
@@ -30,7 +30,7 @@ export function EvmAddress({ network, addr }: { network: string; addr: string })
   const sym = c.nativeToken;
   const [tab, setTab] = useState<Tab>("txs");
 
-  const { data: s, loading, error } = useEvmData<AddressSummary>(c.chainId, `address/${addr}`, undefined, {
+  const { data: s, loading, error, retry } = useEvmData<AddressSummary>(c.chainId, `address/${addr}`, undefined, {
     retry404Ms: 15_000,
   });
   const txs = useEvmData<TxListResponse>(c.chainId, `address/${addr}/txs`, { limit: 50 });
@@ -42,7 +42,9 @@ export function EvmAddress({ network, addr }: { network: string; addr: string })
   return (
     <EvmShell network={network}>
       {loading && <DetailSkeleton label="Address" />}
-      {error && !s && (
+      {/* a 404 means the address is unknown; anything else means the
+          indexer died on us — say so instead of pretending */}
+      {error === "not found" && !s && (
         <Board divide={false} className="px-6 py-16 text-center">
           <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-zinc-400 dark:text-zinc-500">
             Address not found
@@ -50,6 +52,7 @@ export function EvmAddress({ network, addr }: { network: string; addr: string })
           <p className="mt-3 break-all font-mono text-[12px] text-zinc-500 dark:text-zinc-400">{addr}</p>
         </Board>
       )}
+      {error && error !== "not found" && !s && <FeedDown onRetry={retry} />}
       {s && (
         <div className="flex flex-col gap-10">
           <section className="flex flex-col gap-4">
@@ -95,11 +98,14 @@ export function EvmAddress({ network, addr }: { network: string; addr: string })
 
             {tab === "txs" ? (
               <Board>
-                {txList.length === 0 && (
-                  <div className="px-5 py-5 font-mono text-[11px] text-zinc-400 md:px-6 dark:text-zinc-500">
-                    {txs.loading ? "Loading…" : "no transactions"}
-                  </div>
-                )}
+                {txList.length === 0 &&
+                  (txs.error && !txs.loading ? (
+                    <FeedDown compact onRetry={txs.retry} />
+                  ) : (
+                    <div className="px-5 py-5 font-mono text-[11px] text-zinc-400 md:px-6 dark:text-zinc-500">
+                      {txs.loading ? "Loading…" : "no transactions"}
+                    </div>
+                  ))}
                 {txList.map((t) => {
                   const outgoing = t.from.toLowerCase() === addr.toLowerCase();
                   return (
@@ -146,11 +152,14 @@ export function EvmAddress({ network, addr }: { network: string; addr: string })
               </Board>
             ) : (
               <Board>
-                {xferList.length === 0 && (
-                  <div className="px-5 py-5 font-mono text-[11px] text-zinc-400 md:px-6 dark:text-zinc-500">
-                    {transfers.loading ? "Loading…" : "no token transfers"}
-                  </div>
-                )}
+                {xferList.length === 0 &&
+                  (transfers.error && !transfers.loading ? (
+                    <FeedDown compact onRetry={transfers.retry} />
+                  ) : (
+                    <div className="px-5 py-5 font-mono text-[11px] text-zinc-400 md:px-6 dark:text-zinc-500">
+                      {transfers.loading ? "Loading…" : "no token transfers"}
+                    </div>
+                  ))}
                 {xferList.map((x, i) => {
                   const outgoing = x.from.toLowerCase() === addr.toLowerCase();
                   return (

--- a/components/explorer-v2/evm/EvmBlock.tsx
+++ b/components/explorer-v2/evm/EvmBlock.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/explorer-v2/ui";
 import { formatNumber, formatTime, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { formatEther, formatGwei, gasUsedPct } from "./format";
-import { MethodChip } from "./bits";
+import { FeedDown, MethodChip } from "./bits";
 import { useEvmData } from "./hooks";
 import { NotFound, StatusPill } from "./EvmTx";
 import { useChainContext } from "@/app/(home)/explorer/[network]/[chain]/layout.client";
@@ -23,14 +23,16 @@ export function EvmBlock({ network, id }: { network: string; id: string }) {
   const c = useChainContext();
   const base = `/explorer/${network}/${c.chainSlug}`;
   const sym = c.nativeToken;
-  const { data: b, loading, error } = useEvmData<BlockDetail>(c.chainId, `block/${id}`, undefined, {
+  const { data: b, loading, error, retry } = useEvmData<BlockDetail>(c.chainId, `block/${id}`, undefined, {
     retry404Ms: 20_000,
   });
 
   return (
     <EvmShell network={network}>
       {loading && <DetailSkeleton label="Block" />}
-      {error && !b && <NotFound label="Block not found" id={id} />}
+      {/* only a real 404 is "not found" — an indexer outage says so */}
+      {error === "not found" && !b && <NotFound label="Block not found" id={id} />}
+      {error && error !== "not found" && !b && <FeedDown onRetry={retry} />}
       {b && (
         <div className="flex flex-col gap-10">
           <section className="flex flex-col gap-4">

--- a/components/explorer-v2/evm/EvmHome.tsx
+++ b/components/explorer-v2/evm/EvmHome.tsx
@@ -197,10 +197,14 @@ export function EvmHome({ network }: { network: string }) {
             />
           </div>
 
-          {/* what the chain is FOR — the activity breakdown the pre-EvmHome
-              overview carried: stacked behavior bands for the C-Chain, the
-              accent-colored tx line for everyone else. */}
-          {isCchain ? <CchainActivityChart /> : <TxHistoryChart chainId={c.chainId} />}
+          {/* what the chain is FOR — the activity breakdown on the page
+              clock: stacked behavior bands for the C-Chain, the accent
+              area for everyone else. Both door into the Transactions tab. */}
+          {isCchain ? (
+            <CchainActivityChart href={`${base}/txs`} />
+          ) : (
+            <TxHistoryChart chainId={c.chainId} href={`${base}/txs`} />
+          )}
 
           <div className="grid gap-12 lg:grid-cols-2">
             {/* Latest blocks */}

--- a/components/explorer-v2/evm/EvmOverviewStats.tsx
+++ b/components/explorer-v2/evm/EvmOverviewStats.tsx
@@ -3,7 +3,14 @@
 import { useEffect, useMemo, useState } from "react";
 import { Board, BoardHeader, StatCell, StatDash } from "@/components/explorer-v2/ui";
 import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange, type ExplorerRange } from "@/components/explorer-v2/time-range";
-import { fmtCompact, num, useChainMetrics } from "./metric-charts";
+import {
+  Delta,
+  fmtCompact,
+  pctOf,
+  useChainMetrics,
+  windowPair,
+  type WindowPair,
+} from "./metric-charts";
 
 /* The chain's readings, one uniform grid on the page clock: the live
    market row, then the clock's window with its move against the
@@ -18,51 +25,6 @@ const METRICS = [
   "feesPaid",
   "avgGasPrice",
 ].join(",");
-
-interface SeriesPoint {
-  timestamp: number;
-  value: number | string;
-}
-
-interface WindowPair {
-  cur: number;
-  /** null when the series is too short to hold the previous window */
-  prev: number | null;
-}
-
-/* the clock's window vs the window before it — sums for volumes,
-   means for rates. Needs 2N points for a delta; degrades to cur-only. */
-function windowPair(points: SeriesPoint[] | undefined, n: number, mode: "sum" | "avg"): WindowPair | null {
-  if (!points || points.length < Math.min(n, 2)) return null;
-  const sorted = [...points].sort((a, b) => a.timestamp - b.timestamp);
-  const vals = sorted.map((p) => num(p.value as never) ?? 0);
-  const take = (arr: number[]) =>
-    mode === "sum" ? arr.reduce((s, v) => s + v, 0) : arr.reduce((s, v) => s + v, 0) / arr.length;
-  const curSlice = vals.slice(-n);
-  if (!curSlice.length) return null;
-  const prevSlice = vals.slice(-2 * n, -n);
-  return {
-    cur: take(curSlice),
-    prev: prevSlice.length === n ? take(prevSlice) : null,
-  };
-}
-
-function pctOf(p: WindowPair | null): number | null {
-  if (!p || p.prev === null || p.prev === 0) return null;
-  return ((p.cur - p.prev) / p.prev) * 100;
-}
-
-/* the move against the previous window, Etherscan's parenthetical */
-function Delta({ value }: { value: number | null }) {
-  if (value === null) return null;
-  const up = value >= 0;
-  return (
-    <span className={up ? "text-emerald-600 dark:text-emerald-400" : "text-[#E6212F]"}>
-      {up ? "+" : ""}
-      {Math.abs(value) >= 100 ? value.toFixed(0) : value.toFixed(1)}% vs prev
-    </span>
-  );
-}
 
 /* utilization off the blocks table, windowed on the clock; 404 = not ingested */
 function useUtilization(chainId: string, n: number) {

--- a/components/explorer-v2/evm/EvmStats.tsx
+++ b/components/explorer-v2/evm/EvmStats.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useMemo } from "react";
-import Link from "next/link";
-import { ArrowRight } from "lucide-react";
 import {
   Bar,
   ComposedChart,
@@ -17,24 +15,27 @@ import { thin, windowSeries } from "@/components/explorer-v2/staking/data";
 import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import {
   ChartSection,
+  Delta,
   DualChart,
   OverlayKey,
   PUNCH,
   QUIET,
   fmtCompact,
   metricSeries,
-  num,
+  pctOf,
   useChainMetrics,
+  windowPair,
   type DualPoint,
   type IcmPoint,
 } from "./metric-charts";
 
 /* The network-wide Stats surface (chainId="all") — the metrics sheet in
-   Boards on one shared clock. Every chart pairs its headline series with
-   the overlay that explains it (senders under addresses, TPS over
-   transactions, max gas price against the average). Per-chain, these
-   charts live on their subject tabs instead: Accounts, Transactions,
-   Gas, ICM. */
+   the gas page's grammar: a readings board on the shared clock with each
+   figure's move against the previous window, then outlined chart cards.
+   Every chart pairs its headline series with the overlay that explains it
+   (senders under addresses, TPS over transactions, max gas price against
+   the average). Per-chain, these charts live on their subject tabs
+   instead: Accounts, Transactions, Gas, ICM. */
 
 const METRICS = [
   "activeAddresses",
@@ -61,14 +62,16 @@ export function EvmStats({
   chainId: string;
   tokenSymbol?: string;
 }) {
-  // the page clock in the subnav — every chart and label below rides it
+  // the page clock in the subnav — every chart and figure below rides it
   const clock = useExplorerTimeRange();
   const range = RANGE_DAYS[clock];
   const rangeLabel = RANGE_LABEL[clock];
-  const { metrics, failed } = useChainMetrics(chainId, range, METRICS);
+  // fetch double the window so every reading can face its previous window
+  const { metrics, failed } = useChainMetrics(chainId, Math.min(range * 2, 365), METRICS);
 
   const m = metrics ?? {};
   const series = (key: string, overlay?: string): DualPoint[] => metricSeries(m, range, key, overlay);
+  const win = (key: string, mode: "sum" | "avg" = "sum") => windowPair(m[key]?.data, range, mode);
 
   const icmSeries = useMemo(() => {
     const pts = metrics?.icmMessages?.data ?? [];
@@ -81,37 +84,44 @@ export function EvmStats({
     );
   }, [metrics, range]);
 
-  const current = (key: string) => num(m[key]?.current_value);
-
+  // the readings row: the clock's window against the window before it —
+  // sums for volumes, means for rates. No per-cell window labels; the
+  // board header states it once.
   const strip: {
     label: string;
-    value: number | null;
+    pair: ReturnType<typeof win>;
     fmt?: (v: number) => string;
     sub?: string;
   }[] = [
     {
-      label: "Active Addresses · 24h",
-      value: current("activeAddresses"),
-      sub: current("activeSenders") !== null ? `${fmtCompact(current("activeSenders")!)} senders` : undefined,
+      label: "Transactions",
+      pair: win("txCount"),
+      sub: (() => {
+        const tps = win("avgTps", "avg");
+        return tps ? `avg ${tps.cur.toFixed(1)} TPS` : undefined;
+      })(),
     },
     {
-      label: "Transactions · 24h",
-      value: current("txCount"),
-      sub: current("avgTps") !== null ? `avg ${current("avgTps")!.toFixed(1)} TPS` : undefined,
+      label: "Active Addresses",
+      pair: win("activeAddresses", "avg"),
+      sub: range > 1 ? "daily avg" : undefined,
     },
     {
-      label: "Fees Paid · 24h",
-      value: current("feesPaid"),
+      label: "Fees Paid",
+      pair: win("feesPaid"),
       fmt: (v) => `${fmtCompact(v)} ${tokenSymbol}`,
-      sub:
-        current("avgGasPrice") !== null
-          ? `avg gas ${current("avgGasPrice")!.toFixed(2)} n${tokenSymbol}`
-          : undefined,
+      sub: (() => {
+        const gp = win("avgGasPrice", "avg");
+        return gp ? `avg gas ${gp.cur.toFixed(2)} n${tokenSymbol}` : undefined;
+      })(),
     },
     {
-      label: "Contracts Deployed · 24h",
-      value: current("contracts"),
-      sub: current("deployers") !== null ? `${fmtCompact(current("deployers")!)} deployers` : undefined,
+      label: "Contracts Deployed",
+      pair: win("contracts"),
+      sub: (() => {
+        const d = win("deployers");
+        return d ? `${fmtCompact(d.cur)} deployers` : undefined;
+      })(),
     },
   ];
 
@@ -125,14 +135,36 @@ export function EvmStats({
         </div>
       ) : (
         <div className="flex flex-col gap-10">
-          {/* the chain right now — latest full day */}
-          <Board divide={false}>
-            <BoardHeader label="Latest Day" />
+          {/* the window is stated once, up here — everything below follows
+              the same clock unless its label says otherwise */}
+          <Board divide={false} className="border">
+            <BoardHeader
+              label="Network Stats"
+              display
+              action={
+                <span className="shrink-0 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
+                  Last {rangeLabel}
+                </span>
+              }
+            />
             <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
               {strip.map((s) => (
-                <Stat key={s.label} label={s.label} sub={s.sub}>
-                  {s.value !== null ? (
-                    (s.fmt ?? fmtCompact)(s.value)
+                <Stat
+                  key={s.label}
+                  label={s.label}
+                  sub={
+                    s.pair ? (
+                      <>
+                        {s.sub ? <>{s.sub} · </> : null}
+                        <Delta value={pctOf(s.pair)} />
+                      </>
+                    ) : (
+                      s.sub
+                    )
+                  }
+                >
+                  {s.pair !== null ? (
+                    (s.fmt ?? fmtCompact)(s.pair.cur)
                   ) : metrics ? (
                     <StatDash />
                   ) : (
@@ -146,7 +178,7 @@ export function EvmStats({
           {/* who's here */}
           <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
             <ChartSection
-              label={`Active Addresses · ${rangeLabel}`}
+              label="Active Addresses"
               action={<OverlayKey label="senders" />}
             >
               {series("activeAddresses", "activeSenders").length ? (
@@ -163,7 +195,7 @@ export function EvmStats({
             </ChartSection>
 
             <ChartSection
-              label={`Transactions · ${rangeLabel}`}
+              label="Transactions"
               action={<OverlayKey label="avg tps" dashed />}
             >
               {series("txCount", "avgTps").length ? (
@@ -184,7 +216,7 @@ export function EvmStats({
 
           {/* the long arc */}
           <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-            <ChartSection label={`Total Addresses · ${rangeLabel}`}>
+            <ChartSection label="Total Addresses">
               {series("cumulativeAddresses").length ? (
                 <DualChart
                   data={series("cumulativeAddresses")}
@@ -197,7 +229,7 @@ export function EvmStats({
               )}
             </ChartSection>
 
-            <ChartSection label={`Total Transactions · ${rangeLabel}`}>
+            <ChartSection label="Total Transactions">
               {series("cumulativeTxCount").length ? (
                 <DualChart
                   data={series("cumulativeTxCount")}
@@ -214,7 +246,7 @@ export function EvmStats({
           {/* what's being built, and what it burns */}
           <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
             <ChartSection
-              label={`Contracts Deployed · ${rangeLabel}`}
+              label="Contracts Deployed"
               action={<OverlayKey label="deployers" dashed />}
             >
               {series("contracts", "deployers").length ? (
@@ -231,7 +263,7 @@ export function EvmStats({
               )}
             </ChartSection>
 
-            <ChartSection label={`Gas Used · ${rangeLabel}`}>
+            <ChartSection label="Gas Used">
               {series("gasUsed").length ? (
                 <DualChart data={series("gasUsed")} kind="bars" fmt={fmtCompact} aLabel="gas" />
               ) : (
@@ -242,7 +274,7 @@ export function EvmStats({
 
           {/* the price of blockspace */}
           <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-            <ChartSection label={`Fees Paid · ${rangeLabel}`}>
+            <ChartSection label="Fees Paid">
               {series("feesPaid").length ? (
                 <DualChart
                   data={series("feesPaid")}
@@ -256,7 +288,7 @@ export function EvmStats({
             </ChartSection>
 
             <ChartSection
-              label={`Gas Price · ${rangeLabel}`}
+              label="Gas Price"
               action={<OverlayKey label="daily max" dashed />}
               note={`Average price paid per gas unit in n${tokenSymbol}; the dashed line is each day's spike, on its own scale.`}
             >
@@ -276,17 +308,19 @@ export function EvmStats({
             </ChartSection>
           </div>
 
-          {/* cross-chain traffic */}
+          {/* cross-chain traffic — the whole card doors into the observatory */}
           <ChartSection
-            label={`Interchain Messages · ${rangeLabel}`}
+            label="Interchain Messages"
+            href="/explorer/mainnet/icm"
             action={
-              <Link
-                href="/explorer/mainnet/icm"
-                className="group flex shrink-0 items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 transition-colors hover:text-zinc-900 dark:text-zinc-500 dark:hover:text-zinc-100"
-              >
-                ICM observatory
-                <ArrowRight className="h-3 w-3 transition-all group-hover:translate-x-0.5 group-hover:text-[#E6212F]" />
-              </Link>
+              <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
+                <span className="flex items-center gap-1.5">
+                  <span className="h-2.5 w-4 bg-[#A2AFB2]/80" /> received
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <span className="h-2.5 w-4 bg-[#E6212F]/75" /> sent
+                </span>
+              </span>
             }
           >
             {icmSeries.length ? (

--- a/components/explorer-v2/evm/EvmTx.tsx
+++ b/components/explorer-v2/evm/EvmTx.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/explorer-v2/ui";
 import { formatNumber, formatTime, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { formatEther, formatGwei } from "./format";
+import { FeedDown } from "./bits";
 import { useEvmData } from "./hooks";
 import { useChainContext } from "@/app/(home)/explorer/[network]/[chain]/layout.client";
 import type { TxDetail } from "@/lib/evm-explorer";
@@ -58,14 +59,16 @@ export function EvmTx({ network, txHash }: { network: string; txHash: string }) 
   const sym = c.nativeToken;
   // fresh txs exist on-chain seconds before the indexer ingests them — retry a
   // 404 for a short window before giving up (mirrors the pchain detail pages)
-  const { data: t, loading, error } = useEvmData<TxDetail>(c.chainId, `tx/${txHash}`, undefined, {
+  const { data: t, loading, error, retry } = useEvmData<TxDetail>(c.chainId, `tx/${txHash}`, undefined, {
     retry404Ms: 20_000,
   });
 
   return (
     <EvmShell network={network}>
       {loading && <DetailSkeleton label="Transaction" />}
-      {error && !t && <NotFound label="Transaction not found" id={txHash} />}
+      {/* only a real 404 is "not found" — an indexer outage says so */}
+      {error === "not found" && !t && <NotFound label="Transaction not found" id={txHash} />}
+      {error && error !== "not found" && !t && <FeedDown onRetry={retry} />}
       {t && (
         <div className="flex flex-col gap-10">
           <section className="flex flex-col gap-4">

--- a/components/explorer-v2/evm/EvmTxsList.tsx
+++ b/components/explorer-v2/evm/EvmTxsList.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { EvmShell } from "@/components/explorer-v2/EvmShell";
 import { Board, CellLabel, SectionHeader } from "@/components/explorer-v2/ui";
 import { ChartEmpty } from "@/components/explorer-v2/staking/bits";
-import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
+import { RANGE_DAYS, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import { formatNumber, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { formatEther } from "./format";
 import { MethodChip } from "./bits";
@@ -43,7 +43,6 @@ export function EvmTxsList({ network }: { network: string }) {
   // on the page clock
   const clock = useExplorerTimeRange();
   const range = RANGE_DAYS[clock];
-  const rangeLabel = RANGE_LABEL[clock];
   const { metrics, failed } = useChainMetrics(c.chainId, range, METRICS);
   const m = metrics ?? {};
 
@@ -112,7 +111,7 @@ export function EvmTxsList({ network }: { network: string }) {
       {/* the shape of the feed over time — absorbed from the old Stats tab */}
       <div className="mt-10 grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
         <ChartSection
-          label={`Transactions · ${rangeLabel}`}
+          label="Transactions"
           action={<OverlayKey label="avg tps" dashed />}
         >
           {metricSeries(m, range, "txCount", "avgTps").length ? (
@@ -130,7 +129,7 @@ export function EvmTxsList({ network }: { network: string }) {
           )}
         </ChartSection>
 
-        <ChartSection label={`Total Transactions · ${rangeLabel}`}>
+        <ChartSection label="Total Transactions">
           {metricSeries(m, range, "cumulativeTxCount").length ? (
             <DualChart
               data={metricSeries(m, range, "cumulativeTxCount")}

--- a/components/explorer-v2/evm/bits.tsx
+++ b/components/explorer-v2/evm/bits.tsx
@@ -82,3 +82,46 @@ export function GasFill({ used, limit }: { used: number; limit: number }) {
     </span>
   );
 }
+
+/* The honest failure plate: the feed didn't 404, it died (indexer outage,
+   gateway timeout). Shown wherever a list or detail would otherwise sit on
+   "Loading…" forever or claim emptiness it can't know. `compact` renders
+   as a row inside an existing Board; the default is a standalone plate. */
+export function FeedDown({
+  onRetry,
+  compact = false,
+  label = "The indexer isn't answering right now",
+}: {
+  onRetry: () => void;
+  compact?: boolean;
+  label?: string;
+}) {
+  const retryBtn = (
+    <button
+      onClick={onRetry}
+      className="inline-flex items-center border border-zinc-200 bg-white/80 px-3 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-900 transition-colors hover:border-zinc-900 hover:bg-zinc-900 hover:text-white dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-100 dark:hover:border-zinc-100 dark:hover:bg-zinc-100 dark:hover:text-zinc-900"
+    >
+      Retry
+    </button>
+  );
+  if (compact) {
+    return (
+      <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-4 md:px-6">
+        <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[#E6212F]">
+          {label}
+        </span>
+        {retryBtn}
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col items-center gap-5 border-b border-zinc-200 bg-white/80 px-6 py-16 text-center backdrop-blur-sm dark:border-zinc-800 dark:bg-zinc-950/80">
+      <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-[#E6212F]">{label}</p>
+      <p className="max-w-md text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+        The data service behind this page timed out. It usually recovers quickly; the page keeps
+        whatever it already loaded.
+      </p>
+      {retryBtn}
+    </div>
+  );
+}

--- a/components/explorer-v2/evm/hooks.ts
+++ b/components/explorer-v2/evm/hooks.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { evmApiPath } from "@/lib/evm-explorer";
 
 // Default client poll interval for "live" views (home, tx/block lists). Sits
@@ -25,13 +25,17 @@ export function useEvmData<T>(
      *  on-chain seconds before the indexer has ingested them */
     retry404Ms?: number;
   },
-): { data: T | null; loading: boolean; error: string | null } {
+): { data: T | null; loading: boolean; error: string | null; retry: () => void } {
   const key = chainId != null ? evmApiPath(chainId, resource, query) : "";
   const refreshMs = opts?.refreshMs ?? 0;
   const retry404Ms = opts?.retry404Ms ?? 0;
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // bumping the nonce re-runs the whole fetch effect — the "Retry" button
+  // for feeds that died on an upstream outage rather than a 404
+  const [nonce, setNonce] = useState(0);
+  const retry = useCallback(() => setNonce((n) => n + 1), []);
 
   useEffect(() => {
     if (!key) {
@@ -121,7 +125,7 @@ export function useEvmData<T>(
       controller.abort();
       if (timer) clearTimeout(timer);
     };
-  }, [key, refreshMs, retry404Ms]);
+  }, [key, refreshMs, retry404Ms, nonce]);
 
-  return { data, loading, error };
+  return { data, loading, error, retry };
 }

--- a/components/explorer-v2/evm/metric-charts.tsx
+++ b/components/explorer-v2/evm/metric-charts.tsx
@@ -11,7 +11,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { Board, SectionHeader } from "@/components/explorer-v2/ui";
+import { ChartBoard } from "@/components/explorer-v2/ui";
 import { TipPlate } from "@/components/explorer-v2/staking/bits";
 import { thin, windowSeries } from "@/components/explorer-v2/staking/data";
 
@@ -62,6 +62,50 @@ export function num(v: number | string | undefined): number | null {
   if (v === undefined) return null;
   const n = typeof v === "string" ? Number.parseFloat(v) : v;
   return Number.isFinite(n) ? n : null;
+}
+
+export interface WindowPair {
+  cur: number;
+  /** null when the series is too short to hold the previous window */
+  prev: number | null;
+}
+
+/* the clock's window vs the window before it — sums for volumes,
+   means for rates. Needs 2N points for a delta; degrades to cur-only. */
+export function windowPair(
+  points: { timestamp: number; value: number | string }[] | undefined,
+  n: number,
+  mode: "sum" | "avg",
+): WindowPair | null {
+  if (!points || points.length < Math.min(n, 2)) return null;
+  const sorted = [...points].sort((a, b) => a.timestamp - b.timestamp);
+  const vals = sorted.map((p) => num(p.value) ?? 0);
+  const take = (arr: number[]) =>
+    mode === "sum" ? arr.reduce((s, v) => s + v, 0) : arr.reduce((s, v) => s + v, 0) / arr.length;
+  const curSlice = vals.slice(-n);
+  if (!curSlice.length) return null;
+  const prevSlice = vals.slice(-2 * n, -n);
+  return {
+    cur: take(curSlice),
+    prev: prevSlice.length === n ? take(prevSlice) : null,
+  };
+}
+
+export function pctOf(p: WindowPair | null): number | null {
+  if (!p || p.prev === null || p.prev === 0) return null;
+  return ((p.cur - p.prev) / p.prev) * 100;
+}
+
+/* the move against the previous window, Etherscan's parenthetical */
+export function Delta({ value }: { value: number | null }) {
+  if (value === null) return null;
+  const up = value >= 0;
+  return (
+    <span className={up ? "text-emerald-600 dark:text-emerald-400" : "text-[#E6212F]"}>
+      {up ? "+" : ""}
+      {Math.abs(value) >= 100 ? value.toFixed(0) : value.toFixed(1)}% vs prev
+    </span>
+  );
 }
 
 /* one day on the chart: the headline series plus an optional overlay */
@@ -226,19 +270,23 @@ export function ChartSection({
   action,
   children,
   note,
+  href,
 }: {
   label: string;
   action?: React.ReactNode;
   children: React.ReactNode;
   note?: string;
+  /** the stat's detail page — the whole card becomes a door */
+  href?: string;
 }) {
   return (
-    <section className="flex flex-col gap-4">
-      <SectionHeader label={label} action={action} />
-      <Board divide={false} className="px-5 py-5 md:px-6">
+    <section className="flex min-w-0 flex-col gap-3">
+      <ChartBoard label={label} action={action} href={href}>
         {children}
-      </Board>
-      {note && <p className="font-mono text-[11px] text-zinc-400 dark:text-zinc-500">{note}</p>}
+      </ChartBoard>
+      {note && (
+        <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">{note}</p>
+      )}
     </section>
   );
 }

--- a/components/explorer-v2/network/NetworkIcm.tsx
+++ b/components/explorer-v2/network/NetworkIcm.tsx
@@ -22,11 +22,10 @@ import { NetworkShell } from "@/components/explorer-v2/network/NetworkShell";
 import {
   Board,
   BoardHeader,
+  ChartBoard,
   HashChip,
-  SectionHeader,
   StatCell,
   StatFigure,
-  StatStrip,
 } from "@/components/explorer-v2/ui";
 import { ChartEmpty, Stat, TipPlate } from "@/components/explorer-v2/staking/bits";
 import { thin } from "@/components/explorer-v2/staking/data";
@@ -38,12 +37,16 @@ import { useIcmStats } from "@/app/(home)/stats/interchain-messaging/_hooks/useI
 import { useIcttStats } from "@/app/(home)/stats/interchain-messaging/_hooks/useIcttStats";
 import { useIcmFlows } from "@/app/(home)/stats/interchain-messaging/_hooks/useIcmFlows";
 
-/* The network-scope ICM facet, rebuilt in the drafting grammar. The old
+/* The network-scope ICM facet, rebuilt in the gas-page grammar. The old
    port carried the /stats page's furniture wholesale — rounded ChartCard,
    the starfield flow sankey, shadcn pie charts, a chain-category filter.
-   All of that is gone: one clock-driven bar chart in the EvmStats idiom,
-   ledger boards for chains / routes / tokens (share bars instead of pies),
-   and a hairline table for transfers. Data feeds are unchanged. */
+   All of that is gone: a lead board headlines the totals, then every
+   instrument lives in a fully-outlined ChartBoard — one clock-driven bar
+   chart, ledger boards for chains / routes / tokens (share bars instead of
+   pies), and a hairline table for transfers. The page's time window is
+   stated once, on the lead board; charts that follow the clock drop the
+   range suffix, and only fixed / all-time windows carry their own label.
+   Data feeds are unchanged. */
 
 const SHELL_INTRO =
   "Every ICM message and token transfer across the network: volume, routes, and the chains doing the talking. Per-chain message feeds live on each chain's own ICM tab.";
@@ -158,6 +161,16 @@ function LedgerEmpty({ label }: { label: string }) {
     <p className="px-5 py-8 text-center font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-400 dark:text-zinc-500">
       {label}
     </p>
+  );
+}
+
+/* the action-slot qualifier chip — the page clock, an all-time tag, or a
+   count, in the quiet mono voice every board header shares */
+function Chip({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+      {children}
+    </span>
   );
 }
 
@@ -285,24 +298,36 @@ export function NetworkIcm() {
   } else {
     body = (
       <div className="flex flex-col gap-10">
-        <StatStrip cols={3}>
-          <StatCell label={`Total ICM · ${RANGE_LABEL[range]}`}>
-            <StatFigure value={totalICMMessages} />
-          </StatCell>
-          <StatCell label="Latest Day ICM">
-            <StatFigure value={dailyICM} suffix={`avg ${formatNumber(avgDailyICM)}`} />
-          </StatCell>
-          <StatCell label="ICTT Transfers">
-            <StatFigure value={totalICTTTransfers} suffix={`${icttPercentage}% ICM`} />
-          </StatCell>
-        </StatStrip>
+        {/* the lead board: the page's three headline totals, and the one
+            place the time window is named (the ICM figures follow it; the
+            ICTT count is an all-time reading and says so in its own sub) */}
+        <Board divide={false} className="border">
+          <BoardHeader
+            label="Interchain Messaging"
+            display
+            action={<Chip>Last {RANGE_LABEL[range]}</Chip>}
+          />
+          <div className="grid grid-cols-3 divide-x divide-zinc-200 dark:divide-zinc-800">
+            <StatCell label="Total ICM">
+              <StatFigure value={totalICMMessages} />
+            </StatCell>
+            <StatCell label="Latest Day ICM">
+              <StatFigure value={dailyICM} suffix={`avg ${formatNumber(avgDailyICM)}`} />
+            </StatCell>
+            <StatCell
+              label="ICTT Transfers"
+              sub={icttData ? `all-time · ${icttPercentage}% of ICM` : "all-time"}
+            >
+              <StatFigure value={totalICTTTransfers} />
+            </StatCell>
+          </div>
+        </Board>
 
-        {/* the pulse: daily message volume on the page clock */}
-        <section className="flex flex-col gap-4">
-          <SectionHeader label={`Messages · ${RANGE_LABEL[range]}`} />
-          <Board divide={false} className="px-5 py-5 md:px-6">
-            {volumeSeries.length ? (
-              <div className="h-44 text-zinc-900 dark:text-zinc-100">
+        {/* the pulse: daily message volume on the page clock (no range
+            suffix — the lead board's chip carries the window) */}
+        <ChartBoard label="Messages">
+          {volumeSeries.length ? (
+            <div className="h-44 text-zinc-900 dark:text-zinc-100">
                 <ResponsiveContainer width="100%" height="100%">
                   <ComposedChart data={volumeSeries} barCategoryGap="22%">
                     <XAxis dataKey="date" hide />
@@ -340,20 +365,17 @@ export function NetworkIcm() {
                   </ComposedChart>
                 </ResponsiveContainer>
               </div>
-            ) : (
-              <ChartEmpty failed={!!metrics} label={metrics ? "No ICM activity" : "Loading…"} />
-            )}
-          </Board>
-        </section>
+          ) : (
+            <ChartEmpty failed={!!metrics} label={metrics ? "No ICM activity" : "Loading…"} />
+          )}
+        </ChartBoard>
 
         {/* who talks, and to whom — the leaderboard and the route ledger
             (the old flow sankey, flattened into rows) */}
         <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-          <section className="flex min-w-0 flex-col gap-4">
-            <SectionHeader label={`Top Chains · ${RANGE_LABEL[range]}`} />
-            <Board divide={false}>
-              <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
-                {topChains.length === 0 && <LedgerSkeleton />}
+          <ChartBoard label="Top Chains" bodyClassName="p-0" className="min-w-0">
+            <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
+              {topChains.length === 0 && <LedgerSkeleton />}
                 {topChains.map((chain, i) => {
                   const catalog = catalogByName.get(chain.name);
                   return (
@@ -374,17 +396,16 @@ export function NetworkIcm() {
                         </>
                       }
                     />
-                  );
-                })}
-              </div>
-            </Board>
-          </section>
+                );
+              })}
+            </div>
+          </ChartBoard>
 
-          <section className="flex min-w-0 flex-col gap-4">
-            <SectionHeader label="Top Routes · 30 Days" />
-            <Board divide={false}>
-              <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
-                {flowLoading && <LedgerSkeleton />}
+          {/* fixed 30-day upstream window — the one ledger that keeps its
+              own label, since it doesn't follow the page clock */}
+          <ChartBoard label="Top Routes · 30 days" bodyClassName="p-0" className="min-w-0">
+            <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
+              {flowLoading && <LedgerSkeleton />}
                 {!flowLoading && flowError && (
                   <div className="flex flex-col items-center gap-4 px-5 py-8 text-center">
                     <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-400 dark:text-zinc-500">
@@ -415,28 +436,27 @@ export function NetworkIcm() {
                       </>
                     }
                   />
-                ))}
-              </div>
-            </Board>
-          </section>
+              ))}
+            </div>
+          </ChartBoard>
         </div>
 
-        {/* token transfers: the ICTT instrument panel */}
-        <section className="flex flex-col gap-4">
-          <SectionHeader label="Token Transfers · ICTT" />
-          {icttError && !icttData ? (
-            <Board divide={false}>
-              <div className="flex flex-col items-center gap-4 px-5 py-10 text-center">
-                <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-400 dark:text-zinc-500">
-                  ICTT feed unavailable
-                </p>
-                <RetryButton onClick={retryIctt}>Retry</RetryButton>
-              </div>
-            </Board>
-          ) : (
-            <Board divide={false}>
-              <BoardHeader label="All-Time" />
-              <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
+        {/* token transfers: the ICTT instrument panel. All-Time data, so it
+            carries its own qualifier chip instead of following the clock */}
+        {icttError && !icttData ? (
+          <Board divide={false} className="border">
+            <BoardHeader label="Token Transfers · ICTT" action={<Chip>All-Time</Chip>} />
+            <div className="flex flex-col items-center gap-4 px-5 py-10 text-center">
+              <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-400 dark:text-zinc-500">
+                ICTT feed unavailable
+              </p>
+              <RetryButton onClick={retryIctt}>Retry</RetryButton>
+            </div>
+          </Board>
+        ) : (
+          <Board divide={false} className="border">
+            <BoardHeader label="Token Transfers · ICTT" action={<Chip>All-Time</Chip>} />
+            <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
                 <Stat
                   label="Transfers"
                   sub={
@@ -462,21 +482,25 @@ export function NetworkIcm() {
                   label="Top Token"
                   sub={icttData ? `${icttData.overview.topToken.percentage}% of transfers` : undefined}
                 >
-                  {icttData ? icttData.overview.topToken.name : "…"}
-                </Stat>
-              </div>
-            </Board>
-          )}
-        </section>
+                {icttData ? icttData.overview.topToken.name : "…"}
+              </Stat>
+            </div>
+          </Board>
+        )}
 
-        {/* what moves, and along which corridors — the two old pies as ledgers */}
+        {/* what moves, and along which corridors — the two old pies as
+            ledgers. Both read the all-time ICTT feed, so each carries its
+            own All-Time chip rather than the page clock */}
         <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-          <section className="flex min-w-0 flex-col gap-4">
-            <SectionHeader label="Tokens by Transfers" />
-            <Board divide={false}>
-              <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
-                {!icttData && <LedgerSkeleton />}
-                {icttData && topTokens.length === 0 && <LedgerEmpty label="No token data" />}
+          <ChartBoard
+            label="Tokens by Transfers"
+            bodyClassName="p-0"
+            className="min-w-0"
+            action={<Chip>All-Time</Chip>}
+          >
+            <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
+              {!icttData && <LedgerSkeleton />}
+              {icttData && topTokens.length === 0 && <LedgerEmpty label="No token data" />}
                 {topTokens.map((token) => (
                   <LedgerRow
                     key={token.address || token.symbol}
@@ -493,17 +517,19 @@ export function NetworkIcm() {
                       </>
                     }
                   />
-                ))}
-              </div>
-            </Board>
-          </section>
+              ))}
+            </div>
+          </ChartBoard>
 
-          <section className="flex min-w-0 flex-col gap-4">
-            <SectionHeader label="Routes by Transfers" />
-            <Board divide={false}>
-              <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
-                {!icttData && <LedgerSkeleton />}
-                {icttData && icttRoutes.length === 0 && <LedgerEmpty label="No route data" />}
+          <ChartBoard
+            label="Routes by Transfers"
+            bodyClassName="p-0"
+            className="min-w-0"
+            action={<Chip>All-Time</Chip>}
+          >
+            <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
+              {!icttData && <LedgerSkeleton />}
+              {icttData && icttRoutes.length === 0 && <LedgerEmpty label="No route data" />}
                 {icttRoutes.map((route) => (
                   <LedgerRow
                     key={route.name}
@@ -515,26 +541,24 @@ export function NetworkIcm() {
                       </span>
                     }
                   />
-                ))}
-              </div>
-            </Board>
-          </section>
+              ))}
+            </div>
+          </ChartBoard>
         </div>
 
         {/* the raw ledger: per-contract transfer rows, paginated */}
-        <section className="flex flex-col gap-4">
-          <SectionHeader
-            label="Top Transfers"
-            action={
-              icttData?.totalCount ? (
-                <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-                  {icttData.transfers.length} of {icttData.totalCount.toLocaleString("en-US")}
-                </span>
-              ) : undefined
-            }
-          />
-          <Board divide={false} className="overflow-x-auto">
-            <table className="w-full min-w-[52rem] border-collapse">
+        <ChartBoard
+          label="Top Transfers"
+          bodyClassName="p-0 overflow-x-auto"
+          action={
+            icttData?.totalCount ? (
+              <Chip>
+                {icttData.transfers.length} of {icttData.totalCount.toLocaleString("en-US")}
+              </Chip>
+            ) : undefined
+          }
+        >
+          <table className="w-full min-w-[52rem] border-collapse">
               <thead>
                 <tr className="border-b border-zinc-200 text-left dark:border-zinc-800">
                   <th className={TH}>Route</th>
@@ -619,8 +643,7 @@ export function NetworkIcm() {
                 </RetryButton>
               </div>
             )}
-          </Board>
-        </section>
+        </ChartBoard>
       </div>
     );
   }

--- a/components/explorer-v2/network/NetworkValidators.tsx
+++ b/components/explorer-v2/network/NetworkValidators.tsx
@@ -9,9 +9,9 @@ import { AlertTriangle, ArrowRight, Search, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   Board,
-  SectionHeader,
+  BoardHeader,
+  ChartBoard,
   StatCell,
-  StatDash,
   StatFigure,
 } from "@/components/explorer-v2/ui";
 import { NetworkShell } from "@/components/explorer-v2/network/NetworkShell";
@@ -40,6 +40,17 @@ type SortDirection = "asc" | "desc";
 const TH =
   "px-5 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500 md:px-6";
 const TD = "px-5 py-3.5 text-[13px] md:px-6";
+
+/* the action-slot qualifier chip — a window tag or a count, in the quiet
+   mono voice every board header shares (this page has no clock; the one
+   window statement is the lead board's "Current set") */
+function Chip({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+      {children}
+    </span>
+  );
+}
 
 export function NetworkValidators() {
   const { resolvedTheme } = useTheme();
@@ -278,8 +289,9 @@ export function NetworkValidators() {
   if (loading) {
     content = (
       <div className="flex flex-col gap-10" role="status" aria-label="Loading validators">
-        <Board divide={false}>
-          <div className="grid grid-cols-2 divide-x divide-zinc-200 lg:grid-cols-4 dark:divide-zinc-800">
+        <Board divide={false} className="border">
+          <BoardHeader label="Validators" display action={<Chip>Current set</Chip>} />
+          <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
             {Array.from({ length: 4 }, (_, i) => (
               <div key={i} className="flex flex-col gap-2.5 px-5 py-5 md:px-6">
                 <span className="h-2.5 w-20 animate-pulse bg-zinc-100 dark:bg-zinc-900" />
@@ -314,16 +326,20 @@ export function NetworkValidators() {
   } else {
     content = (
       <div className="flex flex-col gap-10">
-        {/* headline metrics — the former hero, now a hairline stat strip */}
-        <Board divide={false}>
-          <div className="grid grid-cols-2 divide-x divide-zinc-200 lg:grid-cols-4 dark:divide-zinc-800">
+        {/* the lead board: the former hero's headline metrics, and the one
+            place the roster window is named. Nothing here follows a clock —
+            this is the live set as it stands, so the chip says "Current set"
+            rather than a time window */}
+        <Board divide={false} className="border">
+          <BoardHeader label="Validators" display action={<Chip>Current set</Chip>} />
+          <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
             <StatCell label="Chains">
               <StatFigure value={aggregatedStats.totalSubnets} />
             </StatCell>
             <StatCell label="Validators">
               <StatFigure value={aggregatedStats.totalNodes} />
             </StatCell>
-            <StatCell label="Up to date">
+            <StatCell label="Up to date" sub={minVersion ? `≥ ${minVersion}` : undefined}>
               <span className="font-mono text-xl tabular-nums tracking-tight text-zinc-900 sm:text-2xl md:text-[1.75rem] dark:text-zinc-50">
                 {upToDatePercentage.toFixed(1)}
                 <span className="ml-0.5 text-sm text-zinc-400 dark:text-zinc-500">%</span>
@@ -336,28 +352,32 @@ export function NetworkValidators() {
         </Board>
 
         {/* client-version spread across the whole network: the stacked
-            distribution bar carries the picture, the labels name it */}
-        <section className="flex flex-col gap-4">
-          <SectionHeader label="Client versions" />
-          <Board divide={false} className="flex flex-col gap-4 px-5 py-5 md:px-6">
-            <VersionBarChart
-              versionBreakdown={{ byClientVersion: totalVersionBreakdown }}
-              minVersion={minVersion}
-              totalNodes={aggregatedStats.totalNodes}
-              height="h-8"
-            />
-            <VersionBreakdownInline
-              versions={totalVersionBreakdown}
-              minVersion={minVersion}
-              limit={5}
-            />
-          </Board>
-        </section>
+            distribution bar carries the picture, the labels name it. The
+            green/gray split is measured against the selected target below,
+            so the header chip names that target */}
+        <ChartBoard
+          label="Client Versions"
+          bodyClassName="flex flex-col gap-4"
+          action={minVersion ? <Chip>target {minVersion}</Chip> : undefined}
+        >
+          <VersionBarChart
+            versionBreakdown={{ byClientVersion: totalVersionBreakdown }}
+            minVersion={minVersion}
+            totalNodes={aggregatedStats.totalNodes}
+            height="h-8"
+          />
+          <VersionBreakdownInline
+            versions={totalVersionBreakdown}
+            minVersion={minVersion}
+            limit={5}
+          />
+        </ChartBoard>
 
-        {/* the validator sets */}
+        {/* the validator sets. The search and target-version controls are
+            page-level furniture (target version also drives the client-version
+            board and the up-to-date stat above), so they lead; the table's
+            own ChartBoard names the section and carries the set count */}
         <section className="flex flex-col gap-4">
-          <SectionHeader label={`Validator sets · ${sortedData.length}`} />
-
           {/* search + target-version filter */}
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="relative w-full sm:max-w-sm">
@@ -407,7 +427,11 @@ export function NetworkValidators() {
             )}
           </div>
 
-          <Board divide={false} className="overflow-x-auto">
+          <ChartBoard
+            label="Validator Sets"
+            bodyClassName="p-0 overflow-x-auto"
+            action={<Chip>{sortedData.length} sets</Chip>}
+          >
             <table className="w-full min-w-[56rem] border-collapse">
               <thead>
                 <tr className="border-b border-zinc-200 text-left dark:border-zinc-800">
@@ -538,18 +562,17 @@ export function NetworkValidators() {
                 })}
               </tbody>
             </table>
-          </Board>
-
-          {hasMoreData && (
-            <div className="flex justify-center">
-              <button
-                onClick={handleLoadMore}
-                className="border border-zinc-200 bg-white/80 px-6 py-2.5 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-500 backdrop-blur-sm transition-colors hover:border-zinc-900 hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-400 dark:hover:border-zinc-100 dark:hover:text-zinc-100"
-              >
-                Load more · {sortedData.length - visibleCount} remaining
-              </button>
-            </div>
-          )}
+            {hasMoreData && (
+              <div className="flex justify-center border-t border-zinc-200 px-5 py-4 dark:border-zinc-800">
+                <button
+                  onClick={handleLoadMore}
+                  className="border border-zinc-200 bg-white/80 px-6 py-2.5 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-500 backdrop-blur-sm transition-colors hover:border-zinc-900 hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-400 dark:hover:border-zinc-100 dark:hover:text-zinc-100"
+                >
+                  Load more · {sortedData.length - visibleCount} remaining
+                </button>
+              </div>
+            )}
+          </ChartBoard>
         </section>
       </div>
     );

--- a/components/explorer-v2/staking/PrimaryStaking.tsx
+++ b/components/explorer-v2/staking/PrimaryStaking.tsx
@@ -14,9 +14,9 @@ import {
   YAxis,
 } from "recharts";
 import { cn } from "@/lib/utils";
-import { Board, BoardHeader, SectionHeader, StatDash } from "@/components/explorer-v2/ui";
+import { Board, BoardHeader, ChartBoard, StatCell, StatDash } from "@/components/explorer-v2/ui";
 import { ChartEmpty, Stat, TipPlate } from "./bits";
-import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
+import { RANGE_DAYS, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import {
   NANO,
   fmtCompact,
@@ -33,7 +33,9 @@ import {
    the network and what securing it pays. Split out of the old validators
    observatory: the set itself (nodes, uptime, versions) lives on the
    Validators tab; this page is the capital. Same grammar as the gas
-   market: a headline strip, then trend boards on one shared clock. */
+   market: lead with the answer (a dark statement panel — what staking
+   pays right now), then the capital strip, then outlined ChartBoards on
+   one shared clock. */
 
 const OWN_COLOR = "currentColor";
 const DELEGATED_COLOR = "#E6212F";
@@ -448,6 +450,30 @@ function LensToggle({ value, onChange }: { value: Lens; onChange: (v: Lens) => v
   );
 }
 
+/* a cell inside the dark statement panel — steel label, ink-white figure,
+   muted sub. The homepage pillar voice, same as the gas page's lead panel. */
+function StatementCell({
+  label,
+  sub,
+  children,
+}: {
+  label: string;
+  sub?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5 px-5 py-5 md:px-6 lg:first:pl-0">
+      <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
+        {label}
+      </span>
+      <span className="min-w-0 truncate font-mono text-xl tabular-nums tracking-tight text-[#EBF0FA] sm:text-2xl md:text-[1.75rem]">
+        {children}
+      </span>
+      {sub != null && <span className="text-xs tabular-nums text-[#A2AFB2]">{sub}</span>}
+    </div>
+  );
+}
+
 /* legend chips for the stacked stake chart */
 function StakeKey() {
   return (
@@ -467,10 +493,10 @@ export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: stri
   const { data: apy, failed: apyFailed } = useStakingApy();
   const { data: sdkValidators, failed: sdkFailed } = useSdkValidators();
 
-  // the page clock in the subnav — one window for every trend below
+  // the page clock in the subnav — one window for every trend below. The
+  // subnav states the window once, so chart titles drop the range suffix.
   const clock = useExplorerTimeRange();
   const range = RANGE_DAYS[clock];
-  const rangeLabel = RANGE_LABEL[clock];
 
   /* -------------------------------------------------------------- */
   /* headline figures                                                */
@@ -590,11 +616,70 @@ export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: stri
 
   return (
     <div className="flex flex-col gap-10">
-      {/* the capital securing the network, right now */}
+      {/* the answer first: what securing the network pays, in the homepage
+          pillar panels' voice (#1F1F1F board, EBF0FA lead over the E6212F
+          punch, steel spec labels) */}
+      <section className="flex flex-col gap-3">
+        <div className="flex flex-col gap-8 bg-[#1F1F1F] p-6 md:p-8">
+          <h3 className="v2-display text-3xl leading-[1.02] md:text-4xl">
+            <span className="block text-[#EBF0FA]">What securing the network</span>
+            <span className="block text-[#E6212F]">pays right now.</span>
+          </h3>
+          <div className="grid grid-cols-2 divide-x divide-y divide-white/10 border-t border-white/10 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0">
+            <StatementCell label="Max APY · Est">
+              {apy?.current ? (
+                <>
+                  {apy.current.maxAPY.toFixed(1)}
+                  <span className="ml-1 text-sm text-[#A2AFB2]">%</span>
+                </>
+              ) : (
+                "—"
+              )}
+            </StatementCell>
+            <StatementCell label="Min APY · Est">
+              {apy?.current ? (
+                <>
+                  {apy.current.minAPY.toFixed(1)}
+                  <span className="ml-1 text-sm text-[#A2AFB2]">%</span>
+                </>
+              ) : (
+                "—"
+              )}
+            </StatementCell>
+            <StatementCell label="Median Delegation Fee" sub="across the current set">
+              {medianFee !== null ? (
+                <>
+                  {medianFee.toFixed(0)}
+                  <span className="ml-1 text-sm text-[#A2AFB2]">%</span>
+                </>
+              ) : (
+                "—"
+              )}
+            </StatementCell>
+            <StatementCell label="Minted Per Day" sub="last full day">
+              {dailyRewards !== null ? (
+                <>
+                  {fmtCompact(dailyRewards)}
+                  <span className="ml-1.5 text-sm text-[#A2AFB2]">AVAX</span>
+                </>
+              ) : (
+                "—"
+              )}
+            </StatementCell>
+          </div>
+        </div>
+        <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+          Estimated annual yield at current conditions; the exact rate varies with stake duration
+          and the validator&apos;s delegation fee. Rewards are newly minted AVAX.
+        </p>
+      </section>
+
+      {/* the capital securing the network — the lead board */}
       <section className="flex flex-col gap-4">
-        <Board divide={false}>
+        <Board divide={false} className="border">
           <BoardHeader
             label="Primary Network Staking"
+            display
             action={
               <Link
                 href={validatorsHref}
@@ -605,7 +690,7 @@ export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: stri
               </Link>
             }
           />
-          <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
+          <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
             <Stat
               label="Total Staked"
               sub={
@@ -623,16 +708,12 @@ export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: stri
                 <StatDash />
               )}
             </Stat>
-            <Stat label="Staking APY · Est" sub="varies with duration and delegation fees">
-              {apy?.current ? (
-                <>
-                  {apy.current.minAPY.toFixed(1)}–{apy.current.maxAPY.toFixed(1)}
-                  <span className="ml-1 text-sm text-zinc-400 dark:text-zinc-500">%</span>
-                </>
-              ) : (
-                <StatDash />
-              )}
-            </Stat>
+            {/* the count is a door into the set itself */}
+            <StatCell label="Validators" href={validatorsHref} sub="current set">
+              <span className="min-w-0 truncate font-mono text-xl tabular-nums tracking-tight text-zinc-900 sm:text-2xl md:text-[1.75rem] dark:text-zinc-50">
+                {sdkValidators?.length ? sdkValidators.length.toLocaleString("en-US") : <StatDash />}
+              </span>
+            </StatCell>
             <Stat
               label="Delegators"
               sub={
@@ -644,7 +725,7 @@ export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: stri
               {delegators !== null ? delegators.toLocaleString("en-US") : <StatDash />}
             </Stat>
             <Stat
-              label="Rewards · All Time"
+              label="Rewards · All-Time"
               sub={dailyRewards !== null ? `≈ ${fmtCompact(dailyRewards)} AVAX/day` : undefined}
             >
               {cumulativeRewards !== null ? (
@@ -661,144 +742,121 @@ export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: stri
       </section>
 
       {/* the centerpiece: how the stake got here */}
-      <section className="flex flex-col gap-4">
-        <SectionHeader
-          label={`Total Stake · ${rangeLabel}`}
-          action={
-            <span className="hidden sm:block">
-              <StakeKey />
-            </span>
-          }
-        />
-        <Board divide={false} className="px-5 py-5 md:px-6">
-          {stakeSeries.length ? (
-            <TotalStakeChart data={stakeSeries} />
-          ) : (
-            <ChartEmpty failed={metricsFailed} />
-          )}
-        </Board>
-      </section>
+      <ChartBoard
+        label="Total Stake"
+        action={
+          <span className="hidden sm:block">
+            <StakeKey />
+          </span>
+        }
+      >
+        {stakeSeries.length ? (
+          <TotalStakeChart data={stakeSeries} />
+        ) : (
+          <ChartEmpty failed={metricsFailed} />
+        )}
+      </ChartBoard>
 
       {/* who delegates, and what staking pays */}
       <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-        <section className="flex flex-col gap-4">
-          <SectionHeader label={`Delegators · ${rangeLabel}`} />
-          <Board divide={false} className="px-5 py-5 md:px-6">
-            {delegatorSeries.length ? (
-              <AreaTrend
-                data={delegatorSeries}
-                format={(v) => Math.round(v).toLocaleString("en-US")}
-                unit="delegators"
-              />
-            ) : (
-              <ChartEmpty failed={metricsFailed} />
-            )}
-          </Board>
-        </section>
+        <ChartBoard label="Delegators">
+          {delegatorSeries.length ? (
+            <AreaTrend
+              data={delegatorSeries}
+              format={(v) => Math.round(v).toLocaleString("en-US")}
+              unit="delegators"
+            />
+          ) : (
+            <ChartEmpty failed={metricsFailed} />
+          )}
+        </ChartBoard>
 
-        <section className="flex flex-col gap-4">
-          <SectionHeader
-            label={`Staking APY · ${rangeLabel}`}
-            action={
-              <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
-                <span className="flex items-center gap-1.5">
-                  <span className="h-0.5 w-4 bg-zinc-900 dark:bg-zinc-100" /> max
-                </span>
-                <span className="flex items-center gap-1.5">
-                  <span className="h-0.5 w-4 border-b border-dashed border-[#A2AFB2]" /> min
-                </span>
+        <ChartBoard
+          label="Staking APY"
+          action={
+            <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
+              <span className="flex items-center gap-1.5">
+                <span className="h-0.5 w-4 bg-zinc-900 dark:bg-zinc-100" /> max
               </span>
-            }
-          />
-          <Board divide={false} className="px-5 py-5 md:px-6">
-            {apySeries.length ? <ApyChart data={apySeries} /> : <ChartEmpty failed={apyFailed} />}
-          </Board>
-        </section>
+              <span className="flex items-center gap-1.5">
+                <span className="h-0.5 w-4 border-b border-dashed border-[#A2AFB2]" /> min
+              </span>
+            </span>
+          }
+        >
+          {apySeries.length ? <ApyChart data={apySeries} /> : <ChartEmpty failed={apyFailed} />}
+        </ChartBoard>
       </div>
 
       {/* what securing the network mints */}
       <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-        <section className="flex flex-col gap-4">
-          <SectionHeader
-            label={`Daily Rewards · ${rangeLabel}`}
-            action={
-              <span className="flex shrink-0 items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
-                <span className="h-0.5 w-4 bg-[#E6212F]" /> 30d avg
-              </span>
-            }
-          />
-          <Board divide={false} className="px-5 py-5 md:px-6">
-            {dailyRewardSeries.length ? (
-              <RewardsBars data={dailyRewardSeries} />
-            ) : (
-              <ChartEmpty failed={metricsFailed} />
-            )}
-          </Board>
-        </section>
+        <ChartBoard
+          label="Daily Rewards"
+          action={
+            <span className="flex shrink-0 items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
+              <span className="h-0.5 w-4 bg-[#E6212F]" /> 30d avg
+            </span>
+          }
+        >
+          {dailyRewardSeries.length ? (
+            <RewardsBars data={dailyRewardSeries} />
+          ) : (
+            <ChartEmpty failed={metricsFailed} />
+          )}
+        </ChartBoard>
 
-        <section className="flex flex-col gap-4">
-          <SectionHeader label={`Cumulative Rewards · ${rangeLabel}`} />
-          <Board divide={false} className="px-5 py-5 md:px-6">
-            {cumulativeRewardSeries.length ? (
-              <AreaTrend data={cumulativeRewardSeries} format={fmtCompact} unit="AVAX" />
-            ) : (
-              <ChartEmpty failed={metricsFailed} />
-            )}
-          </Board>
-        </section>
+        <ChartBoard label="Cumulative Rewards">
+          {cumulativeRewardSeries.length ? (
+            <AreaTrend data={cumulativeRewardSeries} format={fmtCompact} unit="AVAX" />
+          ) : (
+            <ChartEmpty failed={metricsFailed} />
+          )}
+        </ChartBoard>
       </div>
 
-      {/* how the stake spreads across the current set */}
-      <section className="flex flex-col gap-4">
-        <SectionHeader label="Stake Distribution · Current Set" />
-        <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-          <div className="flex flex-col gap-4">
-            <SectionHeader
-              label={`Concentration by Rank · ${LENS_LABEL[lens].toLowerCase()}`}
-              action={<LensToggle value={lens} onChange={setLens} />}
-            />
-            <Board divide={false} className="px-5 py-5 md:px-6">
-              {concentration.length ? (
-                <ConcentrationChart
-                  data={thin(concentration, 300)}
-                  setSize={concentration.length}
-                />
-              ) : (
-                <ChartEmpty failed={sdkFailed} />
-              )}
-            </Board>
-            <p className="font-mono text-[11px] tabular-nums text-zinc-400 dark:text-zinc-500">
-              Bars: each validator&apos;s {LENS_LABEL[lens].toLowerCase()} by rank (right axis). Red
-              line: the cumulative share the top N hold (left axis)
-              {halfClub !== null && (
-                <> — the top {halfClub} together control half of it</>
-              )}
-              . The flatter the climb, the more evenly the network&apos;s security is spread.
-            </p>
-          </div>
-
-          <div className="flex flex-col gap-4">
-            <SectionHeader
-              label="Delegation Fees · Weighted by Stake"
-              action={
-                medianFee !== null ? (
-                  <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-                    median {medianFee.toFixed(0)}%
-                  </span>
-                ) : undefined
-              }
-            />
-            <Board divide={false} className="px-5 py-5 md:px-6">
-              {feeBuckets.length ? <FeeChart data={feeBuckets} /> : <ChartEmpty failed={sdkFailed} />}
-            </Board>
-            <p className="font-mono text-[11px] text-zinc-400 dark:text-zinc-500">
-              Red bars: own stake sitting at each fee (left axis) — where the capital actually
-              lives. Dashed line: validator count at that fee (right axis). The cut is what
-              delegating there costs.
-            </p>
-          </div>
+      {/* how the stake spreads across the current set — two snapshots of the
+          live set, each with its reading below (· current set is the honest
+          qualifier: these don't follow the page clock) */}
+      <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
+        <div className="flex flex-col gap-4">
+          <ChartBoard
+            label="Concentration by Rank · current set"
+            action={<LensToggle value={lens} onChange={setLens} />}
+          >
+            {concentration.length ? (
+              <ConcentrationChart data={thin(concentration, 300)} setSize={concentration.length} />
+            ) : (
+              <ChartEmpty failed={sdkFailed} />
+            )}
+          </ChartBoard>
+          <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+            Bars: each validator&apos;s {LENS_LABEL[lens].toLowerCase()} by rank (right axis). Red
+            line: the cumulative share the top N hold (left axis)
+            {halfClub !== null && <> — the top {halfClub} together control half of it</>}. The
+            flatter the climb, the more evenly the network&apos;s security is spread.
+          </p>
         </div>
-      </section>
+
+        <div className="flex flex-col gap-4">
+          <ChartBoard
+            label="Delegation Fees · current set"
+            action={
+              medianFee !== null ? (
+                <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                  median {medianFee.toFixed(0)}%
+                </span>
+              ) : undefined
+            }
+          >
+            {feeBuckets.length ? <FeeChart data={feeBuckets} /> : <ChartEmpty failed={sdkFailed} />}
+          </ChartBoard>
+          <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+            Red bars: own stake sitting at each fee (left axis) — where the capital actually lives.
+            Dashed line: validator count at that fee (right axis). The cut is what delegating there
+            costs.
+          </p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/explorer-v2/staking/PrimaryValidators.tsx
+++ b/components/explorer-v2/staking/PrimaryValidators.tsx
@@ -17,7 +17,7 @@ import {
   YAxis,
 } from "recharts";
 import { cn } from "@/lib/utils";
-import { Board, BoardHeader, SectionHeader, StatDash } from "@/components/explorer-v2/ui";
+import { Board, BoardHeader, ChartBoard, StatDash } from "@/components/explorer-v2/ui";
 import {
   VersionBarChart,
   VersionBreakdownInline,
@@ -45,7 +45,13 @@ import {
    observatory buried under five chart sections. The economics (stake
    trends, rewards, APY, distribution) moved to the Staking tab; what
    stays here is the machines: who validates, on what version, with what
-   uptime, and for how much longer. */
+   uptime, and for how much longer.
+
+   Same stats grammar as the gas market — outlined ChartBoards, mono titles
+   fused into the border, legends/toggles in the action slot — but
+   deliberately OFF the page clock: this is a roster plus all-time context,
+   not a windowed trend. So there is no range chip; each card states its own
+   basis instead (· current set, · 14d, · all-time). */
 
 const TH =
   "px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500 md:px-5";
@@ -404,9 +410,10 @@ export function PrimaryValidatorsContent({ stakingHref }: { stakingHref: string 
     <div className="flex flex-col gap-10">
       {/* the set at a glance */}
       <section className="flex flex-col gap-4">
-        <Board divide={false}>
+        <Board divide={false} className="border">
           <BoardHeader
             label="Primary Network Validators"
+            display
             action={
               <Link
                 href={stakingHref}
@@ -417,7 +424,7 @@ export function PrimaryValidatorsContent({ stakingHref }: { stakingHref: string 
               </Link>
             }
           />
-          <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
+          <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
             <Stat label="Validators">
               {sdkValidators ? sdkValidators.length.toLocaleString("en-US") : <StatDash />}
             </Stat>
@@ -464,15 +471,10 @@ export function PrimaryValidatorsContent({ stakingHref }: { stakingHref: string 
         </Board>
       </section>
 
-      {/* the roster itself — the page's reason to exist, so it comes first */}
+      {/* the roster itself — the page's reason to exist, so it comes first.
+          the live count rides in the card's action slot as a quiet qualifier
+          (rows / total while filtering) — no window chip, this IS the set */}
       <section className="flex flex-col gap-4">
-        <SectionHeader
-          label={`Validator Set${
-            merged.length
-              ? ` · ${q ? `${rows.length} / ${merged.length}` : merged.length.toLocaleString("en-US")}`
-              : ""
-          }`}
-        />
         <div className="relative w-full sm:max-w-sm">
           <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400 dark:text-zinc-500" />
           <input
@@ -500,7 +502,19 @@ export function PrimaryValidatorsContent({ stakingHref }: { stakingHref: string 
           )}
         </div>
 
-        <Board divide={false} className="overflow-x-auto">
+        <ChartBoard
+          label="Validator Set"
+          action={
+            merged.length ? (
+              <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                {q
+                  ? `${rows.length.toLocaleString("en-US")} / ${merged.length.toLocaleString("en-US")}`
+                  : `${merged.length.toLocaleString("en-US")} validators`}
+              </span>
+            ) : undefined
+          }
+          bodyClassName="p-0 overflow-x-auto"
+        >
           <table className="w-full min-w-[62rem] border-collapse">
             <thead>
               <tr className="border-b border-zinc-200 text-left dark:border-zinc-800">
@@ -616,7 +630,7 @@ export function PrimaryValidatorsContent({ stakingHref }: { stakingHref: string 
               )}
             </tbody>
           </table>
-        </Board>
+        </ChartBoard>
         {shown < rows.length && (
           <button
             onClick={() => setShown((s) => s + 50)}
@@ -628,91 +642,84 @@ export function PrimaryValidatorsContent({ stakingHref }: { stakingHref: string 
       </section>
 
       {/* what the fleet is running */}
-      <section className="flex flex-col gap-4">
-        <SectionHeader
-          label="Client Versions"
-          action={
-            availableVersions.length > 0 ? (
-              <label className="flex shrink-0 items-center gap-2">
-                <span className="font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
-                  Target
-                </span>
-                <select
-                  value={minVersion}
-                  onChange={(e) => setMinVersion(e.target.value)}
-                  className="border border-zinc-200 bg-white/80 px-2.5 py-1 font-mono text-[11px] uppercase tracking-[0.12em] text-zinc-700 outline-none transition-colors focus:border-zinc-900 dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-300 dark:focus:border-zinc-100"
-                >
-                  {availableVersions.map((version) => (
-                    <option key={version} value={version}>
-                      {version}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            ) : undefined
-          }
-        />
-        <Board divide={false} className="flex flex-col gap-4 px-5 py-5 md:px-6">
-          {versions && minVersion ? (
-            <>
-              <VersionBarChart
-                versionBreakdown={versions}
-                minVersion={minVersion}
-                totalNodes={totalNodes}
-                height="h-8"
-              />
-              <VersionBreakdownInline versions={versions.byClientVersion} minVersion={minVersion} limit={5} />
-              {versionStats && (
-                <p className="font-mono text-[11px] tabular-nums text-zinc-500 dark:text-zinc-400">
-                  {versionStats.stakePercentAbove.toFixed(1)}% of stake runs {minVersion} or newer
-                </p>
-              )}
-            </>
-          ) : (
-            <ChartEmpty failed={false} />
-          )}
-        </Board>
-      </section>
+      <ChartBoard
+        label="Client Versions"
+        action={
+          availableVersions.length > 0 ? (
+            <label className="flex shrink-0 items-center gap-2">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
+                Target
+              </span>
+              <select
+                value={minVersion}
+                onChange={(e) => setMinVersion(e.target.value)}
+                className="border border-zinc-200 bg-white/80 px-2.5 py-1 font-mono text-[11px] uppercase tracking-[0.12em] text-zinc-700 outline-none transition-colors focus:border-zinc-900 dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-300 dark:focus:border-zinc-100"
+              >
+                {availableVersions.map((version) => (
+                  <option key={version} value={version}>
+                    {version}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : undefined
+        }
+        bodyClassName="flex flex-col gap-4"
+      >
+        {versions && minVersion ? (
+          <>
+            <VersionBarChart
+              versionBreakdown={versions}
+              minVersion={minVersion}
+              totalNodes={totalNodes}
+              height="h-8"
+            />
+            <VersionBreakdownInline versions={versions.byClientVersion} minVersion={minVersion} limit={5} />
+            {versionStats && (
+              <p className="text-[13px] leading-relaxed tabular-nums text-zinc-500 dark:text-zinc-400">
+                {versionStats.stakePercentAbove.toFixed(1)}% of stake runs {minVersion} or newer
+              </p>
+            )}
+          </>
+        ) : (
+          <ChartEmpty failed={false} />
+        )}
+      </ChartBoard>
 
       {/* how the fleet is behaving */}
       <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-        <section className="flex flex-col gap-4">
-          <SectionHeader label="Block Miss Rate · 14d" />
-          <Board divide={false} className="px-5 py-5 md:px-6">
-            {missBuckets.length ? (
-              <BucketBars
-                data={missBuckets}
-                tint={(b) => (b.label === "0%" ? QUIET_BAR : b.label.startsWith("0–") ? QUIET_BAR : "#E6212F")}
-              />
-            ) : (
-              <ChartEmpty failed={false} />
-            )}
-          </Board>
-        </section>
+        <ChartBoard label="Block Miss Rate · 14d">
+          {missBuckets.length ? (
+            <BucketBars
+              data={missBuckets}
+              tint={(b) => (b.label === "0%" ? QUIET_BAR : b.label.startsWith("0–") ? QUIET_BAR : "#E6212F")}
+            />
+          ) : (
+            <ChartEmpty failed={false} />
+          )}
+        </ChartBoard>
 
-        <section className="flex flex-col gap-4">
-          <SectionHeader label="Time Remaining" />
-          <Board divide={false} className="px-5 py-5 md:px-6">
-            {daysLeftBuckets.length ? (
-              <BucketBars
-                data={daysLeftBuckets}
-                tint={(b) =>
-                  b.label === "< 7d" ? "#E6212F" : b.label === "7–30d" ? "#d97706" : QUIET_BAR
-                }
-              />
-            ) : (
-              <ChartEmpty failed={false} />
-            )}
-          </Board>
-        </section>
+        <ChartBoard label="Time Remaining · current set">
+          {daysLeftBuckets.length ? (
+            <BucketBars
+              data={daysLeftBuckets}
+              tint={(b) =>
+                b.label === "< 7d" ? "#E6212F" : b.label === "7–30d" ? "#d97706" : QUIET_BAR
+              }
+            />
+          ) : (
+            <ChartEmpty failed={false} />
+          )}
+        </ChartBoard>
       </div>
 
       {/* who is actually sealing the chain */}
       {topProducers.length > 0 && (
-        <section className="flex flex-col gap-4">
-          <SectionHeader label="Top Block Producers · 14d" />
-          <Board>
-            {topProducers.map((v, i) => (
+        <ChartBoard
+          label="Top Block Producers · 14d"
+          bodyClassName="p-0 divide-y divide-zinc-200 dark:divide-zinc-800"
+        >
+          {topProducers.map((v, i) => (
               <div
                 key={v.node_id}
                 className="grid grid-cols-[2rem_minmax(0,14rem)_1fr_auto] items-center gap-4 px-5 py-2.5 md:px-6"
@@ -740,13 +747,12 @@ export function PrimaryValidatorsContent({ stakingHref }: { stakingHref: string 
                 </span>
               </div>
             ))}
-          </Board>
-        </section>
+        </ChartBoard>
       )}
 
       {/* how the set got to this size */}
-      <section className="flex flex-col gap-4">
-        <SectionHeader
+      <div className="flex flex-col gap-4">
+        <ChartBoard
           label="Validator Count · All Time"
           action={
             <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
@@ -758,19 +764,18 @@ export function PrimaryValidatorsContent({ stakingHref }: { stakingHref: string 
               </span>
             </span>
           }
-        />
-        <Board divide={false} className="px-5 py-5 md:px-6">
+        >
           {countSeries.length ? (
             <CountChart data={countSeries} />
           ) : (
             <ChartEmpty failed={metricsFailed} />
           )}
-        </Board>
-        <p className="font-mono text-[11px] text-zinc-400 dark:text-zinc-500">
+        </ChartBoard>
+        <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
           After the Etna upgrade (ACP-77), L1 validators no longer stake on the Primary Network —
           the blue line counts every validator seat across the ecosystem since then.
         </p>
-      </section>
+      </div>
     </div>
   );
 }

--- a/components/explorer/ExplorerLayout.tsx
+++ b/components/explorer/ExplorerLayout.tsx
@@ -305,7 +305,8 @@ export function ExplorerLayout({
           out of the header box below: a sticky element only pins while its
           parent is on screen, so its parent must be this full-height column,
           not a box that ends with the header. */}
-      <div className="sticky top-[calc(var(--fd-banner-height,0px)+3.5rem)] z-[45]">
+      {/* z-[35]: above page content, under the global navbar's menus (z-40) */}
+      <div className="sticky top-[calc(var(--fd-banner-height,0px)+3.5rem)] z-[35]">
         <div className="mx-auto w-full max-w-[90rem] px-5 md:px-6">
           <ExplorerSubnav
             network={network}

--- a/components/explorer/IcmMessagesPage.tsx
+++ b/components/explorer/IcmMessagesPage.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
 import { useRouter } from "next/navigation";
 import {
   Bar,
@@ -19,18 +18,23 @@ import {
   formatTimeAgo,
   getChainFromBlockchainId,
 } from "@/components/explorer/L1ExplorerPage";
-import { Board, BoardHeader, SectionHeader, StatDash } from "@/components/explorer-v2/ui";
+import { Board, BoardHeader, ChartBoard, StatDash } from "@/components/explorer-v2/ui";
+import { Stat, TipPlate } from "@/components/explorer-v2/staking/bits";
+import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import { ChainChip } from "@/components/stats/ChainChip";
 import { buildTxUrl } from "@/utils/eip3091";
 import { formatTokenValue } from "@/utils/formatTokenValue";
 import l1ChainsData from "@/constants/l1-chains.json";
 import type { L1Chain } from "@/types/stats";
 
-/* The chain's ICM tab: what the chain SAYS and what it HEARS. The stats
-   half comes from the ClickHouse ICM history (daily sent/received, the
-   routes and who's on the other end); the feed half is the live message
-   stream off the recent block window. The network-wide observatory keeps
-   the ecosystem lens. */
+/* The chain's ICM tab in the gas page's grammar: what the chain SAYS and
+   what it HEARS, on the page clock. The lead board states the window
+   once; the daily chart and route ledger follow it (the chart floors at
+   a week — a one-bar day chart says nothing — and labels that one
+   exception). The stats half comes from the ClickHouse ICM history, the
+   feed half is the live message stream off the recent block window. The
+   network-wide observatory keeps the ecosystem lens; the daily chart
+   doors into it. */
 
 interface IcmTx {
   hash: string;
@@ -66,7 +70,6 @@ interface Route {
 }
 
 const POLL_MS = 15_000;
-const WINDOW_DAYS = 30;
 
 const RECEIVED_COLOR = "#A2AFB2";
 const SENT_COLOR = "#E6212F";
@@ -77,13 +80,16 @@ function fmtCount(v: number): string {
   return v.toLocaleString("en-US");
 }
 
-/* per-chain daily sent/received off the ICM history */
-function useIcmSeries(chainId: string): { days: IcmDay[] | null; failed: boolean } {
+/* per-chain daily sent/received off the ICM history, fetched wide enough
+   for the clock and windowed client-side */
+function useIcmSeries(chainId: string, windowDays: number): { days: IcmDay[] | null; failed: boolean } {
   const [days, setDays] = useState<IcmDay[] | null>(null);
   const [failed, setFailed] = useState(false);
+  const timeRange = windowDays <= 30 ? "30d" : windowDays <= 90 ? "90d" : "1y";
   useEffect(() => {
     let cancelled = false;
-    fetch(`/api/chain-stats/${chainId}?metrics=icmMessages&timeRange=30d`)
+    setDays(null);
+    fetch(`/api/chain-stats/${chainId}?metrics=icmMessages&timeRange=${timeRange}`)
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
       .then((data: { icmMessages?: { data?: IcmDay[] } }) => {
         if (cancelled) return;
@@ -97,18 +103,19 @@ function useIcmSeries(chainId: string): { days: IcmDay[] | null; failed: boolean
     return () => {
       cancelled = true;
     };
-  }, [chainId]);
+  }, [chainId, timeRange]);
   return { days, failed };
 }
 
 /* who this chain talks to, split by direction, plus the network total
-   for the share figure */
-function useIcmRoutes(chainId: string): { routes: Route[] | null; networkTotal: number } {
+   for the share figure — the flow feed takes the clock's window directly */
+function useIcmRoutes(chainId: string, windowDays: number): { routes: Route[] | null; networkTotal: number } {
   const [routes, setRoutes] = useState<Route[] | null>(null);
   const [networkTotal, setNetworkTotal] = useState(0);
   useEffect(() => {
     let cancelled = false;
-    fetch(`/api/icm-flow?days=${WINDOW_DAYS}`)
+    setRoutes(null);
+    fetch(`/api/icm-flow?days=${windowDays}`)
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
       .then((data: { flows?: IcmFlow[]; totalMessages?: number }) => {
         if (cancelled) return;
@@ -142,42 +149,8 @@ function useIcmRoutes(chainId: string): { routes: Route[] | null; networkTotal: 
     return () => {
       cancelled = true;
     };
-  }, [chainId]);
+  }, [chainId, windowDays]);
   return { routes, networkTotal };
-}
-
-function Tip({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="border border-zinc-200 bg-white px-2.5 py-1.5 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
-      {children}
-    </div>
-  );
-}
-
-function StripCell({
-  label,
-  sub,
-  children,
-}: {
-  label: string;
-  sub?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex flex-col gap-1.5 px-5 py-5 md:px-6">
-      <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500 dark:text-zinc-400">
-        {label}
-      </span>
-      <span className="min-w-0 truncate font-mono text-xl tabular-nums tracking-tight text-zinc-900 sm:text-2xl md:text-[1.75rem] dark:text-zinc-50">
-        {children}
-      </span>
-      {sub && (
-        <span className="truncate font-mono text-[11px] tabular-nums text-zinc-400 dark:text-zinc-500">
-          {sub}
-        </span>
-      )}
-    </div>
-  );
 }
 
 /* daily received/sent stacked — steel is what arrived, red is what left */
@@ -186,7 +159,14 @@ function DailyChart({ days }: { days: IcmDay[] }) {
     <div className="h-48">
       <ResponsiveContainer width="100%" height="100%">
         <ComposedChart data={days} barCategoryGap="22%">
-          <XAxis dataKey="date" hide />
+          <XAxis
+            dataKey="date"
+            tickLine={false}
+            axisLine={false}
+            tick={{ fontSize: 10, fill: "#a1a1aa", fontFamily: "monospace" }}
+            minTickGap={48}
+            interval="preserveStartEnd"
+          />
           <YAxis hide domain={[0, "dataMax"]} />
           <RechartsTooltip
             cursor={{ fill: "rgba(161,161,170,0.08)" }}
@@ -194,7 +174,7 @@ function DailyChart({ days }: { days: IcmDay[] }) {
               if (!active || !payload?.[0]) return null;
               const d = payload[0].payload as IcmDay;
               return (
-                <Tip>
+                <TipPlate>
                   <p className="text-[10px] text-zinc-500">{d.date}</p>
                   <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
                     {d.incomingCount.toLocaleString()} received
@@ -202,7 +182,7 @@ function DailyChart({ days }: { days: IcmDay[] }) {
                   <p className="text-[10px] tabular-nums text-zinc-500">
                     {d.outgoingCount.toLocaleString()} sent
                   </p>
-                </Tip>
+                </TipPlate>
               );
             }}
           />
@@ -254,8 +234,15 @@ export function IcmMessagesPage({
   const { buildApiUrl } = useExplorer();
   const [messages, setMessages] = useState<IcmTx[] | null>(null);
 
-  const { days, failed: seriesFailed } = useIcmSeries(chainId);
-  const { routes, networkTotal } = useIcmRoutes(chainId);
+  // the page clock in the subnav — the totals, chart, and routes ride it;
+  // the daily chart floors at a week (one bar says nothing) and labels it
+  const clock = useExplorerTimeRange();
+  const rangeDays = RANGE_DAYS[clock];
+  const rangeLabel = RANGE_LABEL[clock];
+  const chartDays = Math.max(7, rangeDays);
+
+  const { days, failed: seriesFailed } = useIcmSeries(chainId, rangeDays);
+  const { routes, networkTotal } = useIcmRoutes(chainId, rangeDays);
 
   useEffect(() => {
     let cancelled = false;
@@ -278,14 +265,19 @@ export function IcmMessagesPage({
     };
   }, [chainId, buildApiUrl]);
 
-  /* headline figures off the daily history */
+  // the fetched series is wider than the clock on sub-fetch windows —
+  // slice the window for the totals and the chart's floored window
+  const windowed = useMemo(() => (days ? days.slice(-rangeDays) : null), [days, rangeDays]);
+  const chartSeries = useMemo(() => (days ? days.slice(-chartDays) : null), [days, chartDays]);
+
+  /* headline figures off the windowed daily history */
   const totals = useMemo(() => {
-    if (!days?.length) return null;
-    const received = days.reduce((s, d) => s + d.incomingCount, 0);
-    const sent = days.reduce((s, d) => s + d.outgoingCount, 0);
-    const latest = days[days.length - 1];
-    return { received, sent, latest, avg: received / days.length };
-  }, [days]);
+    if (!windowed?.length) return null;
+    const received = windowed.reduce((s, d) => s + d.incomingCount, 0);
+    const sent = windowed.reduce((s, d) => s + d.outgoingCount, 0);
+    const latest = windowed[windowed.length - 1];
+    return { received, sent, latest, avg: received / windowed.length };
+  }, [windowed]);
 
   // share must come from ONE counting basis: the flow table counts each
   // routed message once, so both sides of the ratio use it — mixing in the
@@ -304,77 +296,68 @@ export function IcmMessagesPage({
 
   return (
     <div className="mx-auto flex w-full max-w-[90rem] flex-col gap-10 px-5 pb-16 pt-2 md:px-6">
-      {/* the chain's ICM ledger, 30 complete days */}
-      <section className="flex flex-col gap-4">
-        <Board divide={false}>
-          <BoardHeader
-            label="Interchain Messaging"
-            action={
-              <Link
-                href="/explorer/mainnet/icm"
-                className="group flex shrink-0 items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 transition-colors hover:text-zinc-900 dark:text-zinc-500 dark:hover:text-zinc-100"
-              >
-                Network-wide observatory
-                <ArrowRight className="h-3 w-3 transition-all group-hover:translate-x-0.5 group-hover:text-[#E6212F]" />
-              </Link>
-            }
-          />
-          <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
-            <StripCell
-              label="Messages · 30d"
-              sub={share !== null ? `${share.toFixed(1)}% of all routed messages` : undefined}
-            >
-              {totals ? fmtCount(totals.received + totals.sent) : seriesFailed ? <StatDash /> : "…"}
-            </StripCell>
-            <StripCell
-              label="Received / Sent"
-              sub="received on-chain · sent outward"
-            >
-              {totals ? (
-                <>
-                  {fmtCount(totals.received)}
-                  <span className="mx-1.5 text-sm text-zinc-400 dark:text-zinc-500">/</span>
-                  {fmtCount(totals.sent)}
-                </>
-              ) : (
-                <StatDash />
-              )}
-            </StripCell>
-            <StripCell
-              label="Partner Chains"
-              sub={routes?.length ? `busiest: ${routes[0].name}` : undefined}
-            >
-              {routes ? routes.length : <StatDash />}
-            </StripCell>
-            <StripCell
-              label="Latest Day"
-              sub={totals ? `avg ${fmtCount(Math.round(totals.avg))}/day` : undefined}
-            >
-              {totals?.latest ? fmtCount(totals.latest.incomingCount) : <StatDash />}
-            </StripCell>
-          </div>
-        </Board>
-      </section>
+      {/* the chain's ICM ledger — the window is stated once, up here */}
+      <Board divide={false} className="border">
+        <BoardHeader
+          label="Interchain Messaging"
+          display
+          action={
+            <span className="shrink-0 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
+              Last {rangeLabel}
+            </span>
+          }
+        />
+        <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
+          <Stat
+            label="Messages"
+            sub={share !== null ? `${share.toFixed(1)}% of all routed messages` : undefined}
+          >
+            {totals ? fmtCount(totals.received + totals.sent) : seriesFailed ? <StatDash /> : "…"}
+          </Stat>
+          <Stat label="Received / Sent" sub="received on-chain · sent outward">
+            {totals ? (
+              <>
+                {fmtCount(totals.received)}
+                <span className="mx-1.5 text-sm text-zinc-400 dark:text-zinc-500">/</span>
+                {fmtCount(totals.sent)}
+              </>
+            ) : (
+              <StatDash />
+            )}
+          </Stat>
+          <Stat label="Partner Chains" sub={routes?.length ? `busiest: ${routes[0].name}` : undefined}>
+            {routes ? routes.length : <StatDash />}
+          </Stat>
+          {/* the one cell that doesn't follow the clock, labeled */}
+          <Stat
+            label="Latest Day"
+            sub={totals ? `avg ${fmtCount(Math.round(totals.avg))}/day` : undefined}
+          >
+            {totals?.latest ? fmtCount(totals.latest.incomingCount) : <StatDash />}
+          </Stat>
+        </div>
+      </Board>
 
       <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-        {/* the cadence */}
-        <section className="flex flex-col gap-4">
-          <SectionHeader label="Daily Messages · 30 days" action={<DirectionKey />} />
-          <Board divide={false} className="px-5 py-5 md:px-6">
-            {days?.length ? (
-              <DailyChart days={days} />
-            ) : (
-              <p className="flex h-48 items-center justify-center font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-400 dark:text-zinc-500">
-                {seriesFailed ? "No ICM history for this chain" : "Loading history…"}
-              </p>
-            )}
-          </Board>
-        </section>
+        {/* the cadence — doors into the network-wide observatory */}
+        <ChartBoard
+          label={rangeDays < 7 ? "Daily Messages · 7 days" : "Daily Messages"}
+          action={<DirectionKey />}
+          href="/explorer/mainnet/icm"
+          className="min-w-0"
+        >
+          {chartSeries?.length ? (
+            <DailyChart days={chartSeries} />
+          ) : (
+            <p className="flex h-48 items-center justify-center font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-400 dark:text-zinc-500">
+              {seriesFailed ? "No ICM history for this chain" : "Loading history…"}
+            </p>
+          )}
+        </ChartBoard>
 
         {/* who's on the other end */}
-        <section className="flex flex-col gap-4">
-          <SectionHeader label="Routes · 30 days" />
-          <Board>
+        <ChartBoard label="Routes" bodyClassName="p-0" className="min-w-0">
+          <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {routes === null &&
               Array.from({ length: 6 }).map((_, i) => (
                 <div key={i} className="flex items-center justify-between px-5 py-3.5 md:px-6">
@@ -429,35 +412,31 @@ export function IcmMessagesPage({
                 </div>
               );
             })}
-          </Board>
-        </section>
+          </div>
+        </ChartBoard>
       </div>
 
-      {/* the stream itself */}
-      <section className="flex flex-col gap-4">
-        <SectionHeader label="Live Messages" action={<LiveTag />} />
-
+      {/* the stream itself — live, so it wears the dot, not a window */}
+      <ChartBoard label="Live Messages" action={<LiveTag />} bodyClassName="p-0">
         {messages === null && (
-          <Board>
+          <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {Array.from({ length: 6 }).map((_, i) => (
               <div key={i} className="flex items-center justify-between px-5 py-4 md:px-6">
                 <div className="h-3 w-48 animate-pulse bg-zinc-100 dark:bg-zinc-900" />
                 <div className="h-3 w-16 animate-pulse bg-zinc-100 dark:bg-zinc-900" />
               </div>
             ))}
-          </Board>
+          </div>
         )}
 
         {messages !== null && messages.length === 0 && (
-          <Board divide={false} className="px-6 py-14 text-center">
-            <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-zinc-400 dark:text-zinc-500">
-              No ICM messages in the recent block window
-            </p>
-          </Board>
+          <p className="px-6 py-14 text-center font-mono text-[11px] uppercase tracking-[0.22em] text-zinc-400 dark:text-zinc-500">
+            No ICM messages in the recent block window
+          </p>
         )}
 
         {messages !== null && messages.length > 0 && (
-          <Board>
+          <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {messages.map((tx, index) => {
               const sourceChain = tx.sourceBlockchainId
                 ? getChainFromBlockchainId(tx.sourceBlockchainId)
@@ -508,9 +487,9 @@ export function IcmMessagesPage({
                 </div>
               );
             })}
-          </Board>
+          </div>
         )}
-      </section>
+      </ChartBoard>
     </div>
   );
 }

--- a/lib/explorer-clickhouse.ts
+++ b/lib/explorer-clickhouse.ts
@@ -496,10 +496,19 @@ const TOPIC_1155_SINGLE = "c3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7
 const TOPIC_1155_BATCH = "4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb";
 
 const CCHAIN_EVM_ID = 43114;
-// ~80M logs in the window — give the classification room to run
+// ~80M logs in a fortnight — give the classification room to run
 const CCHAIN_ACTIVITY_TIMEOUT_MS = 60_000;
 
-function sqlCchainClassified(): string {
+/** the page-clock windows the activity chart serves; 90 is the ceiling —
+ *  the per-tx classification over raw_logs spills to disk past a month
+ *  and a full year quadruples the spill for no extra story */
+export type CchainActivityDays = 7 | 30 | 90;
+
+function sqlCchainClassified(days: CchainActivityDays): string {
+  // GROUP BY (day, tx) must hold every tx key in the window at once; the
+  // box caps a query at ~9.3 GiB, which the 32-byte hashes blow past a
+  // month. cityHash64 shrinks the key 4x and external_group_by lets the
+  // rest spill to disk (~10s at 90d, fine behind the 15-minute cache).
   return `
     SELECT
       day,
@@ -509,7 +518,7 @@ function sqlCchainClassified(): string {
     FROM (
       SELECT
         toDate(block_time) AS day,
-        transaction_hash,
+        cityHash64(transaction_hash) AS tx,
         max(multiIf(
           topic0 IN (unhex('${TOPIC_SWAP_V2}'), unhex('${TOPIC_SWAP_V3}'), unhex('${TOPIC_SWAP_LB}')), 3,
           topic0 = unhex('${TOPIC_TRANSFER}') AND topic3 IS NOT NULL, 2,
@@ -519,69 +528,90 @@ function sqlCchainClassified(): string {
         )) AS cls
       FROM raw_logs
       WHERE chain_id = ${CCHAIN_EVM_ID}
-        AND block_time >= toDate(now() - INTERVAL ${DAILY_WINDOW_DAYS} DAY)
-      GROUP BY day, transaction_hash
+        AND block_time >= toDate(now() - INTERVAL ${days} DAY)
+      GROUP BY day, tx
     )
     GROUP BY day
     ORDER BY day
+    SETTINGS max_bytes_before_external_group_by = 3000000000
     FORMAT JSONEachRow
   `;
 }
 
-function sqlCchainDailyTotals(): string {
+function sqlCchainDailyTotals(days: CchainActivityDays): string {
   return `
     SELECT toDate(block_time) AS day, toString(count()) AS total
     FROM evm_txs
     WHERE chain_id = ${CCHAIN_EVM_ID}
-      AND block_time >= toDate(now() - INTERVAL ${DAILY_WINDOW_DAYS} DAY)
+      AND block_time >= toDate(now() - INTERVAL ${days} DAY)
     GROUP BY day
     ORDER BY day
     FORMAT JSONEachRow
   `;
 }
 
-let cchainActivityCache: { data: CchainActivityPoint[]; fetchedAt: number } | null = null;
+const cchainActivityCache = new Map<
+  CchainActivityDays,
+  { data: CchainActivityPoint[]; fetchedAt: number }
+>();
+const cchainActivityInFlight = new Map<
+  CchainActivityDays,
+  Promise<CchainActivityPoint[] | null>
+>();
 
 /**
- * Last-14-day C-Chain activity split by on-chain behavior (DeFi swaps /
- * NFT transfers / token transfers / everything else), padded to exactly
- * 14 points. Mainnet only — that's the chain the log archive covers.
+ * C-Chain activity for the page clock's window, split by on-chain behavior
+ * (DeFi swaps / NFT transfers / token transfers / everything else), padded
+ * to exactly `days` points. Mainnet only — that's the chain the log
+ * archive covers. Cached per window; concurrent first-hits share one query
+ * (the 90d classification takes ~10s cold).
  */
-export async function getCchainDailyActivity(): Promise<CchainActivityPoint[] | null> {
-  if (cchainActivityCache && Date.now() - cchainActivityCache.fetchedAt < DAILY_TTL_MS) {
-    return cchainActivityCache.data;
+export async function getCchainDailyActivity(
+  days: CchainActivityDays = 7,
+): Promise<CchainActivityPoint[] | null> {
+  const cached = cchainActivityCache.get(days);
+  if (cached && Date.now() - cached.fetchedAt < DAILY_TTL_MS) {
+    return cached.data;
   }
+  const inFlight = cchainActivityInFlight.get(days);
+  if (inFlight) return inFlight;
 
-  try {
-    const [classified, totals] = await Promise.all([
-      clickhouseFetch<{ day: string; defi: string; nft: string; tokens: string }>(
-        sqlCchainClassified(),
-        CCHAIN_ACTIVITY_TIMEOUT_MS,
-      ),
-      clickhouseFetch<{ day: string; total: string }>(sqlCchainDailyTotals(), QUERY_TIMEOUT_MS),
-    ]);
-    const classifiedByDay = new Map(classified.map((r) => [r.day, r]));
-    const totalsByDay = new Map(totals.map((r) => [r.day, Number(r.total) || 0]));
-    const data = buildPastDates().map((iso) => {
-      const c = classifiedByDay.get(iso);
-      const defi = Number(c?.defi) || 0;
-      const nft = Number(c?.nft) || 0;
-      const tokens = Number(c?.tokens) || 0;
-      const total = totalsByDay.get(iso) ?? 0;
-      return {
-        date: formatDayLabel(iso),
-        defi,
-        nft,
-        tokens,
-        other: Math.max(0, total - defi - nft - tokens),
-      };
-    });
-    cchainActivityCache = { data, fetchedAt: Date.now() };
-    return data;
-  } catch (err) {
-    console.error('[explorer-clickhouse] cchain activity query failed:', err);
-    return cchainActivityCache?.data ?? null;
-  }
+  const run = (async () => {
+    try {
+      const [classified, totals] = await Promise.all([
+        clickhouseFetch<{ day: string; defi: string; nft: string; tokens: string }>(
+          sqlCchainClassified(days),
+          CCHAIN_ACTIVITY_TIMEOUT_MS,
+        ),
+        clickhouseFetch<{ day: string; total: string }>(sqlCchainDailyTotals(days), QUERY_TIMEOUT_MS),
+      ]);
+      const classifiedByDay = new Map(classified.map((r) => [r.day, r]));
+      const totalsByDay = new Map(totals.map((r) => [r.day, Number(r.total) || 0]));
+      const data = buildPastDates(days).map((iso) => {
+        const c = classifiedByDay.get(iso);
+        const defi = Number(c?.defi) || 0;
+        const nft = Number(c?.nft) || 0;
+        const tokens = Number(c?.tokens) || 0;
+        const total = totalsByDay.get(iso) ?? 0;
+        return {
+          date: formatDayLabel(iso),
+          defi,
+          nft,
+          tokens,
+          other: Math.max(0, total - defi - nft - tokens),
+        };
+      });
+      cchainActivityCache.set(days, { data, fetchedAt: Date.now() });
+      return data;
+    } catch (err) {
+      console.error('[explorer-clickhouse] cchain activity query failed:', err);
+      return cchainActivityCache.get(days)?.data ?? null;
+    } finally {
+      cchainActivityInFlight.delete(days);
+    }
+  })();
+  cchainActivityInFlight.set(days, run);
+  return run;
 }
 
 // --- Gas market (per-chain fee history + top consumers) -------------------


### PR DESCRIPTION
## What

Follow-up to #4366. The gas page's styling is now the de facto standard for stats surfaces; this propagates it to the remaining four pages, plus a z-order fix for the sticky subnav.

### Gas grammar propagation
- **Shared**: `ChartSection` (metric-charts) now renders `ChartBoard` — every chart gets the outlined, title-fused card with optional door `href`. `windowPair`/`pctOf`/`Delta` moved into metric-charts for reuse (EvmOverviewStats imports them).
- **/stats/network-metrics** (EvmStats): "Latest Day" strip → `Network Stats` lead board on the page clock with `% vs prev` deltas (fetches 2× the window); all chart titles drop their `· {range}` suffixes (the window is stated once, on the board header); the ICM chart is a whole-card door into the observatory.
- **/explorer/mainnet/icm** (NetworkIcm): lead board with `Last {window}` chip; ledgers/table framed as ChartBoards; only exceptions labeled (`Top Routes · 30 days` fixed upstream, `All-Time` chips on the ICTT family).
- **c-chain/accounts** (EvmAccounts): readings board on the clock with deltas; leaderboards framed, the year-clock clamp stated as `90 days · longest computed`.
- **c-chain/staking** (PrimaryStaking): leads with the dark statement panel — *"What securing the network pays right now."* (APY range, median delegation fee, AVAX minted/day); Validators count doors into the set; distribution notes converted from 11px mono to readable sans.
- **c-chain/txs** inherited the card grammar via the shared ChartSection.

### Subnav z-order fix
The sticky explorer subnav sat at `z-45`, above `#nd-nav` (`z-40`), so open navbar menus rendered *behind* the rail. Page-level sticky bars are `z-30` (the old `z-40` comment was stale), so the rail drops to `z-35`.

## Verification
- `tsc --noEmit` clean
- Headless probes on all five pages: lead boards, window chips, delta chips, outlined frames, dark panel, zero client errors
- Menu-over-subnav verified by hit-testing the open nav menu inside the pinned subnav band