### PR TITLE
fix: update renamed ACP-194 and ACP-236 doc links

### DIFF
--- a/components/navigation/docs-nav-config.tsx
+++ b/components/navigation/docs-nav-config.tsx
@@ -170,13 +170,13 @@ export const acpsOptions: NavOption[] = [
     title: 'Streaming Asynchronous Execution',
     description: 'ACP-194',
     icon: <Book className="w-5 h-5" />,
-    url: '/docs/acps/194-streaming-asynchronous-execution',
+    url: '/docs/acps/194-continuous-execution',
   },
   {
     title: 'Continuous Staking',
     description: 'ACP-236',
     icon: <Book className="w-5 h-5" />,
-    url: '/docs/acps/236-continuous-staking',
+    url: '/docs/acps/236-auto-renewed-staking',
   },
   {
     title: 'ValidatorManager Contract',

--- a/components/sae/TransactionLifecycle.tsx
+++ b/components/sae/TransactionLifecycle.tsx
@@ -81,7 +81,7 @@ export function TransactionLifecycle() {
         {/* Learn More links */}
         <div className="flex flex-row gap-2 sm:gap-3 justify-center items-center">
           <Link 
-            href="/docs/acps/194-streaming-asynchronous-execution"
+            href="/docs/acps/194-continuous-execution"
             className={`group flex items-center gap-1.5 sm:gap-2 px-2.5 sm:px-4 py-2 border ${colors.border} ${colors.blockBg} hover:${colors.blockBgStrong} transition-all`}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={colors.stroke} strokeWidth="1.5" className="opacity-50 group-hover:opacity-100 transition-opacity shrink-0 sm:w-4 sm:h-4">
@@ -234,7 +234,7 @@ export function TransactionLifecycle() {
           
           <div className="flex flex-row gap-2 sm:gap-4 justify-center items-stretch">
             <Link 
-              href="/docs/acps/194-streaming-asynchronous-execution"
+              href="/docs/acps/194-continuous-execution"
               className={`group flex items-center gap-2 sm:gap-3 px-3 sm:px-6 py-3 sm:py-4 border ${colors.border} ${colors.blockBg} hover:${colors.blockBgStrong} transition-all`}
             >
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={colors.stroke} strokeWidth="1.5" className="opacity-50 group-hover:opacity-100 transition-opacity shrink-0 sm:w-5 sm:h-5">

--- a/content/docs/nodes/architecture/execution/index.mdx
+++ b/content/docs/nodes/architecture/execution/index.mdx
@@ -78,6 +78,6 @@ For **the network**:
 
 ## Related Resources
 
-- [ACP-194: Streaming Asynchronous Execution](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/194-streaming-asynchronous-execution) - Formal specification
+- [ACP-194: Streaming Asynchronous Execution](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/194-continuous-execution) - Formal specification
 - [StreVM Repository](https://github.com/ava-labs/strevm) - Reference SAE implementation
 - [Firewood Repository](https://github.com/ava-labs/firewood) - Database implementation

--- a/content/docs/nodes/architecture/execution/streaming-async-execution.mdx
+++ b/content/docs/nodes/architecture/execution/streaming-async-execution.mdx
@@ -6,7 +6,7 @@ description: Learn how Streaming Asynchronous Execution (SAE) decouples consensu
 Streaming Asynchronous Execution (SAE) is a fundamental architectural change that decouples consensus from execution. By allowing these two critical processes to run concurrently, AvalancheGo can achieve significantly higher throughput without sacrificing security guarantees.
 
 <Callout>
-**Specification**: SAE is defined in [ACP-194](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/194-streaming-asynchronous-execution). The reference implementation is [StreVM](https://github.com/ava-labs/strevm).
+**Specification**: SAE is defined in [ACP-194](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/194-continuous-execution). The reference implementation is [StreVM](https://github.com/ava-labs/strevm).
 </Callout>
 
 ## Summary
@@ -261,6 +261,6 @@ flowchart TB
 
 ### External Links
 
-- [ACP-194 Specification](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/194-streaming-asynchronous-execution)
+- [ACP-194 Specification](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/194-continuous-execution)
 - [StreVM Repository](https://github.com/ava-labs/strevm)
 - [ACP-194 Discussion](https://github.com/avalanche-foundation/ACPs/discussions/196)


### PR DESCRIPTION
Two ACP directories were renamed upstream, which 404s every hand-written link to them:

- `194-streaming-asynchronous-execution` to `194-continuous-execution`
- `236-continuous-staking` to `236-auto-renewed-staking`

## What changed

Updates the six references across the nav config, the SAE components, and two docs pages, including the external `github.com/avalanche-foundation/ACPs` links, which are broken for the same reason.

The generated `content/docs/acps/*.mdx` pages and their `meta.json` are built from the upstream directory names by `utils/remote-content/acps.mts`, so those self-correct on the next `build:remote`. These hand-written references do not.

## Verification

Diffed every `/docs/acps/<slug>` reference in the repo against the live upstream directory listing. These two were the only broken ones, and none remain after this change. `tsc --noEmit` passes.

## Notes

Display labels are deliberately unchanged. "Streaming Asynchronous Execution" is still the name used for the feature throughout these docs, and renaming it to match the ACP's new title is a branding decision rather than a broken link. Happy to follow up if you want the labels aligned.

`.gitignore` lists ACP filenames individually, so the renamed files will not be ignored on the next sync and will show up as untracked. Left out of this PR as a separate concern; a glob would fix it.
