### PR TITLE
fix(docs): redirect legacy docs.avax.network paths for node config flags and AWM

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1829,6 +1829,25 @@ const config = {
         destination: "/docs/nodes/configure/configs-flags",
         permanent: true,
       },
+      // Legacy docs.avax.network IA. That domain is an alias for this app rather
+      // than a forward, so pre-migration paths 404 instead of redirecting. These
+      // three are linked from the upstream avalanche-foundation/ACPs READMEs,
+      // which are fetched into /docs/acps at build time.
+      {
+        source: "/nodes/configure/avalanchego-config-flags",
+        destination: "/docs/nodes/configure/configs-flags",
+        permanent: true,
+      },
+      {
+        source: "/docs/nodes/configure/avalanchego-config-flags",
+        destination: "/docs/nodes/configure/configs-flags",
+        permanent: true,
+      },
+      {
+        source: "/build/cross-chain/awm/overview",
+        destination: "/docs/cross-chain/avalanche-warp-messaging/overview",
+        permanent: true,
+      },
       // Docker node setup redirect
       {
         source: "/docs/nodes/operate/docker",


### PR DESCRIPTION
## What changed

Three legacy docs paths 404 today. Added redirects in `next.config.mjs`, next to the existing `chain-config-flags` rule.

| Source | Destination |
| --- | --- |
| `/nodes/configure/avalanchego-config-flags` | `/docs/nodes/configure/configs-flags` |
| `/docs/nodes/configure/avalanchego-config-flags` | `/docs/nodes/configure/configs-flags` |
| `/build/cross-chain/awm/overview` | `/docs/cross-chain/avalanche-warp-messaging/overview` |

`docs.avax.network` is a domain alias for this app, not a forward: root and `/docs/*` serve 200 directly with no `Location` header. What is missing is path-level mapping for the pre-migration IA, so old paths 404 on the absent `/docs` prefix. The node flags page was also renamed, so mapping the domain alone would still land on a 404.

All three are linked from the upstream `avalanche-foundation/ACPs` READMEs, which are fetched into `/docs/acps` at build time (`utils/remote-content/acps.mts`). Upstream fix for the source links: avalanche-foundation/ACPs#297. This PR is the durable half, since it also heals every already-published copy of those URLs.

## How it was verified

- `curl -o /dev/null -w "%{http_code}"` on the old paths (404 on both `build.avax.network` and `docs.avax.network`) and the destinations (200).
- Imported the config and resolved `redirects()`: all three sources present, 429 rules total, no new duplicate sources.
- Confirmed no `/nodes` or `/build` route exists in `app/`, so no collision.
- Anchor headings confirmed present on the targets. Fragments are reapplied client-side, so `#avalanche-community-proposals` survives the 308.

## Open questions

The legacy IA is broadly unmapped: 436 rules but only one `/build/*` source and, before this, zero `/nodes/*`. A `/nodes/:path*` catch-all would be safe but would not fix renamed pages like this one. Left for a separate pass.