### PR TITLE
feat(explorer): the p-chain type filter covers every type the chain issues

### DIFF
--- a/components/explorer-v2/pchain/PchainTx.tsx
+++ b/components/explorer-v2/pchain/PchainTx.tsx
@@ -52,8 +52,8 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
       tx.details?.stakingTxId ||
       tx.details?.rewardPaid !== undefined)
   );
-  // continuous staking (Granite): the stake renews itself on a period,
-  // optionally compounding rewards back in
+  // auto-renewed staking (ACP-236, Helicon): the stake renews itself on a
+  // period, optionally compounding rewards back in
   const hasContinuous = !!(
     tx &&
     ((tx.period ?? 0) > 0 ||

--- a/components/explorer-v2/pchain/PchainTxsList.tsx
+++ b/components/explorer-v2/pchain/PchainTxsList.tsx
@@ -9,17 +9,35 @@ import { formatNumber, timeAgo, truncate } from "@/components/explorer-v2/format
 import { usePchainData, LIVE_REFRESH_MS } from "./hooks";
 import type { TxSummary } from "@/lib/pchain-explorer";
 
+/* The types the upstream indexer serves, grouped by the same families the
+   pills are toned by (see txToneText/pillTone) so the rail and the table
+   below read as one vocabulary. Every value here is a type the indexer
+   answers `?type=` for; the auto-renewed trio returns nothing until a
+   network has Helicon active, which the empty state states plainly. */
 const TYPE_OPTIONS: { value: string; label: string }[] = [
   { value: "", label: "All types" },
+  // primary-network staking
   { value: "AddPermissionlessValidatorTx", label: "Add Validator" },
   { value: "AddPermissionlessDelegatorTx", label: "Add Delegator" },
   { value: "RewardValidatorTx", label: "Reward" },
+  // auto-renewed staking (ACP-236, Helicon): a cycle-based stake, the
+  // consensus-issued reward at each cycle end, and owner config changes
+  { value: "AddAutoRenewedValidatorTx", label: "Auto-Renew Validator" },
+  { value: "RewardAutoRenewedValidatorTx", label: "Auto-Renew Reward" },
+  { value: "SetAutoRenewedValidatorConfigTx", label: "Auto-Renew Config" },
+  // L1 lifecycle
+  { value: "ConvertSubnetToL1Tx", label: "Convert to L1" },
+  { value: "RegisterL1ValidatorTx", label: "Register L1 Validator" },
+  { value: "SetL1ValidatorWeightTx", label: "Set L1 Weight" },
+  { value: "IncreaseL1ValidatorBalanceTx", label: "Increase L1 Balance" },
+  { value: "DisableL1ValidatorTx", label: "Disable L1 Validator" },
+  // creation
+  { value: "CreateSubnetTx", label: "Create Subnet" },
+  { value: "CreateChainTx", label: "Create Chain" },
+  // value movement
   { value: "ImportTx", label: "Import" },
   { value: "ExportTx", label: "Export" },
   { value: "BaseTx", label: "Transfer" },
-  { value: "CreateSubnetTx", label: "Create Subnet" },
-  { value: "CreateChainTx", label: "Create Chain" },
-  { value: "ConvertSubnetToL1Tx", label: "Convert to L1" },
 ];
 
 export function PchainTxsList({ chain, network }: { chain: string; network: string }) {


### PR DESCRIPTION
The P-Chain tx filter rail offered 9 types; the indexer serves 19. On Fuji, 74 of the last 200 transactions had no chip and were reachable only under "All types".

## Changes

- Adds the four live L1 types that were missing: `RegisterL1ValidatorTx`, `SetL1ValidatorWeightTx`, `IncreaseL1ValidatorBalanceTx`, `DisableL1ValidatorTx`.
- Adds the three types Helicon's ACP-236 introduced: `AddAutoRenewedValidatorTx`, `RewardAutoRenewedValidatorTx`, `SetAutoRenewedValidatorConfigTx`.
- Regroups the rail by tx family (staking, auto-renew, L1 lifecycle, creation, value movement) so chip order matches the tone families the pills already use.
- Fixes a comment that credited continuous staking to Granite instead of Helicon.

## Verification

Helicon activated on Fuji at `heliconTime = 2026-07-28T15:00:00Z`. Every chip was queried through the app's own proxy against the live indexer; all 200s:

| type | rows |
| --- | --- |
| AddAutoRenewedValidatorTx | 2 |
| RewardAutoRenewedValidatorTx | 0 |
| SetAutoRenewedValidatorConfigTx | 0 |
| RegisterL1ValidatorTx | 3 |
| SetL1ValidatorWeightTx | 3 |
| IncreaseL1ValidatorBalanceTx | 3 |
| DisableL1ValidatorTx | 3 |

The first two auto-renewed validators registered during this change (blocks 290392-290393), confirming the indexer decodes the ACP-236 fields the detail card reads: `period`, `periodHuman`, `autoCompoundPercent`, `autoCompoundRewardShares`, `validatorAuthority`.

The two reward/config types return 0 rows because nothing has issued them yet; the list's existing empty state covers that ("No recent X transactions" plus "Show all"). Same on mainnet until Helicon activates there.

`tsc --noEmit` clean.

## Open question

The staking money-flow feed reads `raw_p_reward_utxos` rather than filtering on tx type, so it survives the new reward tx. But ACP-236 restakes the auto-compounded share instead of paying it out. If that share does not mint a reward UTXO, daily reward totals will undercount as adoption grows. Needs confirming with the indexer owner. Not addressed here.
