### PR TITLE
fix(console): allow 12h Fuji validator stakes post-Helicon

### DIFF
--- a/components/toolbox/console/primary-network/Stake.tsx
+++ b/components/toolbox/console/primary-network/Stake.tsx
@@ -74,7 +74,10 @@ const SDK_SOURCES: SDKCodeSource[] = [
 const NETWORK_CONFIG = {
   fuji: {
     minStakeAvax: 1,
-    minEndSeconds: 24 * 60 * 60,
+    // ACP-273 lowered the primary network validator minimum to 12h on Fuji when
+    // Helicon activated (2026-07-28). Mainnet becomes 48h at its activation.
+    minEndSeconds: 12 * 60 * 60,
+    minEndLabel: '12 hours',
     defaultDays: 1,
     presets: [
       { label: '1 day', days: 1 },
@@ -85,6 +88,7 @@ const NETWORK_CONFIG = {
   mainnet: {
     minStakeAvax: 2000,
     minEndSeconds: 14 * 24 * 60 * 60,
+    minEndLabel: '2 weeks',
     defaultDays: 14,
     presets: [
       { label: '2 weeks', days: 14 },
@@ -193,7 +197,7 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
     if (!endTime) return 'End time is required';
     const endUnix = Math.floor(new Date(endTime).getTime() / 1000);
     const duration = endUnix - Math.floor(Date.now() / 1000);
-    if (duration < config.minEndSeconds) return `End time must be at least ${onFuji ? '24 hours' : '2 weeks'} from now`;
+    if (duration < config.minEndSeconds) return `End time must be at least ${config.minEndLabel} from now`;
     if (duration > MAX_END_SECONDS) return 'End time must be within 1 year';
 
     const fee = Number(delegationFee);
@@ -371,12 +375,12 @@ function Stake({ onSuccess }: BaseConsoleToolProps) {
                     value={endTime}
                     onChange={setEndTime}
                     type="datetime-local"
-                    helperText={`Min: ${onFuji ? '24 hours' : '2 weeks'} · Max: 1 year`}
+                    helperText={`Min: ${config.minEndLabel} · Max: 1 year`}
                     error={(() => {
                       if (!endTime || !error) return null;
                       const d = Math.floor(new Date(endTime).getTime() / 1000) - Math.floor(Date.now() / 1000);
                       if (d < config.minEndSeconds)
-                        return `Must be at least ${onFuji ? '24 hours' : '2 weeks'} from now`;
+                        return `Must be at least ${config.minEndLabel} from now`;
                       if (d > MAX_END_SECONDS) return 'Must be within 1 year';
                       return null;
                     })()}


### PR DESCRIPTION
The Stake tool rejects Fuji validator stakes that the chain accepts, as of this morning.

## The bug

ACP-273 lowered the primary network validator minimum staking duration to 12 hours on Fuji when Helicon activated at 2026-07-28 15:00 UTC. `NETWORK_CONFIG.fuji.minEndSeconds` was still `24 * 60 * 60`, so any duration between 12h and 24h fails validation with "End time must be at least 24 hours from now" even though the P-Chain would accept the transaction.

## What changed

- `fuji.minEndSeconds` to `12 * 60 * 60`.
- The "24 hours" / "2 weeks" copy was duplicated inline at three call sites, which is how it drifted out of sync with the threshold. It now comes from a `minEndLabel` on `NETWORK_CONFIG`, next to the number it describes.
- A comment records that Mainnet becomes 48 hours when Helicon activates there, so the next change is a one-line edit in an obvious place.

Mainnet is deliberately left at 14 days, since Helicon is not scheduled there yet. Delegators are unaffected by ACP-273 and this tool only issues `AddPermissionlessValidatorTx`, so no delegation path changes.

## Verification

Value taken from avalanchego `genesis/genesis_fuji.go` (`HeliconMinStakeDuration: 12 * time.Hour`) and the gate in `txs/executor/staker_tx_verification_helpers.go`, which swaps to the Helicon minimum for primary network validators once activated.

`tsc --noEmit` produces byte-identical output on this branch and on `master` (144 pre-existing errors from `prisma generate` not having run, 0 in `components/toolbox`), so this introduces no type errors.

## Not included

The console has no auto-renewed staking (ACP-236) option at all; `Stake.tsx` only issues `AddPermissionlessValidatorTx`. That is a feature rather than a regression, so it is out of scope here.
