### PR TITLE
feat(explorer): P-Chain home Chain Stats board

### DIFF
--- a/components/explorer-v2/pchain/PchainHome.tsx
+++ b/components/explorer-v2/pchain/PchainHome.tsx
@@ -9,6 +9,7 @@ import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
 import { BlockTape, BlockTapeSkeleton, type TapeBlock } from "@/components/explorer-v2/BlockTape";
 import {
   Board,
+  BoardHeader,
   ChartBoard,
   SectionHeader,
   StatCell,
@@ -17,6 +18,14 @@ import {
   TxTypePill,
   txToneText,
 } from "@/components/explorer-v2/ui";
+import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
+import {
+  usePrimaryMetrics,
+  toSeries,
+  fmtCompact,
+  NANO,
+  type SeriesPoint,
+} from "@/components/explorer-v2/staking/data";
 import { formatAvax, formatNumber, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { usePchainData, LIVE_REFRESH_MS } from "./hooks";
 import { PRIMARY_SUBNET_ID } from "@/lib/pchain-node";
@@ -60,6 +69,184 @@ function LiveDot({ onRed = false, className }: { onRed?: boolean; className?: st
   );
 }
 
+
+/* ------------------------------------------------------------------ */
+/* Chain Stats — the P-Chain's readings in the C-Chain board grammar:
+   bordered plate, fused CHAIN STATS title bar, uniform figure grid.
+   The figures are levels (stake, supply, seat counts), not flows, so
+   the window reading is the level's move against N days ago. On
+   mainnet the title carries the page clock and the staking figures
+   their move; other networks get the same plate without the window
+   voice — the metrics feed is mainnet-only. */
+
+const FIG =
+  "min-w-0 whitespace-nowrap font-mono text-xl tabular-nums tracking-tight text-zinc-900 sm:text-2xl dark:text-zinc-50";
+
+interface StatDef {
+  label: string;
+  href?: string;
+  value: React.ReactNode;
+  sub?: React.ReactNode;
+}
+
+/* a level's move over the window: last daily close vs N days before it,
+   in the metric's own unit — absolute heads, not percents */
+function levelDiff(points: SeriesPoint[], n: number): number | null {
+  const cur = points[points.length - 1];
+  const prev = points[points.length - 1 - n];
+  if (!cur || !prev) return null;
+  return cur.value - prev.value;
+}
+
+/* the Etherscan parenthetical in absolute units — the evm Delta chip's
+   voice, but "+327" / "-12.4K AVAX" instead of a percent */
+function DeltaAbs({ value, unit }: { value: number | null; unit?: string }) {
+  if (value === null) return null;
+  const up = value >= 0;
+  return (
+    <span className={up ? "text-emerald-600 dark:text-emerald-400" : "text-[#E6212F]"}>
+      {up ? "+" : "-"}
+      {fmtCompact(Math.abs(value))}
+      {unit ? ` ${unit}` : ""} vs prev
+    </span>
+  );
+}
+
+function buildStatCells(
+  s: Stats | null,
+  totalStake: number | null,
+  stakingRatio: number | null,
+  base: string,
+  subs?: {
+    staked?: React.ReactNode;
+    delegators?: React.ReactNode;
+    validators?: React.ReactNode;
+  },
+): StatDef[] {
+  const avax = (v: number | string) => (
+    <span className={FIG}>
+      {formatAvax(v, { compact: true, symbol: false })}
+      <span className="ml-1.5 text-sm text-zinc-400 dark:text-zinc-500">AVAX</span>
+    </span>
+  );
+  return [
+    {
+      label: "Total Staked",
+      href: `${base}/staking/total-stake`,
+      value: totalStake ? avax(totalStake) : <StatDash />,
+      sub: subs?.staked,
+    },
+    {
+      // denominator is the TOTAL SUPPLY cell beside it — the two read
+      // as one statement
+      label: "Staked · of Total Supply",
+      value:
+        stakingRatio !== null ? (
+          <span className={FIG}>
+            {stakingRatio.toFixed(1)}
+            <span className="ml-1 text-sm text-zinc-400 dark:text-zinc-500">%</span>
+          </span>
+        ) : (
+          <StatDash />
+        ),
+    },
+    {
+      label: "Total Supply",
+      value: s?.currentSupply ? avax(s.currentSupply) : <StatDash />,
+    },
+    {
+      label: "Delegators",
+      href: `${base}/staking/total-stake`,
+      value: s ? <StatFigure value={s.delegatorCount} className="md:text-2xl" /> : <StatDash />,
+      sub: subs?.delegators,
+    },
+    {
+      label: "Primary Validators",
+      href: `${base}/validators`,
+      value: s ? <StatFigure value={s.validatorCount} className="md:text-2xl" /> : <StatDash />,
+      sub: subs?.validators,
+    },
+    {
+      label: "L1 Validators",
+      href: `${base}/validators`,
+      value: s ? <StatFigure value={s.l1ValidatorCount} className="md:text-2xl" /> : <StatDash />,
+    },
+  ];
+}
+
+/* the plate itself — EvmOverviewStats' frame with two rows of three:
+   the money row (stake against supply), then the participants row */
+function ChainStatsBoard({ cells, action }: { cells: StatDef[]; action?: React.ReactNode }) {
+  const grid =
+    "grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-3 lg:divide-y-0 dark:divide-zinc-800";
+  const row = (slice: StatDef[]) =>
+    slice.map((c) => (
+      <StatCell key={c.label} label={c.label} href={c.href} sub={c.sub}>
+        {c.value}
+      </StatCell>
+    ));
+  return (
+    <Board divide={false} className="border">
+      <BoardHeader label="Chain Stats" display action={action} />
+      <div className={`${grid} border-b border-zinc-200 dark:border-zinc-800`}>
+        {row(cells.slice(0, 3))}
+      </div>
+      <div className={grid}>{row(cells.slice(3))}</div>
+    </Board>
+  );
+}
+
+/* mainnet: the board rides the page clock — the subnav range control
+   appears because this registers as a consumer, exactly like the
+   C-Chain's Chain Stats */
+function MainnetChainStats({
+  s,
+  totalStake,
+  stakingRatio,
+  base,
+}: {
+  s: Stats | null;
+  totalStake: number | null;
+  stakingRatio: number | null;
+  base: string;
+}) {
+  const clock = useExplorerTimeRange();
+  const n = RANGE_DAYS[clock];
+  const { data: metrics } = usePrimaryMetrics();
+
+  const moves = useMemo(() => {
+    if (!metrics) return null;
+    const own = toSeries(metrics.validator_weight);
+    const delegated = new Map(toSeries(metrics.delegator_weight).map((p) => [p.day, p.value]));
+    const staked = own.map((p) => ({ day: p.day, value: p.value + (delegated.get(p.day) ?? 0) }));
+    // the weight series ride in nAVAX — the head converts so the chip
+    // speaks the same unit as the figure above it
+    const stakedDiff = levelDiff(staked, n);
+    return {
+      staked: stakedDiff === null ? null : stakedDiff / NANO,
+      delegators: levelDiff(toSeries(metrics.delegator_count), n),
+      validators: levelDiff(toSeries(metrics.validator_count), n),
+    };
+  }, [metrics, n]);
+
+  const sub = (v: number | null | undefined, unit?: string) =>
+    v == null ? undefined : <DeltaAbs value={v} unit={unit} />;
+
+  return (
+    <ChainStatsBoard
+      action={
+        <span className="shrink-0 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
+          Last {RANGE_LABEL[clock]}
+        </span>
+      }
+      cells={buildStatCells(s, totalStake, stakingRatio, base, {
+        staked: sub(moves?.staked, "AVAX"),
+        delegators: sub(moves?.delegators),
+        validators: sub(moves?.validators),
+      })}
+    />
+  );
+}
 
 /* ------------------------------------------------------------------ */
 
@@ -158,53 +345,20 @@ export function PchainHome({ chain, network }: { chain: string; network: string 
               tapeBlocks.length > 0 && <BlockTape blocks={tapeBlocks} />
             )}
 
-            {/* the strip is the P-Chain's actual job: staking. Activity
-                already lives in the tape above. */}
-            <Board divide={false}>
-              <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 sm:grid-cols-3 lg:grid-cols-6 lg:divide-y-0 dark:divide-zinc-800">
-                <StatCell label="TOTAL STAKED">
-                  {totalStake ? (
-                    <span className="whitespace-nowrap font-mono text-xl tabular-nums tracking-tight text-zinc-900 sm:text-2xl md:text-[1.75rem] dark:text-zinc-50">
-                      {formatAvax(totalStake, { compact: true, symbol: false })}
-                      <span className="ml-1.5 text-sm text-zinc-400 dark:text-zinc-500">AVAX</span>
-                    </span>
-                  ) : (
-                    <StatDash />
-                  )}
-                </StatCell>
-                {/* denominator is the TOTAL SUPPLY cell beside it — the two
-                    read as one statement */}
-                <StatCell label="STAKED · OF TOTAL SUPPLY">
-                  {stakingRatio !== null ? (
-                    <span className="whitespace-nowrap font-mono text-xl tabular-nums tracking-tight text-zinc-900 sm:text-2xl md:text-[1.75rem] dark:text-zinc-50">
-                      {stakingRatio.toFixed(1)}
-                      <span className="ml-1 text-sm text-zinc-400 dark:text-zinc-500">%</span>
-                    </span>
-                  ) : (
-                    <StatDash />
-                  )}
-                </StatCell>
-                <StatCell label="TOTAL SUPPLY">
-                  {s?.currentSupply ? (
-                    <span className="whitespace-nowrap font-mono text-xl tabular-nums tracking-tight text-zinc-900 sm:text-2xl md:text-[1.75rem] dark:text-zinc-50">
-                      {formatAvax(s.currentSupply, { compact: true, symbol: false })}
-                      <span className="ml-1.5 text-sm text-zinc-400 dark:text-zinc-500">AVAX</span>
-                    </span>
-                  ) : (
-                    <StatDash />
-                  )}
-                </StatCell>
-                <StatCell label="DELEGATORS">
-                  {s ? <StatFigure value={s.delegatorCount} /> : <StatDash />}
-                </StatCell>
-                <StatCell label="PRIMARY VALIDATORS" href={`${base}/validators`}>
-                  {s ? <StatFigure value={s.validatorCount} /> : <StatDash />}
-                </StatCell>
-                <StatCell label="L1 VALIDATORS">
-                  {s ? <StatFigure value={s.l1ValidatorCount} /> : <StatDash />}
-                </StatCell>
-              </div>
-            </Board>
+            {/* the board is the P-Chain's actual job: staking. Activity
+                already lives in the tape above. Same instrument grammar
+                as the C-Chain's Chain Stats — window tag and moves ride
+                the page clock where the mainnet metrics feed reaches. */}
+            {network === "mainnet" ? (
+              <MainnetChainStats
+                s={s}
+                totalStake={totalStake}
+                stakingRatio={stakingRatio}
+                base={base}
+              />
+            ) : (
+              <ChainStatsBoard cells={buildStatCells(s, totalStake, stakingRatio, base)} />
+            )}
           </div>
 
           {/* staking money-flow: the 30 days behind us in rewards paid out


### PR DESCRIPTION
## Summary
- Reworks the P-Chain home's staking strip into the C-Chain's Chain Stats board grammar: bordered plate, fused `CHAIN STATS` title bar with the page-clock window tag (`LAST 24 HOURS` / `LAST 30 DAYS`…), and a 2×3 grid — money row (Total Staked · Staked % of Supply · Total Supply) over participants row (Delegators · Primary Validators · L1 Validators).
- On mainnet, Total Staked, Delegators, and Primary Validators carry their **absolute** move over the selected window (`+12.4K AVAX vs prev`, `-34 vs prev`) computed from the `/api/primary-network-stats` daily series; the board registers with the explorer time-range clock, so the 1D/1W/1M/3M/1Y control appears in the subnav like on the C-Chain.
- Fuji/devnet render the identical plate without the window tag or deltas — the metrics feed is mainnet-only, and gating by component keeps the range control off pages where it would change nothing.
- Cells door into their sheets: Total Staked and Delegators → `staking/total-stake`, both validator cells → `/validators`.

## Test plan
- [ ] `tsc --noEmit` passes (verified)
- [ ] `/explorer/mainnet/pchain`: board shows title bar + window tag, deltas update when switching 1D/1W/1M/3M/1Y
- [ ] `/explorer/fuji/pchain`: same plate, no window tag, no range control in subnav
- [ ] Cell links open the staking total-stake sheet and validators page