### PR TITLE
fix: disable Helicon banner and fix blog date timezone display

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -15,6 +15,7 @@ import {
 import { BadgeCheck } from "lucide-react";
 import { Feedback } from "@/components/ui/feedback";
 import posthog from "posthog-js";
+import { formatBlogDate } from "@/utils/formatBlogDate";
 
 export const dynamicParams = false;
 
@@ -107,9 +108,7 @@ export default async function Page(props: {
           <div>
             <p className="mb-1 text-sm text-muted-foreground">On</p>
             <p className="font-medium">
-              {new Date(
-                (page.data.date as string) ?? page.url
-              ).toDateString()}
+              {formatBlogDate(page.data.date as string | Date)}
             </p>
           </div>
 

--- a/app/layout-wrapper.client.tsx
+++ b/app/layout-wrapper.client.tsx
@@ -51,7 +51,7 @@ export function LayoutWrapper({ children, baseOptions }: LayoutWrapperProps) {
   return (
     <>
       <ActiveNavHighlighter />
-      <CustomCountdownBanner /> 
+      {/* <CustomCountdownBanner /> */}
       <HomeLayout {...updatedOptions}>{children}</HomeLayout>
     </>
   );

--- a/components/blog/blog-list.tsx
+++ b/components/blog/blog-list.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback } from 'react';
 import Link from 'next/link';
 import { ArrowRight, X } from 'lucide-react';
 import { BlogSearch } from './blog-search';
+import { formatBlogDate } from '@/utils/formatBlogDate';
 
 interface BlogPost {
   url: string;
@@ -70,7 +71,7 @@ export function BlogList({ blogs }: BlogListProps) {
                     Latest
                   </span>
                   <time className="text-xs font-medium text-muted-foreground/70 uppercase tracking-wider">
-                    {new Date(filteredBlogs[0].data.date ?? filteredBlogs[0].url).toDateString()}
+                    {formatBlogDate(filteredBlogs[0].data.date)}
                   </time>
                 </div>
 
@@ -137,7 +138,7 @@ export function BlogList({ blogs }: BlogListProps) {
                 <div className="relative flex flex-col h-full p-6">
                   {/* Header */}
                   <time className="text-xs font-medium text-muted-foreground/70 uppercase tracking-wider mb-3">
-                    {new Date(post.data.date ?? post.url).toDateString()}
+                    {formatBlogDate(post.data.date)}
                   </time>
 
                   {/* Title */}

--- a/content/blog/helicon-upgrade.mdx
+++ b/content/blog/helicon-upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Helicon: Improved Staking Economics and Continuous Execution"
 description: The Avalanche Helicon upgrade activates six ACPs, bringing auto-renewed staking, a higher validator uptime requirement, shorter minimum staking durations, Continuous Execution for the C-Chain, a dynamic minimum gas price, and a recalibrated staking reward curve.
-date: 2026-07-16
+date: 2026-07-28
 authors: [AvaxDevelopers]
 topics: [Network Updates, Helicon Upgrade, Staking, P-Chain, C-Chain, ACP-236, ACP-267, ACP-273, ACP-194, ACP-283, ACP-285]
 comments: true

--- a/utils/formatBlogDate.ts
+++ b/utils/formatBlogDate.ts
@@ -1,0 +1,11 @@
+/**
+ * Formats a blog post date as "Mon Jul 28 2026".
+ * Parses the value in UTC to avoid timezone day-shift (e.g. YAML dates are
+ * UTC midnight, which would display as the previous day in negative-offset zones).
+ */
+export function formatBlogDate(raw: string | Date | undefined): string {
+  if (!raw) return '';
+  const d = raw instanceof Date ? raw : new Date(raw);
+  if (isNaN(d.getTime())) return '';
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), 12)).toDateString();
+}


### PR DESCRIPTION
Post-Fuji activation cleanup and a timezone bug fix on blog date rendering.

## Banner
- Comment out `<CustomCountdownBanner />` in layout-wrapper following the
  established pattern (import kept, JSX commented)

## Blog date timezone fix
- Blog dates (YAML `date: YYYY-MM-DD`) were parsed as UTC midnight and
  rendered via `toDateString()` in local time, showing the previous day
  in negative-offset timezones (e.g. CDT shows Jul 27 instead of Jul 28)
- Extracted `utils/formatBlogDate.ts`, parses UTC date parts via
  `Date.UTC(..., 12)` to anchor at noon UTC, safe for all timezones
- Applied to both `app/blog/[...slug]/page.tsx` and
  `components/blog/blog-list.tsx`
- Updated helicon-upgrade.mdx date to 2026-07-28 (merge date)
