### PR TITLE
chore(console): pin container versions to GitHub releases, bump testnet

### DIFF
--- a/scripts/update_docker_tags.mjs
+++ b/scripts/update_docker_tags.mjs
@@ -3,213 +3,142 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-// ES module equivalent of __dirname
+/**
+ * Updates the container image pins in versions.json.
+ *
+ * Rule: the version number always comes from a GitHub release. Docker Hub is
+ * consulted only to confirm that the matching image tag exists, and never to
+ * choose a version.
+ *
+ * "Latest Docker image" is not "latest release". The newest tag in a Docker
+ * repo is routinely a CI build (a bare commit hash), a release candidate, or a
+ * branch tag with no release behind it. Docker Hub also caps tag listings at
+ * 100 per page regardless of the requested page_size, so the first page is not
+ * even reliably the newest set. Picking a version by listing tags therefore
+ * risks pinning the console to something that was never released; we look up
+ * one exact tag instead.
+ *
+ * Release candidates are never pinned, on mainnet or fuji.
+ *
+ * Set GITHUB_TOKEN to avoid unauthenticated API rate limits (needed in CI).
+ */
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const versionsPath = path.join(__dirname, 'versions.json');
+
+const REQUEST_TIMEOUT_MS = 10000;
 
 function readVersionsFile() {
     const content = fs.readFileSync(versionsPath, 'utf8');
     return JSON.parse(content);
 }
 
-function fetchTags(repoName, isFuji = false) {
+// Resolves { status, body }. Never rejects on a non-2xx; callers decide.
+function request(url, headers = {}) {
     return new Promise((resolve, reject) => {
-        const request = https.get(`https://hub.docker.com/v2/repositories/${repoName}/tags?page_size=1000`, (res) => {
+        const req = https.get(url, { headers: { 'User-Agent': 'builders-hub-updater', ...headers } }, (res) => {
             let data = '';
-
-            res.on('data', (chunk) => {
-                data += chunk;
-            });
-
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(data);
-                    const results = parsedData.results;
-
-                    // Find semantic version tags
-                    const semanticTags = results
-                        .map(tag => tag.name)
-                        .filter(name => {
-                            if (isFuji) {
-                                return /^v\d+\.\d+\.\d+-fuji/.test(name);
-                            } else {
-                                return /^v\d+\.\d+\.\d+$/.test(name) && !name.includes("-");
-                            }
-                        })
-                        .filter(name => !name.includes("-rc."));
-
-                    if (semanticTags.length > 0) {
-                        resolve(semanticTags[0]);
-                    } else {
-                        reject(new Error(`No ${isFuji ? 'fuji ' : ''}semantic version tags found`));
-                    }
-                } catch (e) {
-                    reject(e);
-                }
-            });
+            res.on('data', (chunk) => { data += chunk; });
+            res.on('end', () => resolve({ status: res.statusCode, body: data }));
         });
 
-        request.setTimeout(3000, () => {
-            request.destroy();
+        req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+            req.destroy();
             reject(new Error('Request timeout'));
         });
 
-        request.on('error', reject);
+        req.on('error', reject);
     });
 }
 
-// Fetch all tag names from Docker Hub repo
-function fetchAllTags(repoName) {
-    return new Promise((resolve, reject) => {
-        const request = https.get(`https://hub.docker.com/v2/repositories/${repoName}/tags?page_size=1000`, (res) => {
-            let data = '';
-
-            res.on('data', (chunk) => {
-                data += chunk;
-            });
-
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(data);
-                    const results = parsedData.results;
-                    const names = results.map(t => t.name);
-                    resolve(names);
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
-
-        request.setTimeout(3000, () => {
-            request.destroy();
-            reject(new Error('Request timeout'));
-        });
-
-        request.on('error', reject);
-    });
-}
-
-// Fetch latest stable (non-draft, non-prerelease) GitHub release tag
-function fetchGithubLatestReleaseTag(owner, repo, isFuji = false) {
-    return new Promise((resolve, reject) => {
-        const options = {
-            hostname: 'api.github.com',
-            path: `/repos/${owner}/${repo}/releases?per_page=100`,
-            headers: {
-                'User-Agent': 'builders-hub-updater',
-                'Accept': 'application/vnd.github+json'
-            }
-        };
-
-        const request = https.get(options, (res) => {
-            let data = '';
-
-            res.on('data', (chunk) => {
-                data += chunk;
-            });
-
-            res.on('end', () => {
-                try {
-                    const releases = JSON.parse(data);
-
-                    // Find the latest stable release (non-draft, non-prerelease)
-                    const stableReleases = releases.filter(r => {
-                        if (isFuji) {
-                            // For fuji/testnet, look for pre-releases or releases with -fuji tag
-                            return r.tag_name && r.tag_name.includes('-fuji');
-                        } else {
-                            // For mainnet, only stable releases
-                            return !r.draft && !r.prerelease && r.tag_name && !r.tag_name.includes('-');
-                        }
-                    });
-
-                    if (stableReleases.length > 0) {
-                        resolve(stableReleases[0].tag_name);
-                    } else {
-                        reject(new Error(`No ${isFuji ? 'fuji ' : 'stable '}releases found`));
-                    }
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
-
-        request.setTimeout(3000, () => {
-            request.destroy();
-            reject(new Error('Request timeout'));
-        });
-
-        request.on('error', reject);
-    });
-}
-
-// Fetch GitHub release tag matching a filter
-function fetchGithubLatestTagMatching(owner, repo, filter, isFuji = false) {
-    return new Promise((resolve, reject) => {
-        const options = {
-            hostname: 'api.github.com',
-            path: `/repos/${owner}/${repo}/releases?per_page=100`,
-            headers: {
-                'User-Agent': 'builders-hub-updater',
-                'Accept': 'application/vnd.github+json'
-            }
-        };
-
-        const request = https.get(options, (res) => {
-            let data = '';
-
-            res.on('data', (chunk) => {
-                data += chunk;
-            });
-
-            res.on('end', () => {
-                try {
-                    const releases = JSON.parse(data);
-
-                    // Find the latest release matching the filter
-                    const matchingReleases = releases.filter(r => {
-                        if (!r.draft && r.tag_name && filter(r.tag_name)) {
-                            if (isFuji) {
-                                return r.tag_name.includes('-fuji');
-                            } else {
-                                return !r.prerelease && !r.tag_name.includes('-');
-                            }
-                        }
-                        return false;
-                    });
-
-                    if (matchingReleases.length > 0) {
-                        resolve(matchingReleases[0].tag_name);
-                    } else {
-                        resolve(null); // No matching releases
-                    }
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
-
-        request.setTimeout(3000, () => {
-            request.destroy();
-            reject(new Error('Request timeout'));
-        });
-
-        request.on('error', reject);
-    });
-}
-
-// Compare semver strings
-function compareSemver(a, b) {
-    const ap = a.replace(/^v/, '').split(/[\.-]/);
-    const bp = b.replace(/^v/, '').split(/[\.-]/);
-    for (let i = 0; i < Math.max(ap.length, bp.length); i++) {
-        const anum = parseInt(ap[i] || '0');
-        const bnum = parseInt(bp[i] || '0');
-        if (anum !== bnum) {
-            return anum - bnum;
-        }
+async function fetchGithubReleases(owner, repo) {
+    const headers = { 'Accept': 'application/vnd.github+json' };
+    if (process.env.GITHUB_TOKEN) {
+        headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
     }
-    return 0;
+
+    const { status, body } = await request(
+        `https://api.github.com/repos/${owner}/${repo}/releases?per_page=100`,
+        headers
+    );
+
+    if (status !== 200) {
+        throw new Error(`GitHub returned ${status} for ${owner}/${repo}`);
+    }
+
+    const releases = JSON.parse(body);
+    if (!Array.isArray(releases)) {
+        throw new Error(`Unexpected GitHub response for ${owner}/${repo}`);
+    }
+    return releases;
+}
+
+/**
+ * Newest release version for a network, or null. Releases come back
+ * newest-first.
+ *
+ * `prefix` is the product prefix some monorepos put on a tag, e.g.
+ * "icm-relayer-v1.7.5". It is stripped before the version is inspected and
+ * before the version is returned, because the image tag does not carry it.
+ * Inspecting the raw tag would be wrong: the mainnet rule rejects a version
+ * carrying any suffix, and the hyphen inside "icm-relayer-" would trip it.
+ *
+ * Drafts and release candidates are always excluded. Mainnet additionally
+ * excludes prereleases and suffixed versions; fuji requires -fuji.
+ */
+function pickReleaseVersion(releases, { isFuji, prefix = '' }) {
+    const candidate = releases.find((r) => {
+        const tag = r.tag_name;
+        if (!tag || r.draft || !tag.startsWith(prefix)) return false;
+
+        const version = tag.slice(prefix.length);
+        if (!/^v\d+\.\d+\.\d+/.test(version) || version.includes('-rc.')) return false;
+
+        return isFuji
+            ? version.includes('-fuji')
+            : !r.prerelease && !version.includes('-');
+    });
+    return candidate ? candidate.tag_name.slice(prefix.length) : null;
+}
+
+/**
+ * True only if the exact tag exists. Anything else (404, an outage, a
+ * timeout) returns false so the caller keeps the current pin rather than
+ * publishing an image nobody can pull.
+ */
+async function dockerTagExists(repoName, tag) {
+    try {
+        const { status } = await request(`https://hub.docker.com/v2/repositories/${repoName}/tags/${encodeURIComponent(tag)}`);
+        return status === 200;
+    } catch (_) {
+        return false;
+    }
+}
+
+/**
+ * Pins `image` to `version` if the image tag exists. Returns true if changed.
+ */
+async function applyPin(networkVersions, image, version, label) {
+    const current = networkVersions[image] || '';
+
+    if (!version) {
+        console.warn(`  ${label}: no release found. Keeping ${current}.`);
+        return false;
+    }
+
+    if (version === current) {
+        console.log(`  ${label}: ${version} (same as before)`);
+        return false;
+    }
+
+    if (!(await dockerTagExists(image, version))) {
+        console.warn(`  ${label}: release ${version} has no ${image}:${version} image yet. Keeping ${current}.`);
+        return false;
+    }
+
+    networkVersions[image] = version;
+    console.log(`  ${label}: ${version} (new, was ${current})`);
+    return true;
 }
 
 async function updateNetwork(versions, network) {
@@ -219,87 +148,35 @@ async function updateNetwork(versions, network) {
 
     console.log(`\nChecking ${network} versions:`);
 
-    // Check for AvalancheGo updates
+    // AvalancheGo, and the Subnet-EVM image that bundles it. The
+    // avaplatform/subnet-evm tag matches the AvalancheGo version (e.g.
+    // v1.14.2), so both pins follow the same release.
     try {
-        const latestAvagoTag = await fetchGithubLatestReleaseTag('ava-labs', 'avalanchego', isFuji);
-        const currentAvagoVersion = networkVersions['avaplatform/avalanchego'] || '';
-        const avagoStatus = latestAvagoTag === currentAvagoVersion ? '(same as before)' : '(new)';
-        console.log(`  avalanchego: ${latestAvagoTag} ${avagoStatus}`);
+        const releases = await fetchGithubReleases('ava-labs', 'avalanchego');
+        const avagoVersion = pickReleaseVersion(releases, { isFuji });
 
-        if (latestAvagoTag && latestAvagoTag !== currentAvagoVersion) {
-            networkVersions['avaplatform/avalanchego'] = latestAvagoTag;
+        if (await applyPin(networkVersions, 'avaplatform/avalanchego', avagoVersion, 'avalanchego')) {
             hasChanges = true;
-            console.error(`  New version ${latestAvagoTag} is available for ${network} avalanchego. Current version is ${currentAvagoVersion}`);
         }
 
-        // Check for Subnet-EVM Docker image updates.
-        // The image avaplatform/subnet-evm:<avalanchego-version> bundles AvalancheGo
-        // and the Subnet-EVM plugin together. The tag matches the AvalancheGo version
-        // (e.g. v1.14.2). The legacy avaplatform/subnet-evm_avalanchego repo with
-        // composite tags (v0.8.0_v1.14.0) is deprecated.
-        const currentSubnetEvmVersion = networkVersions['avaplatform/subnet-evm'] || '';
-        let subnetEvmTag = currentSubnetEvmVersion;
-
-        try {
-            const allTags = await fetchAllTags('avaplatform/subnet-evm');
-            const avagoVersion = networkVersions['avaplatform/avalanchego'];
-
-            // Prefer an exact match on the AvalancheGo version
-            if (allTags.includes(avagoVersion)) {
-                subnetEvmTag = avagoVersion;
-            } else {
-                // Fall back to the latest stable v*.*.*  (no -fuji / -rc / build hashes)
-                const stable = allTags.filter(name => /^v\d+\.\d+\.\d+$/.test(name));
-                if (stable.length > 0) {
-                    stable.sort((a, b) => compareSemver(b, a));
-                    subnetEvmTag = stable[0];
-                    console.warn(`  No avaplatform/subnet-evm tag found for ${avagoVersion}. Falling back to latest stable: ${subnetEvmTag}.`);
-                } else {
-                    console.warn(`  No stable avaplatform/subnet-evm tags found. Keeping current: ${currentSubnetEvmVersion}.`);
-                }
-            }
-        } catch (_) {
-            // If Docker Hub listing fails, keep the current version
-        }
-
-        const subnetEvmStatus = subnetEvmTag === currentSubnetEvmVersion ? '(same as before)' : '(new)';
-        console.log(`  subnet-evm: ${subnetEvmTag} ${subnetEvmStatus}`);
-
-        if (subnetEvmTag && subnetEvmTag !== currentSubnetEvmVersion) {
-            networkVersions['avaplatform/subnet-evm'] = subnetEvmTag;
+        // Track whatever avalanchego is actually pinned to, which may still be
+        // the previous version if the bump above was held back.
+        const pinnedAvago = networkVersions['avaplatform/avalanchego'];
+        if (await applyPin(networkVersions, 'avaplatform/subnet-evm', pinnedAvago, 'subnet-evm')) {
             hasChanges = true;
-            console.error(`  New version ${subnetEvmTag} is available for ${network} subnet-evm. Current version is ${currentSubnetEvmVersion}`);
         }
     } catch (error) {
         console.warn(`  Warning for ${network} node versions:`, error.message);
     }
 
-    // Check for icm-relayer updates
+    // ICM relayer, released from icm-services as icm-relayer-vX.Y.Z; the image
+    // tag drops the prefix.
     try {
-        // Pull from GitHub releases of icm-services and extract icm-relayer-* tag
-        const icmRelayerReleaseTag = await fetchGithubLatestTagMatching(
-            'ava-labs',
-            'icm-services',
-            (t) => /^icm-relayer-v\d+\.\d+\.\d+/.test(t),
-            isFuji
-        );
+        const releases = await fetchGithubReleases('ava-labs', 'icm-services');
+        const relayerVersion = pickReleaseVersion(releases, { isFuji, prefix: 'icm-relayer-' });
 
-        let latestRelayerTag = '';
-        if (icmRelayerReleaseTag) {
-            latestRelayerTag = icmRelayerReleaseTag.replace(/^icm-relayer-/, '');
-        } else {
-            // Fallback to Docker Hub tag discovery
-            latestRelayerTag = await fetchTags('avaplatform/icm-relayer', isFuji);
-        }
-
-        const currentRelayerVersion = networkVersions['avaplatform/icm-relayer'] || '';
-        const relayerStatus = latestRelayerTag === currentRelayerVersion ? '(same as before)' : '(new)';
-        console.log(`  icm-relayer: ${latestRelayerTag} ${relayerStatus}`);
-
-        if (latestRelayerTag && latestRelayerTag !== currentRelayerVersion) {
-            networkVersions['avaplatform/icm-relayer'] = latestRelayerTag;
+        if (await applyPin(networkVersions, 'avaplatform/icm-relayer', relayerVersion, 'icm-relayer')) {
             hasChanges = true;
-            console.error(`  New version ${latestRelayerTag} is available for ${network} icm-relayer. Current version is ${currentRelayerVersion}`);
         }
     } catch (error) {
         console.warn(`  Warning for ${network} icm-relayer:`, error.message);
@@ -311,23 +188,16 @@ async function updateNetwork(versions, network) {
 async function main() {
     try {
         const versions = readVersionsFile();
-        let hasChanges = false;
 
-        // Update mainnet versions
         const mainnetChanged = await updateNetwork(versions, 'mainnet');
-        hasChanges = hasChanges || mainnetChanged;
-
-        // Update testnet versions  
         const testnetChanged = await updateNetwork(versions, 'testnet');
-        hasChanges = hasChanges || testnetChanged;
 
-        if (hasChanges) {
-            fs.writeFileSync(versionsPath, JSON.stringify(versions, null, 2));
-            console.error('\nVersions updated. Please commit the changes.');
+        if (mainnetChanged || testnetChanged) {
+            fs.writeFileSync(versionsPath, JSON.stringify(versions, null, 2) + '\n');
+            console.log('\nVersions updated. Please commit the changes.');
         } else {
             console.log('\nAll versions are up to date.');
         }
-
     } catch (error) {
         console.error('Error:', error.message);
         process.exit(1);

--- a/scripts/versions.json
+++ b/scripts/versions.json
@@ -5,9 +5,9 @@
     "avaplatform/icm-relayer": "v1.7.5"
   },
   "testnet": {
-    "avaplatform/avalanchego": "v1.14.0-fuji",
-    "avaplatform/subnet-evm": "v1.14.2",
-    "avaplatform/icm-relayer": "v1.7.2-fuji"
+    "avaplatform/avalanchego": "v1.15.0-fuji",
+    "avaplatform/subnet-evm": "v1.15.0-fuji",
+    "avaplatform/icm-relayer": "v1.8.0-fuji"
   },
   "ava-labs/icm-services": "4d5ab0b6dbc653770cfe9709878c9406eb28b71c",
   "ava-labs/EncryptedERC": "c7eb0e09bc9315e68c35d3c09f5dce4b794d0485"


### PR DESCRIPTION
Testnet was pinned to avalanchego `v1.14.0-fuji`; `v1.15.0-fuji` is out. Mainnet was already current.

| testnet | before | after |
|---|---|---|
| avalanchego | v1.14.0-fuji | v1.15.0-fuji |
| subnet-evm | v1.14.2 | v1.15.0-fuji |
| icm-relayer | v1.7.2-fuji | v1.8.0-fuji |

The updater changed too, because it was picking versions by listing Docker Hub tags. The newest tag there is often a CI build or a release candidate with no release behind it, and Docker Hub caps listings at 100 per page, so with 624 tags on `avaplatform/subnet-evm` the first page was not even the newest set. That is how testnet icm-relayer resolved to `v1.8.0-fuji-rc.0`.

The version now always comes from a GitHub release, and Docker Hub is only asked whether that exact tag exists. If it does not, the current pin is kept. Release candidates are never pinned. Prefixed tags are handled, so the mainnet "no suffix" rule tests `v1.7.5` rather than `icm-relayer-v1.7.5`.

**Verified:** all six pinned tags resolve on Docker Hub and a bogus version is refused. Run against master's file it produces the table above; run again it is a no-op. Fails soft on API errors and offline (exit 0, file untouched), which matters because this runs in `postinstall`.
