### PR TITLE
fix(console): read P-Chain balance from the node, not the indexer

### DIFF
--- a/components/toolbox/services/balanceService.ts
+++ b/components/toolbox/services/balanceService.ts
@@ -1,4 +1,5 @@
 import { getPChainBalance, getNativeTokenBalance, getChains } from '../coreViem/utils/glacier';
+import { getPChainUnlockedNAvax } from '../utils/pChainNodeBalance';
 import { avalancheFuji, avalanche } from 'viem/chains';
 import { createPublicClient, http } from 'viem';
 
@@ -158,12 +159,28 @@ class BalanceService {
   }
 
   // P-Chain balance fetching
+  //
+  // The node is the source of truth. Glacier is only a fallback: its P-Chain
+  // indexer can stall (Fuji froze for ~24h on 2026-07-28), and a stale balance
+  // silently blocks users: the wizards gate on `pChainBalance > 0`, and the
+  // header is what a user checks before topping up.
   async fetchPChainBalance(isTestnet: boolean, pChainAddress: string): Promise<number> {
     if (!pChainAddress) return 0;
 
     try {
+      const unlocked = await getPChainUnlockedNAvax(isTestnet, pChainAddress);
+      return Number(unlocked) / 1e9;
+    } catch (nodeError) {
+      console.warn('P-Chain node balance failed, falling back to the indexer:', nodeError);
+    }
+
+    try {
       const network = isTestnet ? 'testnet' : 'mainnet';
       const response = await getPChainBalance(network, pChainAddress);
+      // `unlockedUnstaked` only. Deliberately NOT summing `atomicMemoryUnlocked`:
+      // funds sitting in shared memory need an ImportTx before the P-Chain can
+      // spend them, so counting them here would overstate what's spendable
+      // (this is exactly why Core's number reads high against the node's).
       return Number(response.balances.unlockedUnstaked[0]?.amount || 0) / 1e9;
     } catch (error) {
       console.error('Failed to fetch P-Chain balance:', error);

--- a/components/toolbox/utils/pChainNodeBalance.ts
+++ b/components/toolbox/utils/pChainNodeBalance.ts
@@ -1,0 +1,62 @@
+/**
+ * P-Chain balance straight from an AvalancheGo node.
+ *
+ * The indexed Data API (Glacier) is the wrong source of truth for a wallet
+ * balance: it can and does fall behind the chain. On 2026-07-28 the Fuji
+ * P-Chain indexer stalled for ~24h, so the console showed a balance that
+ * predated the user's last two imports while Core showed an atomic-memory
+ * entry that an ImportTx had already consumed. Neither number matched the
+ * node. `platform.getBalance` is authoritative and cheap, so read it first
+ * and treat the indexer as a fallback only.
+ */
+
+import { getPChainRpcUrl } from './avalancheEndpoints';
+
+/** platform.getBalance result: nAVAX as decimal strings. */
+interface PlatformGetBalanceResult {
+  balance: string;
+  unlocked: string;
+  lockedStakeable: string;
+  lockedNotStakeable: string;
+}
+
+/** The node rejects a bech32 address without its chain prefix. */
+function withPChainPrefix(address: string): string {
+  return address.includes('-') ? address : `P-${address}`;
+}
+
+/**
+ * Spendable (unlocked, unstaked) nAVAX for a P-Chain address.
+ *
+ * Returns `unlocked` rather than `balance`: `balance` includes stakeable-locked
+ * and platform-locked funds that can't pay a tx fee, which would let the UI
+ * green-light a transaction the node then rejects for insufficient funds.
+ *
+ * Throws on transport or RPC error so the caller can fall back.
+ */
+export async function getPChainUnlockedNAvax(isTestnet: boolean, pChainAddress: string): Promise<bigint> {
+  const response = await fetch(getPChainRpcUrl(isTestnet), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'platform.getBalance',
+      params: { addresses: [withPChainPrefix(pChainAddress)] },
+    }),
+    // A stale balance is worse than a missing one, so don't let a hung node
+    // hold the header's loading state open indefinitely.
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`platform.getBalance failed: ${response.status} ${response.statusText}`);
+  }
+
+  const json = (await response.json()) as { result?: PlatformGetBalanceResult; error?: { message?: string } };
+  if (json.error || !json.result?.unlocked) {
+    throw new Error(`platform.getBalance error: ${json.error?.message ?? 'no result'}`);
+  }
+
+  return BigInt(json.result.unlocked);
+}


### PR DESCRIPTION
## What

The console header read P-Chain balance from Glacier's `balances.unlockedUnstaked`. Glacier's Fuji P-Chain indexer stalled at block 290391 (`2026-07-28 15:36:51 UTC`) while the node was at 290626, so the header showed a ~24h stale number.

`fetchPChainBalance` now calls `platform.getBalance` on the node first and falls back to Glacier only if that fails.

Two deliberate choices:

- Returns the node's `unlocked`, not `balance`. `balance` includes stakeable-locked and platform-locked funds that can't pay a fee, which would let a wizard green-light a tx the node then rejects.
- The Glacier fallback still ignores `atomicMemoryUnlocked`. Shared-memory funds need an ImportTx before P-Chain can spend them, so summing them overstates what's spendable.

## Verification

A user-reported Fuji wallet, `P-fuji13d4qjrqqx6g5xc7f0u4tv974dwdkdjun0frxlj`:

| Source | Shows |
|---|---|
| Node `platform.getBalance` (truth) | 1.701900018 |
| Console before this change | 1.203127225 |
| Core Wallet | 2.202127224 |

The console was missing two not-yet-indexed UTXOs (0.4988 AVAX). Core reads the same stale index and additionally counts an atomic-memory entry that an ImportTx had already consumed (node reports 0 pending imports from both C and X).

- New path returns `1.701900018` for both the store's `P-fuji1…` form and the bare `fuji1…` form. The node rejects unprefixed addresses, hence `withPChainPrefix`.
- `tsc --noEmit` clean, `eslint --max-warnings 0` clean.
- `parsePChainError` tests pass (4/4).
- Checked the other P-Chain balance readers: `Validator-Balance-Topup` and `/api/faucet-balance` already use `platform.getBalance`. The console header was the last Glacier-backed one.

Indexer scope at time of writing: Fuji P-Chain stalled 24h, Fuji X-Chain 7.5h behind, Fuji C-Chain and mainnet P-Chain healthy.

## Not in scope

- Nothing in the console notices when Glacier falls behind the node. A staleness check on the header would have surfaced this in-product.
- The same report included a `-32603` failure broadcasting `CreateSubnetTx`. That comes from Core's `avalanche_sendTransaction`, not from our read path: the SDK routes all `prepareCreateSubnetTxn` preflight reads over HTTP to `api.avax-test.network` (its transport resolver drops a `custom` provider for chain-specific sub-clients), and all of those calls verified healthy. Tracking separately with the Core team.
