### PR TITLE
feat(explorer): staking metric sheets — the gas treatment for the staking page

### DIFF
--- a/app/(home)/explorer/[network]/[chain]/staking/[metric]/page.client.tsx
+++ b/app/(home)/explorer/[network]/[chain]/staking/[metric]/page.client.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { ExplorerLayout } from "@/components/explorer/ExplorerLayout";
+import { StakingMetricContent } from "@/components/explorer-v2/staking/StakingMetricPage";
+import type { StakingMetricKey } from "@/components/explorer-v2/staking/staking-metrics";
+import { useChainContext } from "../../layout.client";
+
+/* A staking metric's detail sheet, mounted inside the chain's own chrome —
+   same shell idiom as the gas sheets. */
+export function ChainStakingMetricPageClient({
+  chainSlug,
+  network,
+  metric,
+}: {
+  chainSlug: string;
+  network: string;
+  metric: StakingMetricKey;
+}) {
+  const chain = useChainContext();
+
+  return (
+    <ExplorerLayout
+      chainId={chain.chainId}
+      chainName={chain.chainName}
+      chainSlug={chain.chainSlug}
+      themeColor={chain.themeColor}
+      chainLogoURI={chain.chainLogoURI}
+      website={chain.website}
+      socials={chain.socials}
+      rpcUrl={chain.rpcUrl}
+      // the sheet carries its own title and breadcrumb; the chain identity
+      // stays in the subnav's switcher
+      hideHeader
+    >
+      <div className="mx-auto flex w-full max-w-[90rem] flex-col gap-10 px-5 pb-16 pt-8 md:px-6">
+        <StakingMetricContent
+          base={`/explorer/${network}/${chainSlug}/staking`}
+          network={network}
+          metric={metric}
+        />
+      </div>
+    </ExplorerLayout>
+  );
+}

--- a/app/(home)/explorer/[network]/[chain]/staking/[metric]/page.tsx
+++ b/app/(home)/explorer/[network]/[chain]/staking/[metric]/page.tsx
@@ -1,0 +1,31 @@
+import { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
+import {
+  STAKING_METRICS,
+  isStakingMetricKey,
+} from "@/components/explorer-v2/staking/staking-metrics";
+import { ChainStakingMetricPageClient } from "./page.client";
+
+interface StakingMetricPageProps {
+  params: Promise<{ network: string; chain: string; metric: string }>;
+}
+
+export async function generateMetadata({ params }: StakingMetricPageProps): Promise<Metadata> {
+  const { metric } = await params;
+  const def = isStakingMetricKey(metric) ? STAKING_METRICS[metric] : undefined;
+  return {
+    title: `${def?.title ?? "Staking"} | Avalanche Explorer`,
+    description: def
+      ? `Primary Network ${def.title.toLowerCase()}: ${def.blurb}`
+      : "Primary Network staking detail.",
+  };
+}
+
+/* Same guard as the staking tab: this is a Primary Network instrument,
+   carried by the C-Chain. */
+export default async function ChainStakingMetricPage({ params }: StakingMetricPageProps) {
+  const { network, chain, metric } = await params;
+  if (chain !== "c-chain") redirect(`/explorer/${network}/${chain}/validators`);
+  if (!isStakingMetricKey(metric)) notFound();
+  return <ChainStakingMetricPageClient chainSlug={chain} network={network} metric={metric} />;
+}

--- a/app/(home)/explorer/[network]/[chain]/staking/page.client.tsx
+++ b/app/(home)/explorer/[network]/[chain]/staking/page.client.tsx
@@ -21,7 +21,10 @@ export function ChainStakingPageClient({ chainSlug }: { chainSlug: string }) {
       rpcUrl={chain.rpcUrl}
     >
       <div className="mx-auto flex w-full max-w-[90rem] flex-col gap-10 px-5 pb-16 pt-2 md:px-6">
-        <PrimaryStakingContent validatorsHref={`/explorer/mainnet/${chainSlug}/validators`} />
+        <PrimaryStakingContent
+          validatorsHref={`/explorer/mainnet/${chainSlug}/validators`}
+          base={`/explorer/mainnet/${chainSlug}/staking`}
+        />
       </div>
     </ExplorerLayout>
   );

--- a/app/(home)/explorer/[network]/p-chain/staking/[metric]/page.client.tsx
+++ b/app/(home)/explorer/[network]/p-chain/staking/[metric]/page.client.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
+import { StakingMetricContent } from "@/components/explorer-v2/staking/StakingMetricPage";
+import type { StakingMetricKey } from "@/components/explorer-v2/staking/staking-metrics";
+
+/* A staking metric's detail sheet in the P-Chain's own chrome — same
+   shell the staking tab it opens from uses. */
+export function PchainStakingMetricPageClient({
+  network,
+  metric,
+}: {
+  network: string;
+  metric: StakingMetricKey;
+}) {
+  return (
+    <ExplorerShell chain="p-chain" network={network}>
+      <StakingMetricContent
+        base={`/explorer/${network}/p-chain/staking`}
+        network={network}
+        metric={metric}
+      />
+    </ExplorerShell>
+  );
+}

--- a/app/(home)/explorer/[network]/p-chain/staking/[metric]/page.client.tsx
+++ b/app/(home)/explorer/[network]/p-chain/staking/[metric]/page.client.tsx
@@ -14,7 +14,9 @@ export function PchainStakingMetricPageClient({
   metric: StakingMetricKey;
 }) {
   return (
-    <ExplorerShell chain="p-chain" network={network}>
+    // the sheet carries its own title and breadcrumb — the chain identity
+    // header and search stay off, per the metric-sheet doctrine
+    <ExplorerShell chain="p-chain" network={network} hideHeader>
       <StakingMetricContent
         base={`/explorer/${network}/p-chain/staking`}
         network={network}

--- a/app/(home)/explorer/[network]/p-chain/staking/[metric]/page.tsx
+++ b/app/(home)/explorer/[network]/p-chain/staking/[metric]/page.tsx
@@ -1,0 +1,33 @@
+import { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
+import { getExplorerChain } from "@/lib/pchain-explorer";
+import {
+  STAKING_METRICS,
+  isStakingMetricKey,
+} from "@/components/explorer-v2/staking/staking-metrics";
+import { PchainStakingMetricPageClient } from "./page.client";
+
+interface PageProps {
+  params: Promise<{ network: string; metric: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { metric } = await params;
+  const def = isStakingMetricKey(metric) ? STAKING_METRICS[metric] : undefined;
+  return {
+    title: `${def?.title ?? "Staking"} | Avalanche Explorer`,
+    description: def
+      ? `Primary Network ${def.title.toLowerCase()}: ${def.blurb}`
+      : "Primary Network staking detail.",
+  };
+}
+
+/* Same guard as the P-Chain staking tab: mainnet only. */
+export default async function PchainStakingMetricPage({ params }: PageProps) {
+  const { network, metric } = await params;
+  const c = getExplorerChain("p-chain");
+  if (!c || !c.networks.includes(network)) notFound();
+  if (network !== "mainnet") redirect(`/explorer/${network}/p-chain/validators`);
+  if (!isStakingMetricKey(metric)) notFound();
+  return <PchainStakingMetricPageClient network={network} metric={metric} />;
+}

--- a/app/api/chain-stats/[chainId]/route.ts
+++ b/app/api/chain-stats/[chainId]/route.ts
@@ -79,33 +79,47 @@ async function fetchMetricsApi(
   fetchAllPages: boolean
 ): Promise<{ value: number; timestamp: number }[]> {
   const dedicatedEvmChainId = resolveDedicatedMetricsChain(chainId);
-  const baseUrl = dedicatedEvmChainId ? DEDICATED_STATS_BASE_URL : METRICS_API_URL;
   const resolvedChainId = dedicatedEvmChainId
     ? dedicatedEvmChainId
     : chainId === 'all' ? 'mainnet' : chainId;
-  const allResults: { value: number; timestamp: number }[] = [];
-  let pageToken: string | undefined;
 
-  do {
-    const url = new URL(`${baseUrl}/v2/chains/${resolvedChainId}/metrics/${metric}`);
-    url.searchParams.set('timeInterval', timeInterval);
-    url.searchParams.set('startTimestamp', String(startTimestamp));
-    url.searchParams.set('endTimestamp', String(endTimestamp));
-    url.searchParams.set('pageSize', String(pageSize));
-    if (pageToken) url.searchParams.set('pageToken', pageToken);
+  const fetchPages = async (baseUrl: string): Promise<{ value: number; timestamp: number }[]> => {
+    const allResults: { value: number; timestamp: number }[] = [];
+    let pageToken: string | undefined;
+    do {
+      const url = new URL(`${baseUrl}/v2/chains/${resolvedChainId}/metrics/${metric}`);
+      url.searchParams.set('timeInterval', timeInterval);
+      url.searchParams.set('startTimestamp', String(startTimestamp));
+      url.searchParams.set('endTimestamp', String(endTimestamp));
+      url.searchParams.set('pageSize', String(pageSize));
+      if (pageToken) url.searchParams.set('pageToken', pageToken);
 
-    const res = await fetchWithTimeout(url.toString());
-    if (!res.ok) throw new Error(`metrics-api ${res.status}: ${res.statusText}`);
-    const data = await res.json();
+      const res = await fetchWithTimeout(url.toString());
+      if (!res.ok) throw new Error(`metrics-api ${res.status}: ${res.statusText}`);
+      const data = await res.json();
 
-    if (data.results && Array.isArray(data.results)) {
-      allResults.push(...data.results);
+      if (data.results && Array.isArray(data.results)) {
+        allResults.push(...data.results);
+      }
+
+      pageToken = data.nextPageToken || undefined;
+    } while (fetchAllPages && pageToken);
+    return allResults;
+  };
+
+  const results = await fetchPages(dedicatedEvmChainId ? DEDICATED_STATS_BASE_URL : METRICS_API_URL!);
+  // the dedicated source doesn't compute every metric (cumulativeAddresses
+  // comes back as `results: null` for the C-Chain) — fall back to the shared
+  // gateway rather than losing the chart. Chains the gateway doesn't know
+  // simply return empty again, which is where we already were.
+  if (results.length === 0 && dedicatedEvmChainId && METRICS_API_URL) {
+    try {
+      return await fetchPages(METRICS_API_URL);
+    } catch {
+      return results;
     }
-
-    pageToken = data.nextPageToken || undefined;
-  } while (fetchAllPages && pageToken);
-
-  return allResults;
+  }
+  return results;
 }
 
 async function getTimeSeriesData(

--- a/app/api/pchain-activity/[network]/route.ts
+++ b/app/api/pchain-activity/[network]/route.ts
@@ -1,18 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getPchainStakingSeries } from "@/lib/explorer-clickhouse";
+import { getPchainStakingSeries, type PchainStakingDays } from "@/lib/explorer-clickhouse";
 
-// Staking money-flow for the P-Chain overview: AVAX rewards paid per day
-// (last 30 days, parsed from the reward-UTXO archive) and stake unlocking
-// per day (next 30 days, from the validator/delegator snapshots). The
+// Staking money-flow for the P-Chain overview and the staking detail
+// sheets: AVAX rewards paid per day (the past ?days, parsed from the
+// reward-UTXO archive) and stake unlocking per day (the next ?days, from
+// the validator/delegator snapshots). ?days=30|90|365, default 30. The
 // indexer API doesn't expose aggregates yet, so this reads the same
-// ClickHouse box directly — read-only user, cached 15 minutes.
+// ClickHouse box directly — read-only user, cached 15 minutes per window.
+
+const WINDOWS: PchainStakingDays[] = [30, 90, 365];
 
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ network: string }> },
 ) {
   const { network } = await params;
-  const series = await getPchainStakingSeries(network);
+  const raw = Number(req.nextUrl.searchParams.get("days") ?? 30);
+  const days = (WINDOWS.includes(raw as PchainStakingDays) ? raw : 30) as PchainStakingDays;
+  const series = await getPchainStakingSeries(network, days);
   if (series === null) {
     return NextResponse.json({ error: "no staking data" }, { status: 404 });
   }

--- a/components/explorer-v2/ExplorerShell.tsx
+++ b/components/explorer-v2/ExplorerShell.tsx
@@ -306,12 +306,17 @@ export function ExplorerShell({
   chain,
   network,
   aside,
+  hideHeader = false,
   children,
 }: {
   chain: string;
   network: string;
   /** Optional right-hand companion for the title row (e.g. a live figure). */
   aside?: React.ReactNode;
+  /** Metric detail sheets carry their own title and breadcrumb — they skip
+   *  the chain identity header and search, keeping only the subnav spine.
+   *  Same contract as ExplorerLayout's hideHeader. */
+  hideHeader?: boolean;
   children: React.ReactNode;
 }) {
   const c = getExplorerChain(chain) ?? EXPLORER_CHAINS["p-chain"];
@@ -327,25 +332,27 @@ export function ExplorerShell({
         {/* load sequence, as on the homepage/solutions: header rises first,
             the page body follows. Rise wraps the <header> from OUTSIDE so its
             div never becomes a `header > div` (the global navbar padding hack). */}
-        <Rise delay={0.05}>
-          <header className="flex flex-col gap-6 pb-10">
-            {/* title row. pl-0!/pr-0! override the global `header > div` navbar
-                padding hack (global.css) that otherwise pushes it in by 3rem. */}
-            <div className="flex flex-wrap items-end justify-between gap-x-6 gap-y-4 pl-0! pr-0!">
-              <div className="flex flex-col gap-2.5">
-                <p className="font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-zinc-500 dark:text-zinc-400">
-                  Avalanche Primary Network
-                </p>
-                <h1 className="v2-display -ml-[0.055em] text-[clamp(1.85rem,4.5vw,3.25rem)] leading-[0.95] text-zinc-900 dark:text-zinc-50">
-                  {c.title}<span className="text-[#E6212F]">.</span>
-                </h1>
+        {!hideHeader && (
+          <Rise delay={0.05}>
+            <header className="flex flex-col gap-6 pb-10">
+              {/* title row. pl-0!/pr-0! override the global `header > div` navbar
+                  padding hack (global.css) that otherwise pushes it in by 3rem. */}
+              <div className="flex flex-wrap items-end justify-between gap-x-6 gap-y-4 pl-0! pr-0!">
+                <div className="flex flex-col gap-2.5">
+                  <p className="font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-zinc-500 dark:text-zinc-400">
+                    Avalanche Primary Network
+                  </p>
+                  <h1 className="v2-display -ml-[0.055em] text-[clamp(1.85rem,4.5vw,3.25rem)] leading-[0.95] text-zinc-900 dark:text-zinc-50">
+                    {c.title}<span className="text-[#E6212F]">.</span>
+                  </h1>
+                </div>
+                {aside}
               </div>
-              {aside}
-            </div>
-            {/* search — its own full-width row */}
-            <SearchBox chain={chain} network={network} />
-          </header>
-        </Rise>
+              {/* search — its own full-width row */}
+              <SearchBox chain={chain} network={network} />
+            </header>
+          </Rise>
+        )}
         <Rise delay={0.14}>{children}</Rise>
       </div>
     </main>

--- a/components/explorer-v2/evm/EvmAccounts.tsx
+++ b/components/explorer-v2/evm/EvmAccounts.tsx
@@ -17,6 +17,7 @@ import {
   OverlayKey,
   fmtCompact,
   metricSeries,
+  weekFloor,
   num,
   pctOf,
   useChainMetrics,
@@ -243,7 +244,7 @@ export function EvmAccounts({ network }: { network: string }) {
         {/* the population over time */}
         <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
           <ChartSection
-            label="Active Addresses"
+            label={`Active Addresses${weekFloor(range)}`}
             action={<OverlayKey label="senders" />}
           >
             {metricSeries(m, range, "activeAddresses", "activeSenders").length ? (
@@ -259,7 +260,7 @@ export function EvmAccounts({ network }: { network: string }) {
             )}
           </ChartSection>
 
-          <ChartSection label="Total Addresses">
+          <ChartSection label={`Total Addresses${weekFloor(range)}`}>
             {metricSeries(m, range, "cumulativeAddresses").length ? (
               <DualChart
                 data={metricSeries(m, range, "cumulativeAddresses")}
@@ -274,7 +275,7 @@ export function EvmAccounts({ network }: { network: string }) {
         </div>
 
         <ChartSection
-          label="Contracts Deployed"
+          label={`Contracts Deployed${weekFloor(range)}`}
           action={<OverlayKey label="deployers" dashed />}
         >
           {metricSeries(m, range, "contracts", "deployers").length ? (

--- a/components/explorer-v2/evm/EvmStats.tsx
+++ b/components/explorer-v2/evm/EvmStats.tsx
@@ -24,6 +24,7 @@ import {
   metricSeries,
   pctOf,
   useChainMetrics,
+  weekFloor,
   windowPair,
   type DualPoint,
   type IcmPoint,
@@ -78,7 +79,7 @@ export function EvmStats({
     return thin(
       windowSeries(
         [...pts].sort((a, b) => a.timestamp - b.timestamp),
-        range,
+        Math.max(7, range),
       ),
       200,
     );
@@ -178,7 +179,7 @@ export function EvmStats({
           {/* who's here */}
           <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
             <ChartSection
-              label="Active Addresses"
+              label={`Active Addresses${weekFloor(range)}`}
               action={<OverlayKey label="senders" />}
             >
               {series("activeAddresses", "activeSenders").length ? (
@@ -195,7 +196,7 @@ export function EvmStats({
             </ChartSection>
 
             <ChartSection
-              label="Transactions"
+              label={`Transactions${weekFloor(range)}`}
               action={<OverlayKey label="avg tps" dashed />}
             >
               {series("txCount", "avgTps").length ? (
@@ -216,7 +217,7 @@ export function EvmStats({
 
           {/* the long arc */}
           <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-            <ChartSection label="Total Addresses">
+            <ChartSection label={`Total Addresses${weekFloor(range)}`}>
               {series("cumulativeAddresses").length ? (
                 <DualChart
                   data={series("cumulativeAddresses")}
@@ -229,7 +230,7 @@ export function EvmStats({
               )}
             </ChartSection>
 
-            <ChartSection label="Total Transactions">
+            <ChartSection label={`Total Transactions${weekFloor(range)}`}>
               {series("cumulativeTxCount").length ? (
                 <DualChart
                   data={series("cumulativeTxCount")}
@@ -246,7 +247,7 @@ export function EvmStats({
           {/* what's being built, and what it burns */}
           <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
             <ChartSection
-              label="Contracts Deployed"
+              label={`Contracts Deployed${weekFloor(range)}`}
               action={<OverlayKey label="deployers" dashed />}
             >
               {series("contracts", "deployers").length ? (
@@ -263,7 +264,7 @@ export function EvmStats({
               )}
             </ChartSection>
 
-            <ChartSection label="Gas Used">
+            <ChartSection label={`Gas Used${weekFloor(range)}`}>
               {series("gasUsed").length ? (
                 <DualChart data={series("gasUsed")} kind="bars" fmt={fmtCompact} aLabel="gas" />
               ) : (
@@ -274,7 +275,7 @@ export function EvmStats({
 
           {/* the price of blockspace */}
           <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-            <ChartSection label="Fees Paid">
+            <ChartSection label={`Fees Paid${weekFloor(range)}`}>
               {series("feesPaid").length ? (
                 <DualChart
                   data={series("feesPaid")}
@@ -288,7 +289,7 @@ export function EvmStats({
             </ChartSection>
 
             <ChartSection
-              label="Gas Price"
+              label={`Gas Price${weekFloor(range)}`}
               action={<OverlayKey label="daily max" dashed />}
               note={`Average price paid per gas unit in n${tokenSymbol}; the dashed line is each day's spike, on its own scale.`}
             >
@@ -310,7 +311,7 @@ export function EvmStats({
 
           {/* cross-chain traffic — the whole card doors into the observatory */}
           <ChartSection
-            label="Interchain Messages"
+            label={`Interchain Messages${weekFloor(range)}`}
             href="/explorer/mainnet/icm"
             action={
               <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">

--- a/components/explorer-v2/evm/EvmTxsList.tsx
+++ b/components/explorer-v2/evm/EvmTxsList.tsx
@@ -18,6 +18,7 @@ import {
   OverlayKey,
   fmtCompact,
   metricSeries,
+  weekFloor,
   useChainMetrics,
 } from "./metric-charts";
 import { useChainContext } from "@/app/(home)/explorer/[network]/[chain]/layout.client";
@@ -111,7 +112,7 @@ export function EvmTxsList({ network }: { network: string }) {
       {/* the shape of the feed over time — absorbed from the old Stats tab */}
       <div className="mt-10 grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
         <ChartSection
-          label="Transactions"
+          label={`Transactions${weekFloor(range)}`}
           action={<OverlayKey label="avg tps" dashed />}
         >
           {metricSeries(m, range, "txCount", "avgTps").length ? (
@@ -129,7 +130,7 @@ export function EvmTxsList({ network }: { network: string }) {
           )}
         </ChartSection>
 
-        <ChartSection label="Total Transactions">
+        <ChartSection label={`Total Transactions${weekFloor(range)}`}>
           {metricSeries(m, range, "cumulativeTxCount").length ? (
             <DualChart
               data={metricSeries(m, range, "cumulativeTxCount")}

--- a/components/explorer-v2/evm/metric-charts.tsx
+++ b/components/explorer-v2/evm/metric-charts.tsx
@@ -124,14 +124,29 @@ export function joinSeries(a: SeriesPoint[] | undefined, b?: SeriesPoint[]): Dua
     .sort((x, y) => (x.date < y.date ? -1 : 1));
 }
 
-/** a metric (and its overlay) windowed to the page clock and thinned */
+/* charts floor at a week — a one-point day chart renders as a lone dot.
+   Callers append `weekFloor(range)` to the card title so the exception is
+   stated, per the label doctrine. */
+export const CHART_FLOOR_DAYS = 7;
+export function weekFloor(range: number): string {
+  return range < CHART_FLOOR_DAYS ? " · 7 days" : "";
+}
+
+/** a metric (and its overlay) windowed to the page clock (floored at a
+ *  week) and thinned */
 export function metricSeries(
   m: Metrics,
   range: number,
   key: string,
   overlay?: string,
 ): DualPoint[] {
-  return thin(windowSeries(joinSeries(m[key]?.data, overlay ? m[overlay]?.data : undefined), range), 200);
+  return thin(
+    windowSeries(
+      joinSeries(m[key]?.data, overlay ? m[overlay]?.data : undefined),
+      Math.max(CHART_FLOOR_DAYS, range),
+    ),
+    200,
+  );
 }
 
 /**

--- a/components/explorer-v2/metric-sheet.tsx
+++ b/components/explorer-v2/metric-sheet.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { toPng } from "html-to-image";
+import { ArrowLeft, ArrowRight, Camera, Maximize2, Minimize2 } from "lucide-react";
+import { CartesianGrid } from "recharts";
+import { cn } from "@/lib/utils";
+import { ChartWatermark } from "@/components/stats/ChartWatermark";
+
+/* The metric detail sheets' shared chrome, extracted from the gas pilot
+   so every stat family (gas, staking, …) frames its sheets identically:
+   breadcrumb + title + blurb up top, the methodology colophon at the
+   bottom, and instruments that carry real axes, a grid, a pan strip,
+   and the fullscreen/PNG toolbar. */
+
+export function SheetFrame({
+  backHref,
+  backLabel,
+  title,
+  blurb,
+  methodology,
+  children,
+}: {
+  backHref: string;
+  backLabel: string;
+  title: string;
+  blurb: string;
+  methodology: string[];
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-10">
+      <header className="flex flex-col gap-3">
+        <Link
+          href={backHref}
+          className="group flex w-fit items-center gap-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-400 transition-colors hover:text-zinc-900 dark:text-zinc-500 dark:hover:text-zinc-100"
+        >
+          <ArrowLeft className="h-3 w-3 transition-transform group-hover:-translate-x-0.5" />
+          {backLabel}
+        </Link>
+        <h2 className="text-3xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+          {title}
+        </h2>
+        <p className="max-w-2xl text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">{blurb}</p>
+      </header>
+
+      {children}
+
+      {/* the colophon: how this figure is measured */}
+      <div className="border-t border-zinc-200 pt-6 dark:border-zinc-800">
+        <p className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-400 dark:text-zinc-500">
+          How this is measured
+        </p>
+        {methodology.map((para) => (
+          <p
+            key={para.slice(0, 32)}
+            className="mt-3 max-w-2xl text-sm leading-relaxed text-zinc-500 dark:text-zinc-400"
+          >
+            {para}
+          </p>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* a full-width door to a sibling metric sheet */
+export function SiblingDoor({ href, label, sub }: { href: string; label: string; sub: string }) {
+  return (
+    <Link
+      href={href}
+      className="group flex items-center justify-between gap-4 border border-zinc-200 px-5 py-4 transition-colors hover:bg-zinc-50 md:px-6 dark:border-zinc-800 dark:hover:bg-zinc-900"
+    >
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-zinc-900 dark:text-zinc-100">
+          {label}
+        </span>
+        <span className="truncate text-xs text-zinc-500 dark:text-zinc-400">{sub}</span>
+      </span>
+      <ArrowRight className="h-4 w-4 shrink-0 text-zinc-300 transition-all group-hover:translate-x-0.5 group-hover:text-[#E6212F] dark:text-zinc-600" />
+    </Link>
+  );
+}
+
+/* ---------------------------------------------------------------- */
+/* shared instruments for the sheets                                 */
+/* ---------------------------------------------------------------- */
+
+/* the detail sheets' chart chrome: every plot here gets real axes, a
+   dashed grid, extra height, and the Builder Hub mark in the paper */
+export const AXIS_TICK = { fontSize: 10, fill: "currentColor", opacity: 0.45 } as const;
+
+export function SheetGrid() {
+  return (
+    <CartesianGrid
+      strokeDasharray="3 3"
+      vertical={false}
+      className="stroke-zinc-200 dark:stroke-zinc-800"
+    />
+  );
+}
+
+/* the plate: watermark in the paper, and a hover toolbar every real
+   instrument carries — fullscreen (native API) and a PNG download that
+   captures the plate, watermark included */
+export function ChartPlate({ children, name = "chart" }: { children: React.ReactNode; name?: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [fs, setFs] = useState(false);
+
+  useEffect(() => {
+    const onChange = () => setFs(document.fullscreenElement === ref.current);
+    document.addEventListener("fullscreenchange", onChange);
+    return () => document.removeEventListener("fullscreenchange", onChange);
+  }, []);
+
+  const toggleFs = () => {
+    if (document.fullscreenElement) void document.exitFullscreen();
+    else void ref.current?.requestFullscreen();
+  };
+
+  const download = async () => {
+    const el = ref.current;
+    if (!el) return;
+    try {
+      const dark = document.documentElement.classList.contains("dark");
+      const dataUrl = await toPng(el, {
+        quality: 1,
+        pixelRatio: 2,
+        backgroundColor: dark ? "#09090b" : "#ffffff",
+        cacheBust: true,
+      });
+      const link = document.createElement("a");
+      link.download = `${name}_${new Date().toISOString().split("T")[0]}.png`;
+      link.href = dataUrl;
+      link.click();
+    } catch {
+      /* capture is best-effort */
+    }
+  };
+
+  const btn =
+    "flex h-6 w-6 items-center justify-center border border-zinc-200 bg-white/90 text-zinc-400 transition-colors hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950/90 dark:hover:text-zinc-100";
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "group/plate relative bg-white dark:bg-zinc-950",
+        fs && "flex flex-col justify-center px-10",
+      )}
+    >
+      <div
+        className={cn(
+          // z-30: ChartWatermark lifts its chart layer to z-10, and the
+          // watermark itself can ride at z-20 — the toolbar tops both
+          "absolute right-0 z-30 flex gap-1 opacity-0 transition-opacity group-hover/plate:opacity-100",
+          fs ? "right-10 top-6" : "-top-1",
+        )}
+      >
+        <button type="button" title="Download as image" onClick={download} className={btn}>
+          <Camera className="h-3.5 w-3.5" />
+        </button>
+        <button type="button" title={fs ? "Exit fullscreen" : "Fullscreen"} onClick={toggleFs} className={btn}>
+          {fs ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
+        </button>
+      </div>
+      <ChartWatermark>
+        <div className={cn("text-zinc-900 dark:text-zinc-100", fs ? "h-[78vh]" : "h-64")}>
+          {children}
+        </div>
+      </ChartWatermark>
+    </div>
+  );
+}
+
+/* the pan strip under a time series — drag the window, drag its edges.
+   Shared styling for every sheet chart's Brush. */
+export const BRUSH_PROPS = {
+  height: 26,
+  travellerWidth: 8,
+  stroke: "#A2AFB2",
+  fill: "rgba(162, 175, 178, 0.06)",
+  tickFormatter: () => "",
+} as const;
+
+export const dayLabel = (d: string) =>
+  new Date(`${d}T00:00:00Z`).toLocaleDateString("en-US", { month: "short", day: "numeric" });

--- a/components/explorer-v2/pchain/PchainHome.tsx
+++ b/components/explorer-v2/pchain/PchainHome.tsx
@@ -9,6 +9,7 @@ import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
 import { BlockTape, BlockTapeSkeleton, type TapeBlock } from "@/components/explorer-v2/BlockTape";
 import {
   Board,
+  ChartBoard,
   SectionHeader,
   StatCell,
   StatDash,
@@ -209,86 +210,85 @@ export function PchainHome({ chain, network }: { chain: string; network: string 
           {/* staking money-flow: the 30 days behind us in rewards paid out
               (red: stake moving) beside the 30 days ahead in stake coming
               unlocked (block gray: value at rest, waiting). Past | future
-              across one rule. */}
+              across one rule; each card doors into its staking sheet.
+              Fixed windows from the feed — the labels say so. */}
           {staking && (
             <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-              <section className="flex flex-col gap-4">
-                <SectionHeader
-                  label="Rewards Paid · last 30 days"
-                  action={
-                    <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-                      {fmtAvaxShort(staking.rewards.reduce((s, d) => s + d.avax, 0))} AVAX
-                    </span>
-                  }
-                />
-                <Board divide={false} className="px-5 py-5 md:px-6">
-                  <div className="h-24">
-                    <ResponsiveContainer width="100%" height="100%">
-                      <BarChart data={staking.rewards} barCategoryGap="18%">
-                        <YAxis hide domain={[0, "dataMax"]} />
-                        <RechartsTooltip
-                          cursor={{ fill: "rgba(161,161,170,0.08)" }}
-                          content={({ active, payload }) => {
-                            if (!active || !payload?.[0]) return null;
-                            const d = payload[0].payload as RewardDay;
-                            return (
-                              <div className="border border-zinc-200 bg-white px-2.5 py-1.5 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
-                                <p className="text-[10px] text-zinc-500">{d.date}</p>
-                                <p className="text-xs font-semibold tabular-nums text-[#E6212F]">
-                                  {Math.round(d.avax).toLocaleString()} AVAX
-                                </p>
-                                <p className="text-[10px] tabular-nums text-zinc-500">
-                                  {d.payouts.toLocaleString()} payouts
-                                </p>
-                              </div>
-                            );
-                          }}
-                        />
-                        <Bar dataKey="avax" fill="#E6212F" />
-                      </BarChart>
-                    </ResponsiveContainer>
-                  </div>
-                </Board>
-              </section>
+              <ChartBoard
+                label="Rewards Paid · last 30 days"
+                href={`${base}/staking/rewards`}
+                className="min-w-0"
+                action={
+                  <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                    {fmtAvaxShort(staking.rewards.reduce((s, d) => s + d.avax, 0))} AVAX
+                  </span>
+                }
+              >
+                <div className="h-24">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={staking.rewards} barCategoryGap="18%">
+                      <YAxis hide domain={[0, "dataMax"]} />
+                      <RechartsTooltip
+                        cursor={{ fill: "rgba(161,161,170,0.08)" }}
+                        content={({ active, payload }) => {
+                          if (!active || !payload?.[0]) return null;
+                          const d = payload[0].payload as RewardDay;
+                          return (
+                            <div className="border border-zinc-200 bg-white px-2.5 py-1.5 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
+                              <p className="text-[10px] text-zinc-500">{d.date}</p>
+                              <p className="text-xs font-semibold tabular-nums text-[#E6212F]">
+                                {Math.round(d.avax).toLocaleString()} AVAX
+                              </p>
+                              <p className="text-[10px] tabular-nums text-zinc-500">
+                                {d.payouts.toLocaleString()} payouts
+                              </p>
+                            </div>
+                          );
+                        }}
+                      />
+                      <Bar dataKey="avax" fill="#E6212F" isAnimationActive={false} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </ChartBoard>
 
-              <section className="flex flex-col gap-4">
-                <SectionHeader
-                  label="Stake Expiring · next 30 days"
-                  action={
-                    <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-                      {fmtAvaxShort(staking.unlocks.reduce((s, d) => s + d.avax, 0))} AVAX
-                    </span>
-                  }
-                />
-                <Board divide={false} className="px-5 py-5 md:px-6">
-                  <div className="h-24">
-                    <ResponsiveContainer width="100%" height="100%">
-                      <BarChart data={staking.unlocks} barCategoryGap="18%">
-                        <YAxis hide domain={[0, "dataMax"]} />
-                        <RechartsTooltip
-                          cursor={{ fill: "rgba(161,161,170,0.08)" }}
-                          content={({ active, payload }) => {
-                            if (!active || !payload?.[0]) return null;
-                            const d = payload[0].payload as UnlockDay;
-                            return (
-                              <div className="border border-zinc-200 bg-white px-2.5 py-1.5 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
-                                <p className="text-[10px] text-zinc-500">{d.date}</p>
-                                <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
-                                  {d.avax.toLocaleString()} AVAX
-                                </p>
-                                <p className="text-[10px] tabular-nums text-zinc-500">
-                                  {d.stakers.toLocaleString()} stake entries end
-                                </p>
-                              </div>
-                            );
-                          }}
-                        />
-                        <Bar dataKey="avax" fill="#A2AFB2" />
-                      </BarChart>
-                    </ResponsiveContainer>
-                  </div>
-                </Board>
-              </section>
+              <ChartBoard
+                label="Stake Expiring · next 30 days"
+                href={`${base}/staking/expiry`}
+                className="min-w-0"
+                action={
+                  <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                    {fmtAvaxShort(staking.unlocks.reduce((s, d) => s + d.avax, 0))} AVAX
+                  </span>
+                }
+              >
+                <div className="h-24">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={staking.unlocks} barCategoryGap="18%">
+                      <YAxis hide domain={[0, "dataMax"]} />
+                      <RechartsTooltip
+                        cursor={{ fill: "rgba(161,161,170,0.08)" }}
+                        content={({ active, payload }) => {
+                          if (!active || !payload?.[0]) return null;
+                          const d = payload[0].payload as UnlockDay;
+                          return (
+                            <div className="border border-zinc-200 bg-white px-2.5 py-1.5 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
+                              <p className="text-[10px] text-zinc-500">{d.date}</p>
+                              <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+                                {d.avax.toLocaleString()} AVAX
+                              </p>
+                              <p className="text-[10px] tabular-nums text-zinc-500">
+                                {d.stakers.toLocaleString()} stake entries end
+                              </p>
+                            </div>
+                          );
+                        }}
+                      />
+                      <Bar dataKey="avax" fill="#A2AFB2" isAnimationActive={false} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </ChartBoard>
             </div>
           )}
 

--- a/components/explorer-v2/pchain/PchainValidators.tsx
+++ b/components/explorer-v2/pchain/PchainValidators.tsx
@@ -98,7 +98,10 @@ export function PchainValidators({ chain, network }: { chain: string; network: s
 export function PchainStaking({ chain, network }: { chain: string; network: string }) {
   return (
     <ExplorerShell chain={chain} network={network}>
-      <PrimaryStakingContent validatorsHref={`/explorer/${network}/${chain}/validators`} />
+      <PrimaryStakingContent
+        validatorsHref={`/explorer/${network}/${chain}/validators`}
+        base={`/explorer/${network}/${chain}/staking`}
+      />
     </ExplorerShell>
   );
 }

--- a/components/explorer-v2/staking/PrimaryStaking.tsx
+++ b/components/explorer-v2/staking/PrimaryStaking.tsx
@@ -506,6 +506,10 @@ export function PrimaryStakingContent({
   // subnav states the window once, so chart titles drop the range suffix.
   const clock = useExplorerTimeRange();
   const range = RANGE_DAYS[clock];
+  // the trend charts floor at a week — a one-point day chart renders as
+  // a lone dot (same rule as the sheets); labels state the exception
+  const chartDays = Math.max(7, range);
+  const weekFloor = range < 7 ? " · 7 days" : "";
 
   /* -------------------------------------------------------------- */
   /* headline figures                                                */
@@ -535,12 +539,12 @@ export function PrimaryStakingContent({
       own: p.value / NANO,
       delegated: (delegated.get(p.day) ?? 0) / NANO,
     }));
-    return thin(windowSeries(joined, range));
-  }, [metrics, range]);
+    return thin(windowSeries(joined, chartDays));
+  }, [metrics, chartDays]);
 
   const delegatorSeries = useMemo(
-    () => thin(windowSeries(toSeries(metrics?.delegator_count), range)),
-    [metrics, range],
+    () => thin(windowSeries(toSeries(metrics?.delegator_count), chartDays)),
+    [metrics, chartDays],
   );
 
   const apySeries = useMemo<ApyPoint[]>(() => {
@@ -548,8 +552,8 @@ export function PrimaryStakingContent({
     const sorted = [...apy.data]
       .sort((a, b) => a.timestamp - b.timestamp)
       .map((p) => ({ day: p.date, maxAPY: p.maxAPY, minAPY: p.minAPY }));
-    return thin(windowSeries(sorted, range));
-  }, [apy, range]);
+    return thin(windowSeries(sorted, chartDays));
+  }, [apy, chartDays]);
 
   const dailyRewardSeries = useMemo<RewardPoint[]>(() => {
     // the moving average runs over the FULL series so the window's left
@@ -561,12 +565,12 @@ export function PrimaryStakingContent({
       if (i >= 30) rolling -= full[i - 30].value;
       return { ...p, ma: rolling / Math.min(i + 1, 30) };
     });
-    return thin(windowSeries(withMa, range), 180);
-  }, [metrics, range]);
+    return thin(windowSeries(withMa, chartDays), 180);
+  }, [metrics, chartDays]);
 
   const cumulativeRewardSeries = useMemo(
-    () => thin(windowSeries(toSeries(metrics?.cumulative_rewards), range)),
-    [metrics, range],
+    () => thin(windowSeries(toSeries(metrics?.cumulative_rewards), chartDays)),
+    [metrics, chartDays],
   );
 
   /* -------------------------------------------------------------- */
@@ -752,7 +756,7 @@ export function PrimaryStakingContent({
 
       {/* the centerpiece: how the stake got here */}
       <ChartBoard
-        label="Total Stake"
+        label={`Total Stake${weekFloor}`}
         href={door("total-stake")}
         action={
           <span className="hidden sm:block">
@@ -769,7 +773,7 @@ export function PrimaryStakingContent({
 
       {/* who delegates, and what staking pays */}
       <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-        <ChartBoard label="Delegators" href={door("total-stake")}>
+        <ChartBoard label={`Delegators${weekFloor}`} href={door("total-stake")}>
           {delegatorSeries.length ? (
             <AreaTrend
               data={delegatorSeries}
@@ -782,7 +786,7 @@ export function PrimaryStakingContent({
         </ChartBoard>
 
         <ChartBoard
-          label="Staking APY"
+          label={`Staking APY${weekFloor}`}
           href={door("apy")}
           action={
             <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
@@ -802,7 +806,7 @@ export function PrimaryStakingContent({
       {/* what securing the network mints */}
       <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
         <ChartBoard
-          label="Daily Rewards"
+          label={`Daily Rewards${weekFloor}`}
           href={door("rewards")}
           action={
             <span className="flex shrink-0 items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
@@ -817,7 +821,7 @@ export function PrimaryStakingContent({
           )}
         </ChartBoard>
 
-        <ChartBoard label="Cumulative Rewards" href={door("rewards")}>
+        <ChartBoard label={`Cumulative Rewards${weekFloor}`} href={door("rewards")}>
           {cumulativeRewardSeries.length ? (
             <AreaTrend data={cumulativeRewardSeries} format={fmtCompact} unit="AVAX" />
           ) : (

--- a/components/explorer-v2/staking/PrimaryStaking.tsx
+++ b/components/explorer-v2/staking/PrimaryStaking.tsx
@@ -254,7 +254,7 @@ function RewardsBars({ data }: { data: RewardPoint[] }) {
   );
 }
 
-interface ConcentrationPoint {
+export interface ConcentrationPoint {
   rank: number;
   /** AVAX */
   weight: number;
@@ -266,7 +266,7 @@ const AXIS_TICK = { fontSize: 10, fill: "#a1a1aa", fontFamily: "monospace" } as 
 /* how evenly the stake spreads across the set — per-rank bars against the
    right axis, the cumulative share climbing the left one; the two shapes
    read together (steep bars + fast climb = concentrated) */
-function ConcentrationChart({ data, setSize }: { data: ConcentrationPoint[]; setSize: number }) {
+export function ConcentrationChart({ data, setSize }: { data: ConcentrationPoint[]; setSize: number }) {
   const rankTicks = [];
   for (let r = 100; r < setSize; r += 100) rankTicks.push(r);
   return (
@@ -343,7 +343,7 @@ function ConcentrationChart({ data, setSize }: { data: ConcentrationPoint[]; set
   );
 }
 
-interface FeeBucket {
+export interface FeeBucket {
   label: string;
   count: number;
   /** AVAX */
@@ -352,7 +352,7 @@ interface FeeBucket {
 
 /* what delegating costs — stake-weighted bars (where the capital sits)
    with the validator count riding the right axis (where the nodes sit) */
-function FeeChart({ data }: { data: FeeBucket[] }) {
+export function FeeChart({ data }: { data: FeeBucket[] }) {
   return (
     <div className="h-56 text-zinc-900 dark:text-zinc-100">
       <ResponsiveContainer width="100%" height="100%">
@@ -418,9 +418,9 @@ function FeeChart({ data }: { data: FeeBucket[] }) {
   );
 }
 
-type Lens = "weight" | "own" | "delegated";
+export type Lens = "weight" | "own" | "delegated";
 
-const LENS_LABEL: Record<Lens, string> = {
+export const LENS_LABEL: Record<Lens, string> = {
   weight: "Weight",
   own: "Own stake",
   delegated: "Delegated",
@@ -428,7 +428,7 @@ const LENS_LABEL: Record<Lens, string> = {
 
 /* the three old distribution charts folded into one instrument — same
    segmented-control idiom as the range toggle */
-function LensToggle({ value, onChange }: { value: Lens; onChange: (v: Lens) => void }) {
+export function LensToggle({ value, onChange }: { value: Lens; onChange: (v: Lens) => void }) {
   return (
     <div className="inline-flex shrink-0 border border-zinc-200 dark:border-zinc-800">
       {(Object.keys(LENS_LABEL) as Lens[]).map((l) => (
@@ -488,7 +488,16 @@ function StakeKey() {
   );
 }
 
-export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: string }) {
+export function PrimaryStakingContent({
+  validatorsHref,
+  base,
+}: {
+  validatorsHref: string;
+  /** the staking tab's own path — every ChartBoard doors into its metric
+   *  sheet under it (base/total-stake, base/apy, …) */
+  base?: string;
+}) {
+  const door = (metric: string) => (base ? `${base}/${metric}` : undefined);
   const { data: metrics, failed: metricsFailed } = usePrimaryMetrics();
   const { data: apy, failed: apyFailed } = useStakingApy();
   const { data: sdkValidators, failed: sdkFailed } = useSdkValidators();
@@ -744,6 +753,7 @@ export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: stri
       {/* the centerpiece: how the stake got here */}
       <ChartBoard
         label="Total Stake"
+        href={door("total-stake")}
         action={
           <span className="hidden sm:block">
             <StakeKey />
@@ -759,7 +769,7 @@ export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: stri
 
       {/* who delegates, and what staking pays */}
       <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-        <ChartBoard label="Delegators">
+        <ChartBoard label="Delegators" href={door("total-stake")}>
           {delegatorSeries.length ? (
             <AreaTrend
               data={delegatorSeries}
@@ -773,6 +783,7 @@ export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: stri
 
         <ChartBoard
           label="Staking APY"
+          href={door("apy")}
           action={
             <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
               <span className="flex items-center gap-1.5">
@@ -792,6 +803,7 @@ export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: stri
       <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
         <ChartBoard
           label="Daily Rewards"
+          href={door("rewards")}
           action={
             <span className="flex shrink-0 items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
               <span className="h-0.5 w-4 bg-[#E6212F]" /> 30d avg
@@ -805,7 +817,7 @@ export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: stri
           )}
         </ChartBoard>
 
-        <ChartBoard label="Cumulative Rewards">
+        <ChartBoard label="Cumulative Rewards" href={door("rewards")}>
           {cumulativeRewardSeries.length ? (
             <AreaTrend data={cumulativeRewardSeries} format={fmtCompact} unit="AVAX" />
           ) : (
@@ -819,6 +831,9 @@ export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: stri
           qualifier: these don't follow the page clock) */}
       <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
         <div className="flex flex-col gap-4">
+          {/* no door here: the lens toggle in the title bar is interactive,
+              and a card-wide Link would swallow its clicks — the fees card
+              and the sheet siblings carry the way in */}
           <ChartBoard
             label="Concentration by Rank · current set"
             action={<LensToggle value={lens} onChange={setLens} />}
@@ -840,6 +855,7 @@ export function PrimaryStakingContent({ validatorsHref }: { validatorsHref: stri
         <div className="flex flex-col gap-4">
           <ChartBoard
             label="Delegation Fees · current set"
+            href={door("distribution")}
             action={
               medianFee !== null ? (
                 <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">

--- a/components/explorer-v2/staking/StakingMetricPage.tsx
+++ b/components/explorer-v2/staking/StakingMetricPage.tsx
@@ -1,0 +1,921 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Area,
+  Bar,
+  Brush,
+  ComposedChart,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  AXIS_TICK,
+  BRUSH_PROPS,
+  ChartPlate,
+  SheetFrame,
+  SheetGrid,
+  SiblingDoor,
+} from "@/components/explorer-v2/metric-sheet";
+import { Board, BoardHeader, StatDash } from "@/components/explorer-v2/ui";
+import { ChartEmpty, Stat, TipPlate } from "./bits";
+import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
+import {
+  NANO,
+  fmtCompact,
+  num,
+  thin,
+  toSeries,
+  usePrimaryMetrics,
+  useSdkValidators,
+  useStakingApy,
+  windowSeries,
+} from "./data";
+import {
+  ConcentrationChart,
+  FeeChart,
+  LENS_LABEL,
+  LensToggle,
+  type ConcentrationPoint,
+  type FeeBucket,
+  type Lens,
+} from "./PrimaryStaking";
+import { STAKING_METRICS, type StakingMetricKey } from "./staking-metrics";
+
+/* The per-metric detail sheets behind the Primary Network Staking page —
+   the gas family's contract, applied to the staking economy: one figure
+   per sheet, real axes, a pan strip, the toolbar, and the methodology
+   colophon. Every sheet except the current-set distribution rides the
+   page clock. */
+
+const OWN_COLOR = "currentColor";
+const DELEGATED_COLOR = "#E6212F";
+const QUIET_BAR = "#A2AFB2";
+
+/* ---------------------------------------------------------------- */
+/* data                                                              */
+/* ---------------------------------------------------------------- */
+
+interface MoneyFlow {
+  rewards: { date: string; avax: number; payouts: number }[];
+  unlocks: { date: string; avax: number; stakers: number }[];
+}
+
+/* the staking money-flow feed (reward payouts behind us, unlocks ahead),
+   fetched at the smallest computed window that covers the clock */
+function useMoneyFlow(network: string, rangeDays: number) {
+  const days = rangeDays <= 30 ? 30 : rangeDays <= 90 ? 90 : 365;
+  const [flow, setFlow] = useState<MoneyFlow | null>(null);
+  const [failed, setFailed] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    setFlow(null);
+    setFailed(false);
+    fetch(`/api/pchain-activity/${network}?days=${days}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then((data: MoneyFlow) => {
+        if (!cancelled) setFlow(data);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [network, days]);
+  return { flow, failed };
+}
+
+/* the sheets' windows floor at a week — a one-bar day chart says nothing */
+function chartWindow(rangeDays: number): number {
+  return Math.max(7, rangeDays);
+}
+
+/* ---------------------------------------------------------------- */
+/* frame + strip                                                     */
+/* ---------------------------------------------------------------- */
+
+function MetricFrame({
+  base,
+  metric,
+  children,
+}: {
+  base: string;
+  metric: StakingMetricKey;
+  children: React.ReactNode;
+}) {
+  const def = STAKING_METRICS[metric];
+  return (
+    <SheetFrame
+      backHref={base}
+      backLabel="Staking · Primary Network"
+      title={def.title}
+      blurb={def.blurb}
+      methodology={def.methodology}
+    >
+      {children}
+    </SheetFrame>
+  );
+}
+
+/* the sheet's readings row: bordered board, the window stated once */
+function SheetStrip({
+  label,
+  chip,
+  children,
+  cols = 4,
+}: {
+  label: string;
+  chip: string;
+  children: React.ReactNode;
+  cols?: 3 | 4;
+}) {
+  return (
+    <Board divide={false} className="border">
+      <BoardHeader
+        label={label}
+        display
+        action={
+          <span className="shrink-0 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
+            {chip}
+          </span>
+        }
+      />
+      <div
+        className={
+          cols === 3
+            ? "grid grid-cols-3 divide-x divide-zinc-200 dark:divide-zinc-800"
+            : "grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800"
+        }
+      >
+        {children}
+      </div>
+    </Board>
+  );
+}
+
+const dateTick = (d: string) => d.slice(5);
+
+/* ---------------------------------------------------------------- */
+/* Total Stake                                                       */
+/* ---------------------------------------------------------------- */
+
+function TotalStakeSheet({ base, network }: { base: string; network: string }) {
+  void network;
+  const clock = useExplorerTimeRange();
+  const range = RANGE_DAYS[clock];
+  const { data: metrics, failed } = usePrimaryMetrics();
+  const { data: apy } = useStakingApy();
+
+  const stakeSeries = useMemo(() => {
+    const own = toSeries(metrics?.validator_weight);
+    const delegated = new Map(toSeries(metrics?.delegator_weight).map((p) => [p.day, p.value]));
+    const joined = own.map((p) => ({
+      day: p.day,
+      own: p.value / NANO,
+      delegated: (delegated.get(p.day) ?? 0) / NANO,
+    }));
+    return thin(windowSeries(joined, chartWindow(range)), 400);
+  }, [metrics, range]);
+
+  const delegatorSeries = useMemo(
+    () => thin(windowSeries(toSeries(metrics?.delegator_count), chartWindow(range)), 400),
+    [metrics, range],
+  );
+
+  const own = num(metrics?.validator_weight?.current_value);
+  const delegated = num(metrics?.delegator_weight?.current_value);
+  const total = own !== null && delegated !== null ? (own + delegated) / NANO : null;
+  const supply = apy?.current?.supply ?? null;
+  const ofSupply = total !== null && supply ? (total / supply) * 100 : null;
+
+  return (
+    <MetricFrame base={base} metric="total-stake">
+      <div className="flex flex-col gap-10">
+        <SheetStrip label="Total Stake" chip="Live set">
+          <Stat label="Total Staked">
+            {total !== null ? `${fmtCompact(total)} AVAX` : <StatDash />}
+          </Stat>
+          <Stat label="Own Stake">
+            {own !== null ? `${fmtCompact(own / NANO)} AVAX` : <StatDash />}
+          </Stat>
+          <Stat label="Delegated">
+            {delegated !== null ? `${fmtCompact(delegated / NANO)} AVAX` : <StatDash />}
+          </Stat>
+          <Stat label="Of Supply" sub={supply ? `${fmtCompact(supply)} AVAX circulating` : undefined}>
+            {ofSupply !== null ? `${ofSupply.toFixed(1)}%` : <StatDash />}
+          </Stat>
+        </SheetStrip>
+
+        <section className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-4">
+            <p className="font-mono text-[11px] font-bold uppercase tracking-[0.22em] text-zinc-900 dark:text-zinc-100">
+              {range < 7 ? "Own + Delegated · 7 days" : "Own + Delegated"}
+            </p>
+            <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
+              <span className="flex items-center gap-1.5">
+                <span className="h-2.5 w-4 bg-zinc-900/15 dark:bg-zinc-100/15" /> own
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="h-2.5 w-4 bg-[#E6212F]/25" /> delegated
+              </span>
+            </span>
+          </div>
+          {stakeSeries.length ? (
+            <ChartPlate name="total-stake">
+              <ResponsiveContainer width="100%" height="100%">
+                <ComposedChart data={stakeSeries} margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
+                  <SheetGrid />
+                  <XAxis dataKey="day" tickLine={false} axisLine={false} minTickGap={48} tick={AXIS_TICK} tickFormatter={dateTick} />
+                  <YAxis
+                    domain={["auto", "auto"]}
+                    width={54}
+                    tickLine={false}
+                    axisLine={false}
+                    tick={AXIS_TICK}
+                    tickFormatter={(v: number) => fmtCompact(v)}
+                  />
+                  <RechartsTooltip
+                    cursor={{ stroke: "rgba(161,161,170,0.35)" }}
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.[0]) return null;
+                      const d = payload[0].payload as { day: string; own: number; delegated: number };
+                      return (
+                        <TipPlate>
+                          <p className="text-[10px] text-zinc-500">{d.day}</p>
+                          <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+                            {fmtCompact(d.own + d.delegated)} AVAX staked
+                          </p>
+                          <p className="text-[10px] tabular-nums text-zinc-500">
+                            own {fmtCompact(d.own)} · delegated {fmtCompact(d.delegated)}
+                          </p>
+                        </TipPlate>
+                      );
+                    }}
+                  />
+                  <Area type="monotone" dataKey="own" stackId="stake" stroke={OWN_COLOR} strokeWidth={1.5} fill={OWN_COLOR} fillOpacity={0.1} isAnimationActive={false} />
+                  <Area type="monotone" dataKey="delegated" stackId="stake" stroke={DELEGATED_COLOR} strokeWidth={1.5} fill={DELEGATED_COLOR} fillOpacity={0.12} isAnimationActive={false} />
+                  <Brush dataKey="day" {...BRUSH_PROPS}>
+                    <LineChart>
+                      <Line dataKey="own" stroke="#A2AFB2" strokeWidth={1} dot={false} isAnimationActive={false} />
+                    </LineChart>
+                  </Brush>
+                </ComposedChart>
+              </ResponsiveContainer>
+            </ChartPlate>
+          ) : (
+            <ChartEmpty failed={failed} />
+          )}
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <p className="font-mono text-[11px] font-bold uppercase tracking-[0.22em] text-zinc-900 dark:text-zinc-100">
+            {range < 7 ? "Delegators · 7 days" : "Delegators"}
+          </p>
+          {delegatorSeries.length ? (
+            <ChartPlate name="delegators">
+              <ResponsiveContainer width="100%" height="100%">
+                <ComposedChart data={delegatorSeries} margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
+                  <SheetGrid />
+                  <XAxis dataKey="day" tickLine={false} axisLine={false} minTickGap={48} tick={AXIS_TICK} tickFormatter={dateTick} />
+                  <YAxis domain={["auto", "auto"]} width={54} tickLine={false} axisLine={false} tick={AXIS_TICK} tickFormatter={(v: number) => fmtCompact(v)} />
+                  <RechartsTooltip
+                    cursor={{ stroke: "rgba(161,161,170,0.35)" }}
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.[0]) return null;
+                      const d = payload[0].payload as { day: string; value: number };
+                      return (
+                        <TipPlate>
+                          <p className="text-[10px] text-zinc-500">{d.day}</p>
+                          <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+                            {Math.round(d.value).toLocaleString("en-US")} delegators
+                          </p>
+                        </TipPlate>
+                      );
+                    }}
+                  />
+                  <Area type="monotone" dataKey="value" stroke="currentColor" strokeWidth={1.5} fill="currentColor" fillOpacity={0.1} isAnimationActive={false} />
+                  <Brush dataKey="day" {...BRUSH_PROPS}>
+                    <LineChart>
+                      <Line dataKey="value" stroke="#A2AFB2" strokeWidth={1} dot={false} isAnimationActive={false} />
+                    </LineChart>
+                  </Brush>
+                </ComposedChart>
+              </ResponsiveContainer>
+            </ChartPlate>
+          ) : (
+            <ChartEmpty failed={failed} />
+          )}
+        </section>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SiblingDoor href={`${base}/apy`} label="Staking APY" sub="What this capital earns, annualized" />
+          <SiblingDoor href={`${base}/expiry`} label="Stake Expiry" sub="When it comes unlocked" />
+        </div>
+      </div>
+    </MetricFrame>
+  );
+}
+
+/* ---------------------------------------------------------------- */
+/* APY                                                               */
+/* ---------------------------------------------------------------- */
+
+function ApySheet({ base, network }: { base: string; network: string }) {
+  void network;
+  const clock = useExplorerTimeRange();
+  const range = RANGE_DAYS[clock];
+  const { data: apy, failed } = useStakingApy();
+
+  const series = useMemo(() => {
+    if (!apy?.data) return [];
+    const sorted = [...apy.data]
+      .sort((a, b) => a.timestamp - b.timestamp)
+      .map((p) => ({ day: p.date, maxAPY: p.maxAPY, minAPY: p.minAPY }));
+    return thin(windowSeries(sorted, chartWindow(range)), 400);
+  }, [apy, range]);
+
+  return (
+    <MetricFrame base={base} metric="apy">
+      <div className="flex flex-col gap-10">
+        <SheetStrip label="Staking APY" chip="Live estimate" cols={3}>
+          <Stat label="Max APY" sub="own node, full-year term">
+            {apy?.current ? `${apy.current.maxAPY.toFixed(2)}%` : <StatDash />}
+          </Stat>
+          <Stat label="Min APY" sub="delegating, after fees">
+            {apy?.current ? `${apy.current.minAPY.toFixed(2)}%` : <StatDash />}
+          </Stat>
+          <Stat label="Supply" sub="AVAX circulating">
+            {apy?.current?.supply ? fmtCompact(apy.current.supply) : <StatDash />}
+          </Stat>
+        </SheetStrip>
+
+        <section className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-4">
+            <p className="font-mono text-[11px] font-bold uppercase tracking-[0.22em] text-zinc-900 dark:text-zinc-100">
+              {range < 7 ? "Yield Curves · 7 days" : "Yield Curves"}
+            </p>
+            <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
+              <span className="flex items-center gap-1.5">
+                <span className="h-0.5 w-4 bg-zinc-900 dark:bg-zinc-100" /> max
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="h-0.5 w-4 border-b border-dashed border-[#A2AFB2]" /> min
+              </span>
+            </span>
+          </div>
+          {series.length ? (
+            <ChartPlate name="staking-apy">
+              <ResponsiveContainer width="100%" height="100%">
+                <ComposedChart data={series} margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
+                  <SheetGrid />
+                  <XAxis dataKey="day" tickLine={false} axisLine={false} minTickGap={48} tick={AXIS_TICK} tickFormatter={dateTick} />
+                  <YAxis
+                    domain={["auto", "auto"]}
+                    width={44}
+                    tickLine={false}
+                    axisLine={false}
+                    tick={AXIS_TICK}
+                    tickFormatter={(v: number) => `${v.toFixed(1)}%`}
+                  />
+                  <RechartsTooltip
+                    cursor={{ stroke: "rgba(161,161,170,0.35)" }}
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.[0]) return null;
+                      const d = payload[0].payload as { day: string; maxAPY: number; minAPY: number };
+                      return (
+                        <TipPlate>
+                          <p className="text-[10px] text-zinc-500">{d.day}</p>
+                          <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+                            {d.maxAPY.toFixed(2)}% max
+                          </p>
+                          <p className="text-[10px] tabular-nums text-zinc-500">min {d.minAPY.toFixed(2)}%</p>
+                        </TipPlate>
+                      );
+                    }}
+                  />
+                  <Line type="monotone" dataKey="maxAPY" stroke="currentColor" strokeWidth={2} dot={false} isAnimationActive={false} />
+                  <Line type="monotone" dataKey="minAPY" stroke={QUIET_BAR} strokeWidth={1.5} strokeDasharray="4 3" dot={false} isAnimationActive={false} />
+                  <Brush dataKey="day" {...BRUSH_PROPS}>
+                    <LineChart>
+                      <Line dataKey="maxAPY" stroke="#A2AFB2" strokeWidth={1} dot={false} isAnimationActive={false} />
+                    </LineChart>
+                  </Brush>
+                </ComposedChart>
+              </ResponsiveContainer>
+            </ChartPlate>
+          ) : (
+            <ChartEmpty failed={failed} />
+          )}
+        </section>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SiblingDoor href={`${base}/rewards`} label="Rewards" sub="What the rate mints, day by day" />
+          <SiblingDoor href={`${base}/total-stake`} label="Total Stake" sub="The denominator: capital at work" />
+        </div>
+      </div>
+    </MetricFrame>
+  );
+}
+
+/* ---------------------------------------------------------------- */
+/* Rewards                                                           */
+/* ---------------------------------------------------------------- */
+
+function RewardsSheet({ base, network }: { base: string; network: string }) {
+  const clock = useExplorerTimeRange();
+  const range = RANGE_DAYS[clock];
+  const rangeLabel = RANGE_LABEL[clock];
+  const { data: metrics, failed } = usePrimaryMetrics();
+  const { flow, failed: flowFailed } = useMoneyFlow(network, range);
+
+  const mintedSeries = useMemo(() => {
+    // the moving average runs over the FULL series so the window's left
+    // edge doesn't start artificially low, then the window slices
+    const full = toSeries(metrics?.daily_rewards);
+    let rolling = 0;
+    const withMa = full.map((p, i) => {
+      rolling += p.value;
+      if (i >= 30) rolling -= full[i - 30].value;
+      return { ...p, ma: rolling / Math.min(i + 1, 30) };
+    });
+    return thin(windowSeries(withMa, chartWindow(range)), 400);
+  }, [metrics, range]);
+
+  const cumulativeSeries = useMemo(
+    () => thin(windowSeries(toSeries(metrics?.cumulative_rewards), chartWindow(range)), 400),
+    [metrics, range],
+  );
+
+  // payouts, windowed to the clock (the feed serves the covering span)
+  const paidSeries = useMemo(
+    () => (flow ? flow.rewards.slice(-chartWindow(range)) : null),
+    [flow, range],
+  );
+  const paidWindow = useMemo(
+    () => (flow ? flow.rewards.slice(-range) : null),
+    [flow, range],
+  );
+  const paidTotal = paidWindow?.reduce((s, d) => s + d.avax, 0) ?? null;
+  const paidCount = paidWindow?.reduce((s, d) => s + d.payouts, 0) ?? null;
+
+  const mintedLastDay = useMemo(() => {
+    const s = toSeries(metrics?.daily_rewards);
+    return s.length ? s[s.length - 1].value : null;
+  }, [metrics]);
+  const cumulative = num(metrics?.cumulative_rewards?.current_value);
+
+  return (
+    <MetricFrame base={base} metric="rewards">
+      <div className="flex flex-col gap-10">
+        <SheetStrip label="Rewards" chip={`Last ${rangeLabel}`}>
+          <Stat label="Paid Out" sub={paidCount !== null ? `${paidCount.toLocaleString()} payouts` : undefined}>
+            {paidTotal !== null ? `${fmtCompact(paidTotal)} AVAX` : <StatDash />}
+          </Stat>
+          <Stat label="Minted" sub="last full day">
+            {mintedLastDay !== null ? `${fmtCompact(mintedLastDay)} AVAX` : <StatDash />}
+          </Stat>
+          <Stat label="Minted · All-Time">
+            {cumulative !== null ? `${fmtCompact(cumulative)} AVAX` : <StatDash />}
+          </Stat>
+          <Stat label="Daily Avg" sub="paid, over the window">
+            {paidTotal !== null && paidWindow?.length
+              ? `${fmtCompact(paidTotal / paidWindow.length)} AVAX`
+              : <StatDash />}
+          </Stat>
+        </SheetStrip>
+
+        <section className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-4">
+            <p className="font-mono text-[11px] font-bold uppercase tracking-[0.22em] text-zinc-900 dark:text-zinc-100">
+              {range < 7 ? "Paid Out Per Day · 7 days" : "Paid Out Per Day"}
+            </p>
+            <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+              reward UTXOs, as they unlocked
+            </span>
+          </div>
+          {paidSeries?.length ? (
+            <ChartPlate name="rewards-paid">
+              <ResponsiveContainer width="100%" height="100%">
+                <ComposedChart data={paidSeries} margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
+                  <SheetGrid />
+                  <XAxis dataKey="date" tickLine={false} axisLine={false} minTickGap={48} tick={AXIS_TICK} />
+                  <YAxis domain={[0, "dataMax"]} width={54} tickLine={false} axisLine={false} tick={AXIS_TICK} tickFormatter={(v: number) => fmtCompact(v)} />
+                  <RechartsTooltip
+                    cursor={{ fill: "rgba(161,161,170,0.08)" }}
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.[0]) return null;
+                      const d = payload[0].payload as { date: string; avax: number; payouts: number };
+                      return (
+                        <TipPlate>
+                          <p className="text-[10px] text-zinc-500">{d.date}</p>
+                          <p className="text-xs font-semibold tabular-nums text-[#E6212F]">
+                            {Math.round(d.avax).toLocaleString()} AVAX paid
+                          </p>
+                          <p className="text-[10px] tabular-nums text-zinc-500">
+                            {d.payouts.toLocaleString()} payouts
+                          </p>
+                        </TipPlate>
+                      );
+                    }}
+                  />
+                  <Bar dataKey="avax" fill={DELEGATED_COLOR} fillOpacity={0.8} minPointSize={1} isAnimationActive={false} />
+                  <Brush dataKey="date" {...BRUSH_PROPS}>
+                    <LineChart>
+                      <Line dataKey="avax" stroke="#A2AFB2" strokeWidth={1} dot={false} isAnimationActive={false} />
+                    </LineChart>
+                  </Brush>
+                </ComposedChart>
+              </ResponsiveContainer>
+            </ChartPlate>
+          ) : (
+            <ChartEmpty failed={flowFailed} />
+          )}
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-4">
+            <p className="font-mono text-[11px] font-bold uppercase tracking-[0.22em] text-zinc-900 dark:text-zinc-100">
+              {range < 7 ? "Minted Per Day · 7 days" : "Minted Per Day"}
+            </p>
+            <span className="flex shrink-0 items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
+              <span className="h-0.5 w-4 bg-[#E6212F]" /> 30d avg
+            </span>
+          </div>
+          {mintedSeries.length ? (
+            <ChartPlate name="rewards-minted">
+              <ResponsiveContainer width="100%" height="100%">
+                <ComposedChart data={mintedSeries} margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
+                  <SheetGrid />
+                  <XAxis dataKey="day" tickLine={false} axisLine={false} minTickGap={48} tick={AXIS_TICK} tickFormatter={dateTick} />
+                  <YAxis domain={[0, "dataMax"]} width={54} tickLine={false} axisLine={false} tick={AXIS_TICK} tickFormatter={(v: number) => fmtCompact(v)} />
+                  <RechartsTooltip
+                    cursor={{ fill: "rgba(161,161,170,0.08)" }}
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.[0]) return null;
+                      const d = payload[0].payload as { day: string; value: number; ma: number };
+                      return (
+                        <TipPlate>
+                          <p className="text-[10px] text-zinc-500">{d.day}</p>
+                          <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+                            {fmtCompact(d.value)} AVAX minted
+                          </p>
+                          <p className="text-[10px] tabular-nums text-zinc-500">30d average {fmtCompact(d.ma)}</p>
+                        </TipPlate>
+                      );
+                    }}
+                  />
+                  <Bar dataKey="value" fill={QUIET_BAR} minPointSize={1} isAnimationActive={false} />
+                  <Line type="monotone" dataKey="ma" stroke={DELEGATED_COLOR} strokeWidth={1.5} dot={false} isAnimationActive={false} />
+                  <Brush dataKey="day" {...BRUSH_PROPS}>
+                    <LineChart>
+                      <Line dataKey="value" stroke="#A2AFB2" strokeWidth={1} dot={false} isAnimationActive={false} />
+                    </LineChart>
+                  </Brush>
+                </ComposedChart>
+              </ResponsiveContainer>
+            </ChartPlate>
+          ) : (
+            <ChartEmpty failed={failed} />
+          )}
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <p className="font-mono text-[11px] font-bold uppercase tracking-[0.22em] text-zinc-900 dark:text-zinc-100">
+            {range < 7 ? "Cumulative · 7 days" : "Cumulative"}
+          </p>
+          {cumulativeSeries.length ? (
+            <ChartPlate name="rewards-cumulative">
+              <ResponsiveContainer width="100%" height="100%">
+                <ComposedChart data={cumulativeSeries} margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
+                  <SheetGrid />
+                  <XAxis dataKey="day" tickLine={false} axisLine={false} minTickGap={48} tick={AXIS_TICK} tickFormatter={dateTick} />
+                  <YAxis domain={["auto", "auto"]} width={54} tickLine={false} axisLine={false} tick={AXIS_TICK} tickFormatter={(v: number) => fmtCompact(v)} />
+                  <RechartsTooltip
+                    cursor={{ stroke: "rgba(161,161,170,0.35)" }}
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.[0]) return null;
+                      const d = payload[0].payload as { day: string; value: number };
+                      return (
+                        <TipPlate>
+                          <p className="text-[10px] text-zinc-500">{d.day}</p>
+                          <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+                            {fmtCompact(d.value)} AVAX all-time
+                          </p>
+                        </TipPlate>
+                      );
+                    }}
+                  />
+                  <Area type="monotone" dataKey="value" stroke="currentColor" strokeWidth={1.5} fill="currentColor" fillOpacity={0.1} isAnimationActive={false} />
+                </ComposedChart>
+              </ResponsiveContainer>
+            </ChartPlate>
+          ) : (
+            <ChartEmpty failed={failed} />
+          )}
+        </section>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SiblingDoor href={`${base}/apy`} label="Staking APY" sub="The rate behind the minting" />
+          <SiblingDoor href={`${base}/expiry`} label="Stake Expiry" sub="When the payouts burst: terms ending" />
+        </div>
+      </div>
+    </MetricFrame>
+  );
+}
+
+/* ---------------------------------------------------------------- */
+/* Expiry                                                            */
+/* ---------------------------------------------------------------- */
+
+function ExpirySheet({ base, network }: { base: string; network: string }) {
+  const clock = useExplorerTimeRange();
+  const range = RANGE_DAYS[clock];
+  const rangeLabel = RANGE_LABEL[clock];
+  const { data: metrics } = usePrimaryMetrics();
+  const { flow, failed } = useMoneyFlow(network, range);
+
+  // the mirrored FUTURE window: the clock's span, ahead of now
+  const days = Math.max(7, range);
+  const series = useMemo(() => {
+    if (!flow) return null;
+    let cum = 0;
+    return flow.unlocks.slice(0, days).map((d) => {
+      cum += d.avax;
+      return { ...d, cumulative: cum };
+    });
+  }, [flow, days]);
+
+  const windowTotal = useMemo(
+    () => flow?.unlocks.slice(0, range).reduce((s, d) => s + d.avax, 0) ?? null,
+    [flow, range],
+  );
+  const windowEntries = useMemo(
+    () => flow?.unlocks.slice(0, range).reduce((s, d) => s + d.stakers, 0) ?? null,
+    [flow, range],
+  );
+  const biggestDay = useMemo(() => {
+    const w = flow?.unlocks.slice(0, range) ?? [];
+    return w.length ? w.reduce((a, b) => (b.avax > a.avax ? b : a)) : null;
+  }, [flow, range]);
+
+  const own = num(metrics?.validator_weight?.current_value);
+  const delegated = num(metrics?.delegator_weight?.current_value);
+  const totalStaked = own !== null && delegated !== null ? (own + delegated) / NANO : null;
+  const shareOfStake =
+    windowTotal !== null && totalStaked ? (windowTotal / totalStaked) * 100 : null;
+
+  return (
+    <MetricFrame base={base} metric="expiry">
+      <div className="flex flex-col gap-10">
+        <SheetStrip label="Stake Expiry" chip={`Next ${rangeLabel}`}>
+          <Stat label="Expiring">
+            {windowTotal !== null ? `${fmtCompact(windowTotal)} AVAX` : <StatDash />}
+          </Stat>
+          <Stat label="Of Total Stake">
+            {shareOfStake !== null ? `${shareOfStake.toFixed(1)}%` : <StatDash />}
+          </Stat>
+          <Stat label="Entries Ending" sub="validators + delegators">
+            {windowEntries !== null ? windowEntries.toLocaleString("en-US") : <StatDash />}
+          </Stat>
+          <Stat label="Biggest Day" sub={biggestDay ? biggestDay.date : undefined}>
+            {biggestDay ? `${fmtCompact(biggestDay.avax)} AVAX` : <StatDash />}
+          </Stat>
+        </SheetStrip>
+
+        <section className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-4">
+            <p className="font-mono text-[11px] font-bold uppercase tracking-[0.22em] text-zinc-900 dark:text-zinc-100">
+              {range < 7 ? "Unlock Schedule · next 7 days" : "Unlock Schedule"}
+            </p>
+            <span className="flex shrink-0 items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
+              <span className="h-0.5 w-4 bg-[#E6212F]" /> cumulative
+            </span>
+          </div>
+          {series?.length ? (
+            <ChartPlate name="stake-expiry">
+              <ResponsiveContainer width="100%" height="100%">
+                <ComposedChart data={series} margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
+                  <SheetGrid />
+                  <XAxis dataKey="date" tickLine={false} axisLine={false} minTickGap={48} tick={AXIS_TICK} />
+                  <YAxis yAxisId="day" domain={[0, "dataMax"]} width={54} tickLine={false} axisLine={false} tick={AXIS_TICK} tickFormatter={(v: number) => fmtCompact(v)} />
+                  <YAxis yAxisId="cum" orientation="right" domain={[0, "dataMax"]} width={54} tickLine={false} axisLine={false} tick={AXIS_TICK} tickFormatter={(v: number) => fmtCompact(v)} />
+                  <RechartsTooltip
+                    cursor={{ fill: "rgba(161,161,170,0.08)" }}
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.[0]) return null;
+                      const d = payload[0].payload as {
+                        date: string;
+                        avax: number;
+                        stakers: number;
+                        cumulative: number;
+                      };
+                      return (
+                        <TipPlate>
+                          <p className="text-[10px] text-zinc-500">{d.date}</p>
+                          <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+                            {fmtCompact(d.avax)} AVAX unlocks
+                          </p>
+                          <p className="text-[10px] tabular-nums text-zinc-500">
+                            {d.stakers.toLocaleString()} entries end · {fmtCompact(d.cumulative)} cumulative
+                          </p>
+                        </TipPlate>
+                      );
+                    }}
+                  />
+                  <Bar yAxisId="day" dataKey="avax" fill={QUIET_BAR} fillOpacity={0.8} minPointSize={1} isAnimationActive={false} />
+                  <Line yAxisId="cum" type="monotone" dataKey="cumulative" stroke={DELEGATED_COLOR} strokeWidth={1.5} dot={false} isAnimationActive={false} />
+                  <Brush dataKey="date" {...BRUSH_PROPS}>
+                    <LineChart>
+                      <Line dataKey="avax" stroke="#A2AFB2" strokeWidth={1} dot={false} isAnimationActive={false} />
+                    </LineChart>
+                  </Brush>
+                </ComposedChart>
+              </ResponsiveContainer>
+            </ChartPlate>
+          ) : (
+            <ChartEmpty failed={failed} />
+          )}
+          <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+            The maximum that can unlock, not a prediction of selling — most stake re-enters within
+            days. Bars are per-day totals (left axis); the red line accumulates across the window
+            (right axis).
+          </p>
+        </section>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SiblingDoor href={`${base}/total-stake`} label="Total Stake" sub="The pool this drains from" />
+          <SiblingDoor href={`${base}/rewards`} label="Rewards" sub="What lands when terms end" />
+        </div>
+      </div>
+    </MetricFrame>
+  );
+}
+
+/* ---------------------------------------------------------------- */
+/* Distribution                                                      */
+/* ---------------------------------------------------------------- */
+
+function DistributionSheet({ base, network }: { base: string; network: string }) {
+  void network;
+  const { data: sdkValidators, failed } = useSdkValidators();
+  const [lens, setLens] = useState<Lens>("weight");
+
+  const concentration = useMemo<ConcentrationPoint[]>(() => {
+    if (!sdkValidators?.length) return [];
+    const pick = (v: (typeof sdkValidators)[number]): number => {
+      const own = num(v.amountStaked) ?? 0;
+      const delegated = num(v.amountDelegated) ?? 0;
+      return lens === "own" ? own : lens === "delegated" ? delegated : own + delegated;
+    };
+    const weights = sdkValidators.map((v) => pick(v) / NANO).sort((a, b) => b - a);
+    const total = weights.reduce((s, w) => s + w, 0);
+    if (total <= 0) return [];
+    let cumulative = 0;
+    return weights.map((weight, i) => {
+      cumulative += weight;
+      return { rank: i + 1, weight, cumulativePct: (cumulative / total) * 100 };
+    });
+  }, [sdkValidators, lens]);
+
+  const halfClub = useMemo(() => {
+    const hit = concentration.find((p) => p.cumulativePct >= 50);
+    return hit?.rank ?? null;
+  }, [concentration]);
+
+  const feeBuckets = useMemo<FeeBucket[]>(() => {
+    if (!sdkValidators?.length) return [];
+    const buckets = new Map<number, { count: number; weight: number }>();
+    for (const v of sdkValidators) {
+      const fee = Math.round(num(v.delegationFee) ?? 0);
+      const key = Math.min(fee, 16);
+      const b = buckets.get(key) ?? { count: 0, weight: 0 };
+      b.count += 1;
+      b.weight += (num(v.amountStaked) ?? 0) / NANO;
+      buckets.set(key, b);
+    }
+    return Array.from(buckets.entries())
+      .sort((a, b) => a[0] - b[0])
+      .map(([fee, b]) => ({ label: fee >= 16 ? "16%+" : `${fee}%`, ...b }));
+  }, [sdkValidators]);
+
+  const medianFee = useMemo(() => {
+    if (!sdkValidators?.length) return null;
+    const fees = sdkValidators
+      .map((v) => num(v.delegationFee))
+      .filter((f): f is number => f !== null)
+      .sort((a, b) => a - b);
+    return fees.length ? fees[Math.floor(fees.length / 2)] : null;
+  }, [sdkValidators]);
+
+  const largestShare = concentration.length
+    ? (concentration[0].weight /
+        concentration.reduce((s, p) => s + p.weight, 0)) *
+      100
+    : null;
+
+  return (
+    <MetricFrame base={base} metric="distribution">
+      <div className="flex flex-col gap-10">
+        <SheetStrip label="Stake Distribution" chip="Current set">
+          <Stat label="Validators">
+            {sdkValidators ? sdkValidators.length.toLocaleString("en-US") : <StatDash />}
+          </Stat>
+          <Stat label="Half the Stake" sub="smallest club controlling 50%">
+            {halfClub !== null ? `top ${halfClub}` : <StatDash />}
+          </Stat>
+          <Stat label="Largest Validator">
+            {largestShare !== null ? `${largestShare.toFixed(2)}%` : <StatDash />}
+          </Stat>
+          <Stat label="Median Fee">
+            {medianFee !== null ? `${medianFee.toFixed(0)}%` : <StatDash />}
+          </Stat>
+        </SheetStrip>
+
+        <section className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-4">
+            <p className="font-mono text-[11px] font-bold uppercase tracking-[0.22em] text-zinc-900 dark:text-zinc-100">
+              Concentration by Rank · {LENS_LABEL[lens].toLowerCase()}
+            </p>
+            <LensToggle value={lens} onChange={setLens} />
+          </div>
+          {concentration.length ? (
+            <ChartPlate name="stake-concentration">
+              <ConcentrationChart data={thin(concentration, 400)} setSize={concentration.length} />
+            </ChartPlate>
+          ) : (
+            <ChartEmpty failed={failed} />
+          )}
+          <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+            Bars: each validator&apos;s {LENS_LABEL[lens].toLowerCase()} by rank (right axis). Red
+            line: the cumulative share the top N hold (left axis)
+            {halfClub !== null && <> — the top {halfClub} together control half of it</>}. The
+            flatter the climb, the more evenly the network&apos;s security is spread.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-4">
+            <p className="font-mono text-[11px] font-bold uppercase tracking-[0.22em] text-zinc-900 dark:text-zinc-100">
+              Delegation Fees · weighted by stake
+            </p>
+            {medianFee !== null && (
+              <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                median {medianFee.toFixed(0)}%
+              </span>
+            )}
+          </div>
+          {feeBuckets.length ? (
+            <ChartPlate name="delegation-fees">
+              <FeeChart data={feeBuckets} />
+            </ChartPlate>
+          ) : (
+            <ChartEmpty failed={failed} />
+          )}
+          <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+            Red bars: own stake sitting at each fee (left axis) — where the capital actually lives.
+            Dashed line: validator count at that fee (right axis). The cut is what delegating there
+            costs.
+          </p>
+        </section>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SiblingDoor href={`${base}/total-stake`} label="Total Stake" sub="The capital being distributed" />
+          <SiblingDoor href={`${base}/apy`} label="Staking APY" sub="What each slice of it earns" />
+        </div>
+      </div>
+    </MetricFrame>
+  );
+}
+
+/* ---------------------------------------------------------------- */
+/* entry                                                             */
+/* ---------------------------------------------------------------- */
+
+export function StakingMetricContent({
+  base,
+  network,
+  metric,
+}: {
+  /** the staking tab's own path — the sheet's breadcrumb and siblings */
+  base: string;
+  network: string;
+  metric: StakingMetricKey;
+}) {
+  switch (metric) {
+    case "total-stake":
+      return <TotalStakeSheet base={base} network={network} />;
+    case "apy":
+      return <ApySheet base={base} network={network} />;
+    case "rewards":
+      return <RewardsSheet base={base} network={network} />;
+    case "expiry":
+      return <ExpirySheet base={base} network={network} />;
+    case "distribution":
+      return <DistributionSheet base={base} network={network} />;
+  }
+}

--- a/components/explorer-v2/staking/staking-metrics.ts
+++ b/components/explorer-v2/staking/staking-metrics.ts
@@ -1,0 +1,70 @@
+/* The staking metric registry — one entry per figure on the Primary
+   Network Staking page that opens into its own detail sheet at
+   /explorer/[network]/[chain]/staking/[metric]. Data-only (no "use
+   client"), so the server routes read titles for metadata and the client
+   template reads everything else. Adding a metric here plus a section
+   composition in StakingMetricPage is the whole cost of a new sheet —
+   the same contract as the gas family. */
+
+export type StakingMetricKey = "total-stake" | "apy" | "rewards" | "expiry" | "distribution";
+
+export interface StakingMetricDef {
+  /** page + tab title, e.g. "Total Stake" */
+  title: string;
+  /** one-line intro under the title — what this number is */
+  blurb: string;
+  /** the methodology colophon: how the figure is measured, one string per paragraph */
+  methodology: string[];
+}
+
+export const STAKING_METRICS: Record<StakingMetricKey, StakingMetricDef> = {
+  "total-stake": {
+    title: "Total Stake",
+    blurb:
+      "The capital securing the Primary Network: validators' own stake and everything delegated on top of it.",
+    methodology: [
+      "Own stake and delegated stake are daily aggregates over the current validator and delegator sets, from the chain-metrics indexer. The stacked view keeps the two apart because they behave differently: own stake moves when operators join, leave, or restake; delegated stake follows retail sentiment and unlock schedules.",
+      "The delegator count rides the same indexer. A rising count against flat delegated stake means smaller average positions — worth reading together, not separately.",
+    ],
+  },
+  apy: {
+    title: "Staking APY",
+    blurb:
+      "What staking pays, annualized: the ceiling for a validator running its own node, the floor for a delegator behind the median fee.",
+    methodology: [
+      "The reward rate follows the network's emission schedule: rewards are newly minted AVAX, scaled by the staking ratio — the more of the supply is staked, the lower the rate for everyone. The max curve assumes a validator staking for a full year at perfect uptime; the min curve is the same position behind delegation fees.",
+      "The exact rate for any position varies with its duration and, for delegators, the validator's fee. Rewards are only paid if the validator meets the uptime requirement through the whole term — APY is a projection, not a promise.",
+    ],
+  },
+  rewards: {
+    title: "Rewards",
+    blurb:
+      "What securing the network mints: rewards accrued per day, the all-time total, and what actually landed in wallets.",
+    methodology: [
+      "Minted rewards are the indexer's daily accrual series — what the emission schedule credits to active stake each day. Paid rewards are parsed from the reward-UTXO archive in ClickHouse: the amounts that actually became spendable when staking periods ended. Accrual is smooth; payouts are lumpy, because they arrive in bursts as terms expire.",
+      "Every reward is newly minted AVAX — staking rewards are inflation, offset by the fees the network burns.",
+    ],
+  },
+  expiry: {
+    title: "Stake Expiry",
+    blurb:
+      "Stake coming unlocked: how much AVAX ends its staking term on each day ahead, and how it accumulates.",
+    methodology: [
+      "Every active validator and delegator position carries an immutable end time, set when the stake was locked. This schedule sums them by day from the latest set snapshot — it is the maximum that CAN unlock, not a prediction of selling: most stake re-enters within days.",
+      "Large single-day spikes are usually a few whale positions or a cohort staked together (an exchange batch, a launch-day rush) reaching term in step. The cumulative line answers the practical question: how much of today's security budget rolls over within the window.",
+    ],
+  },
+  distribution: {
+    title: "Stake Distribution",
+    blurb:
+      "How evenly the network's security spreads across the validator set — and what delegating to each slice costs.",
+    methodology: [
+      "Concentration ranks the current set by weight and climbs the cumulative share: the rank where the red line crosses 50% is the smallest club of validators that together control half the network. The flatter the climb, the more evenly security is spread. The lens toggle re-ranks by total weight, own stake, or delegated stake — the three tell different stories about where power actually sits.",
+      "Delegation fees are bucketed by percentage, weighted by the stake that actually lives at each fee. A tall bar at a low fee means the market has already found the cheap validators; a fat tail at high fees is capital that isn't shopping.",
+    ],
+  },
+};
+
+export function isStakingMetricKey(key: string): key is StakingMetricKey {
+  return key in STAKING_METRICS;
+}

--- a/components/explorer/GasMetricPage.tsx
+++ b/components/explorer/GasMetricPage.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { toPng } from "html-to-image";
-import { ArrowLeft, ArrowRight, Camera, Maximize2, Minimize2 } from "lucide-react";
 import {
   Bar,
   Brush,
-  CartesianGrid,
   ComposedChart,
   Line,
   LineChart,
@@ -17,7 +14,15 @@ import {
   YAxis,
 } from "recharts";
 import { cn } from "@/lib/utils";
-import { ChartWatermark } from "@/components/stats/ChartWatermark";
+import {
+  AXIS_TICK,
+  BRUSH_PROPS,
+  ChartPlate,
+  SheetFrame,
+  SheetGrid,
+  SiblingDoor,
+  dayLabel,
+} from "@/components/explorer-v2/metric-sheet";
 import { Board, BoardHeader, ChartBoard, StatDash } from "@/components/explorer-v2/ui";
 import {
   RANGE_DAYS,
@@ -92,6 +97,9 @@ function historyDays(range: ExplorerRange): GasHistoryDays {
 /* shared frame                                                      */
 /* ---------------------------------------------------------------- */
 
+/* the sheet chrome and instruments live in the shared metric-sheet module
+   (extracted for the staking sheets); this wrapper keeps the gas registry
+   lookup local so call sites stay one-liner */
 function MetricFrame({
   base,
   chainName,
@@ -105,157 +113,17 @@ function MetricFrame({
 }) {
   const def = GAS_METRICS[metric];
   return (
-    <div className="flex flex-col gap-10">
-      <header className="flex flex-col gap-3">
-        <Link
-          href={`${base}/gas`}
-          className="group flex w-fit items-center gap-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-400 transition-colors hover:text-zinc-900 dark:text-zinc-500 dark:hover:text-zinc-100"
-        >
-          <ArrowLeft className="h-3 w-3 transition-transform group-hover:-translate-x-0.5" />
-          Gas Market · {chainName}
-        </Link>
-        <h2 className="text-3xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
-          {def.title}
-        </h2>
-        <p className="max-w-2xl text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
-          {def.blurb}
-        </p>
-      </header>
-
+    <SheetFrame
+      backHref={`${base}/gas`}
+      backLabel={`Gas Market · ${chainName}`}
+      title={def.title}
+      blurb={def.blurb}
+      methodology={def.methodology}
+    >
       {children}
-
-      {/* the colophon: how this figure is measured */}
-      <div className="border-t border-zinc-200 pt-6 dark:border-zinc-800">
-        <p className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-400 dark:text-zinc-500">
-          How this is measured
-        </p>
-        {def.methodology.map((para) => (
-          <p key={para.slice(0, 32)} className="mt-3 max-w-2xl text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
-            {para}
-          </p>
-        ))}
-      </div>
-    </div>
+    </SheetFrame>
   );
 }
-
-/* a full-width door to a sibling metric sheet */
-function SiblingDoor({ href, label, sub }: { href: string; label: string; sub: string }) {
-  return (
-    <Link
-      href={href}
-      className="group flex items-center justify-between gap-4 border border-zinc-200 px-5 py-4 transition-colors hover:bg-zinc-50 md:px-6 dark:border-zinc-800 dark:hover:bg-zinc-900"
-    >
-      <span className="flex min-w-0 flex-col gap-0.5">
-        <span className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-zinc-900 dark:text-zinc-100">
-          {label}
-        </span>
-        <span className="truncate text-xs text-zinc-500 dark:text-zinc-400">{sub}</span>
-      </span>
-      <ArrowRight className="h-4 w-4 shrink-0 text-zinc-300 transition-all group-hover:translate-x-0.5 group-hover:text-[#E6212F] dark:text-zinc-600" />
-    </Link>
-  );
-}
-
-const dayLabel = (d: string) =>
-  new Date(`${d}T00:00:00Z`).toLocaleDateString("en-US", { month: "short", day: "numeric" });
-
-/* ---------------------------------------------------------------- */
-/* shared instruments for the sheets                                 */
-/* ---------------------------------------------------------------- */
-
-/* the detail sheets' chart chrome: every plot here gets real axes, a
-   dashed grid, extra height, and the Builder Hub mark in the paper */
-const AXIS_TICK = { fontSize: 10, fill: "currentColor", opacity: 0.45 } as const;
-
-function SheetGrid() {
-  return (
-    <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-800" />
-  );
-}
-
-/* the plate: watermark in the paper, and a hover toolbar every real
-   instrument carries — fullscreen (native API) and a PNG download that
-   captures the plate, watermark included */
-function ChartPlate({ children, name = "chart" }: { children: React.ReactNode; name?: string }) {
-  const ref = useRef<HTMLDivElement>(null);
-  const [fs, setFs] = useState(false);
-
-  useEffect(() => {
-    const onChange = () => setFs(document.fullscreenElement === ref.current);
-    document.addEventListener("fullscreenchange", onChange);
-    return () => document.removeEventListener("fullscreenchange", onChange);
-  }, []);
-
-  const toggleFs = () => {
-    if (document.fullscreenElement) void document.exitFullscreen();
-    else void ref.current?.requestFullscreen();
-  };
-
-  const download = async () => {
-    const el = ref.current;
-    if (!el) return;
-    try {
-      const dark = document.documentElement.classList.contains("dark");
-      const dataUrl = await toPng(el, {
-        quality: 1,
-        pixelRatio: 2,
-        backgroundColor: dark ? "#09090b" : "#ffffff",
-        cacheBust: true,
-      });
-      const link = document.createElement("a");
-      link.download = `${name}_${new Date().toISOString().split("T")[0]}.png`;
-      link.href = dataUrl;
-      link.click();
-    } catch {
-      /* capture is best-effort */
-    }
-  };
-
-  const btn =
-    "flex h-6 w-6 items-center justify-center border border-zinc-200 bg-white/90 text-zinc-400 transition-colors hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950/90 dark:hover:text-zinc-100";
-
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        "group/plate relative bg-white dark:bg-zinc-950",
-        fs && "flex flex-col justify-center px-10",
-      )}
-    >
-      <div
-        className={cn(
-          // z-30: ChartWatermark lifts its chart layer to z-10, and the
-          // watermark itself can ride at z-20 — the toolbar tops both
-          "absolute right-0 z-30 flex gap-1 opacity-0 transition-opacity group-hover/plate:opacity-100",
-          fs ? "right-10 top-6" : "-top-1",
-        )}
-      >
-        <button type="button" title="Download as image" onClick={download} className={btn}>
-          <Camera className="h-3.5 w-3.5" />
-        </button>
-        <button type="button" title={fs ? "Exit fullscreen" : "Fullscreen"} onClick={toggleFs} className={btn}>
-          {fs ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
-        </button>
-      </div>
-      <ChartWatermark>
-        <div className={cn("text-zinc-900 dark:text-zinc-100", fs ? "h-[78vh]" : "h-64")}>
-          {children}
-        </div>
-      </ChartWatermark>
-    </div>
-  );
-}
-
-/* the pan strip under a time series — drag the window, drag its edges.
-   Shared styling for every sheet chart's Brush. */
-const BRUSH_PROPS = {
-  height: 26,
-  travellerWidth: 8,
-  stroke: "#A2AFB2",
-  fill: "rgba(162, 175, 178, 0.06)",
-  tickFormatter: () => "",
-} as const;
 
 /* spike premium: how far p95 rides above the median, per bucket — the
    volatility a single fee line hides. Works on hourly and daily rows. */

--- a/lib/explorer-clickhouse.ts
+++ b/lib/explorer-clickhouse.ts
@@ -29,6 +29,8 @@ const DAILY_WINDOW_DAYS = 14;
 // The staking money-flow charts read better with a wider window: 30 bars
 // of rewards behind, 30 of unlocks ahead.
 const STAKING_WINDOW_DAYS = 30;
+/** windows the staking money-flow feed serves (past rewards / future unlocks) */
+export type PchainStakingDays = 30 | 90 | 365;
 
 type L1ChainEntry = {
   chainId: string;
@@ -356,7 +358,7 @@ export interface PchainStakingSeries {
 const REWARD_AMOUNT_EXPR =
   "reinterpretAsUInt64(reverse(substring(utxo_bytes, 75, 8)))";
 
-function sqlPchainDailyRewards(networkId: number): string {
+function sqlPchainDailyRewards(networkId: number, days: PchainStakingDays): string {
   return `
     SELECT
       toDate(block_time) AS day,
@@ -364,7 +366,7 @@ function sqlPchainDailyRewards(networkId: number): string {
       toString(round(sum(${REWARD_AMOUNT_EXPR}) / 1e9, 2)) AS avax
     FROM raw_p_reward_utxos
     WHERE chain_id = ${networkId}
-      AND block_time >= toDate(now() - INTERVAL ${STAKING_WINDOW_DAYS} DAY)
+      AND block_time >= toDate(now() - INTERVAL ${days} DAY)
     GROUP BY day
     ORDER BY day
     FORMAT JSONEachRow
@@ -373,7 +375,7 @@ function sqlPchainDailyRewards(networkId: number): string {
 
 // Primary Network subnet id is 32 zero bytes; L1/subnet validators don't
 // carry meaningful end_times, so unlocks are primary-only by construction.
-function sqlPchainUnlocks(networkId: number, table: string, amountCol: string): string {
+function sqlPchainUnlocks(networkId: number, table: string, amountCol: string, days: PchainStakingDays): string {
   const subnetFilter =
     table === "p_validator_snapshots"
       ? "AND subnet_id = toFixedString(unhex(repeat('00', 32)), 32)"
@@ -388,7 +390,7 @@ function sqlPchainUnlocks(networkId: number, table: string, amountCol: string): 
       AND snapshot_time = (SELECT max(snapshot_time) FROM ${table} WHERE chain_id = ${networkId})
       ${subnetFilter}
       AND end_time >= now()
-      AND end_time < now() + INTERVAL ${STAKING_WINDOW_DAYS} DAY
+      AND end_time < now() + INTERVAL ${days} DAY
     GROUP BY day
     ORDER BY day
     FORMAT JSONEachRow
@@ -419,11 +421,13 @@ const pchainStakingCache = new Map<
  */
 export async function getPchainStakingSeries(
   network: string,
+  days: PchainStakingDays = STAKING_WINDOW_DAYS,
 ): Promise<PchainStakingSeries | null> {
   const networkId = PCHAIN_NETWORK_IDS[network];
   if (networkId === undefined) return null;
 
-  const cached = pchainStakingCache.get(network);
+  const cacheKey = `${network}:${days}`;
+  const cached = pchainStakingCache.get(cacheKey);
   if (cached && Date.now() - cached.fetchedAt < DAILY_TTL_MS) {
     return cached.data;
   }
@@ -431,19 +435,19 @@ export async function getPchainStakingSeries(
   try {
     type Row = { day: string; avax: string; n?: string; payouts?: string };
     const [rewardRows, validatorRows, delegatorRows] = await Promise.all([
-      clickhouseFetch<Row>(sqlPchainDailyRewards(networkId), QUERY_TIMEOUT_MS),
+      clickhouseFetch<Row>(sqlPchainDailyRewards(networkId, days), QUERY_TIMEOUT_MS),
       clickhouseFetch<Row>(
-        sqlPchainUnlocks(networkId, "p_validator_snapshots", "weight"),
+        sqlPchainUnlocks(networkId, "p_validator_snapshots", "weight", days),
         QUERY_TIMEOUT_MS,
       ),
       clickhouseFetch<Row>(
-        sqlPchainUnlocks(networkId, "p_delegator_snapshots", "stake_amount"),
+        sqlPchainUnlocks(networkId, "p_delegator_snapshots", "stake_amount", days),
         QUERY_TIMEOUT_MS,
       ),
     ]);
 
     const rewardsByDay = new Map(rewardRows.map((r) => [r.day, r]));
-    const rewards = buildPastDates(STAKING_WINDOW_DAYS).map((iso) => ({
+    const rewards = buildPastDates(days).map((iso) => ({
       date: formatDayLabel(iso),
       avax: Number(rewardsByDay.get(iso)?.avax) || 0,
       payouts: Number(rewardsByDay.get(iso)?.payouts) || 0,
@@ -456,14 +460,14 @@ export async function getPchainStakingSeries(
       day.stakers += Number(r.n) || 0;
       unlocksByDay.set(r.day, day);
     }
-    const unlocks = buildFutureDates(STAKING_WINDOW_DAYS).map((iso) => ({
+    const unlocks = buildFutureDates(days).map((iso) => ({
       date: formatDayLabel(iso),
       avax: Math.round(unlocksByDay.get(iso)?.avax ?? 0),
       stakers: unlocksByDay.get(iso)?.stakers ?? 0,
     }));
 
     const data = { rewards, unlocks };
-    pchainStakingCache.set(network, { data, fetchedAt: Date.now() });
+    pchainStakingCache.set(cacheKey, { data, fetchedAt: Date.now() });
     return data;
   } catch (err) {
     console.error('[explorer-clickhouse] pchain staking-series query failed:', err);


### PR DESCRIPTION
Owen's ask: the staking page gets the gas-page work — dedicated subpages with detailed graphs for every stat, and the P-Chain overview's money-flow cards on the new styling.

## Five sheets

`/explorer/mainnet/{c-chain|p-chain}/staking/{metric}`:

- **total-stake** — own + delegated stacked (axes, brush), delegator trend, % of supply
- **apy** — max/min yield curves with honest subs (own node vs delegating after fees)
- **rewards** — *paid out* per day (reward-UTXO archive — the "Rewards Paid" card's detail), *minted* per day with 30d MA, cumulative
- **expiry** — the unlock schedule over the mirrored **future** window (`Next {window}` chip), per-day bars + cumulative line, share-of-stake and biggest-day readings
- **distribution** — concentration by rank with the lens toggle, delegation fees weighted by stake, "half the stake = top N" reading

Each sheet: real axes, pan brush, fullscreen/PNG toolbar, watermark, methodology colophon, sibling doors. All ride the page clock except the current-set distribution (labeled).

## Plumbing

- Sheet chrome extracted from the gas pilot into shared `explorer-v2/metric-sheet.tsx` — GasMetricPage now imports it (no behavior change; regression-probed).
- `/api/pchain-activity?days=30|90|365` (was fixed 30) — cached per window.
- Every ChartBoard on the staking page doors into its sheet (the concentration card deliberately doesn't — its title bar holds the interactive lens toggle; the fees card and siblings carry the way in).
- P-Chain overview's "Rewards Paid · last 30 days" / "Stake Expiring · next 30 days" become ChartBoard doors into the rewards/expiry sheets.

## Verification

30/30 headless checks across all five sheets on both shells, the staking-page doors, the P-Chain home doors, and a gas-sheet regression. API serves all three windows. tsc clean.