### PR TITLE
fix(explorer): hung poll can no longer freeze the live lists

### DIFF
--- a/components/explorer-v2/evm/hooks.ts
+++ b/components/explorer-v2/evm/hooks.ts
@@ -47,12 +47,21 @@ export function useEvmData<T>(
     setLoading(true);
     setError(null);
 
+    // Every request carries a deadline: a fetch that never settles (laptop
+    // sleep mid-request, a proxy socket that never closes) would otherwise
+    // end the poll chain silently — the list freezes and visibly ages while
+    // the rest of the page keeps re-rendering.
+    const pollSignal = () => AbortSignal.any([controller.signal, AbortSignal.timeout(15_000)]);
+
     // silent background refresh: stale data stands on any failure, and the
     // tab pauses polling while hidden so a parked explorer doesn't hammer
     // the (shared, small) upstream API.
+    let inFlight = false;
     const refresh = async () => {
+      if (inFlight) return;
+      inFlight = true;
       try {
-        const res = await fetch(key, { signal: controller.signal });
+        const res = await fetch(key, { signal: pollSignal() });
         if (res.ok) {
           setData((await res.json()) as T);
           setError(null);
@@ -60,14 +69,26 @@ export function useEvmData<T>(
       } catch {
         /* keep showing the last good payload */
       }
+      inFlight = false;
       if (!controller.signal.aborted && refreshMs > 0) schedule();
     };
+    let live = false;
     const schedule = () => {
+      live = true;
       timer = setTimeout(() => {
         if (document.visibilityState === "hidden") schedule();
         else void refresh();
       }, refreshMs);
     };
+    // hidden-tab timers are heavily throttled — on return, poll NOW rather
+    // than leaving minutes-old rows on screen until the next tick lands
+    const onVisible = () => {
+      if (document.visibilityState === "visible" && live && !controller.signal.aborted) {
+        if (timer) clearTimeout(timer);
+        void refresh();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
 
     // a 404 with retry404Ms is usually the indexer trailing the chain by
     // seconds on a fresh tx — keep re-asking until the window closes.
@@ -75,7 +96,7 @@ export function useEvmData<T>(
       timer = setTimeout(async () => {
         if (controller.signal.aborted) return;
         try {
-          const res = await fetch(key, { signal: controller.signal });
+          const res = await fetch(key, { signal: pollSignal() });
           if (res.ok) {
             setData((await res.json()) as T);
             setError(null);
@@ -95,7 +116,7 @@ export function useEvmData<T>(
       let notFound = false;
       for (let attempt = 0; attempt < 3; attempt++) {
         try {
-          const res = await fetch(key, { signal: controller.signal });
+          const res = await fetch(key, { signal: pollSignal() });
           if (res.status === 404) throw new Error("not found");
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           setData((await res.json()) as T);
@@ -123,6 +144,7 @@ export function useEvmData<T>(
 
     return () => {
       controller.abort();
+      document.removeEventListener("visibilitychange", onVisible);
       if (timer) clearTimeout(timer);
     };
   }, [key, refreshMs, retry404Ms, nonce]);

--- a/components/explorer-v2/pchain/hooks.ts
+++ b/components/explorer-v2/pchain/hooks.ts
@@ -43,12 +43,21 @@ export function usePchainData<T>(
     setLoading(true);
     setError(null);
 
+    // Every request carries a deadline: a fetch that never settles (laptop
+    // sleep mid-request, a proxy socket that never closes) would otherwise
+    // end the poll chain silently — the list freezes and visibly ages while
+    // the rest of the page keeps re-rendering.
+    const pollSignal = () => AbortSignal.any([controller.signal, AbortSignal.timeout(15_000)]);
+
     // silent background refresh: stale data stands on any failure, and the
     // tab pauses polling while hidden so a parked explorer doesn't hammer
     // the (shared, small) upstream API.
+    let inFlight = false;
     const refresh = async () => {
+      if (inFlight) return;
+      inFlight = true;
       try {
-        const res = await fetch(key, { signal: controller.signal });
+        const res = await fetch(key, { signal: pollSignal() });
         if (res.ok) {
           setData((await res.json()) as T);
           setError(null);
@@ -56,14 +65,26 @@ export function usePchainData<T>(
       } catch {
         /* keep showing the last good payload */
       }
+      inFlight = false;
       if (!controller.signal.aborted && refreshMs > 0) schedule();
     };
+    let live = false;
     const schedule = () => {
+      live = true;
       timer = setTimeout(() => {
         if (document.visibilityState === "hidden") schedule();
         else void refresh();
       }, refreshMs);
     };
+    // hidden-tab timers are heavily throttled — on return, poll NOW rather
+    // than leaving minutes-old rows on screen until the next tick lands
+    const onVisible = () => {
+      if (document.visibilityState === "visible" && live && !controller.signal.aborted) {
+        if (timer) clearTimeout(timer);
+        void refresh();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
 
     // a 404 with retry404Ms is usually the indexer trailing the chain by
     // seconds on a fresh tx — keep re-asking until the window closes. The
@@ -73,7 +94,7 @@ export function usePchainData<T>(
       timer = setTimeout(async () => {
         if (controller.signal.aborted) return;
         try {
-          const res = await fetch(key, { signal: controller.signal });
+          const res = await fetch(key, { signal: pollSignal() });
           if (res.ok) {
             setData((await res.json()) as T);
             setError(null);
@@ -93,7 +114,7 @@ export function usePchainData<T>(
       let notFound = false;
       for (let attempt = 0; attempt < 3; attempt++) {
         try {
-          const res = await fetch(key, { signal: controller.signal });
+          const res = await fetch(key, { signal: pollSignal() });
           if (res.status === 404) throw new Error("not found");
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           setData((await res.json()) as T);
@@ -121,6 +142,7 @@ export function usePchainData<T>(
 
     return () => {
       controller.abort();
+      document.removeEventListener("visibilitychange", onVisible);
       if (timer) clearTimeout(timer);
     };
   }, [key, refreshMs, retry404Ms]);


### PR DESCRIPTION
## Summary

Reported symptom: `explorer/mainnet/p-chain` showed the latest transaction as "24 mins ago" while the chain had continuous transactions (verified: no gap over 5 minutes in the preceding 77; backend + proxy fresh at every layer).

Root cause is client-side, in the shared polling hooks (`usePchainData` / `useEvmData`): each background poll schedules the next tick only after its own `fetch` settles, and that fetch had **no deadline**. One request that never settles — laptop sleep mid-request, a proxy socket that never closes — silently ends the poll chain. The stats hooks on the same page keep polling and re-rendering, so the frozen txs/blocks list visibly ages on screen until a reload.

## Changes (`pchain/hooks.ts` + `evm/hooks.ts`, kept identical)

- Every request (initial load, background refresh, 404-retry) now races a 15s deadline via `AbortSignal.any([controller.signal, AbortSignal.timeout(15_000)])` — a hung fetch aborts as a swallowed failure (stale data stands, as designed) and the chain reschedules. Unmount aborts (`AbortError`) stay distinguishable from deadline aborts (`TimeoutError`), which the initial-load retry logic relies on.
- On `visibilitychange → visible`, poll immediately instead of waiting out browser-throttled hidden-tab timers (up to ~1 min), so a parked tab is fresh the moment you return.
- An in-flight guard prevents the visibility refresh and a timer-fired refresh from running concurrently and forking the chain into a double-rate poll loop.

## Test plan
- [x] `tsc --noEmit` passes (pre-commit hook)
- [ ] P-Chain/C-Chain home: lists still poll every 12s, detail pages still don't poll
- [ ] Background the tab for several minutes, return — lists refresh immediately
- [ ] DevTools offline mid-poll, restore network — polling resumes within ~27s (15s deadline + 12s tick) instead of freezing