### PR TITLE
docs: note the Helicon parameter changes on the rewards formula page

### DIFF
--- a/content/docs/primary-network/validate/rewards-formula.mdx
+++ b/content/docs/primary-network/validate/rewards-formula.mdx
@@ -107,6 +107,16 @@ For reference we list below the Primary Network parameters on Mainnet:
 - `MaxValidatorWeightFactor = 5`. This is a platformVM parameter rather than a genesis one, so it's shared across networks.
 - `UptimeRequirement = 0.8`, that is `80%`.
 
+<Callout type="info" title="Three of these parameters change with the Helicon upgrade">
+The Helicon upgrade is active on Fuji as of July 28, 2026 at 15:00 UTC and is not yet scheduled on Mainnet. The values above are the Mainnet values in effect today. Three of them change once Helicon activates on a network:
+
+- **`MinConsumptionRate` drops from `0.10` to `0.075`** ([ACP-285](/docs/acps/285-reduce-minimum-consumption-rate)). The change is not applied at once: it ramps linearly over the 90 days following activation, and the rate used for a staking period is the one in effect at that period's **start time**. A stake that starts 45 days after activation therefore uses roughly `0.0875`.
+- **The effective uptime requirement rises from `80%` to `90%`** ([ACP-267](/docs/acps/267-uptime-requirement-increase)). This one is not a genesis parameter: `UptimeRequirement` above stays `0.8`, and the `90%` threshold is applied when deciding reward eligibility for any Primary Network validation whose **start time** is at or after Helicon activation. Validations that started earlier are still judged against `80%`, and Avalanche L1 validators keep the requirement set by their own subnet transformation.
+- **`MinStakeDuration` drops to `48 hours` for Primary Network validators** ([ACP-273](/docs/acps/273-reduce-minimum-staking-duration)). Delegators are unaffected and keep the `2 week` minimum. On Fuji the validator minimum is now `12 hours`.
+
+All three are already in effect on Fuji, so reward figures computed from the Mainnet values above will not match Fuji results.
+</Callout>
+
 ### Interactive Graph
 
 The graph below demonstrates the reward as a function of the length of time


### PR DESCRIPTION
The Mainnet parameter list on this page does not mention that Helicon moves three of its values. Helicon is live on Fuji as of 2026-07-28 15:00 UTC, so reward figures computed from this page already do not match Fuji.

## What changed

Adds one callout. The listed values are **not** edited, because Helicon is not scheduled on Mainnet and every value on the page is still correct there today. The callout covers the three that change at activation:

- `MinConsumptionRate` 0.10 to 0.075 (ACP-285). Ramped linearly over the 90 days after activation, keyed on the staking period's start time, so a stake starting 45 days in uses roughly 0.0875.
- Effective uptime requirement 80% to 90% (ACP-267). Worth calling out explicitly because it is **not** a genesis parameter: `UptimeRequirement` stays `0.8` and the 90% figure is applied when deciding reward eligibility for validations whose start time is at or after activation. Earlier validations keep 80%, and L1 validators keep their own subnet value.
- Validator `MinStakeDuration` to 48 hours (ACP-273). Delegators are unaffected and keep the 2 week minimum.

## Verification

Values read from avalanchego `genesis/genesis_mainnet.go`, `genesis/genesis_fuji.go`, `vms/platformvm/reward/calculator.go` (the `configForStakeStart` ramp), `txs/executor/staker_tx_verification_helpers.go` (validator vs delegator rules), and `block/executor/options.go:178` (the uptime gate).
