### PR TITLE
docs: fix platform-cli install and build instructions

### DIFF
--- a/content/docs/tooling/platform-cli/installation.mdx
+++ b/content/docs/tooling/platform-cli/installation.mdx
@@ -18,10 +18,10 @@ Options:
 curl -sSfL https://build.avax.network/install/platform-cli | sh -s -- -b ~/.local/bin
 
 # Install a specific version
-curl -sSfL https://build.avax.network/install/platform-cli | sh -s -- -v v0.2.0
+curl -sSfL https://build.avax.network/install/platform-cli | sh -s -- -v v2.0.1
 ```
 
-The script auto-detects your OS (Linux/macOS) and architecture (amd64/arm64), downloads the release tarball, verifies checksums, and installs the `platform` binary.
+The script auto-detects your OS (Linux/macOS) and architecture (amd64/arm64), downloads the release tarball, verifies checksums, and installs the `platform-cli` binary.
 
 Verify the installation:
 
@@ -31,12 +31,12 @@ platform-cli --help
 
 ## Build from Source
 
-Requires **Go 1.24+** ([install Go](https://go.dev/dl/)).
+Requires **Go 1.25+** ([install Go](https://go.dev/dl/)).
 
 ```bash
 git clone https://github.com/ava-labs/platform-cli.git
 cd platform-cli
-go build -o platform .
+go build -o platform-cli .
 ```
 
 ### Ledger Support
@@ -44,7 +44,7 @@ go build -o platform .
 To build with Ledger hardware wallet support:
 
 ```bash
-go build -tags ledger -o platform .
+go build -tags ledger -o platform-cli .
 ```
 
 ## Global Flags

--- a/content/docs/tooling/platform-cli/key-management.mdx
+++ b/content/docs/tooling/platform-cli/key-management.mdx
@@ -125,7 +125,7 @@ The ewoq key is pre-funded on local networks. Platform CLI blocks its use on mai
 Build with Ledger support and use the `--ledger` flag:
 
 ```bash
-go build -tags ledger -o platform .
+go build -tags ledger -o platform-cli .
 
 # Use Ledger for any command
 platform-cli wallet address --ledger


### PR DESCRIPTION
Rescoped. The command renames I originally had here landed independently in #4304 and the ACP rebrand commits, so this now carries only what is still wrong on master.

## What is still wrong

`installation.mdx` and `key-management.mdx` still describe v1.x, so a reader who follows them ends up with a binary named `platform`, which has none of the v2 commands the rest of the docs now use:

- The install script is described as installing "the `platform` binary". `install.sh` sets `BINARY="platform-cli"`.
- `go build -o platform .` (twice) and `go build -tags ledger -o platform .` produce a binary whose name matches no documented command.
- "Requires **Go 1.24+**" where `go.mod` requires 1.25.12.
- The version-pin example is `-v v0.2.0`; the latest release is v2.0.1.

## Verification

Binary name confirmed from `.goreleaser.yaml` (`binary: platform-cli`) and `install.sh`, not from a local build. Go version from `go.mod`. Re-checked master after rescoping: 0 stale `platform <group>` invocations remain and every documented command resolves against the v2.0.1 command tree, so the only residue was these install and build instructions.
