### PR TITLE
Explorer UX improvements

### DIFF
--- a/app/(home)/explorer/[network]/p-chain/l1s/page.tsx
+++ b/app/(home)/explorer/[network]/p-chain/l1s/page.tsx
@@ -1,15 +1,15 @@
 import { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { getExplorerChain } from "@/lib/pchain-explorer";
-import { PchainStaking } from "@/components/explorer-v2/pchain/PchainValidators";
+import { PchainL1s } from "@/components/explorer-v2/staking/L1Economy";
 
 export const metadata: Metadata = {
-  title: "Avalanche Staking | Avalanche Explorer",
+  title: "Avalanche L1s | Avalanche Explorer",
   description:
-    "Primary Network staking: total stake and its growth, staking APY, rewards minted and paid, stake unlocks, and how the stake distributes across the validator set.",
+    "The ACP-77 L1 validator economy: active fee-paying seats, the live continuous-fee price and what the whole set burns, Primary-vs-L1 seat growth, and where the seats run.",
 };
 
-export default async function StakingPage({
+export default async function L1sPage({
   params,
 }: {
   params: Promise<{ network: string }>;
@@ -17,7 +17,7 @@ export default async function StakingPage({
   const { network } = await params;
   const c = getExplorerChain("p-chain");
   if (!c || !c.networks.includes(network)) notFound();
-  // the staking feeds watch mainnet; Fuji has no observatory to show
+  // the seat-economy feeds (ecosystem seats, metrics) watch mainnet only
   if (network !== "mainnet") redirect(`/explorer/${network}/p-chain/validators`);
-  return <PchainStaking chain={c.slug} network={network} />;
+  return <PchainL1s chain={c.slug} network={network} />;
 }

--- a/app/(home)/explorer/[network]/p-chain/staking/page.tsx
+++ b/app/(home)/explorer/[network]/p-chain/staking/page.tsx
@@ -6,7 +6,7 @@ import { PchainStaking } from "@/components/explorer-v2/pchain/PchainValidators"
 export const metadata: Metadata = {
   title: "Avalanche Staking | Avalanche Explorer",
   description:
-    "Primary Network staking: total stake and its growth, staking APY, rewards minted, and how the stake distributes across the validator set.",
+    "The Avalanche validator economy: Primary Network stake, APY and rewards, stake unlocks, and the ACP-77 L1 seat market — seats, continuous fees, and where they run.",
 };
 
 export default async function StakingPage({

--- a/app/api/l1-registry/[network]/route.ts
+++ b/app/api/l1-registry/[network]/route.ts
@@ -1,0 +1,148 @@
+import { NextResponse } from "next/server";
+import { EXPLORER_API_BASE, isPchainNetwork } from "@/lib/pchain-explorer";
+
+// The chain build-out registry, aggregated server-side: every subnet the
+// P-Chain has ever created (the box's /v1 subnets endpoint, ~6 pages),
+// reduced to the totals, a monthly cumulative creation series, and the
+// newest launches. Creations are slow-moving — cache aggressively.
+
+export const dynamic = "force-dynamic";
+
+const PAGE_SIZE = 100;
+const FETCH_TIMEOUT_MS = 20_000;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1h in-process
+const CACHE_CONTROL = "public, max-age=900, s-maxage=3600, stale-while-revalidate=86400";
+const PRIMARY_SUBNET_ID = "11111111111111111111111111111111LpoYY";
+
+interface RegistryBlockchain {
+  blockchainId: string;
+  blockchainName?: string;
+  createBlockTimestamp?: number;
+  evmChainId?: number;
+  subnetId?: string;
+  vmId?: string;
+}
+
+interface RegistrySubnet {
+  subnetId: string;
+  isL1?: boolean;
+  createBlockTimestamp?: number;
+  blockchains?: RegistryBlockchain[] | null;
+}
+
+export interface L1Registry {
+  totals: { subnets: number; l1s: number; blockchains: number; evmChains: number };
+  /** oldest-first cumulative counts by month (YYYY-MM) */
+  series: { month: string; blockchains: number; subnets: number }[];
+  /** newest blockchain launches, newest first */
+  recent: {
+    name: string;
+    blockchainId: string;
+    subnetId: string;
+    isL1: boolean;
+    evmChainId?: number;
+    createdAt: number;
+  }[];
+  lastUpdated: number;
+}
+
+const cache = new Map<string, { data: L1Registry; at: number }>();
+
+async function fetchAllSubnets(network: string): Promise<RegistrySubnet[]> {
+  const out: RegistrySubnet[] = [];
+  let pageToken: string | undefined;
+  for (let i = 0; i < 50; i++) {
+    const tok = pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : "";
+    const res = await fetch(
+      `${EXPLORER_API_BASE}/v1/networks/${network}/subnets?pageSize=${PAGE_SIZE}${tok}`,
+      { headers: { accept: "application/json" }, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
+    );
+    if (!res.ok) throw new Error(`subnets upstream ${res.status}`);
+    const page = (await res.json()) as { subnets?: RegistrySubnet[]; nextPageToken?: string };
+    const subnets = page.subnets ?? [];
+    out.push(...subnets);
+    pageToken = page.nextPageToken;
+    if (!pageToken || subnets.length < PAGE_SIZE) break;
+  }
+  return out;
+}
+
+function monthOf(ts: number): string {
+  return new Date(ts * 1000).toISOString().slice(0, 7);
+}
+
+function buildRegistry(subnets: RegistrySubnet[]): L1Registry {
+  const totals = { subnets: 0, l1s: 0, blockchains: 0, evmChains: 0 };
+  const subnetMonths = new Map<string, number>();
+  const chainMonths = new Map<string, number>();
+  const allChains: L1Registry["recent"] = [];
+
+  for (const s of subnets) {
+    if (s.subnetId === PRIMARY_SUBNET_ID) continue;
+    totals.subnets++;
+    if (s.isL1) totals.l1s++;
+    if (s.createBlockTimestamp) {
+      const m = monthOf(s.createBlockTimestamp);
+      subnetMonths.set(m, (subnetMonths.get(m) ?? 0) + 1);
+    }
+    for (const b of s.blockchains ?? []) {
+      totals.blockchains++;
+      if (b.evmChainId) totals.evmChains++;
+      if (b.createBlockTimestamp) {
+        const m = monthOf(b.createBlockTimestamp);
+        chainMonths.set(m, (chainMonths.get(m) ?? 0) + 1);
+        allChains.push({
+          name: b.blockchainName || "Unnamed chain",
+          blockchainId: b.blockchainId,
+          subnetId: s.subnetId,
+          isL1: !!s.isL1,
+          evmChainId: b.evmChainId || undefined,
+          createdAt: b.createBlockTimestamp,
+        });
+      }
+    }
+  }
+
+  // one continuous month axis from the first creation to now, both series
+  // accumulating along it — a cumulative chart must never skip a month
+  const months = [...new Set([...subnetMonths.keys(), ...chainMonths.keys()])].sort();
+  const series: L1Registry["series"] = [];
+  if (months.length) {
+    let cb = 0;
+    let cs = 0;
+    const now = monthOf(Date.now() / 1000);
+    for (let d = new Date(`${months[0]}-01T00:00:00Z`); ; d.setUTCMonth(d.getUTCMonth() + 1)) {
+      const m = d.toISOString().slice(0, 7);
+      cb += chainMonths.get(m) ?? 0;
+      cs += subnetMonths.get(m) ?? 0;
+      series.push({ month: m, blockchains: cb, subnets: cs });
+      if (m >= now) break;
+    }
+  }
+
+  allChains.sort((a, b) => b.createdAt - a.createdAt);
+  return { totals, series, recent: allChains.slice(0, 8), lastUpdated: Date.now() };
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ network: string }> },
+) {
+  const { network } = await params;
+  if (!isPchainNetwork(network)) {
+    return NextResponse.json({ error: `unknown network '${network}'` }, { status: 404 });
+  }
+  const hit = cache.get(network);
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) {
+    return NextResponse.json(hit.data, { headers: { "cache-control": CACHE_CONTROL } });
+  }
+  try {
+    const data = buildRegistry(await fetchAllSubnets(network));
+    cache.set(network, { data, at: Date.now() });
+    return NextResponse.json(data, { headers: { "cache-control": CACHE_CONTROL } });
+  } catch {
+    // serve the stale aggregate over an error — creations move slowly
+    if (hit) return NextResponse.json(hit.data, { headers: { "cache-control": CACHE_CONTROL } });
+    return NextResponse.json({ error: "registry upstream unreachable" }, { status: 504 });
+  }
+}

--- a/app/api/l1-registry/[network]/route.ts
+++ b/app/api/l1-registry/[network]/route.ts
@@ -32,8 +32,6 @@ interface RegistrySubnet {
 
 export interface L1Registry {
   totals: { subnets: number; l1s: number; blockchains: number; evmChains: number };
-  /** oldest-first cumulative counts by month (YYYY-MM) */
-  series: { month: string; blockchains: number; subnets: number }[];
   /** newest blockchain launches, newest first */
   recent: {
     name: string;
@@ -67,30 +65,18 @@ async function fetchAllSubnets(network: string): Promise<RegistrySubnet[]> {
   return out;
 }
 
-function monthOf(ts: number): string {
-  return new Date(ts * 1000).toISOString().slice(0, 7);
-}
-
 function buildRegistry(subnets: RegistrySubnet[]): L1Registry {
   const totals = { subnets: 0, l1s: 0, blockchains: 0, evmChains: 0 };
-  const subnetMonths = new Map<string, number>();
-  const chainMonths = new Map<string, number>();
   const allChains: L1Registry["recent"] = [];
 
   for (const s of subnets) {
     if (s.subnetId === PRIMARY_SUBNET_ID) continue;
     totals.subnets++;
     if (s.isL1) totals.l1s++;
-    if (s.createBlockTimestamp) {
-      const m = monthOf(s.createBlockTimestamp);
-      subnetMonths.set(m, (subnetMonths.get(m) ?? 0) + 1);
-    }
     for (const b of s.blockchains ?? []) {
       totals.blockchains++;
       if (b.evmChainId) totals.evmChains++;
       if (b.createBlockTimestamp) {
-        const m = monthOf(b.createBlockTimestamp);
-        chainMonths.set(m, (chainMonths.get(m) ?? 0) + 1);
         allChains.push({
           name: b.blockchainName || "Unnamed chain",
           blockchainId: b.blockchainId,
@@ -103,25 +89,8 @@ function buildRegistry(subnets: RegistrySubnet[]): L1Registry {
     }
   }
 
-  // one continuous month axis from the first creation to now, both series
-  // accumulating along it — a cumulative chart must never skip a month
-  const months = [...new Set([...subnetMonths.keys(), ...chainMonths.keys()])].sort();
-  const series: L1Registry["series"] = [];
-  if (months.length) {
-    let cb = 0;
-    let cs = 0;
-    const now = monthOf(Date.now() / 1000);
-    for (let d = new Date(`${months[0]}-01T00:00:00Z`); ; d.setUTCMonth(d.getUTCMonth() + 1)) {
-      const m = d.toISOString().slice(0, 7);
-      cb += chainMonths.get(m) ?? 0;
-      cs += subnetMonths.get(m) ?? 0;
-      series.push({ month: m, blockchains: cb, subnets: cs });
-      if (m >= now) break;
-    }
-  }
-
   allChains.sort((a, b) => b.createdAt - a.createdAt);
-  return { totals, series, recent: allChains.slice(0, 8), lastUpdated: Date.now() };
+  return { totals, recent: allChains.slice(0, 8), lastUpdated: Date.now() };
 }
 
 export async function GET(

--- a/app/api/pchain-l1-ops/[network]/route.ts
+++ b/app/api/pchain-l1-ops/[network]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getPchainL1Ops, type PchainL1OpsDays } from "@/lib/explorer-clickhouse";
+
+// The P-Chain's L1 ops ledger for the L1s tab: daily counts of every
+// ACP-77 transaction type it processed (register / set-weight / disable /
+// top-up / convert) over ?days=30|90|365, plus the all-time cumulative
+// conversion curve. Reads the same ClickHouse box as /api/pchain-activity.
+
+const WINDOWS: PchainL1OpsDays[] = [30, 90, 365];
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ network: string }> },
+) {
+  const { network } = await params;
+  const raw = Number(req.nextUrl.searchParams.get("days") ?? 30);
+  const days = (WINDOWS.includes(raw as PchainL1OpsDays) ? raw : 30) as PchainL1OpsDays;
+  const data = await getPchainL1Ops(network, days);
+  if (data === null) {
+    return NextResponse.json({ error: "no l1 ops data" }, { status: 404 });
+  }
+  return NextResponse.json(data, {
+    headers: {
+      "Cache-Control": "public, max-age=300, s-maxage=900, stale-while-revalidate=1800",
+    },
+  });
+}

--- a/app/api/pchain-rpc/[network]/route.ts
+++ b/app/api/pchain-rpc/[network]/route.ts
@@ -17,6 +17,8 @@ const ALLOWED_METHODS = new Set([
   "platform.getCurrentValidators",
   // the node page's network-share denominator
   "platform.getTotalStake",
+  // the L1s tab's continuous-fee price (ACP-77 fee market)
+  "platform.getValidatorFeeState",
 ]);
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ network: string }> }) {

--- a/app/api/validator-stats/route.ts
+++ b/app/api/validator-stats/route.ts
@@ -88,15 +88,14 @@ async function listClassicValidators(network: "mainnet" | "fuji"): Promise<Simpl
 async function listL1Validators(network: "mainnet" | "fuji"): Promise<SimpleValidator[]> {
   // Active L1 validators across all subnets from our P-chain read API.
   //
-  // Upstream bug (2026-07-24, tracked with Ash): includeInactive=false still
-  // returns validators the node has already removed — weight-0 rows with
-  // stale remainingBalance. Mainnet evidence: the endpoint returned 1,231
-  // "active" Coqnet validators while platform.getCurrentValidators showed 6,
-  // and a sampled validationID 404'd on the node. weight > 0 recovers the
-  // node's counts exactly for healthy sets (Beam 236/236, h7egy 25/25) and
-  // collapses wound-down sets to near-truth; without it every consumer of
-  // this aggregate (switcher, portal, chains directory, validators pages,
-  // staking leaderboard) inflates L1 sets by an order of magnitude.
+  // Upstream fixed 2026-07-24 (stats-api PR #8): the endpoint used to ship
+  // removed validators (weight-0 rows with stale balances — Coqnet reported
+  // 1,231 "active" vs 6 on the node) because the replay had ACP-77 removal
+  // and disable semantics inverted. The weight/balance filter below is kept
+  // as a cheap defense against regressions; post-fix it drops nothing the
+  // endpoint should have sent. Counts here are REGISTERED ACTIVE seats —
+  // remainingBalance is still gross of continuous-fee burn upstream, so
+  // drained-but-not-removed seats pass the balance check.
   const vs = await fetchAllPages<any>(`/v1/networks/${network}/l1Validators?includeInactive=false`, "validators");
   return vs
     .filter(v => Number(v.weight) > 0 && Number(v.remainingBalance) > 0)

--- a/app/api/validator-stats/route.ts
+++ b/app/api/validator-stats/route.ts
@@ -87,9 +87,19 @@ async function listClassicValidators(network: "mainnet" | "fuji"): Promise<Simpl
 
 async function listL1Validators(network: "mainnet" | "fuji"): Promise<SimpleValidator[]> {
   // Active L1 validators across all subnets from our P-chain read API.
+  //
+  // Upstream bug (2026-07-24, tracked with Ash): includeInactive=false still
+  // returns validators the node has already removed — weight-0 rows with
+  // stale remainingBalance. Mainnet evidence: the endpoint returned 1,231
+  // "active" Coqnet validators while platform.getCurrentValidators showed 6,
+  // and a sampled validationID 404'd on the node. weight > 0 recovers the
+  // node's counts exactly for healthy sets (Beam 236/236, h7egy 25/25) and
+  // collapses wound-down sets to near-truth; without it every consumer of
+  // this aggregate (switcher, portal, chains directory, validators pages,
+  // staking leaderboard) inflates L1 sets by an order of magnitude.
   const vs = await fetchAllPages<any>(`/v1/networks/${network}/l1Validators?includeInactive=false`, "validators");
   return vs
-    .filter(v => Number(v.remainingBalance) > 0)
+    .filter(v => Number(v.weight) > 0 && Number(v.remainingBalance) > 0)
     .map(v => ({
       nodeId: v.nodeId,
       subnetId: v.subnetId,

--- a/components/explorer-v2/BlockTape.tsx
+++ b/components/explorer-v2/BlockTape.tsx
@@ -40,7 +40,7 @@ const DEPTH = "0.5rem"; // extrusion depth — keep in sync with the -top/-right
 export function BlockTape({ blocks }: { blocks: TapeBlock[] }) {
   return (
     <div className="relative overflow-hidden">
-      <div className="flex gap-2 pr-2 pt-2">
+      <div className="flex gap-2 pr-2 pt-3">
         {blocks.map((b, i) => {
           const live = i === 0;
           const hasFill = typeof b.fill === "number";
@@ -63,13 +63,15 @@ export function BlockTape({ blocks }: { blocks: TapeBlock[] }) {
               // momentum curve: sharp attack, long decay — stretched so a
               // single arriving block glides rather than snaps
               transition={{ duration: 0.85, ease: [0.22, 1, 0.36, 1] }}
-              className="relative w-[96px] shrink-0"
+              // hover lifts the whole cuboid off the sheet: all three faces
+              // ride the same group-hover translate so it moves as one solid
+              className="group relative w-[96px] shrink-0"
             >
               {/* top face — tints only when the block is sealed full */}
               <span
                 aria-hidden
                 className={cn(
-                  "absolute -top-2 left-0 w-full origin-bottom-left skew-x-[-45deg]",
+                  "absolute -top-2 left-0 w-full origin-bottom-left skew-x-[-45deg] transition-transform duration-200 ease-out group-hover:-translate-y-1",
                   live
                     ? "bg-[color-mix(in_srgb,var(--chain-accent,#E6212F)_75%,white)]"
                     : sealed
@@ -84,7 +86,7 @@ export function BlockTape({ blocks }: { blocks: TapeBlock[] }) {
               <span
                 aria-hidden
                 className={cn(
-                  "absolute -right-2 top-0 h-full origin-top-left skew-y-[-45deg] overflow-hidden",
+                  "absolute -right-2 top-0 h-full origin-top-left skew-y-[-45deg] overflow-hidden transition-transform duration-200 ease-out group-hover:-translate-y-1",
                   live
                     ? "bg-[color-mix(in_srgb,var(--chain-accent,#E6212F)_70%,black)]"
                     : carries
@@ -109,7 +111,7 @@ export function BlockTape({ blocks }: { blocks: TapeBlock[] }) {
               <Link
                 href={b.href}
                 className={cn(
-                  "relative flex h-full flex-col gap-1 overflow-hidden px-3 py-2.5 backdrop-blur-sm transition-colors",
+                  "relative flex h-full flex-col gap-1 overflow-hidden px-3 py-2.5 backdrop-blur-sm transition-[background-color,translate] duration-200 ease-out group-hover:-translate-y-1",
                   live
                     ? "bg-[var(--chain-accent,#E6212F)] hover:bg-[color-mix(in_srgb,var(--chain-accent,#E6212F)_80%,black)]"
                     : carries
@@ -206,7 +208,7 @@ export function BlockTape({ blocks }: { blocks: TapeBlock[] }) {
 
 export function BlockTapeSkeleton() {
   return (
-    <div className="flex gap-2 overflow-hidden pr-2 pt-2">
+    <div className="flex gap-2 overflow-hidden pr-2 pt-3">
       {Array.from({ length: 14 }).map((_, i) => (
         <div
           key={i}

--- a/components/explorer-v2/ExplorerSubnav.tsx
+++ b/components/explorer-v2/ExplorerSubnav.tsx
@@ -312,13 +312,22 @@ function buildTabs(network: string, chainSlug: string | undefined): Tab[] {
       { label: "Blocks", href: `${base}/blocks`, isActive: (p) => p.startsWith(`${base}/block`) },
       { label: "Transactions", href: `${base}/txs`, isActive: (p) => p.startsWith(`${base}/tx`) },
     ];
-    // the staking observatory's feeds are mainnet-only
+    // the staking + L1-economy feeds are mainnet-only
     if (network === "mainnet") {
-      tabs.push({
-        label: "Staking",
-        href: `${base}/staking`,
-        isActive: (p) => p.startsWith(`${base}/staking`),
-      });
+      tabs.push(
+        {
+          label: "Staking",
+          href: `${base}/staking`,
+          isActive: (p) => p.startsWith(`${base}/staking`),
+        },
+        // the OTHER validator economy: ACP-77 seats burn where staking
+        // mints — different money, different tab
+        {
+          label: "L1s",
+          href: `${base}/l1s`,
+          isActive: (p) => p.startsWith(`${base}/l1s`),
+        },
+      );
     }
     tabs.push({
       label: "Validators",

--- a/components/explorer-v2/evm/EvmAccounts.tsx
+++ b/components/explorer-v2/evm/EvmAccounts.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { EvmShell } from "@/components/explorer-v2/EvmShell";
-import { Board, BoardHeader, ChartBoard, StatDash } from "@/components/explorer-v2/ui";
+import { Board, BoardHeader, ChartBoard, StatDash, idInk } from "@/components/explorer-v2/ui";
 import { ChartEmpty, Stat } from "@/components/explorer-v2/staking/bits";
 import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import { useContractNames } from "@/lib/sourcify-client";
@@ -130,7 +130,7 @@ function LeaderBoard({
                 {i + 1}
               </span>
               <span
-                className="truncate font-mono text-[12px] text-zinc-900 dark:text-zinc-100"
+                className={`truncate font-mono text-[12px] ${idInk}`}
                 title={name ? `${name} · ${l.address}` : l.address}
               >
                 {name ?? shortAddr(l.address)}

--- a/components/explorer-v2/evm/EvmAddress.tsx
+++ b/components/explorer-v2/evm/EvmAddress.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { EvmShell } from "@/components/explorer-v2/EvmShell";
-import { Board, CellLabel, DetailSkeleton, HashChip, SectionHeader, SpecPlate, SpecRow } from "@/components/explorer-v2/ui";
+import { Board, CellLabel, DetailSkeleton, HashChip, SectionHeader, SpecPlate, SpecRow, idInk } from "@/components/explorer-v2/ui";
 import { formatNumber, formatTime, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { formatEther } from "./format";
 import { FeedDown, MethodChip } from "./bits";
@@ -114,7 +114,7 @@ export function EvmAddress({ network, addr }: { network: string; addr: string })
                       href={`${base}/tx/${t.hash}`}
                       className="grid grid-cols-2 gap-x-4 gap-y-1 px-5 py-3 transition-colors hover:bg-zinc-50 md:grid-cols-[1.4fr_0.9fr_0.6fr_1.3fr_0.8fr_0.7fr] md:items-center md:px-6 dark:hover:bg-zinc-900"
                     >
-                      <span className="truncate font-mono text-[12px] text-zinc-900 dark:text-zinc-100">
+                      <span className={`truncate font-mono text-[12px] ${idInk}`}>
                         {truncate(t.hash, 18)}
                       </span>
                       <span className="min-w-0 justify-self-start">

--- a/components/explorer-v2/evm/EvmBlock.tsx
+++ b/components/explorer-v2/evm/EvmBlock.tsx
@@ -11,6 +11,7 @@ import {
   SpecPlate,
   SpecRow,
   SubjectHeadline,
+  idInk,
 } from "@/components/explorer-v2/ui";
 import { formatNumber, formatTime, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { formatEther, formatGwei, gasUsedPct } from "./format";
@@ -86,7 +87,7 @@ export function EvmBlock({ network, id }: { network: string; id: string }) {
                   href={`${base}/tx/${t.hash}`}
                   className="grid grid-cols-2 gap-x-4 gap-y-1 px-5 py-3 transition-colors hover:bg-zinc-50 md:grid-cols-[1.5fr_8rem_1.4fr_0.9fr_5rem] md:items-center md:px-6 dark:hover:bg-zinc-900"
                 >
-                  <span className="min-w-0 truncate font-mono text-[12px] text-zinc-900 dark:text-zinc-100">
+                  <span className={`min-w-0 truncate font-mono text-[12px] ${idInk}`}>
                     {truncate(t.hash, 20)}
                   </span>
                   <span className="min-w-0">

--- a/components/explorer-v2/evm/EvmBlocksList.tsx
+++ b/components/explorer-v2/evm/EvmBlocksList.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { EvmShell } from "@/components/explorer-v2/EvmShell";
-import { Board, CellLabel, SectionHeader } from "@/components/explorer-v2/ui";
+import { Board, CellLabel, SectionHeader, idInk } from "@/components/explorer-v2/ui";
 import { formatNumber, timeAgo } from "@/components/explorer-v2/format";
 import { GasFill } from "./bits";
 import { useEvmData, LIVE_REFRESH_MS } from "./hooks";
@@ -38,7 +38,7 @@ export function EvmBlocksList({ network }: { network: string }) {
               href={`${base}/block/${b.number}`}
               className="grid grid-cols-2 gap-x-4 gap-y-1 px-5 py-3 transition-colors hover:bg-zinc-50 md:grid-cols-[1fr_0.7fr_1fr_0.7fr] md:items-center md:px-6 dark:hover:bg-zinc-900"
             >
-              <span className="font-mono text-[13px] tabular-nums text-zinc-900 dark:text-zinc-100">
+              <span className={`font-mono text-[13px] tabular-nums ${idInk}`}>
                 #{formatNumber(b.number)}
               </span>
               <span className="font-mono text-[11px] tabular-nums text-zinc-500 md:text-right dark:text-zinc-400">

--- a/components/explorer-v2/evm/EvmTxsList.tsx
+++ b/components/explorer-v2/evm/EvmTxsList.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { EvmShell } from "@/components/explorer-v2/EvmShell";
-import { Board, CellLabel, SectionHeader } from "@/components/explorer-v2/ui";
+import { Board, CellLabel, SectionHeader, idInk } from "@/components/explorer-v2/ui";
 import { ChartEmpty } from "@/components/explorer-v2/staking/bits";
 import { RANGE_DAYS, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import { formatNumber, timeAgo, truncate } from "@/components/explorer-v2/format";
@@ -66,7 +66,7 @@ export function EvmTxsList({ network }: { network: string }) {
               href={`${base}/tx/${t.hash}`}
               className="grid grid-cols-2 gap-x-4 gap-y-1 px-5 py-3 transition-colors hover:bg-zinc-50 md:grid-cols-[1.4fr_8rem_1.5fr_0.9fr_0.7fr_5rem] md:items-center md:px-6 dark:hover:bg-zinc-900"
             >
-              <span className="truncate font-mono text-[12px] text-zinc-900 dark:text-zinc-100">
+              <span className={`truncate font-mono text-[12px] ${idInk}`}>
                 {truncate(t.hash, 18)}
               </span>
               <span className="min-w-0">

--- a/components/explorer-v2/pchain/GenesisViewer.tsx
+++ b/components/explorer-v2/pchain/GenesisViewer.tsx
@@ -69,7 +69,16 @@ interface EvmOverview {
   targetGas?: number;
   timestamp?: number;
   precompiles: string[];
-  alloc: { address: string; balance: string }[];
+  alloc: { address: string; balance: string; contract: boolean }[];
+}
+
+/* one subnet-evm GenesisAccount — alloc entries can be funded accounts
+   (balance) or predeployed contracts (code/storage/nonce), or both */
+interface GenesisAccount {
+  balance?: string;
+  code?: string;
+  storage?: Record<string, string>;
+  nonce?: string | number;
 }
 
 function asNumber(v: unknown): number | undefined {
@@ -85,11 +94,12 @@ function evmOverview(g: Record<string, unknown>): EvmOverview | null {
   const config = g.config as Record<string, unknown> | undefined;
   if (!config || typeof config !== "object") return null;
   const fee = (config.feeConfig ?? {}) as Record<string, unknown>;
-  const allocObj = (g.alloc ?? {}) as Record<string, { balance?: string }>;
+  const allocObj = (g.alloc ?? {}) as Record<string, GenesisAccount>;
   const alloc = Object.entries(allocObj)
     .map(([addr, v]) => ({
       address: addr.startsWith("0x") ? addr : `0x${addr}`,
       balance: v?.balance ?? "0",
+      contract: typeof v?.code === "string" && v.code.length > 2,
     }))
     .sort((a, b) => {
       try {
@@ -112,7 +122,13 @@ function evmOverview(g: Record<string, unknown>): EvmOverview | null {
   };
 }
 
-/* wei (hex or decimal string) → whole native-token units, 2dp when needed */
+const MAX_UINT256 = (1n << 256n) - 1n;
+
+/* wei (hex or decimal string) → whole native-token units, 2dp when needed.
+   Genesis balances can be absurd on purpose — a faucet chain allocates
+   max uint256 (~1.16e59 tokens) to one key. Never expand those into a
+   60-character comma string: it crushes the address column into a one-
+   character-per-line ribbon. */
 function formatTokenBalance(balance: string): string {
   let v: bigint;
   try {
@@ -120,7 +136,13 @@ function formatTokenBalance(balance: string): string {
   } catch {
     return balance;
   }
+  if (v === MAX_UINT256) return "MAX";
   const whole = v / 10n ** 18n;
+  if (whole >= 10n ** 15n) {
+    // beyond any real supply — exponent form keeps the column sane
+    const s = whole.toString();
+    return `${s[0]}.${s.slice(1, 3)}e${s.length - 1}`;
+  }
   const cents = ((v % 10n ** 18n) * 100n) / 10n ** 18n;
   const w = whole.toLocaleString("en-US");
   return cents > 0n ? `${w}.${cents.toString().padStart(2, "0")}` : w;
@@ -310,8 +332,18 @@ export function GenesisViewer({
                   key={a.address}
                   className="flex items-center justify-between gap-4 px-5 py-3 md:px-6"
                 >
-                  <HashChip value={a.address} len={24} />
-                  <span className="shrink-0 font-mono text-[13px] tabular-nums text-zinc-900 dark:text-zinc-100">
+                  <span className="flex min-w-0 items-center gap-2.5">
+                    <HashChip value={a.address} len={24} />
+                    {a.contract && (
+                      <span className="shrink-0 border border-[#0061E2]/35 bg-[#0061E2]/10 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.1em] text-[#0052bd] dark:border-[#0061E2]/50 dark:text-[#5f9dff]">
+                        contract
+                      </span>
+                    )}
+                  </span>
+                  <span
+                    className="shrink-0 font-mono text-[13px] tabular-nums text-zinc-900 dark:text-zinc-100"
+                    title={a.balance}
+                  >
                     {formatTokenBalance(a.balance)}
                   </span>
                 </div>

--- a/components/explorer-v2/pchain/GenesisViewer.tsx
+++ b/components/explorer-v2/pchain/GenesisViewer.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Check, Copy, Download } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Board, HashChip, SectionHeader, SpecPlate, SpecRow } from "@/components/explorer-v2/ui";
+import { formatTime } from "@/components/explorer-v2/format";
+
+/* CreateChainTx genesisData → readable. The node's JSON codec ships the
+   genesis bytes base64-encoded; for EVM chains those bytes ARE the genesis
+   JSON — the chain's founding document. Decode defensively: custom VMs can
+   put anything in there, and the viewer must degrade, never break the page. */
+
+interface DecodedGenesis {
+  /** parsed document, when the bytes are JSON */
+  json?: Record<string, unknown>;
+  /** pretty-printed text of whatever decoded */
+  text: string;
+}
+
+export function decodeGenesisData(genesisData: unknown): DecodedGenesis | null {
+  if (genesisData == null) return null;
+  // some encodings hand the document over already parsed
+  if (typeof genesisData === "object") {
+    return {
+      json: genesisData as Record<string, unknown>,
+      text: JSON.stringify(genesisData, null, 2),
+    };
+  }
+  if (typeof genesisData !== "string") return null;
+  let bytes: Uint8Array | null = null;
+  if (/^0x[0-9a-fA-F]*$/.test(genesisData)) {
+    const clean = genesisData.slice(2);
+    bytes = new Uint8Array(clean.length / 2);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  } else {
+    try {
+      bytes = Uint8Array.from(atob(genesisData), (c) => c.charCodeAt(0));
+    } catch {
+      return null;
+    }
+  }
+  const text = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  try {
+    const json = JSON.parse(text) as Record<string, unknown>;
+    return { json, text: JSON.stringify(json, null, 2) };
+  } catch {
+    // not JSON — worth showing only if it reads as text, not binary noise
+    const nonPrintable = text.replace(/[\x20-\x7e\s]/g, "");
+    return nonPrintable.length / Math.max(text.length, 1) < 0.05 ? { text } : null;
+  }
+}
+
+/* Subnet-EVM stateful precompiles, keyed as they appear in genesis config. */
+const PRECOMPILE_NAMES: Record<string, string> = {
+  contractDeployerAllowListConfig: "Contract Deployer Allow List",
+  contractNativeMinterConfig: "Native Minter",
+  txAllowListConfig: "Transaction Allow List",
+  feeManagerConfig: "Fee Manager",
+  rewardManagerConfig: "Reward Manager",
+  warpConfig: "Warp Messaging",
+};
+
+interface EvmOverview {
+  chainId?: number;
+  gasLimit?: number;
+  targetBlockRate?: number;
+  minBaseFee?: number;
+  targetGas?: number;
+  timestamp?: number;
+  precompiles: string[];
+  alloc: { address: string; balance: string }[];
+}
+
+function asNumber(v: unknown): number | undefined {
+  if (typeof v === "number") return v;
+  if (typeof v === "string") {
+    const n = v.startsWith("0x") ? parseInt(v, 16) : Number(v);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}
+
+function evmOverview(g: Record<string, unknown>): EvmOverview | null {
+  const config = g.config as Record<string, unknown> | undefined;
+  if (!config || typeof config !== "object") return null;
+  const fee = (config.feeConfig ?? {}) as Record<string, unknown>;
+  const allocObj = (g.alloc ?? {}) as Record<string, { balance?: string }>;
+  const alloc = Object.entries(allocObj)
+    .map(([addr, v]) => ({
+      address: addr.startsWith("0x") ? addr : `0x${addr}`,
+      balance: v?.balance ?? "0",
+    }))
+    .sort((a, b) => {
+      try {
+        return BigInt(b.balance) > BigInt(a.balance) ? 1 : -1;
+      } catch {
+        return 0;
+      }
+    });
+  return {
+    chainId: asNumber(config.chainId),
+    gasLimit: asNumber(fee.gasLimit) ?? asNumber(g.gasLimit),
+    targetBlockRate: asNumber(fee.targetBlockRate),
+    minBaseFee: asNumber(fee.minBaseFee),
+    targetGas: asNumber(fee.targetGas),
+    timestamp: asNumber(g.timestamp),
+    precompiles: Object.keys(config).filter(
+      (k) => k.endsWith("Config") && k !== "feeConfig" && config[k] != null,
+    ),
+    alloc,
+  };
+}
+
+/* wei (hex or decimal string) → whole native-token units, 2dp when needed */
+function formatTokenBalance(balance: string): string {
+  let v: bigint;
+  try {
+    v = BigInt(balance);
+  } catch {
+    return balance;
+  }
+  const whole = v / 10n ** 18n;
+  const cents = ((v % 10n ** 18n) * 100n) / 10n ** 18n;
+  const w = whole.toLocaleString("en-US");
+  return cents > 0n ? `${w}.${cents.toString().padStart(2, "0")}` : w;
+}
+
+const ALLOC_PREVIEW = 8;
+
+/* The genesis instrument: an Overview board reading the founding config
+   like a spec sheet (chain id, fee market, precompiles, allocations), and
+   the raw JSON verbatim — copy and download always at hand. Shared by the
+   CreateChainTx page and the chain Details tab. */
+export function GenesisViewer({
+  genesisData,
+  loading = false,
+  label = "Genesis",
+}: {
+  genesisData: unknown;
+  loading?: boolean;
+  label?: string;
+}) {
+  const decoded = useMemo(() => decodeGenesisData(genesisData), [genesisData]);
+  const overview = useMemo(
+    () => (decoded?.json ? evmOverview(decoded.json) : null),
+    [decoded],
+  );
+  const [view, setView] = useState<"overview" | "json">("json");
+  // the data lands async — jump to the richer view the moment it parses
+  useEffect(() => {
+    setView(overview ? "overview" : "json");
+  }, [overview]);
+  const [copied, setCopied] = useState(false);
+  const [showAllAlloc, setShowAllAlloc] = useState(false);
+
+  if (!loading && !decoded) {
+    // undecodable payload: state the fact quietly rather than hiding the row
+    return (
+      <section className="flex flex-col gap-4">
+        <SectionHeader label={label} />
+        <Board divide={false} className="px-5 py-6 text-center md:px-6">
+          <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-zinc-400 dark:text-zinc-500">
+            Genesis payload is not decodable as text
+          </p>
+        </Board>
+      </section>
+    );
+  }
+
+  const copy = async () => {
+    if (!decoded) return;
+    try {
+      await navigator.clipboard.writeText(decoded.text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* text is selectable anyway */
+    }
+  };
+
+  const download = () => {
+    if (!decoded) return;
+    const blob = new Blob([decoded.text], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "genesis.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const visibleAlloc = overview
+    ? showAllAlloc
+      ? overview.alloc
+      : overview.alloc.slice(0, ALLOC_PREVIEW)
+    : [];
+
+  return (
+    <section className="flex flex-col gap-4">
+      <SectionHeader
+        label={label}
+        action={
+          decoded ? (
+            <span className="flex shrink-0 items-center gap-4">
+              {overview && (
+                <div className="inline-flex border border-zinc-200 dark:border-zinc-800">
+                  {(["overview", "json"] as const).map((v) => (
+                    <button
+                      key={v}
+                      onClick={() => setView(v)}
+                      className={cn(
+                        "px-3 py-1 font-mono text-[10px] font-bold uppercase tracking-[0.14em] transition-colors",
+                        view === v
+                          ? "bg-zinc-900 text-zinc-50 dark:bg-zinc-50 dark:text-zinc-900"
+                          : "text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-900",
+                      )}
+                    >
+                      {v}
+                    </button>
+                  ))}
+                </div>
+              )}
+              <button
+                onClick={copy}
+                className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+              >
+                {copied ? <Check className="h-3 w-3 text-[#E6212F]" /> : <Copy className="h-3 w-3" />}
+                Copy
+              </button>
+              <button
+                onClick={download}
+                className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+              >
+                <Download className="h-3 w-3" />
+                genesis.json
+              </button>
+            </span>
+          ) : undefined
+        }
+      />
+      {loading || !decoded ? (
+        <Board divide={false} className="px-5 py-4 md:px-6">
+          <div className="flex flex-col gap-3 py-1">
+            {[0, 1, 2, 3].map((i) => (
+              <div key={i} className="h-3 w-2/3 animate-pulse bg-zinc-100 dark:bg-zinc-900" />
+            ))}
+          </div>
+        </Board>
+      ) : view === "overview" && overview ? (
+        <div className="grid items-start gap-8 lg:grid-cols-2">
+          <Board divide={false} className="px-5 py-4 md:px-6">
+            <SpecPlate>
+              {overview.chainId !== undefined && (
+                <SpecRow label="EVM Chain ID">
+                  <span className="inline-flex items-baseline gap-2">
+                    <span className="font-mono">{overview.chainId}</span>
+                    <span className="font-mono text-[11px] text-zinc-400 dark:text-zinc-500">
+                      0x{overview.chainId.toString(16)}
+                    </span>
+                  </span>
+                </SpecRow>
+              )}
+              {overview.gasLimit !== undefined && (
+                <SpecRow label="Gas Limit">{overview.gasLimit.toLocaleString("en-US")}</SpecRow>
+              )}
+              {overview.targetBlockRate !== undefined && (
+                <SpecRow label="Target Block Rate">{overview.targetBlockRate}s</SpecRow>
+              )}
+              {overview.minBaseFee !== undefined && (
+                <SpecRow label="Min Base Fee">
+                  {(overview.minBaseFee / 1e9).toLocaleString("en-US")} gwei
+                </SpecRow>
+              )}
+              {overview.targetGas !== undefined && (
+                <SpecRow label="Target Gas">{overview.targetGas.toLocaleString("en-US")}</SpecRow>
+              )}
+              {overview.timestamp !== undefined && overview.timestamp > 0 && (
+                <SpecRow label="Genesis Time">{formatTime(overview.timestamp)}</SpecRow>
+              )}
+              {overview.precompiles.length > 0 && (
+                <SpecRow label="Precompiles" align="start">
+                  <span className="flex flex-wrap justify-end gap-1.5">
+                    {overview.precompiles.map((p) => (
+                      <span
+                        key={p}
+                        className="border border-[#0061E2]/35 bg-[#0061E2]/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-[#0052bd] dark:border-[#0061E2]/50 dark:text-[#5f9dff]"
+                      >
+                        {PRECOMPILE_NAMES[p] ?? p.replace(/Config$/, "")}
+                      </span>
+                    ))}
+                  </span>
+                </SpecRow>
+              )}
+            </SpecPlate>
+          </Board>
+          <div className="flex flex-col gap-4">
+            <Board>
+              <div className="flex items-center justify-between gap-4 px-5 py-2.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 md:px-6 dark:text-zinc-500">
+                <span>Genesis Allocations · {overview.alloc.length}</span>
+                <span className="text-right">Balance</span>
+              </div>
+              {overview.alloc.length === 0 && (
+                <div className="px-5 py-4 font-mono text-[11px] text-zinc-400 md:px-6 dark:text-zinc-500">
+                  no pre-funded accounts
+                </div>
+              )}
+              {visibleAlloc.map((a) => (
+                <div
+                  key={a.address}
+                  className="flex items-center justify-between gap-4 px-5 py-3 md:px-6"
+                >
+                  <HashChip value={a.address} len={24} />
+                  <span className="shrink-0 font-mono text-[13px] tabular-nums text-zinc-900 dark:text-zinc-100">
+                    {formatTokenBalance(a.balance)}
+                  </span>
+                </div>
+              ))}
+            </Board>
+            {overview.alloc.length > ALLOC_PREVIEW && (
+              <button
+                onClick={() => setShowAllAlloc((v) => !v)}
+                className="mx-auto border border-zinc-200 px-5 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-zinc-600 transition-colors hover:border-zinc-900 hover:text-zinc-900 dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-100 dark:hover:text-zinc-100"
+              >
+                {showAllAlloc ? "Show fewer" : `Show all ${overview.alloc.length}`}
+              </button>
+            )}
+          </div>
+        </div>
+      ) : (
+        <Board divide={false}>
+          <pre className="max-h-[36rem] overflow-auto whitespace-pre-wrap break-all px-5 py-4 font-mono text-[11.5px] leading-relaxed text-zinc-700 md:px-6 dark:text-zinc-300">
+            {decoded.text}
+          </pre>
+        </Board>
+      )}
+    </section>
+  );
+}

--- a/components/explorer-v2/pchain/PchainAddress.tsx
+++ b/components/explorer-v2/pchain/PchainAddress.tsx
@@ -11,6 +11,7 @@ import {
   SpecPlate,
   SpecRow,
   TxTypePill,
+  idInk,
 } from "@/components/explorer-v2/ui";
 import { formatAvax, formatNumber, formatTime, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { usePchainData } from "./hooks";
@@ -182,7 +183,7 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
                     href={`${base}/tx/${t.txHash}`}
                     className="grid grid-cols-2 gap-x-4 gap-y-1 px-5 py-3 transition-colors hover:bg-zinc-50 md:grid-cols-[2fr_1.2fr_1fr_0.7fr] md:items-center md:px-6 dark:hover:bg-zinc-900"
                   >
-                    <span className="truncate font-mono text-[12px] text-zinc-900 dark:text-zinc-100">
+                    <span className={`truncate font-mono text-[12px] ${idInk}`}>
                       {truncate(t.txHash, 16)}
                     </span>
                     <span className="justify-self-start">

--- a/components/explorer-v2/pchain/PchainBlock.tsx
+++ b/components/explorer-v2/pchain/PchainBlock.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
-import { Board, DetailSkeleton, HashChip, SectionHeader, SpecPlate, SpecRow, SubjectHeadline, TxTypePill } from "@/components/explorer-v2/ui";
+import { Board, DetailSkeleton, HashChip, SectionHeader, SpecPlate, SpecRow, SubjectHeadline, TxTypePill, idInk } from "@/components/explorer-v2/ui";
 import { formatBytes, formatNumber, formatTime, timeAgo } from "@/components/explorer-v2/format";
 import { usePchainData } from "./hooks";
 import { NotFound } from "./PchainTx";
@@ -66,7 +66,7 @@ export function PchainBlock({ chain, network, id }: { chain: string; network: st
                   href={`${base}/tx/${t.txHash}`}
                   className="flex items-center justify-between gap-4 px-5 py-3 transition-colors hover:bg-zinc-50 md:px-6 dark:hover:bg-zinc-900"
                 >
-                  <span className="min-w-0 truncate font-mono text-[12px] text-zinc-900 dark:text-zinc-100">
+                  <span className={`min-w-0 truncate font-mono text-[12px] ${idInk}`}>
                     {t.txHash}
                   </span>
                   <TxTypePill type={t.txType.replace(/Tx$/, "")} />

--- a/components/explorer-v2/pchain/PchainBlocksList.tsx
+++ b/components/explorer-v2/pchain/PchainBlocksList.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
-import { Board, CellLabel, SectionHeader, TxTypePill, TypeFilterRail } from "@/components/explorer-v2/ui";
+import { Board, CellLabel, SectionHeader, TxTypePill, TypeFilterRail, idInk } from "@/components/explorer-v2/ui";
 import { formatBytes, formatNumber, timeAgo } from "@/components/explorer-v2/format";
 import { pchainApiPath, type BlocksList, type BlockSummary } from "@/lib/pchain-explorer";
 import { LIVE_REFRESH_MS } from "./hooks";
@@ -112,7 +112,7 @@ export function PchainBlocksList({ chain, network }: { chain: string; network: s
               onClick={() => router.push(`${base}/block/${b.blockNumber}`)}
               className="grid cursor-pointer grid-cols-2 gap-x-4 gap-y-1 px-5 py-3.5 transition-colors hover:bg-zinc-50 md:grid-cols-[1fr_1.1fr_0.5fr_0.6fr_minmax(19rem,2fr)_0.7fr] md:items-center md:px-6 dark:hover:bg-zinc-900"
             >
-              <span className="font-mono text-[13px] tabular-nums text-zinc-900 dark:text-zinc-100">
+              <span className={`font-mono text-[13px] tabular-nums ${idInk}`}>
                 #{formatNumber(b.blockNumber)}
               </span>
               <span className="justify-self-start">

--- a/components/explorer-v2/pchain/PchainChain.tsx
+++ b/components/explorer-v2/pchain/PchainChain.tsx
@@ -12,10 +12,12 @@ import {
   SectionHeader,
   SpecPlate,
   SpecRow,
+  idInk,
 } from "@/components/explorer-v2/ui";
 import { formatAvax, formatNumber, formatTime, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { usePchainData } from "./hooks";
 import { NotFound } from "./PchainTx";
+import { GenesisViewer } from "./GenesisViewer";
 import l1ChainsData from "@/constants/l1-chains.json";
 import { L1Chain } from "@/types/stats";
 import { hexToCB58 } from "@avalanche-sdk/client/utils";
@@ -26,6 +28,7 @@ import {
   VM_NAMES,
   cb58ToHex,
   getCurrentValidators,
+  getPlatformTx,
   getSubnetInfo,
   type CurrentValidator,
   type SubnetInfo,
@@ -96,6 +99,17 @@ export function ChainDetailsContent({
   const [subnet, setSubnet] = useState<SubnetInfo | null>(null);
   const [validators, setValidators] = useState<CurrentValidator[] | null>(null);
   const [shown, setShown] = useState(50);
+  // the chain's genesis rides in its CreateChainTx — the node keeps the bytes
+  const [genesisData, setGenesisData] = useState<unknown>(undefined);
+
+  useEffect(() => {
+    if (!isChain) return;
+    let cancelled = false;
+    getPlatformTx(network, cb58Id).then((u) => !cancelled && setGenesisData(u?.genesisData));
+    return () => {
+      cancelled = true;
+    };
+  }, [network, cb58Id, isChain]);
 
   useEffect(() => {
     // the Primary Network's subnet is implicit and its validator set is the
@@ -223,9 +237,12 @@ export function ChainDetailsContent({
                   ) : (
                     <>
                       <SpecRow label="Status">Sovereign L1 (converted via ACP-77)</SpecRow>
+                      {/* the ACP-77 conversionID is the SHA-256 of the conversion
+                          data, NOT the ConvertSubnetToL1Tx's ID — there is no tx
+                          at this ID, so it must never link to a tx page */}
                       {subnet.conversionID && (
-                        <SpecRow label="Conversion Tx">
-                          <HashChip value={subnet.conversionID} href={`${base}/tx/${subnet.conversionID}`} len={24} />
+                        <SpecRow label="Conversion ID">
+                          <HashChip value={subnet.conversionID} len={24} />
                         </SpecRow>
                       )}
                       {subnet.managerChainID && (
@@ -270,8 +287,8 @@ export function ChainDetailsContent({
                     href={`${base}/node/${v.nodeID}${subnetId ? `?subnet=${subnetId}` : ""}`}
                     className="grid grid-cols-2 gap-x-4 gap-y-1 px-5 py-3 transition-colors hover:bg-zinc-50 md:grid-cols-[1.6fr_0.8fr_0.8fr_1fr] md:items-center md:px-6 dark:hover:bg-zinc-900"
                   >
-                    <span className="truncate font-mono text-[12px] text-zinc-900 dark:text-zinc-100">
-                      {truncate(v.nodeID, 18)}
+                    <span className={`break-all font-mono text-[12px] ${idInk}`}>
+                      {v.nodeID}
                     </span>
                     <div className="font-mono text-[11px] tabular-nums text-zinc-700 md:text-right dark:text-zinc-300">
                       <CellLabel>Weight</CellLabel>
@@ -298,6 +315,9 @@ export function ChainDetailsContent({
               )}
             </section>
           )}
+
+          {/* the founding document itself, decoded from the CreateChainTx */}
+          {genesisData != null && <GenesisViewer genesisData={genesisData} />}
         </div>
       )}
     </>

--- a/components/explorer-v2/pchain/PchainHome.tsx
+++ b/components/explorer-v2/pchain/PchainHome.tsx
@@ -16,6 +16,7 @@ import {
   StatDash,
   StatFigure,
   TxTypePill,
+  idInk,
   txToneText,
 } from "@/components/explorer-v2/ui";
 import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
@@ -468,7 +469,7 @@ export function PchainHome({ chain, network }: { chain: string; network: string 
                     href={`${base}/block/${b.blockNumber}`}
                     className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_3.5rem] items-center gap-3 px-5 py-3 transition-colors hover:bg-zinc-50 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_2.5rem_3.5rem] md:px-6 dark:hover:bg-zinc-900"
                   >
-                    <span className="font-mono text-[13px] tabular-nums text-zinc-900 dark:text-zinc-100">
+                    <span className={`font-mono text-[13px] tabular-nums ${idInk}`}>
                       #{formatNumber(b.blockNumber)}
                     </span>
                     <span className="min-w-0 text-left">
@@ -506,7 +507,7 @@ export function PchainHome({ chain, network }: { chain: string; network: string 
                     href={`${base}/tx/${t.txHash}`}
                     className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_3.5rem] md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_6.75rem] items-center gap-3 px-5 py-3 transition-colors hover:bg-zinc-50 md:px-6 dark:hover:bg-zinc-900"
                   >
-                    <span className="truncate font-mono text-[12px] text-zinc-900 dark:text-zinc-100">
+                    <span className={`truncate font-mono text-[12px] ${idInk}`}>
                       {truncate(t.txHash, 22)}
                     </span>
                     <span className="min-w-0 text-left">

--- a/components/explorer-v2/pchain/PchainNode.tsx
+++ b/components/explorer-v2/pchain/PchainNode.tsx
@@ -136,15 +136,20 @@ export function PchainNode({
   const validationPayout = identity?.validationRewardOwner ?? identity?.rewardOwner;
   const delegationPayout = identity?.delegationRewardOwner ?? identity?.rewardOwner;
 
-  // L1-only validators never stake on the Primary Network, so the indexer
-  // 404s on them. With a subnet hint we go straight to the node:
+  // L1-only validators never stake on the Primary Network. The subnet can
+  // arrive two ways: a ?subnet= hint on the link, or — since the indexer
+  // learned to return L1-only nodes — the node document's own validations.
+  // Either way we go straight to the node for the rich seat view:
   // platform.getCurrentValidators({subnetID, nodeIDs}).
+  const l1Subnet = subnetHint ?? n?.validations?.find((v) => v.kind === "l1")?.subnetId;
+  // no snapshot, no staking history: the L1 seat IS this node's story
+  const l1Only = !!n && !n.hasSnapshot && (n.history?.length ?? 0) === 0;
   const [l1, setL1] = useState<CurrentValidator | null>(null);
   const [l1Checked, setL1Checked] = useState(false);
   useEffect(() => {
-    if (!error || !subnetHint) return;
+    if (!(error || l1Only) || !l1Subnet) return;
     let cancelled = false;
-    getCurrentValidators(network, subnetHint, [nodeId]).then((vs) => {
+    getCurrentValidators(network, l1Subnet, [nodeId]).then((vs) => {
       if (cancelled) return;
       setL1(vs?.[0] ?? null);
       setL1Checked(true);
@@ -152,7 +157,7 @@ export function PchainNode({
     return () => {
       cancelled = true;
     };
-  }, [error, subnetHint, network, nodeId]);
+  }, [error, l1Only, l1Subnet, network, nodeId]);
 
   const [showAllDelegators, setShowAllDelegators] = useState(false);
   const [showAllHistory, setShowAllHistory] = useState(false);
@@ -180,27 +185,35 @@ export function PchainNode({
   return (
     <ExplorerShell chain={chain} network={network}>
       {loading && <DetailSkeleton label="Validator" />}
-      {error && subnetHint && !l1Checked && <DetailSkeleton label="Validator" />}
-      {error && (!subnetHint || (l1Checked && !l1)) && <NotFound label="Node not found" id={nodeId} />}
-      {error && l1 && <L1ValidatorView nodeId={nodeId} subnetId={subnetHint!} v={l1} base={base} />}
-      {n && (
+      {(error || l1Only) && l1Subnet && !l1Checked && <DetailSkeleton label="Validator" />}
+      {error && (!l1Subnet || (l1Checked && !l1)) && <NotFound label="Node not found" id={nodeId} />}
+      {(error || l1Only) && l1 && l1Subnet && (
+        <L1ValidatorView nodeId={nodeId} subnetId={l1Subnet} v={l1} base={base} />
+      )}
+      {/* the L1-only doc renders the seat view above; fall back to the
+          indexer document only if the RPC no longer knows the seat */}
+      {n && (!l1Only || (l1Checked && !l1)) && (
         <div className="flex flex-col gap-10">
           <section className="flex flex-col gap-4">
             <SectionHeader
               label="Node"
               action={
-                <span
-                  className={`inline-flex items-center gap-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.14em] ${
-                    n.validator.connected ? "text-emerald-600 dark:text-emerald-400" : "text-zinc-400 dark:text-zinc-500"
-                  }`}
-                >
+                // connection state comes from the Primary Network snapshot —
+                // without one it's a zero value, not a real "Offline"
+                n.hasSnapshot ? (
                   <span
-                    className={`h-1.5 w-1.5 rounded-full ${
-                      n.validator.connected ? "bg-emerald-500" : "bg-zinc-400 dark:bg-zinc-600"
+                    className={`inline-flex items-center gap-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.14em] ${
+                      n.validator.connected ? "text-emerald-600 dark:text-emerald-400" : "text-zinc-400 dark:text-zinc-500"
                     }`}
-                  />
-                  {n.validator.connected ? "Connected" : "Offline"}
-                </span>
+                  >
+                    <span
+                      className={`h-1.5 w-1.5 rounded-full ${
+                        n.validator.connected ? "bg-emerald-500" : "bg-zinc-400 dark:bg-zinc-600"
+                      }`}
+                    />
+                    {n.validator.connected ? "Connected" : "Offline"}
+                  </span>
+                ) : undefined
               }
             />
             <SubjectHeadline value={n.nodeId} copyLabel="Copy NodeID" />

--- a/components/explorer-v2/pchain/PchainNode.tsx
+++ b/components/explorer-v2/pchain/PchainNode.tsx
@@ -144,6 +144,19 @@ export function PchainNode({
   const l1Subnet = subnetHint ?? n?.validations?.find((v) => v.kind === "l1")?.subnetId;
   // no snapshot, no staking history: the L1 seat IS this node's story
   const l1Only = !!n && !n.hasSnapshot && (n.history?.length ?? 0) === 0;
+  // the document's own l1 validation, shaped like the RPC record — the
+  // render fallback when the RPC can't answer (rate limit, outage). The
+  // page must never go blank while holding the seat data in hand.
+  const l1FromDoc = useMemo<CurrentValidator | null>(() => {
+    const v = n?.validations?.find((x) => x.kind === "l1");
+    if (!v) return null;
+    return {
+      nodeID: nodeId,
+      weight: String(v.weight),
+      balance: v.balance !== undefined ? String(v.balance) : undefined,
+      validationID: v.validationId,
+    };
+  }, [n, nodeId]);
   const [l1, setL1] = useState<CurrentValidator | null>(null);
   const [l1Checked, setL1Checked] = useState(false);
   useEffect(() => {
@@ -187,12 +200,22 @@ export function PchainNode({
       {loading && <DetailSkeleton label="Validator" />}
       {(error || l1Only) && l1Subnet && !l1Checked && <DetailSkeleton label="Validator" />}
       {error && (!l1Subnet || (l1Checked && !l1)) && <NotFound label="Node not found" id={nodeId} />}
-      {(error || l1Only) && l1 && l1Subnet && (
-        <L1ValidatorView nodeId={nodeId} subnetId={l1Subnet} v={l1} base={base} />
+      {/* the seat view: the RPC record when the node answered, the doc's
+          own copy when it couldn't — a rate-limited RPC must not blank a
+          page whose data is already in hand */}
+      {(error || l1Only) && l1Checked && l1Subnet && (l1 ?? l1FromDoc) && (
+        <L1ValidatorView
+          nodeId={nodeId}
+          subnetId={l1Subnet}
+          v={(l1 ?? l1FromDoc)!}
+          live={!!l1}
+          base={base}
+        />
       )}
-      {/* the L1-only doc renders the seat view above; fall back to the
-          indexer document only if the RPC no longer knows the seat */}
-      {n && (!l1Only || (l1Checked && !l1)) && (
+      {/* nodes with staking history (or no l1 seat at all) keep the full
+          indexer document view — including the corner where a subnet hint
+          exists but neither the RPC nor the doc could produce a seat */}
+      {n && (!l1Only || !l1Subnet || (l1Checked && !l1 && !l1FromDoc)) && (
         <div className="flex flex-col gap-10">
           <section className="flex flex-col gap-4">
             <SectionHeader
@@ -693,11 +716,14 @@ function L1ValidatorView({
   nodeId,
   subnetId,
   v,
+  live = true,
   base,
 }: {
   nodeId: string;
   subnetId: string;
   v: CurrentValidator;
+  /** false when the record came from the indexer snapshot instead of the node */
+  live?: boolean;
   base: string;
 }) {
   return (
@@ -707,7 +733,7 @@ function L1ValidatorView({
           label="Node"
           action={
             <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-              L1 validator · live from P-Chain
+              {live ? "L1 validator · live from P-Chain" : "L1 validator · indexer snapshot"}
             </span>
           }
         />

--- a/components/explorer-v2/pchain/PchainNode.tsx
+++ b/components/explorer-v2/pchain/PchainNode.tsx
@@ -22,6 +22,7 @@ import {
   SpecRow,
   SubjectHeadline,
   TxTypePill,
+  idInk,
 } from "@/components/explorer-v2/ui";
 import { formatAvax, formatNumber, formatTime, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { usePchainData } from "./hooks";
@@ -612,7 +613,7 @@ export function PchainNode({
                       href={`${base}/tx/${d.txId}`}
                       className="flex items-center justify-between gap-4 px-5 py-3 transition-colors hover:bg-zinc-50 md:px-6 dark:hover:bg-zinc-900"
                     >
-                      <span className="font-mono text-[12px] text-zinc-700 dark:text-zinc-300">{truncate(d.txId, 16)}</span>
+                      <span className={`font-mono text-[12px] ${idInk}`}>{truncate(d.txId, 16)}</span>
                       <div className="flex items-center gap-5 font-mono text-[11px] tabular-nums text-zinc-500 dark:text-zinc-400">
                         <span className="font-bold text-zinc-900 dark:text-zinc-100">
                           {formatAvax(d.stakeAmount, { compact: true })}
@@ -645,7 +646,7 @@ export function PchainNode({
                       className="flex items-center justify-between gap-4 px-5 py-3 transition-colors hover:bg-zinc-50 md:px-6 dark:hover:bg-zinc-900"
                     >
                       <div className="flex min-w-0 items-center gap-3">
-                        <span className="truncate font-mono text-[12px] text-zinc-900 dark:text-zinc-100">
+                        <span className={`truncate font-mono text-[12px] ${idInk}`}>
                           {truncate(h.txHash, 16)}
                         </span>
                         <TxTypePill type={h.txType.replace(/Tx$/, "")} />

--- a/components/explorer-v2/pchain/PchainTx.tsx
+++ b/components/explorer-v2/pchain/PchainTx.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/explorer-v2/ui";
 import { formatAvax, formatTime, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { usePchainData } from "./hooks";
+import { GenesisViewer } from "./GenesisViewer";
 import { FundFlowDiagram, NoFundMovement, hasFundMovement } from "./FundFlowDiagram";
 import { knownChainName } from "@/lib/pchain-explorer";
 import type { AssetAmount, Tx, Utxo } from "@/lib/pchain-explorer";
@@ -66,6 +67,8 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
   const hasCreation = !!(tx && (tx.details?.chainName || tx.details?.vmId || tx.details?.subnetOwners?.length));
   const hasCrossChain = !!(tx && (tx.details?.sourceChain || tx.details?.destinationChain || tx.importedFrom));
   const isConvert = tx?.txType === "ConvertSubnetToL1Tx";
+  // a CreateChainTx carries the new chain's genesis — the node has the bytes
+  const isCreateChain = tx?.txType === "CreateChainTx";
   const isWarpOp = tx?.txType === "RegisterL1ValidatorTx" || tx?.txType === "SetL1ValidatorWeightTx";
   const hasContext =
     hasStaking || hasContinuous || hasL1Validation || hasCreation || hasCrossChain || isConvert || isWarpOp;
@@ -73,7 +76,7 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
   // node-decoded inputs for platform ops (shared by the right-rail panels
   // and the full-width initial-validator-set table); on a 404 it doubles
   // as the authoritative "does this tx exist on-chain at all?" check
-  const platformOp = usePlatformTx(network, txHash, isConvert || isWarpOp || notFound);
+  const platformOp = usePlatformTx(network, txHash, isConvert || isWarpOp || isCreateChain || notFound);
 
   return (
     <ExplorerShell chain={chain} network={network}>
@@ -327,6 +330,12 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
           )}
           </div>
 
+          {/* CreateChainTx: the full genesis document, decoded from the
+              node's copy of the tx — overview + raw JSON, full-width */}
+          {isCreateChain && (platformOp.loading || platformOp.data?.genesisData != null) && (
+            <GenesisViewer genesisData={platformOp.data?.genesisData} loading={platformOp.loading} />
+          )}
+
           {/* Fund flow: diagram (default) or ledger table */}
           <section className="flex flex-col gap-4">
             <SectionHeader
@@ -573,7 +582,7 @@ function InitialValidatorSet({
                         <HashChip
                           value={nodeId}
                           href={`${base}/node/${nodeId}${subnetId ? `?subnet=${subnetId}` : ""}`}
-                          len={16}
+                          len={50}
                         />
                       ) : (
                         <span className="font-mono text-[12px] text-zinc-400 dark:text-zinc-500">

--- a/components/explorer-v2/pchain/PchainTxsList.tsx
+++ b/components/explorer-v2/pchain/PchainTxsList.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
-import { Board, CellLabel, SectionHeader, TxTypePill, TypeFilterRail } from "@/components/explorer-v2/ui";
+import { Board, CellLabel, SectionHeader, TxTypePill, TypeFilterRail, idInk } from "@/components/explorer-v2/ui";
 import { formatNumber, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { usePchainData, LIVE_REFRESH_MS } from "./hooks";
 import type { TxSummary } from "@/lib/pchain-explorer";
@@ -70,7 +70,7 @@ export function PchainTxsList({ chain, network }: { chain: string; network: stri
               href={`${base}/tx/${t.txHash}`}
               className="grid grid-cols-2 gap-x-4 gap-y-1 px-5 py-3 transition-colors hover:bg-zinc-50 md:grid-cols-[2fr_1.2fr_0.8fr_0.7fr] md:items-center md:px-6 dark:hover:bg-zinc-900"
             >
-              <span className="truncate font-mono text-[12px] text-zinc-900 dark:text-zinc-100">
+              <span className={`truncate font-mono text-[12px] ${idInk}`}>
                 {truncate(t.txHash, 16)}
               </span>
               <span className="justify-self-start">

--- a/components/explorer-v2/pchain/PchainValidators.tsx
+++ b/components/explorer-v2/pchain/PchainValidators.tsx
@@ -98,9 +98,14 @@ export function PchainValidators({ chain, network }: { chain: string; network: s
 export function PchainStaking({ chain, network }: { chain: string; network: string }) {
   return (
     <ExplorerShell chain={chain} network={network}>
+      {/* the P-Chain owns the whole validator economy: Primary staking
+          plus the ACP-77 L1 seat market. The C-Chain tab mounts the same
+          content without includeL1 — purely Primary Network. */}
       <PrimaryStakingContent
         validatorsHref={`/explorer/${network}/${chain}/validators`}
         base={`/explorer/${network}/${chain}/staking`}
+        network={network}
+        includeL1
       />
     </ExplorerShell>
   );

--- a/components/explorer-v2/pchain/PchainValidators.tsx
+++ b/components/explorer-v2/pchain/PchainValidators.tsx
@@ -98,14 +98,13 @@ export function PchainValidators({ chain, network }: { chain: string; network: s
 export function PchainStaking({ chain, network }: { chain: string; network: string }) {
   return (
     <ExplorerShell chain={chain} network={network}>
-      {/* the P-Chain owns the whole validator economy: Primary staking
-          plus the ACP-77 L1 seat market. The C-Chain tab mounts the same
-          content without includeL1 — purely Primary Network. */}
+      {/* purely the Primary Network's staking economy — the ACP-77 L1
+          seat market lives on its own L1s tab (staking mints; seats burn:
+          different economies, different doors) */}
       <PrimaryStakingContent
         validatorsHref={`/explorer/${network}/${chain}/validators`}
         base={`/explorer/${network}/${chain}/staking`}
         network={network}
-        includeL1
       />
     </ExplorerShell>
   );

--- a/components/explorer-v2/staking/L1Economy.tsx
+++ b/components/explorer-v2/staking/L1Economy.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import {
   Area,
   ComposedChart,
+  Line,
   ResponsiveContainer,
   Tooltip as RechartsTooltip,
   XAxis,
@@ -14,6 +15,7 @@ import {
 import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
 import { Board, BoardHeader, ChartBoard, StatDash } from "@/components/explorer-v2/ui";
 import { ChartEmpty, Stat, TipPlate } from "./bits";
+import { timeAgo } from "@/components/explorer-v2/format";
 import { RANGE_DAYS, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import { PRIMARY_NETWORK_ID, useValidatorStats } from "@/components/explorer-v2/validator-stats";
 import { usePchainData } from "@/components/explorer-v2/pchain/hooks";
@@ -113,6 +115,122 @@ function SeatsKey() {
   );
 }
 
+/* Most L1s never uploaded artwork — a blank circle row after row reads
+   as broken. Deterministic letter tiles instead: hue hashed from the
+   subnet id (stable across renders and sessions), initial from the name. */
+export function ChainBadge({
+  name,
+  logo,
+  id,
+  className = "h-4 w-4 text-[8px]",
+}: {
+  name: string;
+  logo?: string;
+  id: string;
+  className?: string;
+}) {
+  if (logo && hasRealChainLogo(logo)) {
+    return <img src={logo} alt="" className={`${className} shrink-0 rounded-full object-contain`} />;
+  }
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) % 360;
+  return (
+    <span
+      aria-hidden
+      className={`${className} inline-flex shrink-0 items-center justify-center rounded-full font-mono font-bold text-white`}
+      style={{ backgroundColor: `hsl(${h} 40% 42%)` }}
+    >
+      {(name.trim().charAt(0) || "?").toUpperCase()}
+    </span>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* the build-out registry: every subnet/chain the P-Chain ever created  */
+
+interface L1Registry {
+  totals: { subnets: number; l1s: number; blockchains: number; evmChains: number };
+  series: { month: string; blockchains: number; subnets: number }[];
+  recent: {
+    name: string;
+    blockchainId: string;
+    subnetId: string;
+    isL1: boolean;
+    evmChainId?: number;
+    createdAt: number;
+  }[];
+}
+
+function useL1Registry(network: string) {
+  const [data, setData] = useState<L1Registry | null>(null);
+  const [failed, setFailed] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/l1-registry/${network}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then((d: L1Registry) => {
+        if (!cancelled) setData(d);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [network]);
+  return { data, failed };
+}
+
+/* cumulative creations — blockchains as the filled story, subnets dashed */
+function BuildOutChart({ data }: { data: L1Registry["series"] }) {
+  return (
+    <div className="h-56 text-zinc-900 dark:text-zinc-100">
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={data}>
+          <XAxis dataKey="month" hide />
+          <YAxis hide domain={[0, "dataMax"]} />
+          <RechartsTooltip
+            cursor={{ stroke: "rgba(161,161,170,0.35)" }}
+            content={({ active, payload }) => {
+              if (!active || !payload?.[0]) return null;
+              const d = payload[0].payload as L1Registry["series"][number];
+              return (
+                <TipPlate>
+                  <p className="text-[10px] text-zinc-500">{d.month}</p>
+                  <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+                    {d.blockchains.toLocaleString("en-US")} blockchains
+                  </p>
+                  <p className="text-[10px] tabular-nums text-zinc-500">
+                    {d.subnets.toLocaleString("en-US")} subnets created
+                  </p>
+                </TipPlate>
+              );
+            }}
+          />
+          <Area
+            type="monotone"
+            dataKey="blockchains"
+            stroke={L1_COLOR}
+            strokeWidth={1.5}
+            fill={L1_COLOR}
+            fillOpacity={0.12}
+            isAnimationActive={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="subnets"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            strokeDasharray="4 3"
+            dot={false}
+            isAnimationActive={false}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
 const LEADERBOARD_CAP = 12;
 
 interface LiveL1 {
@@ -134,11 +252,7 @@ function SeatsByL1({ sets, network }: { sets: LiveL1[]; network: string }) {
         const row = (
           <>
             <span className="flex min-w-0 items-center gap-2">
-              {l.logo && hasRealChainLogo(l.logo) ? (
-                <img src={l.logo} alt="" className="h-4 w-4 shrink-0 rounded-full object-contain" />
-              ) : (
-                <span className="h-4 w-4 shrink-0 rounded-full bg-zinc-200 dark:bg-zinc-800" />
-              )}
+              <ChainBadge name={l.name} logo={l.logo} id={l.id} />
               <span className="truncate text-[12.5px] font-medium text-zinc-900 dark:text-zinc-100">
                 {l.name}
               </span>
@@ -200,6 +314,7 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
   const { data: seats, failed: seatsFailed } = useEcosystemSeats();
   const feePrice = useValidatorFeePrice(network); // nAVAX/s per seat
   const { subnets, error: setsFailed } = useValidatorStats(network);
+  const { data: registry, failed: registryFailed } = useL1Registry(network);
   // one indexer snapshot carries both counts, so the share can't skew:
   // l1ValidatorCount is the ACTIVE (fee-paying) seats registered on the
   // P-Chain — the number the burn math is honest against
@@ -377,6 +492,105 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
             <ChartEmpty failed={false} label="No live L1 sets" />
           ) : (
             <SeatsByL1 sets={liveSets} network={network} />
+          )}
+        </ChartBoard>
+      </div>
+
+      {/* the build-out: everything the P-Chain has ever created — the
+          registry behind the seat market. Seats are the run-rate; this
+          is the install base. */}
+      <div className="flex flex-col gap-4 pt-2">
+        <Board divide={false} className="border">
+          <BoardHeader
+            label="The Build-Out"
+            display
+            action={
+              <Link
+                href={`/explorer/${network}/chains`}
+                className="group flex shrink-0 items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 transition-colors hover:text-zinc-900 dark:text-zinc-500 dark:hover:text-zinc-100"
+              >
+                Chains directory
+                <ArrowRight className="h-3 w-3 transition-all group-hover:translate-x-0.5 group-hover:text-[#E6212F]" />
+              </Link>
+            }
+          />
+          <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
+            <Stat label="Blockchains Created" sub="all-time, on the P-Chain">
+              {registry ? registry.totals.blockchains.toLocaleString("en-US") : <StatDash />}
+            </Stat>
+            <Stat label="Subnets Created" sub="all-time">
+              {registry ? registry.totals.subnets.toLocaleString("en-US") : <StatDash />}
+            </Stat>
+            <Stat label="Converted to L1" sub="ACP-77 sovereign sets">
+              {registry ? registry.totals.l1s.toLocaleString("en-US") : <StatDash />}
+            </Stat>
+            <Stat label="EVM Chains" sub="carry an EVM chain id">
+              {registry ? registry.totals.evmChains.toLocaleString("en-US") : <StatDash />}
+            </Stat>
+          </div>
+        </Board>
+      </div>
+
+      <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
+        <ChartBoard
+          label="Chains Created · cumulative"
+          action={
+            <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
+              <span className="flex items-center gap-1.5">
+                <span className="h-2.5 w-4 bg-[#0061E2]/25" /> blockchains
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="h-0.5 w-4 border-b border-dashed border-[#A2AFB2]" /> subnets
+              </span>
+            </span>
+          }
+        >
+          {registry?.series.length ? (
+            <BuildOutChart data={registry.series} />
+          ) : (
+            <ChartEmpty failed={registryFailed} />
+          )}
+        </ChartBoard>
+
+        <ChartBoard
+          label="Newest Chains"
+          action={
+            registry?.recent.length ? (
+              <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                latest {registry.recent.length}
+              </span>
+            ) : undefined
+          }
+        >
+          {registry === null ? (
+            <ChartEmpty failed={registryFailed} />
+          ) : (
+            <div className="flex flex-col">
+              {registry.recent.map((c) => (
+                <Link
+                  key={c.blockchainId}
+                  href={`/explorer/${network}/p-chain/chain/${c.blockchainId}`}
+                  className="-mx-2 grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 px-2 py-2 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-900"
+                >
+                  <span className="flex min-w-0 items-center gap-2.5">
+                    <ChainBadge
+                      name={c.name}
+                      id={c.subnetId}
+                      className="h-5 w-5 text-[9px]"
+                    />
+                    <span className="truncate text-[12.5px] font-medium text-zinc-900 dark:text-zinc-100">
+                      {c.name}
+                    </span>
+                  </span>
+                  <span className="shrink-0 font-mono text-[9px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
+                    {c.isL1 ? "L1" : c.evmChainId ? "EVM" : "subnet"}
+                  </span>
+                  <span className="w-16 shrink-0 text-right font-mono text-[11px] tabular-nums text-zinc-500 dark:text-zinc-400">
+                    {timeAgo(c.createdAt)}
+                  </span>
+                </Link>
+              ))}
+            </div>
           )}
         </ChartBoard>
       </div>

--- a/components/explorer-v2/staking/L1Economy.tsx
+++ b/components/explorer-v2/staking/L1Economy.tsx
@@ -514,7 +514,7 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
               </Link>
             }
           />
-          <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
+          <div className="grid grid-cols-1 divide-y divide-zinc-200 sm:grid-cols-3 sm:divide-x sm:divide-y-0 dark:divide-zinc-800">
             <Stat label="Blockchains Created" sub="all-time, on the P-Chain">
               {registry ? registry.totals.blockchains.toLocaleString("en-US") : <StatDash />}
             </Stat>
@@ -523,9 +523,6 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
             </Stat>
             <Stat label="Converted to L1" sub="ACP-77 sovereign sets">
               {registry ? registry.totals.l1s.toLocaleString("en-US") : <StatDash />}
-            </Stat>
-            <Stat label="EVM Chains" sub="carry an EVM chain id">
-              {registry ? registry.totals.evmChains.toLocaleString("en-US") : <StatDash />}
             </Stat>
           </div>
         </Board>

--- a/components/explorer-v2/staking/L1Economy.tsx
+++ b/components/explorer-v2/staking/L1Economy.tsx
@@ -225,12 +225,11 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
       ? (l1Seats / (l1Seats + primarySeats)) * 100
       : null;
 
-  // live L1 sets: registered-active seats per subnet from the
-  // validator-stats aggregate, named by the same feed. Node-verified since
-  // the upstream removal fix (stats-api PR #8): Beam 236/236, h7egy 25/25.
-  // "Registered active" includes seats whose prepaid balance has drained —
-  // still in the set, just not paying — which is exactly the gap between
-  // this board's sum and the fee-paying headline above it.
+  // live L1 sets: fee-paying seats per subnet from the validator-stats
+  // aggregate. Node-verified since the upstream fixes (stats-api PR #8:
+  // removal semantics; PR #9: balances net of continuous-fee burn, drained
+  // seats excluded) — the sum here now matches the fee-paying headline,
+  // and the "of N registered active" sub renders only if they ever drift.
   const liveSets = useMemo<LiveL1[] | null>(() => {
     if (!subnets) return null;
     const slugBySubnet = new Map<string, string>();
@@ -333,8 +332,8 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
           >
             ACP-77
           </Link>
-          ). A seat whose balance runs dry stays registered but goes inactive until topped back
-          up — the gap between the two seat figures. Staking mints; seats burn.
+          ). A seat whose balance runs dry stays registered but goes inactive — no longer counted
+          here — until topped back up. Staking mints; seats burn.
         </p>
       </div>
 

--- a/components/explorer-v2/staking/L1Economy.tsx
+++ b/components/explorer-v2/staking/L1Economy.tsx
@@ -119,13 +119,13 @@ interface LiveL1 {
   name: string;
   logo?: string;
   slug?: string;
-  nodes: number;
+  seats: number;
 }
 
 /* where the seats actually run — proportional bars over the live sets */
 function SeatsByL1({ sets, network }: { sets: LiveL1[]; network: string }) {
-  const max = sets[0]?.nodes ?? 1;
-  const total = sets.reduce((s, l) => s + l.nodes, 0);
+  const max = sets[0]?.seats ?? 1;
+  const total = sets.reduce((s, l) => s + l.seats, 0);
   const visible = sets.slice(0, LEADERBOARD_CAP);
   return (
     <div className="flex flex-col">
@@ -145,13 +145,13 @@ function SeatsByL1({ sets, network }: { sets: LiveL1[]; network: string }) {
             <span className="relative h-2 min-w-0 flex-1 bg-zinc-100 dark:bg-zinc-900">
               <span
                 className="absolute inset-y-0 left-0 bg-[#0061E2]/60"
-                style={{ width: `${(l.nodes / max) * 100}%` }}
+                style={{ width: `${(l.seats / max) * 100}%` }}
               />
             </span>
             <span className="w-20 shrink-0 text-right font-mono text-[11px] tabular-nums text-zinc-700 dark:text-zinc-300">
-              {l.nodes.toLocaleString("en-US")}
+              {l.seats.toLocaleString("en-US")}
               <span className="ml-1 text-zinc-400 dark:text-zinc-600">
-                {total > 0 ? `${Math.round((l.nodes / total) * 100)}%` : ""}
+                {total > 0 ? `${Math.round((l.seats / total) * 100)}%` : ""}
               </span>
             </span>
           </>
@@ -190,8 +190,7 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
   const { subnets, error: setsFailed } = useValidatorStats(network);
   // one indexer snapshot carries both counts, so the share can't skew:
   // l1ValidatorCount is the ACTIVE (fee-paying) seats registered on the
-  // P-Chain — the number the burn math is honest against. The P2P feed
-  // below counts connected nodes instead, which outlives a drained balance.
+  // P-Chain — the number the burn math is honest against
   const { data: chainStats } = usePchainData<Stats>(network, "stats");
 
   const clock = useExplorerTimeRange();
@@ -226,7 +225,11 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
       ? (l1Seats / (l1Seats + primarySeats)) * 100
       : null;
 
-  // live L1 sets (connected validators right now), named by the same feed
+  // live L1 sets: active seats per subnet from the validator-stats
+  // aggregate (indexer rows, weight- and balance-filtered), named by the
+  // same feed. Per-set counts match the node for healthy sets; sets in
+  // wind-down can lag until the upstream removal bug is fixed, which is
+  // why no total is summed anywhere on this board.
   const liveSets = useMemo<LiveL1[] | null>(() => {
     if (!subnets) return null;
     const slugBySubnet = new Map<string, string>();
@@ -240,10 +243,10 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
         name: s.name,
         logo: s.chainLogoURI,
         slug: slugBySubnet.get(s.id),
-        nodes: Object.values(s.byClientVersion ?? {}).reduce((sum, v) => sum + v.nodes, 0),
+        seats: Object.values(s.byClientVersion ?? {}).reduce((sum, v) => sum + v.nodes, 0),
       }))
-      .filter((s) => s.nodes > 0)
-      .sort((a, b) => b.nodes - a.nodes);
+      .filter((s) => s.seats > 0)
+      .sort((a, b) => b.seats - a.seats);
   }, [subnets]);
 
   const perSeatMonth = feePrice !== null ? (feePrice * SECONDS_PER_MONTH) / NANO : null;
@@ -338,15 +341,12 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
           {seatSeries.length ? <SeatsChart data={seatSeries} /> : <ChartEmpty failed={seatsFailed} />}
         </ChartBoard>
 
-        {/* the P2P view: nodes connected and validating each set right now.
-            Deliberately NOT called seats — a node keeps running after its
-            seat's balance drains, so this counts infrastructure, not fees */}
         <ChartBoard
-          label="Validators by L1 · connected now"
+          label="Active Seats by L1"
           action={
             liveSets ? (
               <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-                {liveSets.reduce((s, l) => s + l.nodes, 0).toLocaleString("en-US")} connected
+                {liveSets.length.toLocaleString("en-US")} live sets
               </span>
             ) : undefined
           }

--- a/components/explorer-v2/staking/L1Economy.tsx
+++ b/components/explorer-v2/staking/L1Economy.tsx
@@ -5,17 +5,18 @@ import { useEffect, useMemo, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import {
   Area,
+  Bar,
   ComposedChart,
-  Line,
   ResponsiveContainer,
   Tooltip as RechartsTooltip,
   XAxis,
   YAxis,
 } from "recharts";
 import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
-import { Board, BoardHeader, ChartBoard, StatDash } from "@/components/explorer-v2/ui";
+import { Board, BoardHeader, ChartBoard, StatDash, TxTypePill, idInk } from "@/components/explorer-v2/ui";
 import { ChartEmpty, Stat, TipPlate } from "./bits";
-import { timeAgo } from "@/components/explorer-v2/format";
+import { timeAgo, truncate } from "@/components/explorer-v2/format";
+import { pchainApiPath, type TxSummary } from "@/lib/pchain-explorer";
 import { RANGE_DAYS, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import { PRIMARY_NETWORK_ID, useValidatorStats } from "@/components/explorer-v2/validator-stats";
 import { usePchainData } from "@/components/explorer-v2/pchain/hooks";
@@ -24,6 +25,7 @@ import l1ChainsData from "@/constants/l1-chains.json";
 import type { L1Chain } from "@/types/stats";
 import {
   fmtCompact,
+  moneyFlowWindow,
   thin,
   toSeries,
   useEcosystemSeats,
@@ -150,7 +152,6 @@ export function ChainBadge({
 
 interface L1Registry {
   totals: { subnets: number; l1s: number; blockchains: number; evmChains: number };
-  series: { month: string; blockchains: number; subnets: number }[];
   recent: {
     name: string;
     blockchainId: string;
@@ -181,8 +182,103 @@ function useL1Registry(network: string) {
   return { data, failed };
 }
 
-/* cumulative creations — blockchains as the filled story, subnets dashed */
-function BuildOutChart({ data }: { data: L1Registry["series"] }) {
+/* ------------------------------------------------------------------ */
+/* the P-Chain's L1 ops ledger — every ACP-77 tx type it processed      */
+
+interface L1OpsPoint {
+  date: string;
+  register: number;
+  setWeight: number;
+  disable: number;
+  topUp: number;
+  convert: number;
+}
+
+interface L1Ops {
+  ops: L1OpsPoint[];
+  conversions: { month: string; cumulative: number }[];
+}
+
+function useL1Ops(network: string, days: 30 | 90 | 365) {
+  const [data, setData] = useState<L1Ops | null>(null);
+  const [failed, setFailed] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    setData(null);
+    setFailed(false);
+    fetch(`/api/pchain-l1-ops/${network}?days=${days}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then((d: L1Ops) => {
+        if (!cancelled) setData(d);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [network, days]);
+  return { data, failed };
+}
+
+/* one tone per op family, rhyming with the tx-type pills: routine weight
+   sets are the quiet gray bulk; joins green, top-ups amber, disables red,
+   conversions the subnet blue */
+const OPS_SERIES = [
+  { key: "setWeight", label: "weight sets", color: "#A2AFB2" },
+  { key: "register", label: "registrations", color: "#4e9a52" },
+  { key: "topUp", label: "top-ups", color: "#C7911B" },
+  { key: "disable", label: "disables", color: "#E6212F" },
+  { key: "convert", label: "conversions", color: "#0061E2" },
+] as const;
+
+function L1OpsChart({ data }: { data: L1OpsPoint[] }) {
+  return (
+    <div className="h-56">
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={data}>
+          <XAxis dataKey="date" hide />
+          <YAxis hide domain={[0, "dataMax"]} />
+          <RechartsTooltip
+            cursor={{ fill: "rgba(161,161,170,0.08)" }}
+            content={({ active, payload }) => {
+              if (!active || !payload?.[0]) return null;
+              const d = payload[0].payload as L1OpsPoint;
+              const total = d.register + d.setWeight + d.disable + d.topUp + d.convert;
+              return (
+                <TipPlate>
+                  <p className="text-[10px] text-zinc-500">{d.date}</p>
+                  <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+                    {total.toLocaleString("en-US")} L1 operations
+                  </p>
+                  {OPS_SERIES.filter((s) => d[s.key] > 0).map((s) => (
+                    <p key={s.key} className="text-[10px] tabular-nums text-zinc-500">
+                      <span className="mr-1 inline-block h-2 w-2 align-middle" style={{ backgroundColor: s.color }} />
+                      {d[s.key].toLocaleString("en-US")} {s.label}
+                    </p>
+                  ))}
+                </TipPlate>
+              );
+            }}
+          />
+          {OPS_SERIES.map((s) => (
+            <Bar
+              key={s.key}
+              dataKey={s.key}
+              stackId="ops"
+              fill={s.color}
+              fillOpacity={0.8}
+              isAnimationActive={false}
+            />
+          ))}
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+/* the ACP-77 adoption curve — every conversion since Etna, cumulative */
+function ConversionsChart({ data }: { data: L1Ops["conversions"] }) {
   return (
     <div className="h-56 text-zinc-900 dark:text-zinc-100">
       <ResponsiveContainer width="100%" height="100%">
@@ -193,15 +289,12 @@ function BuildOutChart({ data }: { data: L1Registry["series"] }) {
             cursor={{ stroke: "rgba(161,161,170,0.35)" }}
             content={({ active, payload }) => {
               if (!active || !payload?.[0]) return null;
-              const d = payload[0].payload as L1Registry["series"][number];
+              const d = payload[0].payload as L1Ops["conversions"][number];
               return (
                 <TipPlate>
                   <p className="text-[10px] text-zinc-500">{d.month}</p>
                   <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
-                    {d.blockchains.toLocaleString("en-US")} blockchains
-                  </p>
-                  <p className="text-[10px] tabular-nums text-zinc-500">
-                    {d.subnets.toLocaleString("en-US")} subnets created
+                    {d.cumulative.toLocaleString("en-US")} subnets converted
                   </p>
                 </TipPlate>
               );
@@ -209,20 +302,11 @@ function BuildOutChart({ data }: { data: L1Registry["series"] }) {
           />
           <Area
             type="monotone"
-            dataKey="blockchains"
+            dataKey="cumulative"
             stroke={L1_COLOR}
             strokeWidth={1.5}
             fill={L1_COLOR}
             fillOpacity={0.12}
-            isAnimationActive={false}
-          />
-          <Line
-            type="monotone"
-            dataKey="subnets"
-            stroke="currentColor"
-            strokeWidth={1.5}
-            strokeDasharray="4 3"
-            dot={false}
             isAnimationActive={false}
           />
         </ComposedChart>
@@ -323,6 +407,44 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
   const clock = useExplorerTimeRange();
   const chartDays = Math.max(7, RANGE_DAYS[clock]);
   const weekFloor = RANGE_DAYS[clock] < 7 ? " · 7 days" : "";
+
+  // the ops ledger rides the page clock at the feed's computed windows
+  const opsDays = moneyFlowWindow(RANGE_DAYS[clock]);
+  const { data: ops, failed: opsFailed } = useL1Ops(network, opsDays);
+
+  // the live tape: newest tx of each ACP-77 type, merged — the indexer's
+  // txs feed filters by a single type, so five small fetches interleave
+  const [recentOps, setRecentOps] = useState<TxSummary[] | null>(null);
+  const [recentOpsFailed, setRecentOpsFailed] = useState(false);
+  useEffect(() => {
+    const TYPES = [
+      "RegisterL1ValidatorTx",
+      "SetL1ValidatorWeightTx",
+      "DisableL1ValidatorTx",
+      "IncreaseL1ValidatorBalanceTx",
+      "ConvertSubnetToL1Tx",
+    ];
+    let cancelled = false;
+    Promise.all(
+      TYPES.map((type) =>
+        fetch(pchainApiPath(network, "txs", { limit: 6, type }))
+          .then((res) => (res.ok ? res.json() : []))
+          .catch(() => []),
+      ),
+    ).then((lists: TxSummary[][]) => {
+      if (cancelled) return;
+      const merged = lists
+        .flat()
+        .filter((t) => t?.txHash)
+        .sort((a, b) => b.blockTimestamp - a.blockTimestamp)
+        .slice(0, 8);
+      if (merged.length) setRecentOps(merged);
+      else setRecentOpsFailed(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [network]);
 
   const seatSeries = useMemo<SeatPoint[]>(() => {
     const l1 = toSeries(seats?.l1);
@@ -496,13 +618,14 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
         </ChartBoard>
       </div>
 
-      {/* the build-out: everything the P-Chain has ever created — the
-          registry behind the seat market. Seats are the run-rate; this
-          is the install base. */}
+      {/* the registry, from the P-Chain's chair: it doesn't see "chains
+          launching" — it sees subnets moving through states. Created →
+          converted (ACP-77) → alive with funded seats. The funnel IS
+          the L1 lifecycle. */}
       <div className="flex flex-col gap-4 pt-2">
         <Board divide={false} className="border">
           <BoardHeader
-            label="The Build-Out"
+            label="L1 Lifecycle"
             display
             action={
               <Link
@@ -515,37 +638,93 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
             }
           />
           <div className="grid grid-cols-1 divide-y divide-zinc-200 sm:grid-cols-3 sm:divide-x sm:divide-y-0 dark:divide-zinc-800">
-            <Stat label="Blockchains Created" sub="all-time, on the P-Chain">
-              {registry ? registry.totals.blockchains.toLocaleString("en-US") : <StatDash />}
-            </Stat>
-            <Stat label="Subnets Created" sub="all-time">
+            <Stat
+              label="Subnets Created"
+              sub={
+                registry
+                  ? `carrying ${registry.totals.blockchains.toLocaleString("en-US")} blockchains, all-time`
+                  : "all-time"
+              }
+            >
               {registry ? registry.totals.subnets.toLocaleString("en-US") : <StatDash />}
             </Stat>
-            <Stat label="Converted to L1" sub="ACP-77 sovereign sets">
+            <Stat
+              label="Converted to L1"
+              sub={
+                registry && registry.totals.subnets > 0
+                  ? `${Math.round((registry.totals.l1s / registry.totals.subnets) * 100)}% of all subnets, via ACP-77`
+                  : "via ACP-77"
+              }
+            >
               {registry ? registry.totals.l1s.toLocaleString("en-US") : <StatDash />}
+            </Stat>
+            <Stat label="Live Now" sub="with active, fee-paying seats">
+              {liveSets ? liveSets.length.toLocaleString("en-US") : <StatDash />}
             </Stat>
           </div>
         </Board>
       </div>
 
+      {/* the ops ledger: every one of these is a transaction the P-Chain
+          itself processed — the L1 machinery being used, daily */}
       <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
         <ChartBoard
-          label="Chains Created · cumulative"
+          label={`L1 Operations · last ${opsDays} days`}
           action={
-            <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
-              <span className="flex items-center gap-1.5">
-                <span className="h-2.5 w-4 bg-[#0061E2]/25" /> blockchains
-              </span>
-              <span className="flex items-center gap-1.5">
-                <span className="h-0.5 w-4 border-b border-dashed border-[#A2AFB2]" /> subnets
-              </span>
+            <span className="hidden flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 sm:flex dark:text-zinc-500">
+              {OPS_SERIES.map((s) => (
+                <span key={s.key} className="flex items-center gap-1">
+                  <span className="h-2 w-2" style={{ backgroundColor: s.color }} />
+                  {s.label}
+                </span>
+              ))}
             </span>
           }
         >
-          {registry?.series.length ? (
-            <BuildOutChart data={registry.series} />
+          {ops?.ops.length ? <L1OpsChart data={ops.ops} /> : <ChartEmpty failed={opsFailed} />}
+        </ChartBoard>
+
+        <ChartBoard label="Subnet → L1 Conversions · cumulative">
+          {ops?.conversions.length ? (
+            <ConversionsChart data={ops.conversions} />
           ) : (
-            <ChartEmpty failed={registryFailed} />
+            <ChartEmpty failed={opsFailed} />
+          )}
+        </ChartBoard>
+      </div>
+
+      <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
+        {/* the live tape of those operations, one by one */}
+        <ChartBoard
+          label="Recent L1 Operations"
+          action={
+            <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+              latest on the P-Chain
+            </span>
+          }
+        >
+          {recentOps === null ? (
+            <ChartEmpty failed={recentOpsFailed} />
+          ) : recentOps.length === 0 ? (
+            <ChartEmpty failed={false} label="No recent L1 operations" />
+          ) : (
+            <div className="flex flex-col">
+              {recentOps.map((t) => (
+                <Link
+                  key={t.txHash}
+                  href={`/explorer/${network}/p-chain/tx/${t.txHash}`}
+                  className="-mx-2 grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 px-2 py-2 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-900"
+                >
+                  <span className={`truncate font-mono text-[12px] ${idInk}`}>
+                    {truncate(t.txHash, 16)}
+                  </span>
+                  <TxTypePill type={t.txType.replace(/Tx$/, "")} />
+                  <span className="w-16 shrink-0 text-right font-mono text-[11px] tabular-nums text-zinc-500 dark:text-zinc-400">
+                    {timeAgo(t.blockTimestamp)}
+                  </span>
+                </Link>
+              ))}
+            </div>
           )}
         </ChartBoard>
 

--- a/components/explorer-v2/staking/L1Economy.tsx
+++ b/components/explorer-v2/staking/L1Economy.tsx
@@ -225,11 +225,12 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
       ? (l1Seats / (l1Seats + primarySeats)) * 100
       : null;
 
-  // live L1 sets: active seats per subnet from the validator-stats
-  // aggregate (indexer rows, weight- and balance-filtered), named by the
-  // same feed. Per-set counts match the node for healthy sets; sets in
-  // wind-down can lag until the upstream removal bug is fixed, which is
-  // why no total is summed anywhere on this board.
+  // live L1 sets: registered-active seats per subnet from the
+  // validator-stats aggregate, named by the same feed. Node-verified since
+  // the upstream removal fix (stats-api PR #8): Beam 236/236, h7egy 25/25.
+  // "Registered active" includes seats whose prepaid balance has drained —
+  // still in the set, just not paying — which is exactly the gap between
+  // this board's sum and the fee-paying headline above it.
   const liveSets = useMemo<LiveL1[] | null>(() => {
     if (!subnets) return null;
     const slugBySubnet = new Map<string, string>();
@@ -253,6 +254,13 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
   const burnPerDay =
     feePrice !== null && l1Seats !== null ? (feePrice * l1Seats * SECONDS_PER_DAY) / NANO : null;
 
+  // registered-active seats across all live sets — the fee-paying headline's
+  // wider circle (drained seats stay registered until removed)
+  const registeredSeats = useMemo(
+    () => (liveSets ? liveSets.reduce((s, l) => s + l.seats, 0) : null),
+    [liveSets],
+  );
+
   return (
     <section className="flex flex-col gap-4">
       <div className="flex flex-col gap-4">
@@ -274,9 +282,9 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
             <Stat
               label="L1 Validator Seats"
               sub={
-                liveSets
-                  ? `active · fee-paying, across ${liveSets.length} live L1s`
-                  : "active · fee-paying"
+                registeredSeats !== null && l1Seats !== null && registeredSeats > l1Seats
+                  ? `fee-paying · of ${registeredSeats.toLocaleString("en-US")} registered active`
+                  : "fee-paying"
               }
             >
               {l1Seats !== null ? l1Seats.toLocaleString("en-US") : <StatDash />}
@@ -325,7 +333,8 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
           >
             ACP-77
           </Link>
-          ). Staking mints; seats burn.
+          ). A seat whose balance runs dry stays registered but goes inactive until topped back
+          up — the gap between the two seat figures. Staking mints; seats burn.
         </p>
       </div>
 
@@ -344,9 +353,9 @@ export function L1Economy({ network = "mainnet" }: { network?: string }) {
         <ChartBoard
           label="Active Seats by L1"
           action={
-            liveSets ? (
+            liveSets && registeredSeats !== null ? (
               <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-                {liveSets.length.toLocaleString("en-US")} live sets
+                {registeredSeats.toLocaleString("en-US")} seats · {liveSets.length} sets
               </span>
             ) : undefined
           }

--- a/components/explorer-v2/staking/L1Economy.tsx
+++ b/components/explorer-v2/staking/L1Economy.tsx
@@ -11,6 +11,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
 import { Board, BoardHeader, ChartBoard, StatDash } from "@/components/explorer-v2/ui";
 import { ChartEmpty, Stat, TipPlate } from "./bits";
 import { RANGE_DAYS, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
@@ -181,6 +182,17 @@ function SeatsByL1({ sets, network }: { sets: LiveL1[]; network: string }) {
         </Link>
       )}
     </div>
+  );
+}
+
+/* The P-Chain's L1s tab: the seat economy as its own page. Lived inside
+   the Staking page briefly — but staking and seats are different economies
+   (one mints, one burns), and each deserves its own door in the subnav. */
+export function PchainL1s({ chain, network }: { chain: string; network: string }) {
+  return (
+    <ExplorerShell chain={chain} network={network}>
+      <L1Economy network={network} />
+    </ExplorerShell>
   );
 }
 

--- a/components/explorer-v2/staking/L1Economy.tsx
+++ b/components/explorer-v2/staking/L1Economy.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { ArrowRight } from "lucide-react";
+import {
+  Area,
+  ComposedChart,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Board, BoardHeader, ChartBoard, StatDash } from "@/components/explorer-v2/ui";
+import { ChartEmpty, Stat, TipPlate } from "./bits";
+import { RANGE_DAYS, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
+import { PRIMARY_NETWORK_ID, useValidatorStats } from "@/components/explorer-v2/validator-stats";
+import { usePchainData } from "@/components/explorer-v2/pchain/hooks";
+import { hasRealChainLogo, type Stats } from "@/lib/pchain-explorer";
+import l1ChainsData from "@/constants/l1-chains.json";
+import type { L1Chain } from "@/types/stats";
+import {
+  fmtCompact,
+  thin,
+  toSeries,
+  useEcosystemSeats,
+  useValidatorFeePrice,
+  windowSeries,
+} from "./data";
+
+/* The network's OTHER validator economy, post-ACP-77: L1 seats don't stake
+   AVAX or earn rewards — each one prepays a continuous fee from a balance,
+   burned per second. Staking mints; seats burn. This section puts the two
+   side by side: how many seats, what a seat costs, what the whole set
+   burns, and where the seats actually run. L1s wear the subnet blue
+   throughout, against the Primary Network's ink. */
+
+const L1_COLOR = "#0061E2";
+const NANO = 1e9;
+const SECONDS_PER_DAY = 86_400;
+const SECONDS_PER_MONTH = 30 * SECONDS_PER_DAY;
+
+interface SeatPoint {
+  day: string;
+  primary: number;
+  l1: number;
+}
+
+/* stacked Primary + L1 seats — the Avalanche9000 growth story in one shape */
+function SeatsChart({ data }: { data: SeatPoint[] }) {
+  return (
+    <div className="h-56 text-zinc-900 dark:text-zinc-100">
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={data}>
+          <XAxis dataKey="day" hide />
+          <YAxis hide domain={[0, "dataMax"]} />
+          <RechartsTooltip
+            cursor={{ stroke: "rgba(161,161,170,0.35)" }}
+            content={({ active, payload }) => {
+              if (!active || !payload?.[0]) return null;
+              const d = payload[0].payload as SeatPoint;
+              return (
+                <TipPlate>
+                  <p className="text-[10px] text-zinc-500">{d.day}</p>
+                  <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+                    {(d.primary + d.l1).toLocaleString("en-US")} seats
+                  </p>
+                  <p className="text-[10px] tabular-nums text-zinc-500">
+                    primary {d.primary.toLocaleString("en-US")} · L1{" "}
+                    {d.l1.toLocaleString("en-US")}
+                  </p>
+                </TipPlate>
+              );
+            }}
+          />
+          <Area
+            type="monotone"
+            dataKey="primary"
+            stackId="seats"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            fill="currentColor"
+            fillOpacity={0.1}
+            isAnimationActive={false}
+          />
+          <Area
+            type="monotone"
+            dataKey="l1"
+            stackId="seats"
+            stroke={L1_COLOR}
+            strokeWidth={1.5}
+            fill={L1_COLOR}
+            fillOpacity={0.14}
+            isAnimationActive={false}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function SeatsKey() {
+  return (
+    <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
+      <span className="flex items-center gap-1.5">
+        <span className="h-2.5 w-4 bg-zinc-900/15 dark:bg-zinc-100/15" /> primary
+      </span>
+      <span className="flex items-center gap-1.5">
+        <span className="h-2.5 w-4 bg-[#0061E2]/25" /> L1
+      </span>
+    </span>
+  );
+}
+
+const LEADERBOARD_CAP = 12;
+
+interface LiveL1 {
+  id: string;
+  name: string;
+  logo?: string;
+  slug?: string;
+  nodes: number;
+}
+
+/* where the seats actually run — proportional bars over the live sets */
+function SeatsByL1({ sets, network }: { sets: LiveL1[]; network: string }) {
+  const max = sets[0]?.nodes ?? 1;
+  const total = sets.reduce((s, l) => s + l.nodes, 0);
+  const visible = sets.slice(0, LEADERBOARD_CAP);
+  return (
+    <div className="flex flex-col">
+      {visible.map((l) => {
+        const row = (
+          <>
+            <span className="flex min-w-0 items-center gap-2">
+              {l.logo && hasRealChainLogo(l.logo) ? (
+                <img src={l.logo} alt="" className="h-4 w-4 shrink-0 rounded-full object-contain" />
+              ) : (
+                <span className="h-4 w-4 shrink-0 rounded-full bg-zinc-200 dark:bg-zinc-800" />
+              )}
+              <span className="truncate text-[12.5px] font-medium text-zinc-900 dark:text-zinc-100">
+                {l.name}
+              </span>
+            </span>
+            <span className="relative h-2 min-w-0 flex-1 bg-zinc-100 dark:bg-zinc-900">
+              <span
+                className="absolute inset-y-0 left-0 bg-[#0061E2]/60"
+                style={{ width: `${(l.nodes / max) * 100}%` }}
+              />
+            </span>
+            <span className="w-20 shrink-0 text-right font-mono text-[11px] tabular-nums text-zinc-700 dark:text-zinc-300">
+              {l.nodes.toLocaleString("en-US")}
+              <span className="ml-1 text-zinc-400 dark:text-zinc-600">
+                {total > 0 ? `${Math.round((l.nodes / total) * 100)}%` : ""}
+              </span>
+            </span>
+          </>
+        );
+        const cls = "grid grid-cols-[minmax(7rem,11rem)_1fr_5rem] items-center gap-3 py-2";
+        return l.slug ? (
+          <Link
+            key={l.id}
+            href={`/explorer/${network}/${l.slug}/validators`}
+            className={`${cls} -mx-2 px-2 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-900`}
+          >
+            {row}
+          </Link>
+        ) : (
+          <div key={l.id} className={cls}>
+            {row}
+          </div>
+        );
+      })}
+      {sets.length > LEADERBOARD_CAP && (
+        <Link
+          href={`/explorer/${network}/validators`}
+          className="group mt-2 inline-flex items-center gap-1.5 self-start font-mono text-[10px] uppercase tracking-[0.16em] text-zinc-400 transition-colors hover:text-zinc-900 dark:text-zinc-500 dark:hover:text-zinc-100"
+        >
+          {sets.length - LEADERBOARD_CAP} more sets
+          <ArrowRight className="h-3 w-3 transition-all group-hover:translate-x-0.5 group-hover:text-[#E6212F]" />
+        </Link>
+      )}
+    </div>
+  );
+}
+
+export function L1Economy({ network = "mainnet" }: { network?: string }) {
+  const { data: seats, failed: seatsFailed } = useEcosystemSeats();
+  const feePrice = useValidatorFeePrice(network); // nAVAX/s per seat
+  const { subnets, error: setsFailed } = useValidatorStats(network);
+  // one indexer snapshot carries both counts, so the share can't skew:
+  // l1ValidatorCount is the ACTIVE (fee-paying) seats registered on the
+  // P-Chain — the number the burn math is honest against. The P2P feed
+  // below counts connected nodes instead, which outlives a drained balance.
+  const { data: chainStats } = usePchainData<Stats>(network, "stats");
+
+  const clock = useExplorerTimeRange();
+  const chartDays = Math.max(7, RANGE_DAYS[clock]);
+  const weekFloor = RANGE_DAYS[clock] < 7 ? " · 7 days" : "";
+
+  const seatSeries = useMemo<SeatPoint[]>(() => {
+    const l1 = toSeries(seats?.l1);
+    const primary = new Map(toSeries(seats?.primary).map((p) => [p.day, p.value]));
+    const joined = l1.map((p) => ({
+      day: p.day,
+      l1: p.value,
+      primary: primary.get(p.day) ?? 0,
+    }));
+    return thin(windowSeries(joined, chartDays));
+  }, [seats, chartDays]);
+
+  // headline figures: the indexer snapshot when it's up (live, and the
+  // fee-paying definition), the metrics series' newest point as fallback
+  const l1Seats = useMemo(() => {
+    if (chainStats?.l1ValidatorCount !== undefined) return chainStats.l1ValidatorCount;
+    const s = toSeries(seats?.l1);
+    return s.length ? s[s.length - 1].value : null;
+  }, [chainStats, seats]);
+  const primarySeats = useMemo(() => {
+    if (chainStats?.validatorCount !== undefined) return chainStats.validatorCount;
+    const s = toSeries(seats?.primary);
+    return s.length ? s[s.length - 1].value : null;
+  }, [chainStats, seats]);
+  const l1Share =
+    l1Seats !== null && primarySeats !== null && l1Seats + primarySeats > 0
+      ? (l1Seats / (l1Seats + primarySeats)) * 100
+      : null;
+
+  // live L1 sets (connected validators right now), named by the same feed
+  const liveSets = useMemo<LiveL1[] | null>(() => {
+    if (!subnets) return null;
+    const slugBySubnet = new Map<string, string>();
+    for (const c of l1ChainsData as L1Chain[]) {
+      if (c.isTestnet !== true && c.subnetId && c.slug) slugBySubnet.set(c.subnetId, c.slug);
+    }
+    return subnets
+      .filter((s) => s.isL1 && s.id !== PRIMARY_NETWORK_ID)
+      .map((s) => ({
+        id: s.id,
+        name: s.name,
+        logo: s.chainLogoURI,
+        slug: slugBySubnet.get(s.id),
+        nodes: Object.values(s.byClientVersion ?? {}).reduce((sum, v) => sum + v.nodes, 0),
+      }))
+      .filter((s) => s.nodes > 0)
+      .sort((a, b) => b.nodes - a.nodes);
+  }, [subnets]);
+
+  const perSeatMonth = feePrice !== null ? (feePrice * SECONDS_PER_MONTH) / NANO : null;
+  const burnPerDay =
+    feePrice !== null && l1Seats !== null ? (feePrice * l1Seats * SECONDS_PER_DAY) / NANO : null;
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4">
+        <Board divide={false} className="border">
+          <BoardHeader
+            label="The L1 Validator Economy"
+            display
+            action={
+              <Link
+                href={`/explorer/${network}/validators`}
+                className="group flex shrink-0 items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 transition-colors hover:text-zinc-900 dark:text-zinc-500 dark:hover:text-zinc-100"
+              >
+                All validator sets
+                <ArrowRight className="h-3 w-3 transition-all group-hover:translate-x-0.5 group-hover:text-[#E6212F]" />
+              </Link>
+            }
+          />
+          <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
+            <Stat
+              label="L1 Validator Seats"
+              sub={
+                liveSets
+                  ? `active · fee-paying, across ${liveSets.length} live L1s`
+                  : "active · fee-paying"
+              }
+            >
+              {l1Seats !== null ? l1Seats.toLocaleString("en-US") : <StatDash />}
+            </Stat>
+            <Stat label="Share of All Seats" sub="vs the Primary Network">
+              {l1Share !== null ? (
+                <>
+                  {l1Share.toFixed(1)}
+                  <span className="ml-1 text-sm text-zinc-400 dark:text-zinc-500">%</span>
+                </>
+              ) : (
+                <StatDash />
+              )}
+            </Stat>
+            <Stat
+              label="Fee Per Seat"
+              sub={feePrice !== null ? `${feePrice.toLocaleString("en-US")} nAVAX/s, live` : undefined}
+            >
+              {perSeatMonth !== null ? (
+                <>
+                  {perSeatMonth.toFixed(2)}
+                  <span className="ml-1.5 text-sm text-zinc-400 dark:text-zinc-500">AVAX/mo</span>
+                </>
+              ) : (
+                <StatDash />
+              )}
+            </Stat>
+            <Stat label="Set Burn Rate" sub="at the current seat count">
+              {burnPerDay !== null ? (
+                <>
+                  {fmtCompact(burnPerDay)}
+                  <span className="ml-1.5 text-sm text-zinc-400 dark:text-zinc-500">AVAX/day</span>
+                </>
+              ) : (
+                <StatDash />
+              )}
+            </Stat>
+          </div>
+        </Board>
+        <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+          L1 validators don&apos;t stake AVAX or earn rewards. Each seat prepays a continuous fee
+          from its own balance — burned per second at the network&apos;s current price (
+          <Link
+            href="/docs/acps/77-reinventing-subnets"
+            className="text-[#0061E2] underline-offset-4 hover:underline dark:text-[#5f9dff]"
+          >
+            ACP-77
+          </Link>
+          ). Staking mints; seats burn.
+        </p>
+      </div>
+
+      <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
+        <ChartBoard
+          label={`Validator Seats${weekFloor}`}
+          action={
+            <span className="hidden sm:block">
+              <SeatsKey />
+            </span>
+          }
+        >
+          {seatSeries.length ? <SeatsChart data={seatSeries} /> : <ChartEmpty failed={seatsFailed} />}
+        </ChartBoard>
+
+        {/* the P2P view: nodes connected and validating each set right now.
+            Deliberately NOT called seats — a node keeps running after its
+            seat's balance drains, so this counts infrastructure, not fees */}
+        <ChartBoard
+          label="Validators by L1 · connected now"
+          action={
+            liveSets ? (
+              <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                {liveSets.reduce((s, l) => s + l.nodes, 0).toLocaleString("en-US")} connected
+              </span>
+            ) : undefined
+          }
+        >
+          {liveSets === null ? (
+            <ChartEmpty failed={setsFailed} />
+          ) : liveSets.length === 0 ? (
+            <ChartEmpty failed={false} label="No live L1 sets" />
+          ) : (
+            <SeatsByL1 sets={liveSets} network={network} />
+          )}
+        </ChartBoard>
+      </div>
+    </section>
+  );
+}

--- a/components/explorer-v2/staking/PrimaryStaking.tsx
+++ b/components/explorer-v2/staking/PrimaryStaking.tsx
@@ -15,6 +15,7 @@ import {
 } from "recharts";
 import { cn } from "@/lib/utils";
 import { Board, BoardHeader, ChartBoard, DarkToggle, StatCell, StatDash } from "@/components/explorer-v2/ui";
+import { useTokenUsd } from "@/components/explorer/GasMarketPage";
 import { ChartEmpty, Stat, TipPlate } from "./bits";
 import { RANGE_DAYS, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import {
@@ -199,6 +200,58 @@ function ApyChart({ data }: { data: ApyPoint[] }) {
             strokeWidth={1.5}
             strokeDasharray="4 3"
             dot={false}
+            isAnimationActive={false}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+interface RatioPoint {
+  day: string;
+  /** staked share of circulating supply, % */
+  pct: number;
+  /** AVAX */
+  staked: number;
+  /** AVAX */
+  supply: number;
+}
+
+/* staked share of the circulating supply — the auto domain magnifies the
+   drift, which IS the signal here; the tooltip carries the absolutes */
+function RatioChart({ data }: { data: RatioPoint[] }) {
+  return (
+    <div className="h-40 text-zinc-900 dark:text-zinc-100">
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={data}>
+          <XAxis dataKey="day" hide />
+          <YAxis hide domain={["auto", "auto"]} />
+          <RechartsTooltip
+            cursor={{ stroke: "rgba(161,161,170,0.35)" }}
+            content={({ active, payload }) => {
+              if (!active || !payload?.[0]) return null;
+              const d = payload[0].payload as RatioPoint;
+              return (
+                <TipPlate>
+                  <p className="text-[10px] text-zinc-500">{fmtDay(d.day)}</p>
+                  <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+                    {d.pct.toFixed(1)}% of supply staked
+                  </p>
+                  <p className="text-[10px] tabular-nums text-zinc-500">
+                    {fmtCompact(d.staked)} of {fmtCompact(d.supply)} AVAX
+                  </p>
+                </TipPlate>
+              );
+            }}
+          />
+          <Area
+            type="monotone"
+            dataKey="pct"
+            stroke={DELEGATED_COLOR}
+            strokeWidth={1.5}
+            fill={DELEGATED_COLOR}
+            fillOpacity={0.08}
             isAnimationActive={false}
           />
         </ComposedChart>
@@ -656,7 +709,10 @@ export function PrimaryStakingContent({
   const door = (metric: string) => (base ? `${base}/${metric}` : undefined);
   const { data: metrics, failed: metricsFailed } = usePrimaryMetrics();
   const { data: apy, failed: apyFailed } = useStakingApy();
-  const { data: sdkValidators, failed: sdkFailed } = useSdkValidators();
+  const { data: sdkValidators } = useSdkValidators();
+  // AVAX's USD price via the C-Chain's cached explorer feed — the staking
+  // feeds are mainnet-only, so the mainnet chain id is a constant here
+  const { usd: avaxUsd } = useTokenUsd(43114);
 
   // the page clock in the subnav — one window for every trend below. The
   // subnav states the window once, so chart titles drop the range suffix.
@@ -732,10 +788,20 @@ export function PrimaryStakingContent({
     return thin(windowSeries(withMa, chartDays), 180);
   }, [metrics, chartDays]);
 
-  const cumulativeRewardSeries = useMemo(
-    () => thin(windowSeries(toSeries(metrics?.cumulative_rewards), chartDays)),
-    [metrics, chartDays],
-  );
+  // stake joined with the APY feed's daily supply — the share of all
+  // circulating AVAX that is working. Days the two feeds don't share drop.
+  const ratioSeries = useMemo<RatioPoint[]>(() => {
+    if (!apy?.data) return [];
+    const supplyByDay = new Map(apy.data.map((p) => [p.date, p.supply]));
+    const delegated = new Map(toSeries(metrics?.delegator_weight).map((p) => [p.day, p.value]));
+    const joined = toSeries(metrics?.validator_weight).flatMap((p) => {
+      const supply = supplyByDay.get(p.day);
+      if (!supply) return [];
+      const staked = (p.value + (delegated.get(p.day) ?? 0)) / NANO;
+      return [{ day: p.day, pct: (staked / supply) * 100, staked, supply }];
+    });
+    return thin(windowSeries(joined, chartDays));
+  }, [metrics, apy, chartDays]);
 
   /* -------------------------------------------------------------- */
   /* the money actually moving — accrual is smooth, cash is lumpy    */
@@ -757,45 +823,25 @@ export function PrimaryStakingContent({
   /* the current set, sliced two ways                                */
   /* -------------------------------------------------------------- */
 
-  const [lens, setLens] = useState<Lens>("weight");
-  const concentration = useMemo<ConcentrationPoint[]>(() => {
-    if (!sdkValidators?.length) return [];
-    const pick = (v: (typeof sdkValidators)[number]): number => {
-      const own = num(v.amountStaked) ?? 0;
-      const delegated = num(v.amountDelegated) ?? 0;
-      return lens === "own" ? own : lens === "delegated" ? delegated : own + delegated;
-    };
-    const weights = sdkValidators.map((v) => pick(v) / NANO).sort((a, b) => b - a);
+  // the distribution board's headline readings — the full rank-by-rank
+  // instrument (and its lens toggle) lives on the distribution sheet
+  const setStats = useMemo(() => {
+    if (!sdkValidators?.length) return null;
+    const weights = sdkValidators
+      .map((v) => ((num(v.amountStaked) ?? 0) + (num(v.amountDelegated) ?? 0)) / NANO)
+      .sort((a, b) => b - a);
     const total = weights.reduce((s, w) => s + w, 0);
-    if (total <= 0) return [];
+    if (total <= 0) return null;
     let cumulative = 0;
-    return weights.map((weight, i) => {
-      cumulative += weight;
-      return { rank: i + 1, weight, cumulativePct: (cumulative / total) * 100 };
-    });
-  }, [sdkValidators, lens]);
-
-  // the smallest club of validators that already controls half of the lens
-  const halfClub = useMemo(() => {
-    const hit = concentration.find((p) => p.cumulativePct >= 50);
-    return hit?.rank ?? null;
-  }, [concentration]);
-
-  const feeBuckets = useMemo<FeeBucket[]>(() => {
-    if (!sdkValidators?.length) return [];
-    const buckets = new Map<number, { count: number; weight: number }>();
-    for (const v of sdkValidators) {
-      const fee = Math.round(num(v.delegationFee) ?? 0);
-      // the long tail above 15% is a rounding drawer, not fifteen bars
-      const key = Math.min(fee, 16);
-      const b = buckets.get(key) ?? { count: 0, weight: 0 };
-      b.count += 1;
-      b.weight += (num(v.amountStaked) ?? 0) / NANO;
-      buckets.set(key, b);
+    let halfClub: number | null = null;
+    for (let i = 0; i < weights.length; i++) {
+      cumulative += weights[i];
+      if (cumulative >= total / 2) {
+        halfClub = i + 1;
+        break;
+      }
     }
-    return Array.from(buckets.entries())
-      .sort((a, b) => a[0] - b[0])
-      .map(([fee, b]) => ({ label: fee >= 16 ? "16%+" : `${fee}%`, ...b }));
+    return { halfClub, largestPct: (weights[0] / total) * 100, avgStake: total / weights.length };
   }, [sdkValidators]);
 
   const medianFee = useMemo(() => {
@@ -850,8 +896,13 @@ export function PrimaryStakingContent({
             <Stat
               label="Total Staked"
               sub={
-                ownStake !== null && delegatedStake !== null
-                  ? `${stakingRatio !== null ? `${stakingRatio.toFixed(1)}% of supply · ` : ""}own ${fmtCompact(ownStake / NANO)} · delegated ${fmtCompact(delegatedStake / NANO)}`
+                totalStaked !== null
+                  ? [
+                      avaxUsd !== null ? `≈ $${fmtCompact(totalStaked * avaxUsd)}` : null,
+                      stakingRatio !== null ? `${stakingRatio.toFixed(1)}% of supply` : null,
+                    ]
+                      .filter(Boolean)
+                      .join(" · ") || undefined
                   : undefined
               }
             >
@@ -866,9 +917,9 @@ export function PrimaryStakingContent({
             </Stat>
             {/* the count is a door into the set itself */}
             <StatCell label="Validators" href={validatorsHref} sub="current set">
-              <span className="min-w-0 truncate font-mono text-xl tabular-nums tracking-tight text-zinc-900 sm:text-2xl md:text-[1.75rem] dark:text-zinc-50">
+              <CellFigure>
                 {sdkValidators?.length ? sdkValidators.length.toLocaleString("en-US") : <StatDash />}
-              </span>
+              </CellFigure>
             </StatCell>
             <Stat
               label="Delegators"
@@ -920,17 +971,24 @@ export function PrimaryStakingContent({
         )}
       </ChartBoard>
 
-      {/* who delegates, and what staking pays */}
+      {/* the capital's quality: how much of the supply is working, and
+          what working pays */}
       <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-        <ChartBoard label={`Delegators${weekFloor}`} href={door("total-stake")}>
-          {delegatorSeries.length ? (
-            <AreaTrend
-              data={delegatorSeries}
-              format={(v) => Math.round(v).toLocaleString("en-US")}
-              unit="delegators"
-            />
+        <ChartBoard
+          label={`Staking Ratio${weekFloor}`}
+          href={door("total-stake")}
+          action={
+            stakingRatio !== null ? (
+              <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                {stakingRatio.toFixed(1)}% today
+              </span>
+            ) : undefined
+          }
+        >
+          {ratioSeries.length ? (
+            <RatioChart data={ratioSeries} />
           ) : (
-            <ChartEmpty failed={metricsFailed} />
+            <ChartEmpty failed={metricsFailed || apyFailed} />
           )}
         </ChartBoard>
 
@@ -954,7 +1012,7 @@ export function PrimaryStakingContent({
         </ChartBoard>
       </div>
 
-      {/* what securing the network mints */}
+      {/* what securing the network mints, and who shows up to earn it */}
       <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
         <ChartBoard
           label={`Daily Rewards${weekFloor}`}
@@ -972,9 +1030,13 @@ export function PrimaryStakingContent({
           )}
         </ChartBoard>
 
-        <ChartBoard label={`Cumulative Rewards${weekFloor}`} href={door("rewards")}>
-          {cumulativeRewardSeries.length ? (
-            <AreaTrend data={cumulativeRewardSeries} format={fmtCompact} unit="AVAX" />
+        <ChartBoard label={`Delegators${weekFloor}`} href={door("total-stake")}>
+          {delegatorSeries.length ? (
+            <AreaTrend
+              data={delegatorSeries}
+              format={(v) => Math.round(v).toLocaleString("en-US")}
+              unit="delegators"
+            />
           ) : (
             <ChartEmpty failed={metricsFailed} />
           )}
@@ -1023,53 +1085,74 @@ export function PrimaryStakingContent({
         </ChartBoard>
       </div>
 
-      {/* how the stake spreads across the current set — two snapshots of the
-          live set, each with its reading below (· current set is the honest
-          qualifier: these don't follow the page clock) */}
-      <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
-        <div className="flex flex-col gap-4">
-          {/* no door here: the lens toggle in the title bar is interactive,
-              and a card-wide Link would swallow its clicks — the fees card
-              and the sheet siblings carry the way in */}
-          <ChartBoard
-            label="Concentration by Rank · current set"
-            action={<LensToggle value={lens} onChange={setLens} />}
-          >
-            {concentration.length ? (
-              <ConcentrationChart data={thin(concentration, 300)} setSize={concentration.length} />
-            ) : (
-              <ChartEmpty failed={sdkFailed} />
-            )}
-          </ChartBoard>
-          <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
-            Bars: each validator&apos;s {LENS_LABEL[lens].toLowerCase()} by rank (right axis). Red
-            line: the cumulative share the top N hold (left axis)
-            {halfClub !== null && <> — the top {halfClub} together control half of it</>}. The
-            flatter the climb, the more evenly the network&apos;s security is spread.
-          </p>
-        </div>
-
-        <div className="flex flex-col gap-4">
-          <ChartBoard
-            label="Delegation Fees · current set"
-            href={door("distribution")}
+      {/* how the stake spreads across the current set — the headline
+          readings only; the rank-by-rank concentration and fee instruments
+          live on the distribution sheet, one door away */}
+      <section className="flex flex-col gap-3">
+        <Board divide={false} className="border">
+          <BoardHeader
+            label="Stake Distribution"
+            display
             action={
-              medianFee !== null ? (
-                <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-                  median {medianFee.toFixed(0)}%
-                </span>
+              door("distribution") ? (
+                <Link
+                  href={door("distribution")!}
+                  className="group flex shrink-0 items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 transition-colors hover:text-zinc-900 dark:text-zinc-500 dark:hover:text-zinc-100"
+                >
+                  Full breakdown
+                  <ArrowRight className="h-3 w-3 transition-all group-hover:translate-x-0.5 group-hover:text-[#E6212F]" />
+                </Link>
               ) : undefined
             }
-          >
-            {feeBuckets.length ? <FeeChart data={feeBuckets} /> : <ChartEmpty failed={sdkFailed} />}
-          </ChartBoard>
-          <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
-            Red bars: own stake sitting at each fee (left axis) — where the capital actually lives.
-            Dashed line: validator count at that fee (right axis). The cut is what delegating there
-            costs.
-          </p>
-        </div>
-      </div>
+          />
+          <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
+            <StatCell
+              label="Half the Stake"
+              href={door("distribution")}
+              sub="smallest club controlling 50%"
+            >
+              <CellFigure>
+                {setStats?.halfClub != null ? `top ${setStats.halfClub}` : <StatDash />}
+              </CellFigure>
+            </StatCell>
+            <StatCell label="Largest Validator" href={door("distribution")} sub="of total weight">
+              <CellFigure>
+                {setStats ? `${setStats.largestPct.toFixed(1)}%` : <StatDash />}
+              </CellFigure>
+            </StatCell>
+            <StatCell
+              label="Median Fee"
+              href={door("distribution")}
+              sub="the cut on delegation rewards"
+            >
+              <CellFigure>
+                {medianFee !== null ? `${medianFee.toFixed(0)}%` : <StatDash />}
+              </CellFigure>
+            </StatCell>
+            <StatCell
+              label="Avg per Validator"
+              href={door("distribution")}
+              sub="mean weight across the set"
+            >
+              <CellFigure>
+                {setStats ? (
+                  <>
+                    {fmtCompact(setStats.avgStake)}
+                    <span className="ml-1.5 text-sm text-zinc-400 dark:text-zinc-500">AVAX</span>
+                  </>
+                ) : (
+                  <StatDash />
+                )}
+              </CellFigure>
+            </StatCell>
+          </div>
+        </Board>
+        <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+          The current set, read for decentralization: the fewer validators it takes to reach half
+          the stake, the more concentrated the network&apos;s security. The full rank-by-rank
+          concentration curve and the delegation-fee market live in the breakdown.
+        </p>
+      </section>
 
       {/* the protocol's fixed terms — the orientation plate for anyone the
           numbers above just convinced */}
@@ -1100,6 +1183,16 @@ export function PrimaryStakingContent({
         </Board>
       </section>
     </div>
+  );
+}
+
+/* the stat strips' figure voice, for StatCell children (Stat styles its
+   own; StatCell leaves the figure to the caller) */
+function CellFigure({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="min-w-0 truncate font-mono text-xl tabular-nums tracking-tight text-zinc-900 sm:text-2xl md:text-[1.75rem] dark:text-zinc-50">
+      {children}
+    </span>
   );
 }
 

--- a/components/explorer-v2/staking/PrimaryStaking.tsx
+++ b/components/explorer-v2/staking/PrimaryStaking.tsx
@@ -17,7 +17,6 @@ import { cn } from "@/lib/utils";
 import { Board, BoardHeader, ChartBoard, StatCell, StatDash } from "@/components/explorer-v2/ui";
 import { ChartEmpty, Stat, TipPlate } from "./bits";
 import { RANGE_DAYS, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
-import { L1Economy } from "./L1Economy";
 import {
   NANO,
   fmtCompact,
@@ -534,7 +533,6 @@ export function PrimaryStakingContent({
   validatorsHref,
   base,
   network = "mainnet",
-  includeL1 = false,
 }: {
   validatorsHref: string;
   /** the staking tab's own path — every ChartBoard doors into its metric
@@ -542,9 +540,6 @@ export function PrimaryStakingContent({
   base?: string;
   /** the staking feeds watch mainnet; both mounts guard the route already */
   network?: string;
-  /** the P-Chain mount adds the ACP-77 seat economy; the C-Chain tab
-   *  stays purely Primary Network */
-  includeL1?: boolean;
 }) {
   const door = (metric: string) => (base ? `${base}/${metric}` : undefined);
   const { data: metrics, failed: metricsFailed } = usePrimaryMetrics();
@@ -955,10 +950,6 @@ export function PrimaryStakingContent({
           )}
         </ChartBoard>
       </div>
-
-      {/* the P-Chain page carries the network's OTHER validator economy —
-          ACP-77 L1 seats, which burn instead of mint */}
-      {includeL1 && <L1Economy network={network} />}
 
       {/* how the stake spreads across the current set — two snapshots of the
           live set, each with its reading below (· current set is the honest

--- a/components/explorer-v2/staking/PrimaryStaking.tsx
+++ b/components/explorer-v2/staking/PrimaryStaking.tsx
@@ -14,7 +14,7 @@ import {
   YAxis,
 } from "recharts";
 import { cn } from "@/lib/utils";
-import { Board, BoardHeader, ChartBoard, StatCell, StatDash } from "@/components/explorer-v2/ui";
+import { Board, BoardHeader, ChartBoard, DarkToggle, StatCell, StatDash } from "@/components/explorer-v2/ui";
 import { ChartEmpty, Stat, TipPlate } from "./bits";
 import { RANGE_DAYS, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import {
@@ -514,37 +514,6 @@ const DURATIONS = [
 function effectiveConsumptionRate(days: number): number {
   const t = Math.min(1, Math.max(0, days / 365));
   return MIN_CONSUMPTION * (1 - t) + MAX_CONSUMPTION * t;
-}
-
-/* segmented control in the dark panel's voice */
-function DarkToggle<T extends string>({
-  options,
-  value,
-  onChange,
-}: {
-  options: { value: T; label: string }[];
-  value: T;
-  onChange: (v: T) => void;
-}) {
-  return (
-    <div className="inline-flex shrink-0 border border-white/15">
-      {options.map((o) => (
-        <button
-          key={o.value}
-          type="button"
-          onClick={() => onChange(o.value)}
-          className={cn(
-            "px-2.5 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.14em] transition-colors",
-            o.value === value
-              ? "bg-[#EBF0FA] text-zinc-900"
-              : "text-[#A2AFB2] hover:bg-white/10 hover:text-[#EBF0FA]",
-          )}
-        >
-          {o.label}
-        </button>
-      ))}
-    </div>
-  );
 }
 
 function YieldCalculator({

--- a/components/explorer-v2/staking/PrimaryStaking.tsx
+++ b/components/explorer-v2/staking/PrimaryStaking.tsx
@@ -17,12 +17,14 @@ import { cn } from "@/lib/utils";
 import { Board, BoardHeader, ChartBoard, StatCell, StatDash } from "@/components/explorer-v2/ui";
 import { ChartEmpty, Stat, TipPlate } from "./bits";
 import { RANGE_DAYS, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
+import { L1Economy } from "./L1Economy";
 import {
   NANO,
   fmtCompact,
   num,
   thin,
   toSeries,
+  useMoneyFlow,
   usePrimaryMetrics,
   useSdkValidators,
   useStakingApy,
@@ -248,6 +250,46 @@ function RewardsBars({ data }: { data: RewardPoint[] }) {
             dot={false}
             isAnimationActive={false}
           />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+interface FlowDay {
+  date: string;
+  avax: number;
+  count: number;
+}
+
+/* one day-bar shape for both money-flow cards — payouts landed (red, stake
+   moving) and stake reaching term (block gray, value at rest) */
+function MoneyBars({ data, color, noun }: { data: FlowDay[]; color: string; noun: string }) {
+  return (
+    <div className="h-40">
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={data}>
+          <XAxis dataKey="date" hide />
+          <YAxis hide domain={[0, "dataMax"]} />
+          <RechartsTooltip
+            cursor={{ fill: "rgba(161,161,170,0.08)" }}
+            content={({ active, payload }) => {
+              if (!active || !payload?.[0]) return null;
+              const d = payload[0].payload as FlowDay;
+              return (
+                <TipPlate>
+                  <p className="text-[10px] text-zinc-500">{fmtDay(d.date)}</p>
+                  <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+                    {fmtCompact(d.avax)} AVAX
+                  </p>
+                  <p className="text-[10px] tabular-nums text-zinc-500">
+                    {d.count.toLocaleString("en-US")} {noun}
+                  </p>
+                </TipPlate>
+              );
+            }}
+          />
+          <Bar dataKey="avax" fill={color} minPointSize={1} isAnimationActive={false} />
         </ComposedChart>
       </ResponsiveContainer>
     </div>
@@ -491,11 +533,18 @@ function StakeKey() {
 export function PrimaryStakingContent({
   validatorsHref,
   base,
+  network = "mainnet",
+  includeL1 = false,
 }: {
   validatorsHref: string;
   /** the staking tab's own path — every ChartBoard doors into its metric
    *  sheet under it (base/total-stake, base/apy, …) */
   base?: string;
+  /** the staking feeds watch mainnet; both mounts guard the route already */
+  network?: string;
+  /** the P-Chain mount adds the ACP-77 seat economy; the C-Chain tab
+   *  stays purely Primary Network */
+  includeL1?: boolean;
 }) {
   const door = (metric: string) => (base ? `${base}/${metric}` : undefined);
   const { data: metrics, failed: metricsFailed } = usePrimaryMetrics();
@@ -521,6 +570,14 @@ export function PrimaryStakingContent({
     ownStake !== null && delegatedStake !== null ? (ownStake + delegatedStake) / NANO : null;
   const delegators = num(metrics?.delegator_count?.current_value);
   const cumulativeRewards = num(metrics?.cumulative_rewards?.current_value);
+  // the APY feed carries the live circulating supply (AVAX units) and the
+  // all-time burn — the ratio is THE number behind the reward rate
+  const supplyAvax = num(apy?.current?.supply);
+  const totalBurned = num(apy?.current?.totalBurned);
+  const stakingRatio =
+    totalStaked !== null && supplyAvax !== null && supplyAvax > 0
+      ? (totalStaked / supplyAvax) * 100
+      : null;
   // today's row is partial — the last full day is the honest daily figure
   const dailyRewards = useMemo(() => {
     const series = toSeries(metrics?.daily_rewards);
@@ -572,6 +629,22 @@ export function PrimaryStakingContent({
     () => thin(windowSeries(toSeries(metrics?.cumulative_rewards), chartDays)),
     [metrics, chartDays],
   );
+
+  /* -------------------------------------------------------------- */
+  /* the money actually moving — accrual is smooth, cash is lumpy    */
+  /* -------------------------------------------------------------- */
+
+  const { flow, failed: flowFailed, days: flowDays } = useMoneyFlow(network, range);
+  const rewardsPaid = useMemo<FlowDay[]>(
+    () => (flow?.rewards ?? []).map((r) => ({ date: r.date, avax: r.avax, count: r.payouts })),
+    [flow],
+  );
+  const unlocking = useMemo<FlowDay[]>(
+    () => (flow?.unlocks ?? []).map((u) => ({ date: u.date, avax: u.avax, count: u.stakers })),
+    [flow],
+  );
+  const paidSum = useMemo(() => rewardsPaid.reduce((s, d) => s + d.avax, 0), [rewardsPaid]);
+  const unlockSum = useMemo(() => unlocking.reduce((s, d) => s + d.avax, 0), [unlocking]);
 
   /* -------------------------------------------------------------- */
   /* the current set, sliced two ways                                */
@@ -659,10 +732,15 @@ export function PrimaryStakingContent({
                 "—"
               )}
             </StatementCell>
-            <StatementCell label="Median Delegation Fee" sub="across the current set">
-              {medianFee !== null ? (
+            {/* the ratio IS the reward rate's denominator — it earns the
+                panel over the median fee, which lives on the fees chart */}
+            <StatementCell
+              label="Staked of Supply"
+              sub={supplyAvax !== null ? `of ${fmtCompact(supplyAvax)} AVAX` : undefined}
+            >
+              {stakingRatio !== null ? (
                 <>
-                  {medianFee.toFixed(0)}
+                  {stakingRatio.toFixed(1)}
                   <span className="ml-1 text-sm text-[#A2AFB2]">%</span>
                 </>
               ) : (
@@ -739,7 +817,13 @@ export function PrimaryStakingContent({
             </Stat>
             <Stat
               label="Rewards · All-Time"
-              sub={dailyRewards !== null ? `≈ ${fmtCompact(dailyRewards)} AVAX/day` : undefined}
+              sub={
+                dailyRewards !== null
+                  ? totalBurned !== null
+                    ? `≈ ${fmtCompact(dailyRewards)}/day · ${fmtCompact(totalBurned)} burned all-time`
+                    : `≈ ${fmtCompact(dailyRewards)} AVAX/day`
+                  : undefined
+              }
             >
               {cumulativeRewards !== null ? (
                 <>
@@ -830,6 +914,52 @@ export function PrimaryStakingContent({
         </ChartBoard>
       </div>
 
+      {/* the cash view: accrual above is smooth, payouts and unlocks are
+          lumpy — what actually landed in wallets behind us, what reaches
+          term ahead. Past | future across one rule, like the P-Chain home,
+          but on the page clock (the feed's computed windows) */}
+      <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-2">
+        <ChartBoard
+          label={`Rewards Paid · last ${flowDays} days`}
+          href={door("rewards")}
+          action={
+            flow ? (
+              <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                {fmtCompact(paidSum)} AVAX
+              </span>
+            ) : undefined
+          }
+        >
+          {flow ? (
+            <MoneyBars data={rewardsPaid} color={DELEGATED_COLOR} noun="payouts" />
+          ) : (
+            <ChartEmpty failed={flowFailed} />
+          )}
+        </ChartBoard>
+
+        <ChartBoard
+          label={`Stake Expiring · next ${flowDays} days`}
+          href={door("expiry")}
+          action={
+            flow ? (
+              <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                {fmtCompact(unlockSum)} AVAX
+              </span>
+            ) : undefined
+          }
+        >
+          {flow ? (
+            <MoneyBars data={unlocking} color={QUIET_BAR} noun="stake entries end" />
+          ) : (
+            <ChartEmpty failed={flowFailed} />
+          )}
+        </ChartBoard>
+      </div>
+
+      {/* the P-Chain page carries the network's OTHER validator economy —
+          ACP-77 L1 seats, which burn instead of mint */}
+      {includeL1 && <L1Economy network={network} />}
+
       {/* how the stake spreads across the current set — two snapshots of the
           live set, each with its reading below (· current set is the honest
           qualifier: these don't follow the page clock) */}
@@ -877,6 +1007,51 @@ export function PrimaryStakingContent({
           </p>
         </div>
       </div>
+
+      {/* the protocol's fixed terms — the orientation plate for anyone the
+          numbers above just convinced */}
+      <section className="flex flex-col gap-4">
+        <Board divide={false} className="border">
+          <BoardHeader
+            label="Staking Parameters"
+            action={
+              <Link
+                href="/docs/primary-network/validate/how-to-stake"
+                className="group flex shrink-0 items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 transition-colors hover:text-zinc-900 dark:text-zinc-500 dark:hover:text-zinc-100"
+              >
+                How to stake
+                <ArrowRight className="h-3 w-3 transition-all group-hover:translate-x-0.5 group-hover:text-[#E6212F]" />
+              </Link>
+            }
+          />
+          {/* hairline mosaic: the gap paints the rules, so the grid can
+              wrap 2 → 3 → 6 columns without divide-* bookkeeping */}
+          <div className="grid grid-cols-2 gap-px bg-zinc-200 sm:grid-cols-3 lg:grid-cols-6 dark:bg-zinc-800">
+            <ParamCell label="Min Validator Stake" value="2,000 AVAX" />
+            <ParamCell label="Max Validator Weight" value="3M AVAX" sub="≤ 5× own stake" />
+            <ParamCell label="Min Delegation" value="25 AVAX" />
+            <ParamCell label="Staking Term" value="2 wk – 1 yr" />
+            <ParamCell label="Uptime Required" value="≥ 80%" sub="or no reward" />
+            <ParamCell label="Min Delegation Fee" value="2%" />
+          </div>
+        </Board>
+      </section>
+    </div>
+  );
+}
+
+/* a quiet rules cell — smaller voice than the stat strips: these are
+   constants, not readings */
+function ParamCell({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="flex flex-col gap-1 bg-white px-4 py-3.5 dark:bg-zinc-950">
+      <span className="font-mono text-[9px] font-bold uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+        {label}
+      </span>
+      <span className="font-mono text-[13px] font-medium tabular-nums text-zinc-900 dark:text-zinc-100">
+        {value}
+      </span>
+      {sub && <span className="font-mono text-[10px] text-zinc-400 dark:text-zinc-500">{sub}</span>}
     </div>
   );
 }

--- a/components/explorer-v2/staking/PrimaryStaking.tsx
+++ b/components/explorer-v2/staking/PrimaryStaking.tsx
@@ -491,26 +491,162 @@ export function LensToggle({ value, onChange }: { value: Lens; onChange: (v: Len
   );
 }
 
-/* a cell inside the dark statement panel — steel label, ink-white figure,
-   muted sub. The homepage pillar voice, same as the gas page's lead panel. */
-function StatementCell({
-  label,
-  sub,
-  children,
+/* ------------------------------------------------------------------ */
+/* The yield calculator — ONE hero rate instead of a strip of cells,
+   and the inputs that make it yours: amount, duration, role. Mirrors
+   /api/staking-apy's official formula exactly (same constants):
+     reward = amount × (720M − supply)/supply × ECR(d) × d/365
+     ECR(d) = 10% → 12%, linear in duration
+   Delegators additionally hand the validator its fee cut.             */
+
+const MAX_SUPPLY = 720_000_000; // AVAX supply cap — the emission source
+const MIN_CONSUMPTION = 0.1;
+const MAX_CONSUMPTION = 0.12;
+
+const DURATIONS = [
+  { key: "2w", label: "2W", days: 14 },
+  { key: "1m", label: "1M", days: 30 },
+  { key: "3m", label: "3M", days: 91 },
+  { key: "6m", label: "6M", days: 182 },
+  { key: "1y", label: "1Y", days: 365 },
+] as const;
+
+function effectiveConsumptionRate(days: number): number {
+  const t = Math.min(1, Math.max(0, days / 365));
+  return MIN_CONSUMPTION * (1 - t) + MAX_CONSUMPTION * t;
+}
+
+/* segmented control in the dark panel's voice */
+function DarkToggle<T extends string>({
+  options,
+  value,
+  onChange,
 }: {
-  label: string;
-  sub?: React.ReactNode;
-  children: React.ReactNode;
+  options: { value: T; label: string }[];
+  value: T;
+  onChange: (v: T) => void;
 }) {
   return (
-    <div className="flex flex-col gap-1.5 px-5 py-5 md:px-6 lg:first:pl-0">
-      <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
-        {label}
-      </span>
-      <span className="min-w-0 truncate font-mono text-xl tabular-nums tracking-tight text-[#EBF0FA] sm:text-2xl md:text-[1.75rem]">
-        {children}
-      </span>
-      {sub != null && <span className="text-xs tabular-nums text-[#A2AFB2]">{sub}</span>}
+    <div className="inline-flex shrink-0 border border-white/15">
+      {options.map((o) => (
+        <button
+          key={o.value}
+          type="button"
+          onClick={() => onChange(o.value)}
+          className={cn(
+            "px-2.5 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.14em] transition-colors",
+            o.value === value
+              ? "bg-[#EBF0FA] text-zinc-900"
+              : "text-[#A2AFB2] hover:bg-white/10 hover:text-[#EBF0FA]",
+          )}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function YieldCalculator({
+  supply,
+  medianFee,
+}: {
+  /** circulating AVAX, the emission formula's denominator */
+  supply: number | null;
+  /** the current set's median delegation fee, % */
+  medianFee: number | null;
+}) {
+  const [amountRaw, setAmountRaw] = useState("1,000");
+  const [durationKey, setDurationKey] = useState<(typeof DURATIONS)[number]["key"]>("1y");
+  const [role, setRole] = useState<"delegating" | "validating">("delegating");
+
+  const amount = Number(amountRaw.replace(/[^0-9.]/g, "")) || 0;
+  const days = DURATIONS.find((d) => d.key === durationKey)!.days;
+  const fee = medianFee ?? 2; // protocol floor if the set hasn't loaded
+
+  // the official emission math, then the delegator's haircut
+  const calc = useMemo(() => {
+    if (supply === null || supply <= 0 || supply >= MAX_SUPPLY) return null;
+    const gross = ((MAX_SUPPLY - supply) / supply) * effectiveConsumptionRate(days);
+    const net = role === "delegating" ? gross * (1 - fee / 100) : gross;
+    return {
+      annualPct: net * 100,
+      reward: amount * net * (days / 365),
+    };
+  }, [supply, days, role, fee, amount]);
+
+  return (
+    <div className="flex flex-col gap-8 bg-[#1F1F1F] p-6 md:p-8">
+      {/* headline left, the ONE number right — big enough to read from
+          across the room */}
+      <div className="flex flex-wrap items-end justify-between gap-x-12 gap-y-8">
+        <h3 className="v2-display text-3xl leading-[1.02] md:text-4xl">
+          <span className="block text-[#EBF0FA]">What securing the network</span>
+          <span className="block text-[#E6212F]">pays right now.</span>
+        </h3>
+        <div className="flex flex-col items-end gap-1">
+          <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
+            {role} · {DURATIONS.find((d) => d.key === durationKey)!.label} · est
+          </span>
+          <span className="font-mono text-6xl tabular-nums tracking-tight text-[#EBF0FA] md:text-7xl">
+            {calc ? calc.annualPct.toFixed(1) : "—"}
+            <span className="ml-1 text-2xl text-[#A2AFB2]">%</span>
+            <span className="ml-2 text-lg text-[#A2AFB2]">/ yr</span>
+          </span>
+        </div>
+      </div>
+
+      {/* the calculator: make the rate yours */}
+      <div className="flex flex-col gap-5 border-t border-white/10 pt-6">
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-4">
+          <label className="flex items-center gap-3">
+            <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
+              Stake
+            </span>
+            <span className="flex items-baseline gap-2 border-b border-white/25 focus-within:border-[#E6212F]">
+              <input
+                value={amountRaw}
+                onChange={(e) => setAmountRaw(e.target.value)}
+                onBlur={() =>
+                  setAmountRaw(amount > 0 ? amount.toLocaleString("en-US") : "1,000")
+                }
+                inputMode="decimal"
+                aria-label="AVAX amount to stake"
+                className="w-32 bg-transparent py-1 text-right font-mono text-xl tabular-nums text-[#EBF0FA] outline-none placeholder:text-[#A2AFB2]/50"
+              />
+              <span className="pb-0.5 font-mono text-xs text-[#A2AFB2]">AVAX</span>
+            </span>
+          </label>
+          <label className="flex items-center gap-3">
+            <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
+              For
+            </span>
+            <DarkToggle
+              options={DURATIONS.map((d) => ({ value: d.key, label: d.label }))}
+              value={durationKey}
+              onChange={setDurationKey}
+            />
+          </label>
+          <DarkToggle
+            options={[
+              { value: "delegating" as const, label: "Delegating" },
+              { value: "validating" as const, label: "Validating" },
+            ]}
+            value={role}
+            onChange={setRole}
+          />
+        </div>
+        <p className="font-mono text-lg text-[#A2AFB2] md:text-xl">
+          earns ≈{" "}
+          <span className="text-3xl font-bold tabular-nums text-[#E6212F] md:text-4xl">
+            {calc && amount > 0 ? fmtCompact(calc.reward) : "—"}
+          </span>{" "}
+          <span className="text-[#EBF0FA]">AVAX</span>
+          {role === "delegating" && (
+            <span className="ml-3 text-xs">after the median {fee.toFixed(0)}% validator fee</span>
+          )}
+        </p>
+      </div>
     </div>
   );
 }
@@ -697,66 +833,21 @@ export function PrimaryStakingContent({
 
   return (
     <div className="flex flex-col gap-10">
-      {/* the answer first: what securing the network pays, in the homepage
-          pillar panels' voice (#1F1F1F board, EBF0FA lead over the E6212F
-          punch, steel spec labels) */}
+      {/* the answer first — ONE number and the calculator that makes it
+          yours, in the homepage pillar panels' voice (#1F1F1F board,
+          EBF0FA lead over the E6212F punch, steel spec labels) */}
       <section className="flex flex-col gap-3">
-        <div className="flex flex-col gap-8 bg-[#1F1F1F] p-6 md:p-8">
-          <h3 className="v2-display text-3xl leading-[1.02] md:text-4xl">
-            <span className="block text-[#EBF0FA]">What securing the network</span>
-            <span className="block text-[#E6212F]">pays right now.</span>
-          </h3>
-          <div className="grid grid-cols-2 divide-x divide-y divide-white/10 border-t border-white/10 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0">
-            <StatementCell label="Max APY · Est">
-              {apy?.current ? (
-                <>
-                  {apy.current.maxAPY.toFixed(1)}
-                  <span className="ml-1 text-sm text-[#A2AFB2]">%</span>
-                </>
-              ) : (
-                "—"
-              )}
-            </StatementCell>
-            <StatementCell label="Min APY · Est">
-              {apy?.current ? (
-                <>
-                  {apy.current.minAPY.toFixed(1)}
-                  <span className="ml-1 text-sm text-[#A2AFB2]">%</span>
-                </>
-              ) : (
-                "—"
-              )}
-            </StatementCell>
-            {/* the ratio IS the reward rate's denominator — it earns the
-                panel over the median fee, which lives on the fees chart */}
-            <StatementCell
-              label="Staked of Supply"
-              sub={supplyAvax !== null ? `of ${fmtCompact(supplyAvax)} AVAX` : undefined}
-            >
-              {stakingRatio !== null ? (
-                <>
-                  {stakingRatio.toFixed(1)}
-                  <span className="ml-1 text-sm text-[#A2AFB2]">%</span>
-                </>
-              ) : (
-                "—"
-              )}
-            </StatementCell>
-            <StatementCell label="Minted Per Day" sub="last full day">
-              {dailyRewards !== null ? (
-                <>
-                  {fmtCompact(dailyRewards)}
-                  <span className="ml-1.5 text-sm text-[#A2AFB2]">AVAX</span>
-                </>
-              ) : (
-                "—"
-              )}
-            </StatementCell>
-          </div>
-        </div>
+        <YieldCalculator supply={supplyAvax} medianFee={medianFee} />
         <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
-          Estimated annual yield at current conditions; the exact rate varies with stake duration
-          and the validator&apos;s delegation fee. Rewards are newly minted AVAX.
+          Estimates at current network conditions — rewards are newly minted AVAX, and the rate
+          scales with duration. Continuous staking (
+          <Link
+            href="/docs/acps/236-continuous-staking"
+            className="text-[#0061E2] underline-offset-4 hover:underline dark:text-[#5f9dff]"
+          >
+            ACP-236
+          </Link>
+          ) is rolling out: positions will renew and compound automatically.
         </p>
       </section>
 
@@ -781,7 +872,7 @@ export function PrimaryStakingContent({
               label="Total Staked"
               sub={
                 ownStake !== null && delegatedStake !== null
-                  ? `own ${fmtCompact(ownStake / NANO)} · delegated ${fmtCompact(delegatedStake / NANO)}`
+                  ? `${stakingRatio !== null ? `${stakingRatio.toFixed(1)}% of supply · ` : ""}own ${fmtCompact(ownStake / NANO)} · delegated ${fmtCompact(delegatedStake / NANO)}`
                   : undefined
               }
             >

--- a/components/explorer-v2/staking/PrimaryStaking.tsx
+++ b/components/explorer-v2/staking/PrimaryStaking.tsx
@@ -175,10 +175,10 @@ function ApyChart({ data }: { data: ApyPoint[] }) {
                 <TipPlate>
                   <p className="text-[10px] text-zinc-500">{fmtDay(d.day)}</p>
                   <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
-                    {d.maxAPY.toFixed(2)}% max
+                    {d.maxAPY.toFixed(2)}% · 1-year term
                   </p>
                   <p className="text-[10px] tabular-nums text-zinc-500">
-                    min {d.minAPY.toFixed(2)}%
+                    2-week {d.minAPY.toFixed(2)}%
                   </p>
                 </TipPlate>
               );
@@ -578,15 +578,17 @@ function YieldCalculator({
   return (
     <div className="flex flex-col gap-8 bg-[#1F1F1F] p-6 md:p-8">
       {/* headline left, the ONE number right — big enough to read from
-          across the room */}
+          across the room. "Minting" is the factual verb: the protocol
+          mints rewards on a public schedule; nothing here promises them
+          to anyone. */}
       <div className="flex flex-wrap items-end justify-between gap-x-12 gap-y-8">
         <h3 className="v2-display text-3xl leading-[1.02] md:text-4xl">
           <span className="block text-[#EBF0FA]">What securing the network</span>
-          <span className="block text-[#E6212F]">pays right now.</span>
+          <span className="block text-[#E6212F]">is minting right now.</span>
         </h3>
         <div className="flex flex-col items-end gap-1">
           <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
-            {role} · {DURATIONS.find((d) => d.key === durationKey)!.label} · est
+            {role} · {DURATIONS.find((d) => d.key === durationKey)!.label} · est. rate
           </span>
           <span className="font-mono text-6xl tabular-nums tracking-tight text-[#EBF0FA] md:text-7xl">
             {calc ? calc.annualPct.toFixed(1) : "—"}
@@ -596,55 +598,60 @@ function YieldCalculator({
         </div>
       </div>
 
-      {/* the calculator: make the rate yours */}
-      <div className="flex flex-col gap-5 border-t border-white/10 pt-6">
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-4">
-          <label className="flex items-center gap-3">
-            <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
-              Stake
-            </span>
-            <span className="flex items-baseline gap-2 border-b border-white/25 focus-within:border-[#E6212F]">
-              <input
-                value={amountRaw}
-                onChange={(e) => setAmountRaw(e.target.value)}
-                onBlur={() =>
-                  setAmountRaw(amount > 0 ? amount.toLocaleString("en-US") : "1,000")
-                }
-                inputMode="decimal"
-                aria-label="AVAX amount to stake"
-                className="w-32 bg-transparent py-1 text-right font-mono text-xl tabular-nums text-[#EBF0FA] outline-none placeholder:text-[#A2AFB2]/50"
+      {/* the calculator: make the rate yours — inputs left, the estimate
+          answering on the same rule */}
+      <div className="flex flex-col gap-3 border-t border-white/10 pt-6">
+        <div className="flex flex-wrap items-center justify-between gap-x-10 gap-y-5">
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-4">
+            <label className="flex items-center gap-3">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
+                Stake
+              </span>
+              <span className="flex items-baseline gap-2 border-b border-white/25 focus-within:border-[#E6212F]">
+                <input
+                  value={amountRaw}
+                  onChange={(e) => setAmountRaw(e.target.value)}
+                  onBlur={() =>
+                    setAmountRaw(amount > 0 ? amount.toLocaleString("en-US") : "1,000")
+                  }
+                  inputMode="decimal"
+                  aria-label="AVAX amount to stake"
+                  className="w-32 bg-transparent py-1 text-right font-mono text-xl tabular-nums text-[#EBF0FA] outline-none placeholder:text-[#A2AFB2]/50"
+                />
+                <span className="pb-0.5 font-mono text-xs text-[#A2AFB2]">AVAX</span>
+              </span>
+            </label>
+            <label className="flex items-center gap-3">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
+                For
+              </span>
+              <DarkToggle
+                options={DURATIONS.map((d) => ({ value: d.key, label: d.label }))}
+                value={durationKey}
+                onChange={setDurationKey}
               />
-              <span className="pb-0.5 font-mono text-xs text-[#A2AFB2]">AVAX</span>
-            </span>
-          </label>
-          <label className="flex items-center gap-3">
-            <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
-              For
-            </span>
+            </label>
             <DarkToggle
-              options={DURATIONS.map((d) => ({ value: d.key, label: d.label }))}
-              value={durationKey}
-              onChange={setDurationKey}
+              options={[
+                { value: "delegating" as const, label: "Delegating" },
+                { value: "validating" as const, label: "Validating" },
+              ]}
+              value={role}
+              onChange={setRole}
             />
-          </label>
-          <DarkToggle
-            options={[
-              { value: "delegating" as const, label: "Delegating" },
-              { value: "validating" as const, label: "Validating" },
-            ]}
-            value={role}
-            onChange={setRole}
-          />
+          </div>
+          <p className="font-mono text-base text-[#A2AFB2]">
+            est. rewards{" "}
+            <span className="mx-1 align-baseline text-4xl font-bold tabular-nums text-[#E6212F] md:text-5xl">
+              {calc && amount > 0 ? fmtCompact(calc.reward) : "—"}
+            </span>{" "}
+            <span className="text-[#EBF0FA]">AVAX</span>
+          </p>
         </div>
-        <p className="font-mono text-lg text-[#A2AFB2] md:text-xl">
-          earns ≈{" "}
-          <span className="text-3xl font-bold tabular-nums text-[#E6212F] md:text-4xl">
-            {calc && amount > 0 ? fmtCompact(calc.reward) : "—"}
-          </span>{" "}
-          <span className="text-[#EBF0FA]">AVAX</span>
-          {role === "delegating" && (
-            <span className="ml-3 text-xs">after the median {fee.toFixed(0)}% validator fee</span>
-          )}
+        <p className="font-mono text-[11px] text-[#A2AFB2]/80">
+          {role === "delegating"
+            ? `after the current median ${fee.toFixed(0)}% validator fee · min 25 AVAX to delegate`
+            : "running your own node · min 2,000 AVAX to validate"}
         </p>
       </div>
     </div>
@@ -839,8 +846,11 @@ export function PrimaryStakingContent({
       <section className="flex flex-col gap-3">
         <YieldCalculator supply={supplyAvax} medianFee={medianFee} />
         <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
-          Estimates at current network conditions — rewards are newly minted AVAX, and the rate
-          scales with duration. Continuous staking (
+          Estimates only, computed from the protocol&apos;s public emission formula at current
+          network conditions — not a promise of any return and not financial advice. Actual
+          rewards change as the staking ratio moves, and are paid only if the validator maintains
+          the uptime requirement through the whole term. Rewards are newly minted AVAX. Continuous
+          staking (
           <Link
             href="/docs/acps/236-continuous-staking"
             className="text-[#0061E2] underline-offset-4 hover:underline dark:text-[#5f9dff]"
@@ -955,16 +965,18 @@ export function PrimaryStakingContent({
           )}
         </ChartBoard>
 
+        {/* max/min are DURATIONS (1-year vs 2-week terms), not a promise
+            band — the legend says which is which */}
         <ChartBoard
-          label={`Staking APY${weekFloor}`}
+          label={`Reward Rate · est${weekFloor}`}
           href={door("apy")}
           action={
             <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
               <span className="flex items-center gap-1.5">
-                <span className="h-0.5 w-4 bg-zinc-900 dark:bg-zinc-100" /> max
+                <span className="h-0.5 w-4 bg-zinc-900 dark:bg-zinc-100" /> 1-year term
               </span>
               <span className="flex items-center gap-1.5">
-                <span className="h-0.5 w-4 border-b border-dashed border-[#A2AFB2]" /> min
+                <span className="h-0.5 w-4 border-b border-dashed border-[#A2AFB2]" /> 2-week
               </span>
             </span>
           }

--- a/components/explorer-v2/staking/PrimaryStaking.tsx
+++ b/components/explorer-v2/staking/PrimaryStaking.tsx
@@ -21,6 +21,7 @@ import { RANGE_DAYS, useExplorerTimeRange } from "@/components/explorer-v2/time-
 import {
   NANO,
   fmtCompact,
+  joinStakingRatio,
   num,
   thin,
   toSeries,
@@ -29,6 +30,7 @@ import {
   useSdkValidators,
   useStakingApy,
   windowSeries,
+  type RatioPoint,
 } from "./data";
 
 /* The Primary Network's staking economy as one instrument — what secures
@@ -206,16 +208,6 @@ function ApyChart({ data }: { data: ApyPoint[] }) {
       </ResponsiveContainer>
     </div>
   );
-}
-
-interface RatioPoint {
-  day: string;
-  /** staked share of circulating supply, % */
-  pct: number;
-  /** AVAX */
-  staked: number;
-  /** AVAX */
-  supply: number;
 }
 
 /* staked share of the circulating supply — the auto domain magnifies the
@@ -788,20 +780,12 @@ export function PrimaryStakingContent({
     return thin(windowSeries(withMa, chartDays), 180);
   }, [metrics, chartDays]);
 
-  // stake joined with the APY feed's daily supply — the share of all
-  // circulating AVAX that is working. Days the two feeds don't share drop.
-  const ratioSeries = useMemo<RatioPoint[]>(() => {
-    if (!apy?.data) return [];
-    const supplyByDay = new Map(apy.data.map((p) => [p.date, p.supply]));
-    const delegated = new Map(toSeries(metrics?.delegator_weight).map((p) => [p.day, p.value]));
-    const joined = toSeries(metrics?.validator_weight).flatMap((p) => {
-      const supply = supplyByDay.get(p.day);
-      if (!supply) return [];
-      const staked = (p.value + (delegated.get(p.day) ?? 0)) / NANO;
-      return [{ day: p.day, pct: (staked / supply) * 100, staked, supply }];
-    });
-    return thin(windowSeries(joined, chartDays));
-  }, [metrics, apy, chartDays]);
+  // the share of all circulating AVAX that is working — the same join the
+  // total-stake sheet charts in full
+  const ratioSeries = useMemo<RatioPoint[]>(
+    () => thin(windowSeries(joinStakingRatio(metrics, apy), chartDays)),
+    [metrics, apy, chartDays],
+  );
 
   /* -------------------------------------------------------------- */
   /* the money actually moving — accrual is smooth, cash is lumpy    */

--- a/components/explorer-v2/staking/StakingMetricPage.tsx
+++ b/components/explorer-v2/staking/StakingMetricPage.tsx
@@ -30,6 +30,7 @@ import {
   num,
   thin,
   toSeries,
+  useMoneyFlow,
   usePrimaryMetrics,
   useSdkValidators,
   useStakingApy,
@@ -59,36 +60,6 @@ const QUIET_BAR = "#A2AFB2";
 /* ---------------------------------------------------------------- */
 /* data                                                              */
 /* ---------------------------------------------------------------- */
-
-interface MoneyFlow {
-  rewards: { date: string; avax: number; payouts: number }[];
-  unlocks: { date: string; avax: number; stakers: number }[];
-}
-
-/* the staking money-flow feed (reward payouts behind us, unlocks ahead),
-   fetched at the smallest computed window that covers the clock */
-function useMoneyFlow(network: string, rangeDays: number) {
-  const days = rangeDays <= 30 ? 30 : rangeDays <= 90 ? 90 : 365;
-  const [flow, setFlow] = useState<MoneyFlow | null>(null);
-  const [failed, setFailed] = useState(false);
-  useEffect(() => {
-    let cancelled = false;
-    setFlow(null);
-    setFailed(false);
-    fetch(`/api/pchain-activity/${network}?days=${days}`)
-      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
-      .then((data: MoneyFlow) => {
-        if (!cancelled) setFlow(data);
-      })
-      .catch(() => {
-        if (!cancelled) setFailed(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [network, days]);
-  return { flow, failed };
-}
 
 /* the sheets' windows floor at a week — a one-bar day chart says nothing */
 function chartWindow(rangeDays: number): number {

--- a/components/explorer-v2/staking/StakingMetricPage.tsx
+++ b/components/explorer-v2/staking/StakingMetricPage.tsx
@@ -284,7 +284,7 @@ function TotalStakeSheet({ base, network }: { base: string; network: string }) {
         </section>
 
         <div className="grid gap-4 sm:grid-cols-2">
-          <SiblingDoor href={`${base}/apy`} label="Staking APY" sub="What this capital earns, annualized" />
+          <SiblingDoor href={`${base}/apy`} label="Reward Rate" sub="What the protocol mints, annualized · est" />
           <SiblingDoor href={`${base}/expiry`} label="Stake Expiry" sub="When it comes unlocked" />
         </div>
       </div>
@@ -313,11 +313,13 @@ function ApySheet({ base, network }: { base: string; network: string }) {
   return (
     <MetricFrame base={base} metric="apy">
       <div className="flex flex-col gap-10">
-        <SheetStrip label="Staking APY" chip="Live estimate" cols={3}>
-          <Stat label="Max APY" sub="own node, full-year term">
+        <SheetStrip label="Reward Rate" chip="Live estimate" cols={3}>
+          {/* the two figures differ by TERM LENGTH, not by role — the
+              consumption rate interpolates 10% → 12% across durations */}
+          <Stat label="1-Year Term · Est" sub="maximum duration rate">
             {apy?.current ? `${apy.current.maxAPY.toFixed(2)}%` : <StatDash />}
           </Stat>
-          <Stat label="Min APY" sub="delegating, after fees">
+          <Stat label="2-Week Term · Est" sub="minimum duration rate">
             {apy?.current ? `${apy.current.minAPY.toFixed(2)}%` : <StatDash />}
           </Stat>
           <Stat label="Supply" sub="AVAX circulating">
@@ -328,14 +330,14 @@ function ApySheet({ base, network }: { base: string; network: string }) {
         <section className="flex flex-col gap-3">
           <div className="flex items-center justify-between gap-4">
             <p className="font-mono text-[11px] font-bold uppercase tracking-[0.22em] text-zinc-900 dark:text-zinc-100">
-              {range < 7 ? "Yield Curves · 7 days" : "Yield Curves"}
+              {range < 7 ? "Rate Curves · 7 days" : "Rate Curves"}
             </p>
             <span className="flex shrink-0 items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
               <span className="flex items-center gap-1.5">
-                <span className="h-0.5 w-4 bg-zinc-900 dark:bg-zinc-100" /> max
+                <span className="h-0.5 w-4 bg-zinc-900 dark:bg-zinc-100" /> 1-year term
               </span>
               <span className="flex items-center gap-1.5">
-                <span className="h-0.5 w-4 border-b border-dashed border-[#A2AFB2]" /> min
+                <span className="h-0.5 w-4 border-b border-dashed border-[#A2AFB2]" /> 2-week
               </span>
             </span>
           </div>
@@ -362,9 +364,9 @@ function ApySheet({ base, network }: { base: string; network: string }) {
                         <TipPlate>
                           <p className="text-[10px] text-zinc-500">{d.day}</p>
                           <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
-                            {d.maxAPY.toFixed(2)}% max
+                            {d.maxAPY.toFixed(2)}% · 1-year term
                           </p>
-                          <p className="text-[10px] tabular-nums text-zinc-500">min {d.minAPY.toFixed(2)}%</p>
+                          <p className="text-[10px] tabular-nums text-zinc-500">2-week {d.minAPY.toFixed(2)}%</p>
                         </TipPlate>
                       );
                     }}
@@ -591,7 +593,7 @@ function RewardsSheet({ base, network }: { base: string; network: string }) {
         </section>
 
         <div className="grid gap-4 sm:grid-cols-2">
-          <SiblingDoor href={`${base}/apy`} label="Staking APY" sub="The rate behind the minting" />
+          <SiblingDoor href={`${base}/apy`} label="Reward Rate" sub="The rate behind the minting · est" />
           <SiblingDoor href={`${base}/expiry`} label="Stake Expiry" sub="When the payouts burst: terms ending" />
         </div>
       </div>
@@ -856,7 +858,7 @@ function DistributionSheet({ base, network }: { base: string; network: string })
 
         <div className="grid gap-4 sm:grid-cols-2">
           <SiblingDoor href={`${base}/total-stake`} label="Total Stake" sub="The capital being distributed" />
-          <SiblingDoor href={`${base}/apy`} label="Staking APY" sub="What each slice of it earns" />
+          <SiblingDoor href={`${base}/apy`} label="Reward Rate" sub="The estimated rate behind each slice" />
         </div>
       </div>
     </MetricFrame>

--- a/components/explorer-v2/staking/StakingMetricPage.tsx
+++ b/components/explorer-v2/staking/StakingMetricPage.tsx
@@ -27,6 +27,7 @@ import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/expl
 import {
   NANO,
   fmtCompact,
+  joinStakingRatio,
   num,
   thin,
   toSeries,
@@ -35,6 +36,7 @@ import {
   useSdkValidators,
   useStakingApy,
   windowSeries,
+  type RatioPoint,
 } from "./data";
 import {
   ConcentrationChart,
@@ -158,6 +160,11 @@ function TotalStakeSheet({ base, network }: { base: string; network: string }) {
     [metrics, range],
   );
 
+  const ratioSeries = useMemo<RatioPoint[]>(
+    () => thin(windowSeries(joinStakingRatio(metrics, apy), chartWindow(range)), 400),
+    [metrics, apy, range],
+  );
+
   const own = num(metrics?.validator_weight?.current_value);
   const delegated = num(metrics?.delegator_weight?.current_value);
   const total = own !== null && delegated !== null ? (own + delegated) / NANO : null;
@@ -241,6 +248,66 @@ function TotalStakeSheet({ base, network }: { base: string; network: string }) {
           ) : (
             <ChartEmpty failed={failed} />
           )}
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-4">
+            <p className="font-mono text-[11px] font-bold uppercase tracking-[0.22em] text-zinc-900 dark:text-zinc-100">
+              {range < 7 ? "Staking Ratio · 7 days" : "Staking Ratio"}
+            </p>
+            <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+              staked share of circulating supply
+            </span>
+          </div>
+          {ratioSeries.length ? (
+            <ChartPlate name="staking-ratio">
+              <ResponsiveContainer width="100%" height="100%">
+                <ComposedChart data={ratioSeries} margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
+                  <SheetGrid />
+                  <XAxis dataKey="day" tickLine={false} axisLine={false} minTickGap={48} tick={AXIS_TICK} tickFormatter={dateTick} />
+                  <YAxis
+                    domain={["auto", "auto"]}
+                    width={44}
+                    tickLine={false}
+                    axisLine={false}
+                    tick={AXIS_TICK}
+                    tickFormatter={(v: number) => `${v.toFixed(0)}%`}
+                  />
+                  <RechartsTooltip
+                    cursor={{ stroke: "rgba(161,161,170,0.35)" }}
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.[0]) return null;
+                      const d = payload[0].payload as RatioPoint;
+                      return (
+                        <TipPlate>
+                          <p className="text-[10px] text-zinc-500">{d.day}</p>
+                          <p className="text-xs font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+                            {d.pct.toFixed(1)}% of supply staked
+                          </p>
+                          <p className="text-[10px] tabular-nums text-zinc-500">
+                            {fmtCompact(d.staked)} of {fmtCompact(d.supply)} AVAX
+                          </p>
+                        </TipPlate>
+                      );
+                    }}
+                  />
+                  <Area type="monotone" dataKey="pct" stroke={DELEGATED_COLOR} strokeWidth={1.5} fill={DELEGATED_COLOR} fillOpacity={0.08} isAnimationActive={false} />
+                  <Brush dataKey="day" {...BRUSH_PROPS}>
+                    <LineChart>
+                      <Line dataKey="pct" stroke="#A2AFB2" strokeWidth={1} dot={false} isAnimationActive={false} />
+                    </LineChart>
+                  </Brush>
+                </ComposedChart>
+              </ResponsiveContainer>
+            </ChartPlate>
+          ) : (
+            <ChartEmpty failed={failed} />
+          )}
+          <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+            Total stake read against the circulating supply the emission feed reports for the same
+            day. The axis floats to magnify the drift — the range across the whole history is only
+            a few points, and the drift is the signal.
+          </p>
         </section>
 
         <section className="flex flex-col gap-3">

--- a/components/explorer-v2/staking/data.ts
+++ b/components/explorer-v2/staking/data.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { PrimaryNetworkMetrics, TimeSeriesMetric } from "@/types/stats";
+import { getValidatorFeeState } from "@/lib/pchain-node";
 
 /* Shared feeds for the Primary Network's two instruments — Staking (the
    economics) and Validators (the set). Every endpoint returns a whole
@@ -99,6 +100,85 @@ export function useTotalSeats() {
     const metric = (raw as { total_validator_seats?: TimeSeriesMetric })?.total_validator_seats;
     return metric?.data ? metric : null;
   });
+}
+
+/* the same feed, all three series — the L1 economy section reads the
+   split (stake-backed Primary seats vs pay-as-you-go L1 seats) */
+export interface EcosystemSeats {
+  total: TimeSeriesMetric | null;
+  l1: TimeSeriesMetric | null;
+  primary: TimeSeriesMetric | null;
+}
+
+export function useEcosystemSeats() {
+  return useLoad<EcosystemSeats>("/api/total-ecosystem-validators?timeRange=all", (raw) => {
+    const r = raw as {
+      total_validator_seats?: TimeSeriesMetric;
+      l1_validator_seats?: TimeSeriesMetric;
+      primary_network_validator_count?: TimeSeriesMetric;
+    };
+    if (!r?.total_validator_seats?.data) return null;
+    return {
+      total: r.total_validator_seats ?? null,
+      l1: r.l1_validator_seats ?? null,
+      primary: r.primary_network_validator_count ?? null,
+    };
+  });
+}
+
+/* the ACP-77 continuous fee price (nAVAX per second per L1 seat), straight
+   from the node — null while loading or if the RPC is unreachable */
+export function useValidatorFeePrice(network = "mainnet") {
+  const [price, setPrice] = useState<number | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    getValidatorFeeState(network).then((f) => {
+      if (!cancelled) setPrice(f ? f.price : null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [network]);
+  return price;
+}
+
+/* ------------------------------------------------------------------ */
+/* staking money-flow — reward payouts behind us, unlocks ahead        */
+/* ------------------------------------------------------------------ */
+
+export interface MoneyFlow {
+  rewards: { date: string; avax: number; payouts: number }[];
+  unlocks: { date: string; avax: number; stakers: number }[];
+}
+
+/** the feed serves fixed computed windows — pick the smallest that covers the clock */
+export function moneyFlowWindow(rangeDays: number): 30 | 90 | 365 {
+  return rangeDays <= 30 ? 30 : rangeDays <= 90 ? 90 : 365;
+}
+
+/* fetched at the window covering the page clock; resets on window change
+   so a stale wide window never poses as the narrow one */
+export function useMoneyFlow(network: string, rangeDays: number) {
+  const days = moneyFlowWindow(rangeDays);
+  const [flow, setFlow] = useState<MoneyFlow | null>(null);
+  const [failed, setFailed] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    setFlow(null);
+    setFailed(false);
+    fetch(`/api/pchain-activity/${network}?days=${days}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then((data: MoneyFlow) => {
+        if (!cancelled) setFlow(data);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [network, days]);
+  return { flow, failed, days };
 }
 
 /* ------------------------------------------------------------------ */

--- a/components/explorer-v2/staking/data.ts
+++ b/components/explorer-v2/staking/data.ts
@@ -190,6 +190,38 @@ export interface SeriesPoint {
   value: number;
 }
 
+/* ------------------------------------------------------------------ */
+/* staking ratio — stake joined with the emission feed's daily supply  */
+/* ------------------------------------------------------------------ */
+
+export interface RatioPoint {
+  day: string;
+  /** staked share of circulating supply, % */
+  pct: number;
+  /** AVAX */
+  staked: number;
+  /** AVAX */
+  supply: number;
+}
+
+/* the full oldest-first series; days the two feeds don't share drop.
+   One join, two instruments: the staking page's trend card and the
+   total-stake sheet's full-axes section read the same points. */
+export function joinStakingRatio(
+  metrics: PrimaryNetworkMetrics | null,
+  apy: StakingApy | null,
+): RatioPoint[] {
+  if (!apy?.data) return [];
+  const supplyByDay = new Map(apy.data.map((p) => [p.date, p.supply]));
+  const delegated = new Map(toSeries(metrics?.delegator_weight).map((p) => [p.day, p.value]));
+  return toSeries(metrics?.validator_weight).flatMap((p) => {
+    const supply = supplyByDay.get(p.day);
+    if (!supply) return [];
+    const staked = (p.value + (delegated.get(p.day) ?? 0)) / NANO;
+    return [{ day: p.day, pct: (staked / supply) * 100, staked, supply }];
+  });
+}
+
 export function toSeries(metric: TimeSeriesMetric | null | undefined): SeriesPoint[] {
   if (!metric?.data) return [];
   const today = new Date().toISOString().split("T")[0];

--- a/components/explorer-v2/staking/staking-metrics.ts
+++ b/components/explorer-v2/staking/staking-metrics.ts
@@ -24,6 +24,7 @@ export const STAKING_METRICS: Record<StakingMetricKey, StakingMetricDef> = {
       "The capital securing the Primary Network: validators' own stake and everything delegated on top of it.",
     methodology: [
       "Own stake and delegated stake are daily aggregates over the current validator and delegator sets, from the chain-metrics indexer. The stacked view keeps the two apart because they behave differently: own stake moves when operators join, leave, or restake; delegated stake follows retail sentiment and unlock schedules.",
+      "The staking ratio divides that total by the circulating supply the emission feed reports for the same day — the share of all AVAX in existence that is working as security. Days the two feeds don't share are dropped rather than interpolated.",
       "The delegator count rides the same indexer. A rising count against flat delegated stake means smaller average positions — worth reading together, not separately.",
     ],
   },

--- a/components/explorer-v2/staking/staking-metrics.ts
+++ b/components/explorer-v2/staking/staking-metrics.ts
@@ -28,12 +28,12 @@ export const STAKING_METRICS: Record<StakingMetricKey, StakingMetricDef> = {
     ],
   },
   apy: {
-    title: "Staking APY",
+    title: "Reward Rate",
     blurb:
-      "What staking pays, annualized: the ceiling for a validator running its own node, the floor for a delegator behind the median fee.",
+      "The protocol's estimated annual reward rate: a full-year term sets the upper curve, the two-week minimum term the lower one.",
     methodology: [
-      "The reward rate follows the network's emission schedule: rewards are newly minted AVAX, scaled by the staking ratio — the more of the supply is staked, the lower the rate for everyone. The max curve assumes a validator staking for a full year at perfect uptime; the min curve is the same position behind delegation fees.",
-      "The exact rate for any position varies with its duration and, for delegators, the validator's fee. Rewards are only paid if the validator meets the uptime requirement through the whole term — APY is a projection, not a promise.",
+      "The rate follows the network's public emission formula: rewards are newly minted AVAX, scaled by how much of the remaining supply is left to mint and by the staking ratio — the more of the supply is staked, the lower the rate for everyone. The two curves differ only by term length: the consumption rate interpolates from 10% at the two-week minimum to 12% at the one-year maximum.",
+      "These are estimates computed from current conditions, not a promise of any return. The realized rate for any position also depends on the validator's delegation fee (for delegators) and on the validator maintaining the uptime requirement through the whole term — miss it and the reward is zero.",
     ],
   },
   rewards: {

--- a/components/explorer-v2/ui.tsx
+++ b/components/explorer-v2/ui.tsx
@@ -446,6 +446,13 @@ export function CellLabel({ children }: { children: React.ReactNode }) {
 }
 
 /* ------------------------------------------------------------------ */
+/* Identifier ink — the one blue every clickable identifier wears,
+   whether it's a standalone HashChip link or the lead cell of a row-
+   Link (where a nested <a> is invalid and the row itself navigates).
+   Blue = "this ID takes you to its page", everywhere, no exceptions. */
+export const idInk = "text-[#0061E2] dark:text-[#5f9dff]";
+
+/* ------------------------------------------------------------------ */
 /* HashChip — mono truncated hash/address with copy                    */
 export function HashChip({
   value,
@@ -482,7 +489,7 @@ export function HashChip({
       {href ? (
         <Link
           href={href}
-          className={cn(textCls, "text-[#0061E2] underline-offset-4 hover:text-[#E6212F] hover:underline dark:text-[#5f9dff]")}
+          className={cn(textCls, idInk, "underline-offset-4 hover:text-[#E6212F] hover:underline")}
           title={value}
         >
           {text}

--- a/components/explorer-v2/ui.tsx
+++ b/components/explorer-v2/ui.tsx
@@ -446,6 +446,39 @@ export function CellLabel({ children }: { children: React.ReactNode }) {
 }
 
 /* ------------------------------------------------------------------ */
+/* DarkToggle — segmented control in the dark statement panels' voice
+   (#1F1F1F boards: the staking calculator, the gas cost panel).        */
+export function DarkToggle<T extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: { value: T; label: string }[];
+  value: T;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="inline-flex shrink-0 flex-wrap border border-white/15">
+      {options.map((o) => (
+        <button
+          key={o.value}
+          type="button"
+          onClick={() => onChange(o.value)}
+          className={cn(
+            "px-2.5 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.14em] transition-colors",
+            o.value === value
+              ? "bg-[#EBF0FA] text-zinc-900"
+              : "text-[#A2AFB2] hover:bg-white/10 hover:text-[#EBF0FA]",
+          )}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /* Identifier ink — the one blue every clickable identifier wears,
    whether it's a standalone HashChip link or the lead cell of a row-
    Link (where a nested <a> is invalid and the row itself navigates).

--- a/components/explorer/GasMarketPage.tsx
+++ b/components/explorer/GasMarketPage.tsx
@@ -18,7 +18,7 @@ import {
   YAxis,
 } from "recharts";
 import { cn } from "@/lib/utils";
-import { Board, BoardHeader, ChartBoard, StatDash } from "@/components/explorer-v2/ui";
+import { Board, BoardHeader, ChartBoard, DarkToggle, StatDash } from "@/components/explorer-v2/ui";
 import {
   useExplorerTimeRange,
   RANGE_DAYS,
@@ -270,6 +270,109 @@ const ACTIONS: { label: string; gas: number }[] = [
   { label: "DEX Swap", gas: 165_000 },
   { label: "NFT Mint", gas: 120_000 },
 ];
+
+/* The statement panel as a calculator — same idiom as the staking page:
+   ONE hero number, and the inputs that make it yours. Pick an action
+   preset or dial the gas units to match your contract; the hero answers
+   in money, priced live at base fee + median tip. */
+function CostPanel({
+  effectiveWei,
+  usd,
+  usdSettled,
+  symbol,
+  unit,
+}: {
+  effectiveWei: number | null;
+  usd: number | null;
+  usdSettled: boolean;
+  symbol: string;
+  unit: string;
+}) {
+  const [gasRaw, setGasRaw] = useState(ACTIONS[0].gas.toLocaleString("en-US"));
+  const gas = Number(gasRaw.replace(/[^0-9]/g, "")) || 0;
+  const active = ACTIONS.find((a) => a.gas === gas);
+  const costWei = effectiveWei !== null && gas > 0 ? effectiveWei * gas : null;
+
+  return (
+    <div className="flex flex-col gap-8 bg-[#1F1F1F] p-6 md:p-8">
+      {/* headline left, the ONE number right */}
+      <div className="flex flex-wrap items-end justify-between gap-x-12 gap-y-8">
+        <h3 className="v2-display text-3xl leading-[1.02] md:text-4xl">
+          <span className="block text-[#EBF0FA]">What a transaction</span>
+          <span className="block text-[#E6212F]">costs right now.</span>
+        </h3>
+        <div className="flex flex-col items-end gap-1">
+          <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
+            {active ? active.label : "Custom gas"} · live
+          </span>
+          <span className="font-mono text-6xl tabular-nums tracking-tight text-[#EBF0FA] md:text-7xl">
+            {/* hold the figure until the price feed settles — painting
+                native and flipping to dollars a beat later reads as a
+                glitch. Native is the fallback for unlisted tokens only. */}
+            {costWei !== null && usd !== null ? (
+              fmtUsd((costWei / 1e18) * usd)
+            ) : costWei !== null && !usdSettled ? (
+              <span
+                className="inline-block h-[0.85em] w-44 animate-pulse bg-white/10 align-middle"
+                aria-label="Loading price"
+              />
+            ) : costWei !== null ? (
+              <>
+                {fmtNative(costWei)}
+                <span className="ml-2 text-2xl text-[#A2AFB2]">{symbol}</span>
+              </>
+            ) : (
+              "—"
+            )}
+          </span>
+          {costWei !== null && usd !== null && (
+            <span className="font-mono text-xs tabular-nums text-[#A2AFB2]">
+              = {fmtNative(costWei)} {symbol} · {fmtNano(costWei)} {unit} total
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* the calculator: preset actions, or your contract's real gas */}
+      <div className="flex flex-wrap items-center justify-between gap-x-10 gap-y-5 border-t border-white/10 pt-6">
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-4">
+          <DarkToggle
+            options={ACTIONS.map((a) => ({ value: String(a.gas), label: a.label }))}
+            value={active ? String(active.gas) : ""}
+            onChange={(v) => setGasRaw(Number(v).toLocaleString("en-US"))}
+          />
+          <label className="flex items-center gap-3">
+            <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
+              Gas
+            </span>
+            <span className="flex items-baseline gap-2 border-b border-white/25 focus-within:border-[#E6212F]">
+              <input
+                value={gasRaw}
+                onChange={(e) => setGasRaw(e.target.value)}
+                onBlur={() =>
+                  setGasRaw(
+                    gas > 0
+                      ? gas.toLocaleString("en-US")
+                      : ACTIONS[0].gas.toLocaleString("en-US"),
+                  )
+                }
+                inputMode="numeric"
+                aria-label="Gas units"
+                className="w-28 bg-transparent py-1 text-right font-mono text-xl tabular-nums text-[#EBF0FA] outline-none"
+              />
+              <span className="pb-0.5 font-mono text-xs text-[#A2AFB2]">units</span>
+            </span>
+          </label>
+        </div>
+        {usd !== null && (
+          <span className="font-mono text-[11px] text-[#A2AFB2]/80">
+            {symbol} at ${usd.toFixed(2)} · base fee + median priority tip
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
 
 /* the shared tooltip chrome — same plate PchainHome's charts wear */
 export function TipPlate({ children }: { children: React.ReactNode }) {
@@ -890,56 +993,16 @@ export function GasMarketContent({ catalog, base }: { catalog: L1Chain; base: st
           homepage pillar panels' voice (#1F1F1F board, EBF0FA lead over
           the E6212F punch, steel spec labels) */}
       <section className="flex flex-col gap-3">
-        <div className="flex flex-col gap-8 bg-[#1F1F1F] p-6 md:p-8">
-          <div className="flex items-start justify-between gap-6">
-            <h3 className="v2-display text-3xl leading-[1.02] md:text-4xl">
-              <span className="block text-[#EBF0FA]">What a transaction</span>
-              <span className="block text-[#E6212F]">costs right now.</span>
-            </h3>
-            {usd !== null && (
-              <span className="shrink-0 pt-1 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-[#A2AFB2]">
-                {symbol} at ${usd.toFixed(2)}
-              </span>
-            )}
-          </div>
-          <div className="grid grid-cols-2 divide-x divide-y divide-white/10 border-t border-white/10 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0">
-            {ACTIONS.map((a) => {
-              const costWei = effectiveWei !== null ? effectiveWei * a.gas : null;
-              return (
-                <div key={a.label} className="flex flex-col gap-1.5 px-5 py-5 md:px-6 lg:first:pl-0">
-                  <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
-                    {a.label}
-                  </span>
-                  <span className="min-w-0 truncate font-mono text-xl tabular-nums tracking-tight text-[#EBF0FA] sm:text-2xl md:text-[1.75rem]">
-                    {/* hold the figure until the price feed settles — painting
-                        native and flipping to dollars a beat later reads as a
-                        glitch. Native is the fallback for unlisted tokens only. */}
-                    {costWei !== null && usd !== null ? (
-                      fmtUsd((costWei / 1e18) * usd)
-                    ) : costWei !== null && !usdSettled ? (
-                      <span
-                        className="inline-block h-[1.05em] w-24 animate-pulse bg-white/10 align-middle"
-                        aria-label="Loading price"
-                      />
-                    ) : costWei !== null ? (
-                      `${fmtNative(costWei)} ${symbol}`
-                    ) : (
-                      "—"
-                    )}
-                  </span>
-                  {costWei !== null && (
-                    <span className="text-xs tabular-nums text-[#A2AFB2]">
-                      {fmtNano(costWei)} {unit}
-                    </span>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
+        <CostPanel
+          effectiveWei={effectiveWei}
+          usd={usd}
+          usdSettled={usdSettled}
+          symbol={symbol}
+          unit={unit}
+        />
         <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
-          Priced at the live base fee plus the median priority tip, using typical gas for each
-          action. Actual usage varies by contract.
+          Priced live at the base fee plus the median priority tip. The presets are typical gas
+          for each action — real usage varies by contract, so dial the gas units to match yours.
         </p>
       </section>
 

--- a/components/explorer/GasMarketPage.tsx
+++ b/components/explorer/GasMarketPage.tsx
@@ -18,7 +18,7 @@ import {
   YAxis,
 } from "recharts";
 import { cn } from "@/lib/utils";
-import { Board, BoardHeader, ChartBoard, DarkToggle, StatDash } from "@/components/explorer-v2/ui";
+import { Board, BoardHeader, ChartBoard, StatDash } from "@/components/explorer-v2/ui";
 import {
   useExplorerTimeRange,
   RANGE_DAYS,
@@ -271,10 +271,10 @@ const ACTIONS: { label: string; gas: number }[] = [
   { label: "NFT Mint", gas: 120_000 },
 ];
 
-/* The statement panel as a calculator — same idiom as the staking page:
-   ONE hero number, and the inputs that make it yours. Pick an action
-   preset or dial the gas units to match your contract; the hero answers
-   in money, priced live at base fee + median tip. */
+/* The statement panel, purely observational — no inputs, no gas jargon:
+   ONE hero number (what sending the native token costs, in money, off
+   the live market) with the other everyday actions reading quietly
+   below. Same hero grammar as the staking panel next door. */
 function CostPanel({
   effectiveWei,
   usd,
@@ -288,10 +288,23 @@ function CostPanel({
   symbol: string;
   unit: string;
 }) {
-  const [gasRaw, setGasRaw] = useState(ACTIONS[0].gas.toLocaleString("en-US"));
-  const gas = Number(gasRaw.replace(/[^0-9]/g, "")) || 0;
-  const active = ACTIONS.find((a) => a.gas === gas);
-  const costWei = effectiveWei !== null && gas > 0 ? effectiveWei * gas : null;
+  // one money formatter for every figure on the panel — USD when the
+  // token is priced, native units otherwise, skeleton while settling
+  const price = (gas: number): React.ReactNode => {
+    const costWei = effectiveWei !== null ? effectiveWei * gas : null;
+    if (costWei === null) return "—";
+    if (usd !== null) return fmtUsd((costWei / 1e18) * usd);
+    if (!usdSettled)
+      return (
+        <span
+          className="inline-block h-[0.85em] w-16 animate-pulse bg-white/10 align-middle"
+          aria-label="Loading price"
+        />
+      );
+    return `${fmtNative(costWei)} ${symbol}`;
+  };
+  const hero = ACTIONS[0]; // the native transfer — the everyman number
+  const heroWei = effectiveWei !== null ? effectiveWei * hero.gas : null;
 
   return (
     <div className="flex flex-col gap-8 bg-[#1F1F1F] p-6 md:p-8">
@@ -303,66 +316,47 @@ function CostPanel({
         </h3>
         <div className="flex flex-col items-end gap-1">
           <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
-            {active ? active.label : "Custom gas"} · live
+            Sending {symbol || "the native token"} · live
           </span>
           <span className="font-mono text-6xl tabular-nums tracking-tight text-[#EBF0FA] md:text-7xl">
-            {/* hold the figure until the price feed settles — painting
-                native and flipping to dollars a beat later reads as a
-                glitch. Native is the fallback for unlisted tokens only. */}
-            {costWei !== null && usd !== null ? (
-              fmtUsd((costWei / 1e18) * usd)
-            ) : costWei !== null && !usdSettled ? (
+            {heroWei !== null && usd !== null ? (
+              fmtUsd((heroWei / 1e18) * usd)
+            ) : heroWei !== null && !usdSettled ? (
               <span
                 className="inline-block h-[0.85em] w-44 animate-pulse bg-white/10 align-middle"
                 aria-label="Loading price"
               />
-            ) : costWei !== null ? (
+            ) : heroWei !== null ? (
               <>
-                {fmtNative(costWei)}
+                {fmtNative(heroWei)}
                 <span className="ml-2 text-2xl text-[#A2AFB2]">{symbol}</span>
               </>
             ) : (
               "—"
             )}
           </span>
-          {costWei !== null && usd !== null && (
+          {heroWei !== null && usd !== null && (
             <span className="font-mono text-xs tabular-nums text-[#A2AFB2]">
-              = {fmtNative(costWei)} {symbol} · {fmtNano(costWei)} {unit} total
+              = {fmtNative(heroWei)} {symbol} · {fmtNano(heroWei)} {unit} total
             </span>
           )}
         </div>
       </div>
 
-      {/* the calculator: preset actions, or your contract's real gas */}
+      {/* the rest of an everyday session, reading quietly on one rule —
+          plain label→figure pairs, no boxes, no dividers */}
       <div className="flex flex-wrap items-center justify-between gap-x-10 gap-y-5 border-t border-white/10 pt-6">
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-4">
-          <DarkToggle
-            options={ACTIONS.map((a) => ({ value: String(a.gas), label: a.label }))}
-            value={active ? String(active.gas) : ""}
-            onChange={(v) => setGasRaw(Number(v).toLocaleString("en-US"))}
-          />
-          <label className="flex items-center gap-3">
-            <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
-              Gas
+        <div className="flex flex-wrap items-baseline gap-x-10 gap-y-4">
+          {ACTIONS.slice(1).map((a) => (
+            <span key={a.label} className="flex items-baseline gap-2.5">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#A2AFB2]">
+                {a.label}
+              </span>
+              <span className="font-mono text-xl tabular-nums tracking-tight text-[#EBF0FA] md:text-2xl">
+                {price(a.gas)}
+              </span>
             </span>
-            <span className="flex items-baseline gap-2 border-b border-white/25 focus-within:border-[#E6212F]">
-              <input
-                value={gasRaw}
-                onChange={(e) => setGasRaw(e.target.value)}
-                onBlur={() =>
-                  setGasRaw(
-                    gas > 0
-                      ? gas.toLocaleString("en-US")
-                      : ACTIONS[0].gas.toLocaleString("en-US"),
-                  )
-                }
-                inputMode="numeric"
-                aria-label="Gas units"
-                className="w-28 bg-transparent py-1 text-right font-mono text-xl tabular-nums text-[#EBF0FA] outline-none"
-              />
-              <span className="pb-0.5 font-mono text-xs text-[#A2AFB2]">units</span>
-            </span>
-          </label>
+          ))}
         </div>
         {usd !== null && (
           <span className="font-mono text-[11px] text-[#A2AFB2]/80">
@@ -1001,8 +995,8 @@ export function GasMarketContent({ catalog, base }: { catalog: L1Chain; base: st
           unit={unit}
         />
         <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
-          Priced live at the base fee plus the median priority tip. The presets are typical gas
-          for each action — real usage varies by contract, so dial the gas units to match yours.
+          Priced at the live base fee plus the median priority tip, using typical gas for each
+          action. Actual costs vary by contract.
         </p>
       </section>
 

--- a/lib/explorer-clickhouse.ts
+++ b/lib/explorer-clickhouse.ts
@@ -475,6 +475,139 @@ export async function getPchainStakingSeries(
   }
 }
 
+// --- P-Chain L1 operations ----------------------------------------------------
+// The P-Chain's own view of the L1 world: every seat registration, weight
+// set, disable, top-up, and subnet conversion is a P-Chain transaction it
+// processed. Daily counts by type (the ops ledger) plus the all-time
+// cumulative conversion curve — the ACP-77 adoption story.
+
+export type PchainL1OpsDays = 30 | 90 | 365;
+
+export interface PchainL1OpsPoint {
+  date: string;
+  register: number;
+  setWeight: number;
+  disable: number;
+  topUp: number;
+  convert: number;
+}
+
+export interface PchainL1ConversionPoint {
+  /** YYYY-MM */
+  month: string;
+  cumulative: number;
+}
+
+export interface PchainL1Ops {
+  ops: PchainL1OpsPoint[];
+  conversions: PchainL1ConversionPoint[];
+}
+
+const L1_OP_TYPES = [
+  "RegisterL1ValidatorTx",
+  "SetL1ValidatorWeightTx",
+  "DisableL1ValidatorTx",
+  "IncreaseL1ValidatorBalanceTx",
+  "ConvertSubnetToL1Tx",
+] as const;
+
+function sqlPchainL1Ops(networkId: number, days: PchainL1OpsDays): string {
+  const types = L1_OP_TYPES.map((t) => `'${t}'`).join(",");
+  return `
+    SELECT toDate(block_time) AS day, tx_type, toString(count()) AS n
+    FROM decoded_p_txs
+    WHERE chain_id = ${networkId}
+      AND tx_type IN (${types})
+      AND block_time >= toDate(now() - INTERVAL ${days} DAY)
+    GROUP BY day, tx_type
+    ORDER BY day
+    FORMAT JSONEachRow
+  `;
+}
+
+function sqlPchainL1Conversions(networkId: number): string {
+  return `
+    SELECT toString(toStartOfMonth(block_time)) AS month, toString(count()) AS n
+    FROM decoded_p_txs
+    WHERE chain_id = ${networkId} AND tx_type = 'ConvertSubnetToL1Tx'
+    GROUP BY month
+    ORDER BY month
+    FORMAT JSONEachRow
+  `;
+}
+
+const pchainL1OpsCache = new Map<string, { data: PchainL1Ops; fetchedAt: number }>();
+
+export async function getPchainL1Ops(
+  network: string,
+  days: PchainL1OpsDays = 30,
+): Promise<PchainL1Ops | null> {
+  const networkId = PCHAIN_NETWORK_IDS[network];
+  if (networkId === undefined) return null;
+
+  const cacheKey = `${network}:${days}`;
+  const cached = pchainL1OpsCache.get(cacheKey);
+  if (cached && Date.now() - cached.fetchedAt < DAILY_TTL_MS) {
+    return cached.data;
+  }
+
+  try {
+    type OpRow = { day: string; tx_type: string; n: string };
+    type ConvRow = { month: string; n: string };
+    const [opRows, convRows] = await Promise.all([
+      clickhouseFetch<OpRow>(sqlPchainL1Ops(networkId, days), QUERY_TIMEOUT_MS),
+      clickhouseFetch<ConvRow>(sqlPchainL1Conversions(networkId), QUERY_TIMEOUT_MS),
+    ]);
+
+    const byDay = new Map<string, PchainL1OpsPoint>();
+    for (const iso of buildPastDates(days)) {
+      byDay.set(iso, {
+        date: formatDayLabel(iso),
+        register: 0,
+        setWeight: 0,
+        disable: 0,
+        topUp: 0,
+        convert: 0,
+      });
+    }
+    const FIELD: Record<string, keyof Omit<PchainL1OpsPoint, "date">> = {
+      RegisterL1ValidatorTx: "register",
+      SetL1ValidatorWeightTx: "setWeight",
+      DisableL1ValidatorTx: "disable",
+      IncreaseL1ValidatorBalanceTx: "topUp",
+      ConvertSubnetToL1Tx: "convert",
+    };
+    for (const r of opRows) {
+      const p = byDay.get(r.day);
+      const f = FIELD[r.tx_type];
+      if (p && f) p[f] += Number(r.n) || 0;
+    }
+
+    // continuous month axis from the first conversion to now — a
+    // cumulative curve must never skip a quiet month
+    const convByMonth = new Map(convRows.map((r) => [r.month.slice(0, 7), Number(r.n) || 0]));
+    const conversions: PchainL1ConversionPoint[] = [];
+    const months = [...convByMonth.keys()].sort();
+    if (months.length) {
+      let cum = 0;
+      const now = new Date().toISOString().slice(0, 7);
+      for (let d = new Date(`${months[0]}-01T00:00:00Z`); ; d.setUTCMonth(d.getUTCMonth() + 1)) {
+        const m = d.toISOString().slice(0, 7);
+        cum += convByMonth.get(m) ?? 0;
+        conversions.push({ month: m, cumulative: cum });
+        if (m >= now) break;
+      }
+    }
+
+    const data = { ops: [...byDay.values()], conversions };
+    pchainL1OpsCache.set(cacheKey, { data, fetchedAt: Date.now() });
+    return data;
+  } catch (err) {
+    console.error("[explorer-clickhouse] pchain l1-ops query failed:", err);
+    return cached?.data ?? null;
+  }
+}
+
 // --- C-Chain activity by behavior --------------------------------------------
 // Categorize each tx by what its event logs SAY it did — no contract-label
 // curation needed. Priority per tx: DeFi swap beats NFT transfer beats

--- a/lib/pchain-node.ts
+++ b/lib/pchain-node.ts
@@ -103,6 +103,28 @@ export async function getSubnetInfo(network: string, subnetID: string): Promise<
   return rpc<SubnetInfo>(network, "platform.getSubnet", { subnetID });
 }
 
+/** ACP-77 L1 validator fee market: `price` is the continuous fee every L1
+ *  validator seat pays right now, in nAVAX per second, burned from the
+ *  seat's prepaid balance. */
+export interface ValidatorFeeState {
+  excess: number;
+  /** nAVAX per second per seat */
+  price: number;
+  timestamp: string;
+}
+
+export async function getValidatorFeeState(network: string): Promise<ValidatorFeeState | null> {
+  const r = await rpc<{ excess?: number | string; price?: number | string; timestamp?: string }>(
+    network,
+    "platform.getValidatorFeeState",
+    {},
+  );
+  if (!r || r.price === undefined) return null;
+  const price = Number(r.price);
+  if (!Number.isFinite(price)) return null;
+  return { excess: Number(r.excess ?? 0), price, timestamp: r.timestamp ?? "" };
+}
+
 export async function getCurrentValidators(
   network: string,
   subnetID: string,


### PR DESCRIPTION
## Summary

Rolling collection of UX improvements across the explorer (`/explorer/*`). Draft — more improvements will pile in here before review.

### Landed so far

**Block tape hover** — hovering a block in the treadmill lifts the whole axonometric cuboid (top face, right face, front) 4px off the sheet as one solid. Shared by EVM homes, P-Chain home, and the network tape.

**Genesis viewer** — `CreateChainTx` pages (e.g. [`UhReZ…`](https://build.avax.network/explorer/mainnet/p-chain/tx/UhReZTXT8Cqsjat9ghRtCe5kBQPQexQB5zG5Fvf3egrdYfyoJ)) and chain **Details** tabs now decode and render the full genesis document:
- Overview board: EVM chain ID, gas limit, target block rate, min base fee, genesis time, activated precompiles, and the allocation table with token-unit balances
- Raw JSON view with copy + `genesis.json` download
- Defensive decode (base64 → UTF-8 → JSON, hex/plain-text fallbacks) so custom-VM payloads degrade instead of breaking the page

**Conversion ID fix** — the L1 details "Conversion Tx" linked `platform.getSubnet`'s `conversionID` to a tx page that 404s. Per ACP-77 that ID is the SHA-256 of the conversion data, not a transaction ID. Relabeled **Conversion ID**, copyable, unlinked.

**One identifier ink** — new `idInk` constant in `ui.tsx`; every clickable identifier (standalone `HashChip` links and the lead cells of row-links) now wears the same blue across P-Chain and EVM lists, blocks, txs, addresses, nodes, and accounts. Previously rows mixed zinc lead IDs with blue secondary links.

**Full NodeIDs** — validators tables (L1 details, ConvertSubnetToL1Tx initial validator set) no longer truncate NodeIDs, and color them as links.

## Test plan

- [ ] `/explorer/mainnet/lamina1/details` — Conversion ID unlinked, validators show full blue NodeIDs, genesis section renders
- [ ] `/explorer/mainnet/p-chain/tx/UhReZTXT8Cqsjat9ghRtCe5kBQPQexQB5zG5Fvf3egrdYfyoJ` — genesis overview/JSON toggle, copy, download
- [ ] Block tape hover lift on EVM + P-Chain homes (light/dark)
- [ ] Spot-check list pages for the blue identifier ink

**Staking observatory v2** (P-Chain `/p-chain/staking` + C-Chain `/c-chain/staking`) —

- Statement panel now leads with **staked-of-supply ratio** (the denominator behind the reward rate); the all-time rewards figure states the offsetting all-time **burn**
- New **money-flow row** on the page clock: rewards actually paid out (past window) beside stake reaching term (next window) — accrual is smooth, cash is lumpy; both door into their metric sheets
- **P-Chain only: the L1 validator economy** — active fee-paying seats (P-Chain indexer), share of all seats, the live ACP-77 continuous fee (`platform.getValidatorFeeState`, per-seat AVAX/month + whole-set burn/day), a Primary-vs-L1 seats trend, and a connected-nodes-by-L1 leaderboard linking each set's validators tab. Staking mints; seats burn.
- **Staking parameters plate** (min stake, term, uptime, fee floor) with a door to the how-to-stake docs
- C-Chain's staking tab stays purely Primary Network, per scope

Additional test items:
- [ ] `/explorer/mainnet/p-chain/staking` — L1 section renders (seats ≈ indexer count, fee 512 nAVAX/s → 1.33 AVAX/mo), leaderboard links work
- [ ] `/explorer/mainnet/c-chain/staking` — no L1 section; ratio + money-flow cards present
- [ ] Money-flow windows follow the 1M/3M/1Y clock