### PR TITLE
fix(explorer): hold usd figures until the price feed settles

### DIFF
--- a/components/explorer-v2/evm/EvmHome.tsx
+++ b/components/explorer-v2/evm/EvmHome.tsx
@@ -27,22 +27,33 @@ interface PriceData {
   marketCap: number;
 }
 
-function usePrice(chainId: string | number | undefined): PriceData | null {
-  const [price, setPrice] = useState<PriceData | null>(null);
+function usePrice(chainId: string | number | undefined): {
+  price: PriceData | null;
+  /** the fetch resolved — distinguishes "loading" from "token isn't listed",
+   *  so USD-or-native cells can hold instead of flipping units */
+  settled: boolean;
+} {
+  const [state, setState] = useState<{ price: PriceData | null; settled: boolean }>({
+    price: null,
+    settled: false,
+  });
   useEffect(() => {
     if (chainId == null) return;
     let cancelled = false;
+    setState({ price: null, settled: false });
     fetch(`/api/explorer/${chainId}?priceOnly=true`)
       .then((res) => (res.ok ? res.json() : null))
       .then((data: { price?: PriceData } | null) => {
-        if (!cancelled && data?.price) setPrice(data.price);
+        if (!cancelled) setState({ price: data?.price ?? null, settled: true });
       })
-      .catch(() => {});
+      .catch(() => {
+        if (!cancelled) setState({ price: null, settled: true });
+      });
     return () => {
       cancelled = true;
     };
   }, [chainId]);
-  return price;
+  return state;
 }
 
 /* wei (decimal string) → the tx list's value column, adaptive precision */
@@ -90,7 +101,7 @@ export function EvmHome({ network }: { network: string }) {
   const s = stats.data;
   const blockList = blocks.data?.blocks ?? [];
   const txList = txs.data?.transactions ?? [];
-  const price = usePrice(c.chainId);
+  const { price, settled: priceSettled } = usePrice(c.chainId);
   const isCchain = String(c.chainId) === "43114";
 
   // Cadence figures from the freshest slice of Ash's blocks feed: the list
@@ -154,6 +165,7 @@ export function EvmHome({ network }: { network: string }) {
               base={base}
               symbol={sym}
               usdPrice={price?.price ?? null}
+              usdSettled={priceSettled}
               liveCells={[
                 ...(price
                   ? [

--- a/components/explorer-v2/evm/EvmOverviewStats.tsx
+++ b/components/explorer-v2/evm/EvmOverviewStats.tsx
@@ -67,6 +67,7 @@ export function EvmOverviewStats({
   base,
   symbol = "AVAX",
   usdPrice,
+  usdSettled = true,
   liveCells = [],
 }: {
   chainId: string;
@@ -74,6 +75,9 @@ export function EvmOverviewStats({
   symbol?: string;
   /** native token USD price when the token is listed; fees stay native without it */
   usdPrice: number | null;
+  /** the price fetch resolved — USD-or-native cells hold until then so a
+   *  late price never flips an already-painted native figure to dollars */
+  usdSettled?: boolean;
   /** the live figures (price, block time, latest block …) — same small
    *  cells, first row of the grid */
   liveCells?: LiveCell[];
@@ -190,7 +194,14 @@ export function EvmOverviewStats({
           `Avg Tx Fee`,
           `${base}/gas`,
           derived.avgFee,
-          (v) => (usdPrice !== null ? `$${(v * usdPrice).toFixed(4)}` : `${v.toFixed(5)} ${symbol}`),
+          // USD when listed, native once the price feed has SETTLED without
+          // one — never native-then-dollars as the price straggles in
+          (v) =>
+            usdPrice !== null
+              ? `$${(v * usdPrice).toFixed(4)}`
+              : usdSettled
+                ? `${v.toFixed(5)} ${symbol}`
+                : "…",
           usdPrice !== null && derived.avgFee ? `${derived.avgFee.cur.toFixed(5)} ${symbol}` : undefined,
         )}
         {cell(`Avg Gas Price`, `${base}/gas/base-fee`, win("avgGasPrice", "avg"), (v) =>

--- a/components/explorer/GasMarketPage.tsx
+++ b/components/explorer/GasMarketPage.tsx
@@ -132,22 +132,34 @@ export function useFeeHistory(rpcUrl: string | undefined): FeeSnapshot {
 }
 
 /* native token USD price, one fetch — the explorer route caches CoinGecko */
-export function useTokenUsd(evmChainId: number): number | null {
-  const [usd, setUsd] = useState<number | null>(null);
+/* the chain's USD price via the legacy explorer route's priceOnly mode
+   (server-cached, much lighter than the full payload). `settled` separates
+   "still loading" from "token isn't listed" — the cost panel holds its
+   figures on the former and only falls back to native units on the
+   latter, so a price that arrives late never flips an already-painted
+   number from AVAX to dollars. */
+export function useTokenUsd(evmChainId: number): { usd: number | null; settled: boolean } {
+  const [state, setState] = useState<{ usd: number | null; settled: boolean }>({
+    usd: null,
+    settled: false,
+  });
   useEffect(() => {
     if (!Number.isFinite(evmChainId)) return;
     let cancelled = false;
-    fetch(`/api/explorer/${evmChainId}`)
+    setState({ usd: null, settled: false });
+    fetch(`/api/explorer/${evmChainId}?priceOnly=true`)
       .then((res) => (res.ok ? res.json() : null))
       .then((data: { price?: { price?: number } } | null) => {
-        if (!cancelled && data?.price?.price) setUsd(data.price.price);
+        if (!cancelled) setState({ usd: data?.price?.price ?? null, settled: true });
       })
-      .catch(() => {});
+      .catch(() => {
+        if (!cancelled) setState({ usd: null, settled: true });
+      });
     return () => {
       cancelled = true;
     };
   }, [evmChainId]);
-  return usd;
+  return state;
 }
 
 /* the page clock's window, in the vocabulary the gas-history feed accepts —
@@ -797,7 +809,7 @@ export function GasMarketContent({ catalog, base }: { catalog: L1Chain; base: st
   const symbol = catalog.networkToken?.symbol ?? "";
   const unit = nanoUnit(symbol);
   const fee = useFeeHistory(catalog.rpcUrl);
-  const usd = useTokenUsd(evmChainId);
+  const { usd, settled: usdSettled } = useTokenUsd(evmChainId);
 
   // the page-level clock in the subnav drives the demand window; calling
   // the hook unconditionally registers this page as a consumer, which is
@@ -899,8 +911,16 @@ export function GasMarketContent({ catalog, base }: { catalog: L1Chain; base: st
                     {a.label}
                   </span>
                   <span className="min-w-0 truncate font-mono text-xl tabular-nums tracking-tight text-[#EBF0FA] sm:text-2xl md:text-[1.75rem]">
+                    {/* hold the figure until the price feed settles — painting
+                        native and flipping to dollars a beat later reads as a
+                        glitch. Native is the fallback for unlisted tokens only. */}
                     {costWei !== null && usd !== null ? (
                       fmtUsd((costWei / 1e18) * usd)
+                    ) : costWei !== null && !usdSettled ? (
+                      <span
+                        className="inline-block h-[1.05em] w-24 animate-pulse bg-white/10 align-middle"
+                        aria-label="Loading price"
+                      />
                     ) : costWei !== null ? (
                       `${fmtNative(costWei)} ${symbol}`
                     ) : (


### PR DESCRIPTION
The gas page's dark cost panel painted native AVAX figures the moment fee data landed, then flipped them to dollars when the CoinGecko price arrived a beat later — reads as a glitch (Owen's report).

- `useTokenUsd` now returns `{usd, settled}` — distinguishing *price still loading* from *token isn't listed* — and rides the light `priceOnly` mode instead of the full explorer payload.
- The panel holds each figure behind a quiet shimmer until it can paint the FINAL value; native units are now strictly the unlisted-token fallback, never an intermediate state.
- Same rule on the chain overview's Avg Tx Fee cell via an optional `usdSettled` prop.

Verified headlessly with the price response artificially delayed 4s: sequence is dash → shimmer → $ figure, no native intermediate; and with a stubbed unlisted token: settles to native correctly.