### PR TITLE
feat(solutions): reframe pillars as Control · Reach · Performance

### DIFF
--- a/app/(home)/solutions/page.tsx
+++ b/app/(home)/solutions/page.tsx
@@ -4,7 +4,7 @@ import SolutionsIndex from '@/components/landing-v2/SolutionsIndex';
 export const metadata: Metadata = {
   title: 'Solutions | Avalanche Builder Hub',
   description:
-    'Performance, interoperability, privacy, and compliance: the four guarantees enterprise chains on Avalanche are built on.',
+    'Control, reach, and performance: the three guarantees enterprise chains on Avalanche are built on.',
 };
 
 export default function SolutionsPage() {

--- a/app/layout.config.tsx
+++ b/app/layout.config.tsx
@@ -25,7 +25,6 @@ import {
   Search,
   Bell,
   Gauge,
-  EyeOff,
   ShieldCheck,
   Landmark,
 } from 'lucide-react';
@@ -41,12 +40,12 @@ export const solutionsMenu: LinkItemType = {
       icon: <Landmark />,
       text: 'Why Avalanche',
       description:
-        'The guarantees enterprise chains are built on: performance, interoperability, privacy, and compliance.',
+        'The guarantees enterprise chains are built on: control, reach, and performance.',
       url: '/solutions',
       menu: {
-        // featured panel: the image leads, the four pillars stack in the
+        // featured panel: the image leads, the three pillars stack in the
         // right rail. .nav-featured + the :has() popover rules in global.css.
-        className: 'nav-featured lg:col-start-1 lg:row-start-1 lg:row-span-4',
+        className: 'nav-featured lg:col-start-1 lg:row-start-1 lg:row-span-3',
         banner: (
           <Image
             src="/nav/why-avalanche.webp"
@@ -59,43 +58,33 @@ export const solutionsMenu: LinkItemType = {
       },
     },
     {
-      icon: <Gauge />,
-      text: 'Performance',
+      icon: <ShieldCheck />,
+      text: 'Control',
       description:
-        'Sub-second, irreversible finality on dedicated blockspace.',
-      url: '/solutions/performance',
+        'Sovereignty over who validates, who transacts, and who can see the chain. Permissioning and privacy enforced by the protocol.',
+      url: '/solutions/control',
       menu: {
         className: 'lg:col-start-2 lg:row-start-1',
       },
     },
     {
       icon: <ArrowLeftRight />,
-      text: 'Interoperability',
+      text: 'Reach',
       description:
-        'Native messaging and asset transfer between public, permissioned, and private chains.',
-      url: '/solutions/interoperability',
+        'Native messaging and shared liquidity across public, permissioned, and private chains, with no third-party bridge in the path.',
+      url: '/solutions/reach',
       menu: {
         className: 'lg:col-start-2 lg:row-start-2',
       },
     },
     {
-      icon: <EyeOff />,
-      text: 'Privacy',
+      icon: <Gauge />,
+      text: 'Performance',
       description:
-        'Privacy configured to your requirements: closed networks, placed data, and the cryptography you choose.',
-      url: '/solutions/privacy',
+        'Sub-second, irreversible finality on dedicated blockspace.',
+      url: '/solutions/performance',
       menu: {
         className: 'lg:col-start-2 lg:row-start-3',
-      },
-    },
-    {
-      icon: <ShieldCheck />,
-      text: 'Compliance',
-      description:
-        'Permissioning enforced on-chain with allowlist precompiles.',
-      url: '/solutions/compliance',
-      menu: {
-        className: 'lg:col-start-2 lg:row-start-4',
       },
     },
   ],

--- a/components/landing-v2/PillarDiagrams.tsx
+++ b/components/landing-v2/PillarDiagrams.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 /* ------------------------------------------------------------------ */
-/* Pillar diagrams — one small animated instrument per guarantee        */
+/* Pillar diagrams: one small animated instrument per guarantee         */
 /*                                                                      */
 /* Same drawing language as ArchitectureDiagram: hairline strokes,      */
 /* zinc structure, red reserved for the thing that is alive (a pulsing  */
@@ -20,7 +20,7 @@ const NODE_FILL = "fill-zinc-700 dark:fill-zinc-300";
    thin strip; the privacy seal is nearly square), so sharing one 480×360
    frame left some of them small and off-center in their stage. A tight
    box also raises the viewBox→viewport scale, so strokes, nodes, and
-   labels all render heavier — the boldness comes from the crop, not from
+   labels all render heavier. The boldness comes from the crop, not from
    retouching every element. max-w per diagram equalizes optical mass. */
 function svgProps(label: string, viewBox: string, sizeClass: string) {
   return {
@@ -31,7 +31,7 @@ function svgProps(label: string, viewBox: string, sizeClass: string) {
   };
 }
 
-/* Performance — a transaction leaves SUBMITTED, locks at FINAL. The    */
+/* Performance: a transaction leaves SUBMITTED, locks at FINAL. The     */
 /* lock ring pulses once per pass: settlement is an event, not a curve. */
 function PerformanceDiagram() {
   return (
@@ -56,7 +56,7 @@ function PerformanceDiagram() {
         <animate attributeName="opacity" values="0.35;0" keyTimes="0;1" dur="0.9s" repeatCount="indefinite" />
       </circle>
 
-      {/* not one transaction — a pipeline of them, each final in under a
+      {/* not one transaction but a pipeline of them, each final in under a
           second. The evenly staggered stream is the throughput story. */}
       {[0, 0.3, 0.6, 0.9, 1.2, 1.5].map((delay) => (
         <circle key={delay} cy={180} r={3.5} fill="#E6212F">
@@ -130,8 +130,8 @@ function InteropRing({
   );
 }
 
-/* Interoperability — one message relays around all three kinds of      */
-/* chain: public, permissioned, and private. The boundaries differ; the */
+/* Reach: one message relays around all three kinds of chain:           */
+/* public, permissioned, and private. The boundaries differ; the        */
 /* messaging doesn't.                                                   */
 function InteropDiagram() {
   return (
@@ -162,71 +162,10 @@ function InteropDiagram() {
   );
 }
 
-/* Privacy — a sealed chain; outside probes reach the boundary and die. */
-function PrivacyDiagram() {
-  // inner nodes on R=64 (64·sin60 = 55.43, 64·cos60 = 32)
-  const inner: [number, number][] = [
-    [0, -64],
-    [55.43, -32],
-    [55.43, 32],
-    [0, 64],
-    [-55.43, 32],
-    [-55.43, -32],
-  ];
-  // observers at R=170 / probe tips at the boundary R=122, pre-rounded
-  const probes: { ox: number; oy: number; bx: number; by: number; begin: string }[] = [
-    { ox: 387.22, oy: 95, bx: 345.66, by: 119, begin: "0s" },
-    { ox: 92.78, oy: 265, bx: 134.34, by: 241, begin: "2.3s" },
-    { ox: 210.48, oy: 12.58, bx: 218.82, by: 59.85, begin: "4.6s" },
-  ];
-  return (
-    <svg {...svgProps("A validator-only L1 invisible to outside observers", "82 2 316 304", "max-w-[460px]")}>
-      {/* the chain, alive inside its boundary */}
-      {inner.map(([dx, dy], i) => (
-        <g key={i}>
-          <line x1={240} y1={180} x2={240 + dx} y2={180 + dy} strokeWidth={1} className={HAIRLINE} />
-          <circle cx={240 + dx} cy={180 + dy} r={6} className={NODE_FILL} />
-        </g>
-      ))}
-      <circle cx={240} cy={180} r={20} strokeWidth={1.5} className={`fill-white ${STRONG} dark:fill-zinc-950`} />
-      <circle cx={240} cy={180} r={5} fill="#E6212F">
-        <animate attributeName="opacity" values="1;0.4;1" dur="2.5s" repeatCount="indefinite" />
-      </circle>
-
-      {/* sealed double boundary */}
-      <circle cx={240} cy={180} r={110} fill="none" strokeWidth={1.5} className={STRONG} />
-      <circle cx={240} cy={180} r={118} fill="none" strokeWidth={1} opacity={0.5} className={STRONG} />
-
-      {/* probes: appear, reach the boundary, find nothing, fade */}
-      {probes.map((p, i) => (
-        <g key={i} opacity={0}>
-          <animate
-            attributeName="opacity"
-            values="0;1;1;0;0"
-            keyTimes="0;0.1;0.45;0.6;1"
-            dur="7s"
-            begin={p.begin}
-            repeatCount="indefinite"
-          />
-          <circle cx={p.ox} cy={p.oy} r={4} className="fill-zinc-400 dark:fill-zinc-500" />
-          <line
-            x1={p.ox}
-            y1={p.oy}
-            x2={p.bx}
-            y2={p.by}
-            strokeDasharray="2 5"
-            strokeWidth={1}
-            className="stroke-zinc-400 dark:stroke-zinc-500"
-          />
-        </g>
-      ))}
-    </svg>
-  );
-}
-
-/* Compliance — one gate in the boundary: the allowlisted transaction   */
-/* passes, the unknown one stops at the line.                           */
-function ComplianceDiagram() {
+/* Control: one gate in the boundary. The allowlisted transaction       */
+/* passes, the unknown one stops at the line; the permissioned chain    */
+/* lives sealed inside its own perimeter.                               */
+function ControlDiagram() {
   // 5 inner nodes on R=56 around (300,180), pre-rounded
   const inner: [number, number][] = [
     [300, 124],
@@ -290,14 +229,12 @@ function ComplianceDiagram() {
 
 export default function PillarDiagram({ slug }: { slug: string }) {
   switch (slug) {
+    case "control":
+      return <ControlDiagram />;
+    case "reach":
+      return <InteropDiagram />;
     case "performance":
       return <PerformanceDiagram />;
-    case "interoperability":
-      return <InteropDiagram />;
-    case "privacy":
-      return <PrivacyDiagram />;
-    case "compliance":
-      return <ComplianceDiagram />;
     default:
       return null;
   }

--- a/components/landing-v2/SolutionsIndex.tsx
+++ b/components/landing-v2/SolutionsIndex.tsx
@@ -7,14 +7,14 @@ import ConsoleBar from "@/components/landing-v2/ConsoleBar";
 import { PillarRows } from "@/components/landing-v2/PillarsChapter";
 
 /* ------------------------------------------------------------------ */
-/* /solutions — the four pillars, stated in one line                   */
+/* /solutions: the three pillars, stated in one line                   */
 /* ------------------------------------------------------------------ */
 
-const PILLAR_WORDS = ["Performance", "Interoperability", "Privacy", "Compliance"];
+const PILLAR_WORDS = ["Control", "Reach", "Performance"];
 
 // the avalanche pass: a step every CASCADE_MS while the pulse is on a word
-// (steps 0-3), then the remaining steps are the rest at the bottom before
-// the next slide — the headline black again, only the final period red
+// (steps 0-2), then the remaining steps are the rest at the bottom before
+// the next slide, the headline black again, only the final period red
 const CASCADE_MS = 650;
 const CASCADE_STEPS = PILLAR_WORDS.length + 12;
 
@@ -49,7 +49,7 @@ export default function SolutionsIndex() {
                 column, bottom-aligned so it meets the closing line. The stack
                 steps right per line (horizontal momentum) and hands off to the
                 dek across a short vertical rule. Display size is bounded by
-                INTEROPERABILITY (~10.2em + step) fitting its column. */}
+                PERFORMANCE (the longest word) plus its step fitting the column. */}
             <div className="lg:grid lg:grid-cols-[minmax(0,8fr)_minmax(0,4fr)] lg:gap-14">
               <h1 className="v2-display text-[clamp(1.85rem,4.5vw,4.5rem)]">
                 {PILLAR_WORDS.map((word, i) => {
@@ -76,9 +76,11 @@ export default function SolutionsIndex() {
               <div className="lg:flex lg:flex-col lg:justify-end lg:border-l lg:border-zinc-200 lg:pl-10 dark:lg:border-zinc-800">
                 <p className="mt-8 max-w-2xl pb-1 text-lg leading-relaxed text-zinc-600 dark:text-zinc-300 lg:mt-0 lg:max-w-none lg:text-xl lg:leading-relaxed">
                   Configurable infrastructure for regulated finance: a chain
-                  tuned to how fast it settles, what it connects to, who can see
-                  it, and who can transact. Each capability opens into the
-                  institutional patterns it makes possible.
+                  where you set who validates, who transacts, and who can see
+                  it, connected to public liquidity without leaving your
+                  perimeter, settling with finality that scales with a market.
+                  Each capability opens into the institutional patterns it
+                  makes possible.
                 </p>
               </div>
             </div>

--- a/components/landing-v2/pillars.ts
+++ b/components/landing-v2/pillars.ts
@@ -1,6 +1,22 @@
 /**
- * The four enterprise pillars — single source of truth for the homepage
+ * The three enterprise pillars: single source of truth for the homepage
  * "Why Avalanche" chapter, the /solutions splash pages, and the nav menu.
+ *
+ * The framing is Control · Reach · Performance: the institutional pitch Mike
+ * gives regulated buyers: control without isolation, connection without
+ * compromise, performance that scales with finance. Both halves of his tension
+ * are here: job one is control (you answer to regulators and clients), job two
+ * is reach (markets are networks; you cannot afford to be walled off from the
+ * liquidity, developers, and customers outside your perimeter).
+ *
+ * "Control" carries what were previously the privacy and compliance pillars
+ * (who validates, who transacts, who can see the chain), so the site's altitude
+ * matches the presentation buyers hear before they land here.
+ *
+ * Naming note: the pillars are never presented as an initialism, and the second
+ * pillar is "Reach" rather than "Connection" so the set does not abbreviate to
+ * an unfortunate trigram. Mike's phrase "connection without compromise" is kept
+ * in that pillar's prose.
  *
  * Copy is a working draft: every claim must stay verifiable against shipped
  * protocol behavior (pending a story pass with comms/Mike before production).
@@ -12,10 +28,9 @@ export interface PillarLink {
 }
 
 export type PillarSlug =
-  | "interoperability"
-  | "performance"
-  | "privacy"
-  | "compliance";
+  | "control"
+  | "reach"
+  | "performance";
 
 export interface Pillar {
   slug: PillarSlug;
@@ -34,7 +49,7 @@ export interface Pillar {
   capabilities: { title: string; body: string }[];
   resources: { heading: string; links: PillarLink[] }[];
   /**
-   * Optional: architecture models — the shapes this pillar's primitives
+   * Optional: architecture models, the shapes this pillar's primitives
    * compose into. Rendered as a section only when present.
    */
   models?: {
@@ -50,7 +65,7 @@ export interface Pillar {
 }
 
 /**
- * Institutional use cases — the spine of the /solutions story.
+ * Institutional use cases: the spine of the /solutions story.
  *
  * These are architecture patterns, not marketing tiles: a business framing,
  * the Avalanche shape that implements it, and the guarantees that shape buys.
@@ -81,16 +96,103 @@ export interface UseCase {
 
 export const PILLARS: Pillar[] = [
   {
-    slug: "interoperability",
-    display: { lead: ["Chain to chain,", "natively,"], punch: "no intermediaries" },
-    label: "INTEROPERABILITY",
-    title: "Every chain speaks natively",
+    slug: "control",
+    display: { lead: ["Your chain,", "your rules,"], punch: "your perimeter" },
+    label: "CONTROL",
+    title: "Control without isolation",
     tagline:
-      "Native messaging between Avalanche chains, public or private, verified against validator sets on the P-Chain.",
+      "Sovereignty over who validates, who transacts, and who can see the chain at all. Permissioning and privacy enforced by the protocol, not by policy documents.",
     metaDescription:
-      "Interchain Messaging is built into Avalanche: authenticated messages and token transfers between public, permissioned, and private chains, verified against P-Chain validator sets.",
+      "Avalanche gives regulated institutions control at the protocol level: allowlist precompiles for deployers and transactors, permissioned validator sets, validator-only L1s, and operator-controlled data residency.",
     intro:
-      "An Interchain Messaging (ICM) message carries an aggregate signature from the source chain's validators, verified against the P-Chain's validator registry. No committee, no custodian.",
+      "In regulated finance, job number one is control: you answer to your clients and your regulators before anyone else. On an Avalanche L1 that control is a protocol primitive: you set who validates, who deploys, who transacts, and where the ledger physically lives. The rules are enforced by the chain and auditable on it, and the chain stays fully EVM-compatible.",
+    proofs: [
+      { label: "NETWORK ACCESS", value: "VALIDATOR-ONLY" },
+      { label: "TRANSACTION ACCESS", value: "ALLOWLIST PRECOMPILE" },
+      { label: "DATA RESIDENCY", value: "OPERATOR-CONTROLLED" },
+    ],
+    capabilities: [
+      {
+        title: "Protocol-level permissioning",
+        body: "Allowlist precompiles gate who can deploy contracts and who can transact at all: approved addresses in, everyone else out. Enforcement happens at execution rather than by convention.",
+      },
+      {
+        title: "Permissioned validator set",
+        body: "You decide which operators validate, your own machines or named partners, and admit or remove them through the validator manager contract. Permissioning a regulator node is straightforward.",
+      },
+      {
+        title: "Closed networks, placed data",
+        body: "One configuration flag closes an L1: only nodes you admit can sync, query, or even see it. Validators are machines you place, so every copy of the ledger stays in a jurisdiction, a data center, or your own racks.",
+      },
+    ],
+    resources: [
+      {
+        heading: "DOCUMENTATION",
+        links: [
+          { text: "Avalanche L1s", href: "/docs/avalanche-l1s" },
+          { text: "Deployer allowlist", href: "/docs/avalanche-l1s/precompiles/deployer-allowlist" },
+          { text: "Transaction allowlist", href: "/docs/avalanche-l1s/precompiles/transaction-allowlist" },
+          { text: "Validator-only configuration", href: "/docs/nodes/configure/avalanche-l1-configs" },
+        ],
+      },
+      {
+        heading: "LEARN",
+        links: [
+          { text: "Permissioned L1s", href: "/academy/avalanche-l1/permissioned-l1s" },
+          { text: "Access restriction", href: "/academy/avalanche-l1/access-restriction" },
+          { text: "Avalanche fundamentals", href: "/academy/avalanche-l1/avalanche-fundamentals" },
+        ],
+      },
+      {
+        heading: "TOOLING",
+        links: [
+          { text: "Deployer allowlist tool", href: "/console/l1-access-restrictions/deployer-allowlist" },
+          { text: "Transactor allowlist tool", href: "/console/l1-access-restrictions/transactor-allowlist" },
+          { text: "Create an L1 in the Console", href: "/console/create-l1" },
+        ],
+      },
+    ],
+    models: [
+      {
+        label: "MODEL 01",
+        name: "Walled Garden",
+        tagline: "Full control over who enters the perimeter",
+        description:
+          "You decide who participates. The network sits behind a permissioned perimeter: no outsider can query it, read its transactions, or join without approval. Inside, everything is visible to participants; outside, the network is invisible.",
+        bestFor: "Closed consortia, single-institution tokenization, regulated market infrastructure.",
+        diagram: "walled-garden",
+      },
+      {
+        label: "MODEL 02",
+        name: "Partitioned Ledger",
+        tagline: "Each party holds only their own ledger",
+        description:
+          "Every counterparty pair runs its own isolated ledger, exchanging settlement proofs directly rather than on a shared global one. Non-parties see nothing: no amounts, no identities, no timing.",
+        bestFor: "DVP settlement, inter-bank clearing, FX netting, bilateral repo.",
+        diagram: "partitioned-ledger",
+      },
+      {
+        label: "MODEL 03",
+        name: "Encrypted Settlement",
+        tagline: "Amounts encrypted on shared infrastructure",
+        description:
+          "Transactions run on shared infrastructure, so everyone keeps shared liquidity and interoperability, but amounts, counterparties, and logic stay encrypted. Settlement is verified without anyone reading the underlying values.",
+        bestFor: "Tokenized assets, cross-institution liquidity pools, digital bonds.",
+        diagram: "encrypted-settlement",
+      },
+    ],
+  },
+  {
+    slug: "reach",
+    display: { lead: ["Chain to chain,", "natively,"], punch: "no intermediaries" },
+    label: "REACH",
+    title: "Reach without compromise",
+    tagline:
+      "Native messaging and shared liquidity across every Avalanche chain, public or private, verified against validator sets on the P-Chain, with no third-party bridge in the settlement path.",
+    metaDescription:
+      "Interchain Messaging is built into Avalanche: authenticated messages, token transfers, and shared liquidity between public, permissioned, and private chains, verified against P-Chain validator sets with no third-party bridge.",
+    intro:
+      "Markets are networks. You need the liquidity, the developers, and the customers on the other side of your perimeter: connection without compromise. An Interchain Messaging (ICM) message carries an aggregate signature from the source chain's validators, verified against the P-Chain's validator registry. No committee, no custodian, no third-party bridge.",
     proofs: [
       { label: "MESSAGING", value: "PROTOCOL-NATIVE" },
       { label: "ATTESTATION", value: "SOURCE VALIDATOR SET" },
@@ -99,15 +201,15 @@ export const PILLARS: Pillar[] = [
     capabilities: [
       {
         title: "Authenticated messaging",
-        body: "Messages carry aggregate BLS signatures from the source validator set, verified at the destination against the validator registry on the P-Chain.",
+        body: "Messages carry aggregate BLS signatures from the source validator set, verified at the destination against the validator registry on the P-Chain. The destination trusts the source chain, never a messenger in the middle.",
       },
       {
         title: "Native token transfer",
-        body: "Interchain Token Transfer (ICTT) moves tokens between L1s over ICM, with contracts you deploy and control.",
+        body: "Interchain Token Transfer (ICTT) moves tokens between L1s over ICM, with contracts you deploy and control, so a permissioned chain can reach public liquidity without a custodial bridge.",
       },
       {
-        title: "Permissionless relay",
-        body: "Messages are carried by relayers anyone can run. The destination chain verifies the source validators' signatures, never the messenger.",
+        title: "Shared tooling and liquidity",
+        body: "Every chain shares the same SDK, Console, and messaging layer, and settles against the same public pools. Connection is common tooling and shared liquidity, not just a bridge.",
       },
     ],
     resources: [
@@ -197,151 +299,10 @@ export const PILLARS: Pillar[] = [
       },
     ],
   },
-  {
-    slug: "privacy",
-    display: { lead: ["Visible to you,", "invisible to"], punch: "everyone else" },
-    label: "PRIVACY",
-    title: "Visible to participants. Invisible to everyone else",
-    tagline:
-      "Whatever your privacy requirement, the architecture meets it: close the network, place the data, extend the VM with the cryptography you choose.",
-    metaDescription:
-      "Avalanche privacy is configurable to your requirements: validator-only L1s, operator-controlled data residency, and a VM you can extend with the cryptography you choose.",
-    intro:
-      "Run a validator-only L1 and the chain's data stops at the network's edge. Only nodes you admit can sync, query, or even see it.",
-    proofs: [
-      { label: "NETWORK ACCESS", value: "VALIDATOR-ONLY" },
-      { label: "DATA RESIDENCY", value: "OPERATOR-CONTROLLED" },
-      { label: "OUTSIDE VISIBILITY", value: "NONE" },
-    ],
-    capabilities: [
-      {
-        title: "Validator-only networks",
-        body: "One configuration flag closes the chain. Only validators and the nodes they admit can connect, sync, or serve its data.",
-      },
-      {
-        title: "Data residency",
-        body: "Validators are machines you place: keep every copy of the ledger in a jurisdiction, a data center, or your own racks.",
-      },
-      {
-        title: "Encrypted transport",
-        body: "Traffic between nodes runs over TLS. Even on the network path between your data centers, the chain's data is never readable in transit.",
-      },
-    ],
-    resources: [
-      {
-        heading: "DOCUMENTATION",
-        links: [
-          { text: "Avalanche L1s", href: "/docs/avalanche-l1s" },
-          { text: "Validator-only configuration", href: "/docs/nodes/configure/avalanche-l1-configs" },
-          { text: "Node configuration flags", href: "/docs/nodes/configure/configs-flags" },
-        ],
-      },
-      {
-        heading: "LEARN",
-        links: [
-          { text: "Permissioned L1s", href: "/academy/avalanche-l1/permissioned-l1s" },
-          { text: "Avalanche fundamentals", href: "/academy/avalanche-l1/avalanche-fundamentals" },
-        ],
-      },
-      {
-        heading: "TOOLING",
-        links: [
-          { text: "Create an L1 in the Console", href: "/console/create-l1" },
-          { text: "Avalanche SDK", href: "/docs/tooling/avalanche-sdk" },
-        ],
-      },
-    ],
-    models: [
-      {
-        label: "MODEL 01",
-        name: "Walled Garden",
-        tagline: "Full control over who enters the perimeter",
-        description:
-          "You decide who participates. The network sits behind a permissioned perimeter: no outsider can query it, read its transactions, or join without approval. Inside, everything is visible to participants; outside, the network is invisible.",
-        bestFor: "Closed consortia, single-institution tokenization, regulated market infrastructure.",
-        diagram: "walled-garden",
-      },
-      {
-        label: "MODEL 02",
-        name: "Partitioned Ledger",
-        tagline: "Each party holds only their own ledger",
-        description:
-          "Every counterparty pair runs its own isolated ledger, exchanging settlement proofs directly rather than on a shared global one. Non-parties see nothing: no amounts, no identities, no timing.",
-        bestFor: "DVP settlement, inter-bank clearing, FX netting, bilateral repo.",
-        diagram: "partitioned-ledger",
-      },
-      {
-        label: "MODEL 03",
-        name: "Encrypted Settlement",
-        tagline: "Amounts encrypted on shared infrastructure",
-        description:
-          "Transactions run on shared infrastructure, so everyone keeps shared liquidity and interoperability, but amounts, counterparties, and logic stay encrypted. Settlement is verified without anyone reading the underlying values.",
-        bestFor: "Tokenized assets, cross-institution liquidity pools, digital bonds.",
-        diagram: "encrypted-settlement",
-      },
-    ],
-  },
-  {
-    slug: "compliance",
-    display: { lead: ["Your rules,", "enforced by"], punch: "the protocol" },
-    label: "COMPLIANCE",
-    title: "Policy enforced by the protocol",
-    tagline:
-      "Allowlist validators, deployers, and transactors at the chain level. The rules live in precompiles, not policy documents.",
-    metaDescription:
-      "Avalanche L1s enforce permissioning at the protocol level: allowlist precompiles for deployers and transactions, and permissioned validator sets.",
-    intro:
-      "On an Avalanche L1, permissioning is a protocol primitive: precompiles gate who deploys and who transacts, and the validator set itself can be permissioned. The rules are enforced by the chain and auditable on it, and the chain stays fully EVM-compatible.",
-    proofs: [
-      { label: "CONTRACT DEPLOYMENT", value: "ALLOWLIST PRECOMPILE" },
-      { label: "TRANSACTION ACCESS", value: "ALLOWLIST PRECOMPILE" },
-      { label: "VALIDATOR SET", value: "PERMISSIONED OPTION" },
-    ],
-    capabilities: [
-      {
-        title: "Deployer allowlists",
-        body: "The ContractDeployerAllowList precompile restricts deployment to addresses you approve, enforced at execution rather than by convention.",
-      },
-      {
-        title: "Transaction gating",
-        body: "The TxAllowList precompile controls who can transact at all: approved wallets in, everyone else out.",
-      },
-      {
-        title: "Permissioned validator set",
-        body: "You decide which operators validate, your machines or named partners, and admit or remove them through the validator manager contract.",
-      },
-    ],
-    resources: [
-      {
-        heading: "DOCUMENTATION",
-        links: [
-          { text: "Deployer allowlist", href: "/docs/avalanche-l1s/precompiles/deployer-allowlist" },
-          { text: "Transaction allowlist", href: "/docs/avalanche-l1s/precompiles/transaction-allowlist" },
-          { text: "AllowList interface", href: "/docs/avalanche-l1s/precompiles/allowlist-interface" },
-          { text: "Native minter precompile", href: "/docs/avalanche-l1s/precompiles/native-minter" },
-        ],
-      },
-      {
-        heading: "LEARN",
-        links: [
-          { text: "Access restriction", href: "/academy/avalanche-l1/access-restriction" },
-          { text: "Permissioned L1s", href: "/academy/avalanche-l1/permissioned-l1s" },
-        ],
-      },
-      {
-        heading: "TOOLING",
-        links: [
-          { text: "Deployer allowlist tool", href: "/console/l1-access-restrictions/deployer-allowlist" },
-          { text: "Transactor allowlist tool", href: "/console/l1-access-restrictions/transactor-allowlist" },
-          { text: "Create an L1 in the Console", href: "/console/create-l1" },
-        ],
-      },
-    ],
-  },
 ];
 
 export const USE_CASES: UseCase[] = [
-  /* ---- interoperability ---- */
+  /* ---- reach ---- */
   {
     slug: "public-liquidity",
     label: "LIQUIDITY ACCESS",
@@ -356,7 +317,7 @@ export const USE_CASES: UseCase[] = [
       { label: "CUSTODY RISK", value: "NONE IN PATH" },
       { label: "FINALITY", value: "SUB-SECOND" },
     ],
-    pillar: "interoperability",
+    pillar: "reach",
     diagram: "public-liquidity",
   },
   {
@@ -373,7 +334,7 @@ export const USE_CASES: UseCase[] = [
       { label: "SUPPLY", value: "HOME-ANCHORED" },
       { label: "ATTESTATION", value: "SOURCE VALIDATORS" },
     ],
-    pillar: "interoperability",
+    pillar: "reach",
     diagram: "token-issuance",
   },
 
@@ -413,7 +374,7 @@ export const USE_CASES: UseCase[] = [
     diagram: "dvp-settlement",
   },
 
-  /* ---- privacy ---- */
+  /* ---- control (privacy patterns) ---- */
   {
     slug: "tokenized-deposits",
     label: "TOKENIZED DEPOSITS",
@@ -428,7 +389,7 @@ export const USE_CASES: UseCase[] = [
       { label: "CROSS-ISSUER", value: "BURN-AND-MINT" },
       { label: "VISIBILITY", value: "COUNTERPARTY-ONLY" },
     ],
-    pillar: "privacy",
+    pillar: "control",
     diagram: "tokenized-deposits",
   },
   {
@@ -445,11 +406,11 @@ export const USE_CASES: UseCase[] = [
       { label: "VISIBILITY", value: "PARTIES-ONLY" },
       { label: "STREET VIEW", value: "NONE" },
     ],
-    pillar: "privacy",
+    pillar: "control",
     diagram: "bilateral-repo",
   },
 
-  /* ---- compliance ---- */
+  /* ---- control (compliance patterns) ---- */
   {
     slug: "structured-credit",
     label: "STRUCTURED CREDIT",
@@ -464,7 +425,7 @@ export const USE_CASES: UseCase[] = [
       { label: "ELIGIBILITY", value: "RULE-ENFORCED" },
       { label: "CASH SETTLEMENT", value: "STABLECOIN VIA ICM" },
     ],
-    pillar: "compliance",
+    pillar: "control",
     diagram: "structured-credit",
   },
   {
@@ -481,7 +442,7 @@ export const USE_CASES: UseCase[] = [
       { label: "ENFORCEMENT", value: "AT EXECUTION" },
       { label: "AUDIT TRAIL", value: "ON-CHAIN" },
     ],
-    pillar: "compliance",
+    pillar: "control",
     diagram: "permissioned-venue",
   },
 ];

--- a/components/navigation/nav-config.ts
+++ b/components/navigation/nav-config.ts
@@ -31,10 +31,9 @@ export const menuSections: NavSection[] = [
     href: '/solutions',
     items: [
       { text: 'Why Avalanche', href: '/solutions' },
+      { text: 'Control', href: '/solutions/control' },
+      { text: 'Reach', href: '/solutions/reach' },
       { text: 'Performance', href: '/solutions/performance' },
-      { text: 'Interoperability', href: '/solutions/interoperability' },
-      { text: 'Privacy', href: '/solutions/privacy' },
-      { text: 'Compliance', href: '/solutions/compliance' },
     ],
   },
     {


### PR DESCRIPTION
Consolidates the `/solutions` pillars from four to three.

| Before | After |
|---|---|
| Privacy + Compliance | **Control** |
| Interoperability | **Reach** |
| Performance | **Performance** |

Privacy and compliance were one promise (sovereignty over your own chain) split across two doors, so Control absorbs both. Reach states interoperability as the outcome rather than the mechanism.

`pillars.ts` is the single source of truth, so the hero, both nav menus, the detail routes, `generateStaticParams`, and the homepage chapter all follow from it. Every technical claim carries over unchanged and nothing new is asserted. The eight institutional patterns re-home to their pillar. The allowlist-gate diagram becomes `ControlDiagram`; the unused privacy-seal diagram is removed.

**Verified:** `tsc --noEmit` clean. `/solutions`, `/solutions/control`, `/solutions/reach`, `/solutions/performance` all render 200.

**Note:** old slugs (`/solutions/privacy`, `/solutions/compliance`, `/solutions/interoperability`) now 404. Happy to add redirects if wanted.

Draft pending copy sign-off.
