### PR TITLE
feat(explorer): P-Chain node validation history, address USD value, and a readability pass

### DIFF
--- a/app/api/pchain-validations/[network]/[nodeId]/route.ts
+++ b/app/api/pchain-validations/[network]/[nodeId]/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from "next/server";
+import { Avalanche } from "@avalanche-sdk/chainkit";
+import type { ValidationPeriod, ValidationsResponse } from "@/lib/pchain-explorer";
+
+/* Completed validation periods for a P-Chain node.
+ *
+ * The explorer's own node document already carries a `history` list, but it is
+ * an unfiltered feed of the node's recent staking txs capped at 100 rows
+ * upstream (no filter or limit param is honoured). On a popular validator all
+ * 100 of those rows are delegator additions, so the node's own past validation
+ * periods are pushed clean out of the payload. That is why the rebuilt node
+ * page lost the track record the old one showed.
+ *
+ * The Data API indexes the periods themselves, which is the shape a would-be
+ * delegator is actually reading: how long this node has been validating, and
+ * whether each term paid out. Note it does NOT retain per-period uptime, only
+ * the rewards that were paid. Since a term only pays when the node met the
+ * uptime requirement, the payout IS the performance record.
+ */
+
+export const dynamic = "force-dynamic";
+
+const FETCH_TIMEOUT_MS = 15_000;
+// A period is immutable once the term closes; the only change is a new row
+// appearing when the current term ends. Cache hard, revalidate in the
+// background, and spare the Data API the repeat traffic.
+const CACHE_CONTROL = "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400";
+// Enough to cover the longest-serving mainnet validators (1-year max terms
+// since genesis) without paginating.
+const PAGE_SIZE = 100;
+
+const NETWORKS = { mainnet: "mainnet", fuji: "fuji" } as const;
+type ExplorerNetwork = keyof typeof NETWORKS;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ network: string; nodeId: string }> },
+) {
+  const { network, nodeId } = await params;
+
+  if (!(network in NETWORKS)) {
+    return NextResponse.json({ error: `unknown network '${network}'` }, { status: 404 });
+  }
+  if (!nodeId.startsWith("NodeID-")) {
+    return NextResponse.json({ error: "expected a NodeID-… identifier" }, { status: 400 });
+  }
+
+  try {
+    const periods = await withTimeout(fetchPeriods(network as ExplorerNetwork, nodeId));
+    const body: ValidationsResponse = { nodeId, periods, totals: summarize(periods) };
+    return NextResponse.json(body, { headers: { "cache-control": CACHE_CONTROL } });
+  } catch (err) {
+    const timedOut = err instanceof Error && err.message === "timeout";
+    // No cache header on failure: a transient Data API blip must not be
+    // pinned at the edge for an hour.
+    return NextResponse.json(
+      { error: timedOut ? "data API timeout" : "data API unreachable" },
+      { status: 504 },
+    );
+  }
+}
+
+async function fetchPeriods(network: ExplorerNetwork, nodeId: string): Promise<ValidationPeriod[]> {
+  const avalanche = new Avalanche({ network: NETWORKS[network] });
+  const pages = await avalanche.data.primaryNetwork.getValidatorDetails({
+    nodeId,
+    validationStatus: "completed",
+    sortOrder: "desc",
+    pageSize: PAGE_SIZE,
+  });
+
+  const periods: ValidationPeriod[] = [];
+  for await (const page of pages) {
+    for (const v of page.result?.validators ?? []) {
+      // The union also covers active/pending/removed shapes; only completed
+      // ones carry a settled `rewards` object.
+      if (!("rewards" in v) || v.validationStatus !== "completed") continue;
+      const validationReward = v.rewards?.validationRewardAmount ?? "0";
+      periods.push({
+        txHash: v.txHash,
+        startTimestamp: v.startTimestamp,
+        endTimestamp: v.endTimestamp,
+        amountStaked: v.amountStaked,
+        delegationFeePercent: Number(v.delegationFee ?? 0),
+        delegatorCount: v.delegatorCount,
+        amountDelegated: v.amountDelegated ?? "0",
+        validationReward,
+        delegationReward: v.rewards?.delegationRewardAmount ?? "0",
+        rewardTxHash: v.rewards?.rewardTxHash,
+        rewarded: toBig(validationReward) > 0n,
+      });
+    }
+    // One page is the whole record for every real validator; bail rather than
+    // walking the iterator into more Data API calls we have no use for.
+    break;
+  }
+  return periods;
+}
+
+function summarize(periods: ValidationPeriod[]): ValidationsResponse["totals"] {
+  // nAVAX totals over a multi-year validator exceed what a double holds
+  // exactly, so sum in BigInt and hand the caller strings.
+  let validation = 0n;
+  let delegation = 0n;
+  for (const p of periods) {
+    validation += toBig(p.validationReward);
+    delegation += toBig(p.delegationReward);
+  }
+  return {
+    periods: periods.length,
+    validationReward: validation.toString(),
+    delegationReward: delegation.toString(),
+    firstStart: periods.length ? Math.min(...periods.map((p) => p.startTimestamp)) : null,
+    unrewarded: periods.filter((p) => !p.rewarded).length,
+  };
+}
+
+/** Data API amounts are decimal strings, but treat a malformed one as zero
+ *  rather than letting BigInt() throw the whole response away. */
+function toBig(v: string | undefined): bigint {
+  if (!v || !/^\d+$/.test(v)) return 0n;
+  return BigInt(v);
+}
+
+function withTimeout<T>(p: Promise<T>): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, reject) => setTimeout(() => reject(new Error("timeout")), FETCH_TIMEOUT_MS)),
+  ]);
+}

--- a/components/explorer-v2/format.ts
+++ b/components/explorer-v2/format.ts
@@ -20,6 +20,22 @@ export function formatNumber(n: number | undefined): string {
   return n === undefined || n === null ? "—" : n.toLocaleString("en-US");
 }
 
+/** nAVAX + a USD/AVAX rate → "$1,234.56". Returns undefined when there is no
+ *  rate to apply, so callers can omit the line entirely rather than render a
+ *  confident "$0.00" for a price we simply do not have. */
+export function formatUsd(nAvax: string | number | undefined, avaxUsd: number | null): string | undefined {
+  if (!avaxUsd || avaxUsd <= 0 || nAvax === undefined || nAvax === null || nAvax === "") return undefined;
+  const usd = (Number(nAvax) / 1e9) * avaxUsd;
+  if (Number.isNaN(usd)) return undefined;
+  // An empty bucket needs no fiat gloss: "$0.00" under "0 AVAX / 0.0%" is
+  // three ways of saying nothing.
+  if (usd === 0) return undefined;
+  // Sub-cent holdings are common on P-Chain change UTXOs; "<$0.01" beats
+  // rounding them to nothing.
+  if (usd > 0 && usd < 0.01) return "<$0.01";
+  return `$${usd.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
 export function timeAgo(unixSecs: number | undefined): string {
   if (!unixSecs) return "—";
   const s = Math.floor(Date.now() / 1000 - unixSecs);

--- a/components/explorer-v2/pchain/PchainAddress.tsx
+++ b/components/explorer-v2/pchain/PchainAddress.tsx
@@ -68,38 +68,25 @@ interface MetricRow {
   lead?: boolean;
 }
 
-const TH = "px-5 py-2.5 font-mono text-[10px] font-normal uppercase tracking-[0.14em] text-zinc-400 md:px-6 dark:text-zinc-500";
-/* One vertical hairline, between the two columns: the value column stays
-   open to the board edge so the rules read as a table, not a set of boxes. */
-const RULE = "border-r border-zinc-200 dark:border-zinc-800";
-
 function MetricTable({ rows }: { rows: MetricRow[] }) {
+  /* Label at the left edge, figure at the right, one metric per row, the
+     rule carrying the eye between them. No column headers: on a two-column
+     key/value block "Metric" and "Value" are furniture, and the labels say
+     what they are. Right-aligning the figures is what closes the gap that
+     left-aligned values opened in a 1,390px table. */
   return (
-    <Board divide={false} className="overflow-x-auto">
-      <table className="w-full border-collapse text-left">
-        <thead>
-          <tr className="border-b border-zinc-200 dark:border-zinc-800">
-            <th scope="col" className={cn(TH, RULE, "w-[30%] md:w-[22%]")}>
-              Metric
-            </th>
-            <th scope="col" className={TH}>
-              Value
-            </th>
-          </tr>
-        </thead>
+    <Board divide={false}>
+      <table className="w-full border-collapse">
         <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
           {rows.map((r) => (
             <tr key={r.label}>
               <th
                 scope="row"
-                className={cn(
-                  RULE,
-                  "px-5 py-3 align-top font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-zinc-500 md:px-6 dark:text-zinc-400",
-                )}
+                className="px-5 py-3.5 text-left align-baseline font-mono text-[11px] font-medium uppercase tracking-[0.14em] whitespace-nowrap text-zinc-500 md:px-6 dark:text-zinc-400"
               >
                 {r.label}
               </th>
-              <td className="px-5 py-3 align-top md:px-6">
+              <td className="px-5 py-3.5 text-right align-baseline md:px-6">
                 <span
                   className={cn(
                     "block font-mono tabular-nums tracking-tight text-zinc-900 dark:text-zinc-50",
@@ -209,8 +196,11 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
       metricRows.push({
         label: "First funded",
         value: timeAgo(a.fundedBy.blockTimestamp),
+        // justify-end, not text-right: the cell's text alignment does not
+        // reach flex children, which is what left these two rows floating
+        // mid-row while every plain-text value sat flush right
         detail: (
-          <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="flex flex-wrap items-center justify-end gap-x-2 gap-y-1">
             {formatAvax(a.fundedBy.amount)}
             <span aria-hidden>·</span>
             <HashChip value={a.fundedBy.txHash} href={`${base}/tx/${a.fundedBy.txHash}`} len={16} />
@@ -221,7 +211,7 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
         metricRows.push({
           label: "Funded from",
           value: (
-            <span className="flex flex-col gap-1">
+            <span className="flex flex-col items-end gap-1">
               {a.fundedBy.funders.map((f) => (
                 <HashChip key={f} value={f} href={`${base}/address/${f}`} len={18} />
               ))}
@@ -307,9 +297,7 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
                 ) : undefined
               }
             />
-            {/* a single-type address needs no filter, and one chip reading
-                "All types" next to one reading "Export" is just furniture */}
-            {typeOptions.length > 2 && (
+            {txs.length > 0 && (
               <TypeFilterRail options={typeOptions} value={txType} onChange={setTxType} />
             )}
             {/* no internal scroll: the old max-height box clipped a half row
@@ -331,7 +319,7 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
                   >
                     <span className={`truncate font-mono text-[12px] ${idInk}`}>{truncate(t.txHash, 20)}</span>
                     <span className="justify-self-start">
-                      <TxTypePill type={t.txType.replace(/Tx$/, "")} />
+                      <TxTypePill type={t.txType} label={txTypeLabel(t.txType)} />
                     </span>
                     <div
                       className={`font-mono text-[11px] tabular-nums md:text-right ${

--- a/components/explorer-v2/pchain/PchainAddress.tsx
+++ b/components/explorer-v2/pchain/PchainAddress.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
 import {
@@ -8,8 +9,9 @@ import {
   DetailSkeleton,
   HashChip,
   SectionHeader,
-  SpecPlate,
-  SpecRow,
+  StatCell,
+  StatStrip,
+  SubjectHeadline,
   TxTypePill,
   idInk,
 } from "@/components/explorer-v2/ui";
@@ -18,10 +20,19 @@ import { useAvaxUsd, usePchainData } from "./hooks";
 import { NotFound } from "./PchainTx";
 import type { Address, AddressTxs } from "@/lib/pchain-explorer";
 
-/* Address view in the two-rail grammar the tx pages use: identity, balance
-   composition, and holdings on the left; the activity ledger on the right.
-   Long lists (txs, UTXOs) scroll inside their boards so no single section
-   can run the page off the sheet. */
+/* Address view: subject, then figures, then activity.
+ *
+ * The page opens on the address itself at headline weight, the way every
+ * other detail page opens on its tx hash / block / NodeID. The figures a
+ * visitor came for (what is here, what it is worth) sit in one strip
+ * directly under it, and the two long lists run full width below rather
+ * than in a short rail that leaves a half-page gutter.
+ *
+ * Balance composition is deliberately conditional: most P-Chain addresses
+ * are 100% unlocked, and for those the bar plus its three-row legend was
+ * restating the hero figure three times. It only earns its space when
+ * there is actually something locked or staked to split out.
+ */
 
 const BALANCE_TONES = {
   unlocked: "bg-[#A2AFB2]",
@@ -29,168 +40,169 @@ const BALANCE_TONES = {
   staked: "bg-[#E6212F]",
 } as const;
 
+/* How many UTXO rows to mount before the reader asks for more. The API
+   returns up to 1,000, and a 4,000-UTXO exchange address was mounting all
+   of them into a box that shows eight. */
+const UTXO_PAGE = 50;
+
+/* The strip's figure type, matching the shared StatFigure scale (which we
+   can't use directly: it count-up animates a Number and would round AVAX
+   to whole units). */
+function Figure({ value, unit }: { value: string; unit?: string }) {
+  return (
+    <span className="font-mono text-xl tabular-nums tracking-tight text-zinc-900 sm:text-2xl md:text-[1.75rem] dark:text-zinc-50">
+      {value}
+      {unit && <span className="ml-1.5 text-sm text-zinc-400 dark:text-zinc-500">{unit}</span>}
+    </span>
+  );
+}
+
 export function PchainAddress({ chain, network, addr }: { chain: string; network: string; addr: string }) {
   const base = `/explorer/${network}/${chain}`;
   const { data: a, loading, error } = usePchainData<Address>(network, `address/${addr}`);
   const { data: history } = usePchainData<AddressTxs>(network, `address/${addr}/txs`, { limit: 50 });
   // mainnet only: Fuji AVAX has no market value to quote
   const avaxUsd = useAvaxUsd(network === "mainnet");
+  const [utxoLimit, setUtxoLimit] = useState(UTXO_PAGE);
 
   const totalRaw = a ? Number(a.balance.total) : 0;
+  const lockedRaw = a ? Number(a.balance.locked) : 0;
+  const stakedRaw = a ? Number(a.balance.staked) : 0;
+  // the bar and legend only mean something when the balance actually splits
+  const isSplit = lockedRaw > 0 || stakedRaw > 0;
   const composition = a
     ? ([
         { key: "unlocked" as const, label: "Unlocked", raw: Number(a.balance.unlocked) },
-        { key: "locked" as const, label: "Locked", raw: Number(a.balance.locked) },
-        { key: "staked" as const, label: "Staked", raw: Number(a.balance.staked) },
+        { key: "locked" as const, label: "Locked", raw: lockedRaw },
+        { key: "staked" as const, label: "Staked", raw: stakedRaw },
       ] as const)
     : [];
+  const usd = a ? formatUsd(a.balance.total, avaxUsd) : undefined;
 
   return (
     <ExplorerShell chain={chain} network={network}>
       {loading && <DetailSkeleton label="Address" />}
       {error && <NotFound label="Address not found" id={addr} />}
       {a && (
-        <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-[1fr_1.45fr]">
-          {/* ---------------- left rail: who this address is ---------------- */}
-          <div className="flex flex-col gap-10">
-            {/* identity + provenance in one plate — the old page spent a full
-                section of whitespace on "first funded by" alone */}
-            <section className="flex flex-col gap-4">
-              <SectionHeader label="Address" />
-              <Board divide={false} className="px-5 py-4 md:px-6">
-                <SpecPlate>
-                  <SpecRow label="Address">
-                    <HashChip value={a.address} len={26} />
-                  </SpecRow>
-                  <SpecRow label="Unspent UTXOs">{formatNumber(a.utxoCount)}</SpecRow>
-                  {a.fundedBy && (
-                    <>
-                      <SpecRow label="First funded">
-                        {formatAvax(a.fundedBy.amount)} · {timeAgo(a.fundedBy.blockTimestamp)}
-                      </SpecRow>
-                      <SpecRow label="Funding tx">
-                        <HashChip value={a.fundedBy.txHash} href={`${base}/tx/${a.fundedBy.txHash}`} len={16} />
-                      </SpecRow>
-                      {a.fundedBy.funders.length > 0 && (
-                        <SpecRow label="Funded from" align="start">
-                          <span className="flex flex-col items-end gap-1">
-                            {a.fundedBy.funders.map((f) => (
-                              <HashChip key={f} value={f} href={`${base}/address/${f}`} len={16} />
-                            ))}
-                          </span>
-                        </SpecRow>
-                      )}
-                    </>
-                  )}
-                </SpecPlate>
-              </Board>
-            </section>
+        <div className="flex flex-col gap-10">
+          {/* ---------------- the subject ---------------- */}
+          <section className="flex flex-col gap-4">
+            <SectionHeader label="Address" />
+            <SubjectHeadline value={a.address} copyLabel="Copy address" />
+          </section>
 
-            {/* balance — one hero figure, then the composition bar shows at a
-                glance where the AVAX sits (red = staked, at work) */}
+          {/* ---------------- the ledger strip ---------------- */}
+          <StatStrip cols={usd ? 4 : 3}>
+            <StatCell
+              label="Balance"
+              sub={
+                // lead with whatever is at work rather than with the unlocked
+                // share: on a validator's payout address that reads "0.0%
+                // unlocked", which is true and tells the reader nothing
+                stakedRaw > 0
+                  ? `${((stakedRaw / totalRaw) * 100).toFixed(1)}% staked`
+                  : lockedRaw > 0
+                    ? `${((lockedRaw / totalRaw) * 100).toFixed(1)}% locked`
+                    : "all unlocked"
+              }
+            >
+              <Figure value={formatAvax(a.balance.total, { symbol: false })} unit="AVAX" />
+            </StatCell>
+            {usd && (
+              <StatCell label="In USD" sub={`at $${avaxUsd?.toFixed(2)}/AVAX`}>
+                <Figure value={usd} />
+              </StatCell>
+            )}
+            <StatCell
+              label="Unspent UTXOs"
+              sub={
+                // the API returns the newest 1,000; say so rather than
+                // letting the list quietly disagree with the count
+                a.utxos.length < a.utxoCount
+                  ? `${formatNumber(a.utxos.length)} newest indexed`
+                  : undefined
+              }
+            >
+              <Figure value={formatNumber(a.utxoCount)} />
+            </StatCell>
+            <StatCell
+              label="First funded"
+              sub={a.fundedBy ? `${formatAvax(a.fundedBy.amount)} · view tx` : undefined}
+              href={a.fundedBy ? `${base}/tx/${a.fundedBy.txHash}` : undefined}
+            >
+              {a.fundedBy ? (
+                <Figure value={timeAgo(a.fundedBy.blockTimestamp).replace(" ago", "")} unit="ago" />
+              ) : (
+                <Figure value="—" />
+              )}
+            </StatCell>
+          </StatStrip>
+
+          {/* provenance as one hairline line, not the five-row plate it was:
+              the funders matter for tracing, but not at plate weight */}
+          {a.fundedBy && a.fundedBy.funders.length > 0 && (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 font-mono text-[11px] text-zinc-400 dark:text-zinc-500">
+              <span className="uppercase tracking-[0.16em]">Funded from</span>
+              {a.fundedBy.funders.map((f) => (
+                <HashChip key={f} value={f} href={`${base}/address/${f}`} len={20} />
+              ))}
+            </div>
+          )}
+
+          {/* balance composition, only when there is a split to show */}
+          {isSplit && (
             <section className="flex flex-col gap-4">
-              <SectionHeader label="Balance" />
+              <SectionHeader label="Balance composition" />
               <Board divide={false} className="flex flex-col gap-5 px-5 py-5 md:px-6">
-                <div className="flex flex-col gap-1">
-                  <div className="flex flex-wrap items-baseline gap-2">
-                    <span className="font-mono text-3xl tabular-nums tracking-tight text-zinc-900 md:text-[2.25rem] dark:text-zinc-50">
-                      {formatAvax(a.balance.total, { symbol: false })}
-                    </span>
-                    <span className="font-mono text-sm text-zinc-400 dark:text-zinc-500">AVAX</span>
-                  </div>
-                  {/* the fiat line rides under the hero figure, never replaces
-                      it: AVAX is the ledger unit, USD is the gloss */}
-                  {formatUsd(a.balance.total, avaxUsd) && (
-                    <span className="font-mono text-[13px] tabular-nums text-zinc-500 dark:text-zinc-400">
-                      {formatUsd(a.balance.total, avaxUsd)}
-                      <span className="ml-2 text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-                        at ${avaxUsd?.toFixed(2)}/AVAX
-                      </span>
-                    </span>
-                  )}
+                <div className="flex h-2 w-full overflow-hidden" aria-hidden>
+                  {composition
+                    .filter((p) => p.raw > 0)
+                    .map((p) => (
+                      <span
+                        key={p.key}
+                        className={BALANCE_TONES[p.key]}
+                        style={{ width: `${(p.raw / totalRaw) * 100}%` }}
+                      />
+                    ))}
                 </div>
-                {totalRaw > 0 && (
-                  <div className="flex h-2 w-full overflow-hidden" aria-hidden>
-                    {composition
-                      .filter((p) => p.raw > 0)
-                      .map((p) => (
-                        <span
-                          key={p.key}
-                          className={BALANCE_TONES[p.key]}
-                          style={{ width: `${(p.raw / totalRaw) * 100}%` }}
-                        />
-                      ))}
-                  </div>
-                )}
                 <dl className="divide-y divide-zinc-200 dark:divide-zinc-800">
-                  {composition.map((p) => (
-                    <div key={p.key} className="flex items-baseline justify-between gap-6 py-2.5">
-                      <dt className="flex items-center gap-2 font-mono text-[10px] font-medium uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
-                        <span className={`h-2 w-2 shrink-0 ${BALANCE_TONES[p.key]}`} aria-hidden />
-                        {p.label}
-                      </dt>
-                      <dd className="flex items-baseline gap-3 text-[13.5px] font-medium tabular-nums text-zinc-900 dark:text-zinc-50">
-                        <span className="flex flex-col items-end">
-                          {formatAvax(p.raw)}
-                          {formatUsd(p.raw, avaxUsd) && (
-                            <span className="font-mono text-[10px] tabular-nums text-zinc-400 dark:text-zinc-500">
-                              {formatUsd(p.raw, avaxUsd)}
-                            </span>
-                          )}
-                        </span>
-                        <span className="font-mono text-[10px] tabular-nums text-zinc-400 dark:text-zinc-500">
-                          {totalRaw > 0 ? `${((p.raw / totalRaw) * 100).toFixed(1)}%` : "—"}
-                        </span>
-                      </dd>
-                    </div>
-                  ))}
+                  {composition
+                    .filter((p) => p.raw > 0)
+                    .map((p) => (
+                      <div key={p.key} className="flex items-baseline justify-between gap-6 py-2.5">
+                        <dt className="flex items-center gap-2 font-mono text-[10px] font-medium uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
+                          <span className={`h-2 w-2 shrink-0 ${BALANCE_TONES[p.key]}`} aria-hidden />
+                          {p.label}
+                        </dt>
+                        <dd className="flex items-baseline gap-3 text-[13.5px] font-medium tabular-nums text-zinc-900 dark:text-zinc-50">
+                          <span className="flex flex-col items-end">
+                            {formatAvax(p.raw)}
+                            {formatUsd(p.raw, avaxUsd) && (
+                              <span className="font-mono text-[10px] tabular-nums text-zinc-400 dark:text-zinc-500">
+                                {formatUsd(p.raw, avaxUsd)}
+                              </span>
+                            )}
+                          </span>
+                          <span className="w-12 text-right font-mono text-[10px] tabular-nums text-zinc-400 dark:text-zinc-500">
+                            {((p.raw / totalRaw) * 100).toFixed(1)}%
+                          </span>
+                        </dd>
+                      </div>
+                    ))}
                 </dl>
               </Board>
             </section>
+          )}
 
-            {/* Unspent UTXOs — scrolls in place past ~8 rows */}
-            <section className="flex flex-col gap-4">
-              <SectionHeader label={`Unspent UTXOs · ${formatNumber(a.utxoCount)}`} />
-              <Board className="max-h-[21rem] overflow-y-auto">
-                {a.utxos.map((u, i) => (
-                  <div key={`${u.utxoId}-${i}`} className="flex items-center justify-between gap-4 px-5 py-3 md:px-6">
-                    <div className="flex min-w-0 items-center gap-3">
-                      <span className="font-mono text-[12px] tabular-nums text-zinc-900 dark:text-zinc-100">
-                        {formatAvax(u.amount)}
-                      </span>
-                      <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-zinc-400 dark:text-zinc-500">
-                        {u.utxoKind}
-                      </span>
-                      {u.staked && (
-                        <span className="border border-[#E6212F]/40 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.1em] text-[#E6212F]">
-                          staked
-                        </span>
-                      )}
-                    </div>
-                    <Link
-                      href={`${base}/block/${u.blockNumber}`}
-                      className="shrink-0 font-mono text-[11px] tabular-nums text-[#0061E2] hover:text-[#E6212F] dark:text-[#5f9dff]"
-                    >
-                      #{formatNumber(Number(u.blockNumber))}
-                    </Link>
-                  </div>
-                ))}
-                {a.utxos.length === 0 && (
-                  <div className="px-5 py-5 font-mono text-[11px] text-zinc-400 md:px-6 dark:text-zinc-500">
-                    no unspent UTXOs
-                  </div>
-                )}
-              </Board>
-            </section>
-          </div>
-
-          {/* ---------------- right rail: what it has done ---------------- */}
+          {/* ---------------- activity, full width ---------------- */}
           <section className="flex flex-col gap-4">
             <SectionHeader
               label={`Transactions${history ? ` · ${history.txs.length}${history.truncated ? "+" : ""}` : ""}`}
             />
-            <Board className="max-h-[52rem] overflow-y-auto">
-              <div className="sticky top-0 z-10 hidden grid-cols-[2fr_1.2fr_1fr_0.7fr] gap-4 bg-white px-5 py-2.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 md:grid md:px-6 dark:bg-zinc-950 dark:text-zinc-500">
+            {/* no internal scroll: the old max-height box clipped a half row
+                at its top edge under the sticky header, which read as broken */}
+            <Board>
+              <div className="hidden grid-cols-[2.2fr_1fr_1fr_0.8fr] gap-4 px-5 py-2.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 md:grid md:px-6 dark:text-zinc-500">
                 <span>Hash</span>
                 <span>Type</span>
                 <span className="text-right">Net</span>
@@ -202,11 +214,9 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
                   <Link
                     key={t.txHash}
                     href={`${base}/tx/${t.txHash}`}
-                    className="grid grid-cols-2 gap-x-4 gap-y-1 px-5 py-3 transition-colors hover:bg-zinc-50 md:grid-cols-[2fr_1.2fr_1fr_0.7fr] md:items-center md:px-6 dark:hover:bg-zinc-900"
+                    className="grid grid-cols-2 gap-x-4 gap-y-1 px-5 py-3 transition-colors hover:bg-zinc-50 md:grid-cols-[2.2fr_1fr_1fr_0.8fr] md:items-center md:px-6 dark:hover:bg-zinc-900"
                   >
-                    <span className={`truncate font-mono text-[12px] ${idInk}`}>
-                      {truncate(t.txHash, 16)}
-                    </span>
+                    <span className={`truncate font-mono text-[12px] ${idInk}`}>{truncate(t.txHash, 20)}</span>
                     <span className="justify-self-start">
                       <TxTypePill type={t.txType.replace(/Tx$/, "")} />
                     </span>
@@ -237,6 +247,67 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
                 <div className="px-5 py-5 font-mono text-[11px] text-zinc-400 md:px-6 dark:text-zinc-500">
                   no transactions
                 </div>
+              )}
+            </Board>
+          </section>
+
+          <section className="flex flex-col gap-4">
+            <SectionHeader
+              label={`Unspent UTXOs · ${formatNumber(a.utxoCount)}`}
+              action={
+                a.utxos.length > utxoLimit ? (
+                  <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                    showing {formatNumber(utxoLimit)} of {formatNumber(a.utxos.length)}
+                  </span>
+                ) : undefined
+              }
+            />
+            <Board>
+              <div className="hidden grid-cols-[1.4fr_1fr_1fr_0.8fr] gap-4 px-5 py-2.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 md:grid md:px-6 dark:text-zinc-500">
+                <span>Amount</span>
+                <span>Kind</span>
+                <span />
+                <span className="text-right">Block</span>
+              </div>
+              {a.utxos.slice(0, utxoLimit).map((u, i) => (
+                <div
+                  key={`${u.utxoId}-${i}`}
+                  className="grid grid-cols-2 gap-x-4 gap-y-1 px-5 py-3 md:grid-cols-[1.4fr_1fr_1fr_0.8fr] md:items-center md:px-6"
+                >
+                  <span className="font-mono text-[12px] tabular-nums text-zinc-900 dark:text-zinc-100">
+                    {formatAvax(u.amount)}
+                  </span>
+                  <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-zinc-400 dark:text-zinc-500">
+                    {u.utxoKind}
+                  </span>
+                  <span>
+                    {u.staked && (
+                      <span className="border border-[#E6212F]/40 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.1em] text-[#E6212F]">
+                        staked
+                      </span>
+                    )}
+                  </span>
+                  <Link
+                    href={`${base}/block/${u.blockNumber}`}
+                    className={`font-mono text-[11px] tabular-nums md:text-right ${idInk}`}
+                  >
+                    #{formatNumber(Number(u.blockNumber))}
+                  </Link>
+                </div>
+              ))}
+              {a.utxos.length === 0 && (
+                <div className="px-5 py-5 font-mono text-[11px] text-zinc-400 md:px-6 dark:text-zinc-500">
+                  no unspent UTXOs
+                </div>
+              )}
+              {a.utxos.length > utxoLimit && (
+                <button
+                  type="button"
+                  onClick={() => setUtxoLimit((n) => n + UTXO_PAGE * 4)}
+                  className="w-full px-5 py-3 text-left font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-500 transition-colors hover:bg-zinc-50 hover:text-zinc-900 md:px-6 dark:text-zinc-400 dark:hover:bg-zinc-900 dark:hover:text-zinc-100"
+                >
+                  Show more
+                </button>
               )}
             </Board>
           </section>

--- a/components/explorer-v2/pchain/PchainAddress.tsx
+++ b/components/explorer-v2/pchain/PchainAddress.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
 import {
@@ -11,13 +11,14 @@ import {
   SectionHeader,
   SubjectHeadline,
   TxTypePill,
+  TypeFilterRail,
   idInk,
 } from "@/components/explorer-v2/ui";
 import { cn } from "@/lib/utils";
 import { formatAvax, formatNumber, formatTime, formatUsd, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { useAvaxUsd, usePchainData } from "./hooks";
 import { NotFound } from "./PchainTx";
-import type { Address, AddressTxs } from "@/lib/pchain-explorer";
+import { txTypeLabel, type Address, type AddressTxs } from "@/lib/pchain-explorer";
 
 /* Address view: subject, then figures, then activity.
  *
@@ -44,23 +45,32 @@ const BALANCE_TONES = {
    of them into a box that shows eight. */
 const UTXO_PAGE = 50;
 
+/* Transaction paging. The type filter runs client-side because the address
+   txs endpoint ignores a `type` param (unlike the /txs list endpoint), so
+   the filter can only see what has been loaded, and the UI says so.
+   TX_MAX is the API's own ceiling: it clamps `limit` to 200. */
+const TX_PAGE = 50;
+const TX_MAX = 200;
+
 /* ---- the summary table ----------------------------------------------
-   A real table rather than a grid of stacked cells: one row per metric,
-   with the label, the figure, and its qualifier each in their own aligned
-   column. Balance keeps its prominence through type weight (`lead`)
-   instead of through layout. */
+   A real table rather than a grid of stacked cells: labels in their own
+   aligned column, figures in theirs. Two columns only. A third "detail"
+   column earned a header and a rule for what is only ever a short
+   qualifier, so the qualifier rides under its own figure instead.
+   Balance keeps its prominence through type weight (`lead`), not layout. */
 
 interface MetricRow {
   label: string;
   value: React.ReactNode;
+  /** muted qualifier under the figure: a share, a rate, a source */
   detail?: React.ReactNode;
   /** the page's headline figure, set larger and bolder than the rest */
   lead?: boolean;
 }
 
 const TH = "px-5 py-2.5 font-mono text-[10px] font-normal uppercase tracking-[0.14em] text-zinc-400 md:px-6 dark:text-zinc-500";
-/* Vertical hairlines only between columns, so the last cell stays open to
-   the board edge and the rules read as a table rather than a set of boxes. */
+/* One vertical hairline, between the two columns: the value column stays
+   open to the board edge so the rules read as a table, not a set of boxes. */
 const RULE = "border-r border-zinc-200 dark:border-zinc-800";
 
 function MetricTable({ rows }: { rows: MetricRow[] }) {
@@ -69,14 +79,11 @@ function MetricTable({ rows }: { rows: MetricRow[] }) {
       <table className="w-full border-collapse text-left">
         <thead>
           <tr className="border-b border-zinc-200 dark:border-zinc-800">
-            <th scope="col" className={cn(TH, RULE, "w-[26%]")}>
+            <th scope="col" className={cn(TH, RULE, "w-[30%] md:w-[22%]")}>
               Metric
             </th>
-            <th scope="col" className={cn(TH, RULE, "w-[34%]")}>
-              Value
-            </th>
             <th scope="col" className={TH}>
-              Detail
+              Value
             </th>
           </tr>
         </thead>
@@ -92,17 +99,20 @@ function MetricTable({ rows }: { rows: MetricRow[] }) {
               >
                 {r.label}
               </th>
-              <td
-                className={cn(
-                  RULE,
-                  "px-5 py-3 align-top font-mono tabular-nums tracking-tight text-zinc-900 md:px-6 dark:text-zinc-50",
-                  r.lead ? "text-lg font-bold md:text-xl" : "text-[13px]",
+              <td className="px-5 py-3 align-top md:px-6">
+                <span
+                  className={cn(
+                    "block font-mono tabular-nums tracking-tight text-zinc-900 dark:text-zinc-50",
+                    r.lead ? "text-lg font-bold md:text-xl" : "text-[13px]",
+                  )}
+                >
+                  {r.value}
+                </span>
+                {r.detail != null && (
+                  <span className="mt-1 block font-mono text-[11px] tabular-nums text-zinc-400 dark:text-zinc-500">
+                    {r.detail}
+                  </span>
                 )}
-              >
-                {r.value}
-              </td>
-              <td className="px-5 py-3 align-top font-mono text-[11px] tabular-nums text-zinc-400 md:px-6 dark:text-zinc-500">
-                {r.detail}
               </td>
             </tr>
           ))}
@@ -115,10 +125,37 @@ function MetricTable({ rows }: { rows: MetricRow[] }) {
 export function PchainAddress({ chain, network, addr }: { chain: string; network: string; addr: string }) {
   const base = `/explorer/${network}/${chain}`;
   const { data: a, loading, error } = usePchainData<Address>(network, `address/${addr}`);
-  const { data: history } = usePchainData<AddressTxs>(network, `address/${addr}/txs`, { limit: 50 });
+  const [txLimit, setTxLimit] = useState(TX_PAGE);
+  const { data: history, loading: txsLoading } = usePchainData<AddressTxs>(
+    network,
+    `address/${addr}/txs`,
+    { limit: txLimit },
+  );
   // mainnet only: Fuji AVAX has no market value to quote
   const avaxUsd = useAvaxUsd(network === "mainnet");
   const [utxoLimit, setUtxoLimit] = useState(UTXO_PAGE);
+  const [txType, setTxType] = useState("");
+
+  const txs = history?.txs ?? [];
+
+  /* Filter options are derived from what this address has actually done,
+     not from the global list of P-Chain tx types. Offering "Create Chain"
+     on an exchange hot wallet that has only ever exported is a chip that
+     can only ever return nothing. Counts ride in the label. */
+  const typeOptions = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const t of txs) counts.set(t.txType, (counts.get(t.txType) ?? 0) + 1);
+    return [
+      { value: "", label: `All types ${txs.length}` },
+      ...[...counts.entries()]
+        .sort((x, y) => y[1] - x[1])
+        .map(([v, n]) => ({ value: v, label: `${txTypeLabel(v)} ${n}` })),
+    ];
+  }, [txs]);
+
+  const shownTxs = txType ? txs.filter((t) => t.txType === txType) : txs;
+  // more to fetch, and headroom under the API's 200-row ceiling
+  const canLoadMore = Boolean(history?.truncated) && txLimit < TX_MAX;
 
   const totalRaw = a ? Number(a.balance.total) : 0;
   const lockedRaw = a ? Number(a.balance.locked) : 0;
@@ -258,18 +295,33 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
           {/* ---------------- activity, full width ---------------- */}
           <section className="flex flex-col gap-4">
             <SectionHeader
-              label={`Transactions${history ? ` · ${history.txs.length}${history.truncated ? "+" : ""}` : ""}`}
+              label={`Transactions${history ? ` · ${shownTxs.length}${!txType && history.truncated ? "+" : ""}` : ""}`}
+              action={
+                txType ? (
+                  <button
+                    onClick={() => setTxType("")}
+                    className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 transition-colors hover:text-[#E6212F] dark:text-zinc-500"
+                  >
+                    Clear filter ✕
+                  </button>
+                ) : undefined
+              }
             />
+            {/* a single-type address needs no filter, and one chip reading
+                "All types" next to one reading "Export" is just furniture */}
+            {typeOptions.length > 2 && (
+              <TypeFilterRail options={typeOptions} value={txType} onChange={setTxType} />
+            )}
             {/* no internal scroll: the old max-height box clipped a half row
                 at its top edge under the sticky header, which read as broken */}
-            <Board>
+            <Board className={cn(txsLoading && txs.length > 0 && "opacity-60 transition-opacity")}>
               <div className="hidden grid-cols-[2.2fr_1fr_1fr_0.8fr] gap-4 px-5 py-2.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 md:grid md:px-6 dark:text-zinc-500">
                 <span>Hash</span>
                 <span>Type</span>
                 <span className="text-right">Net</span>
                 <span className="text-right">Age</span>
               </div>
-              {(history?.txs ?? []).map((t) => {
+              {shownTxs.map((t) => {
                 const net = Number(t.net);
                 return (
                   <Link
@@ -304,12 +356,33 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
                   </Link>
                 );
               })}
-              {history && history.txs.length === 0 && (
+              {history && shownTxs.length === 0 && (
                 <div className="px-5 py-5 font-mono text-[11px] text-zinc-400 md:px-6 dark:text-zinc-500">
-                  no transactions
+                  {txType
+                    ? `no ${txTypeLabel(txType)} transactions among the ${formatNumber(txs.length)} loaded`
+                    : "no transactions"}
                 </div>
               )}
             </Board>
+            {/* The filter is client-side, so "42 Export" means 42 of the rows
+                loaded so far, not of the address's whole history. Say that
+                plainly rather than letting a filtered count read as a total. */}
+            {history?.truncated && (
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+                {canLoadMore && (
+                  <button
+                    onClick={() => setTxLimit((n) => Math.min(TX_MAX, n + TX_PAGE))}
+                    className="border border-zinc-200 px-5 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-zinc-600 transition-colors hover:border-zinc-900 hover:text-zinc-900 dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-100 dark:hover:text-zinc-100"
+                  >
+                    Load more
+                  </button>
+                )}
+                <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                  {txType ? "filtering the" : "showing the"} newest {formatNumber(txs.length)}
+                  {!canLoadMore && ", the most this endpoint returns"}
+                </span>
+              </div>
+            )}
           </section>
 
           <section className="flex flex-col gap-4">

--- a/components/explorer-v2/pchain/PchainAddress.tsx
+++ b/components/explorer-v2/pchain/PchainAddress.tsx
@@ -9,12 +9,11 @@ import {
   DetailSkeleton,
   HashChip,
   SectionHeader,
-  StatCell,
-  StatStrip,
   SubjectHeadline,
   TxTypePill,
   idInk,
 } from "@/components/explorer-v2/ui";
+import { cn } from "@/lib/utils";
 import { formatAvax, formatNumber, formatTime, formatUsd, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { useAvaxUsd, usePchainData } from "./hooks";
 import { NotFound } from "./PchainTx";
@@ -45,15 +44,71 @@ const BALANCE_TONES = {
    of them into a box that shows eight. */
 const UTXO_PAGE = 50;
 
-/* The strip's figure type, matching the shared StatFigure scale (which we
-   can't use directly: it count-up animates a Number and would round AVAX
-   to whole units). */
-function Figure({ value, unit }: { value: string; unit?: string }) {
+/* ---- the summary table ----------------------------------------------
+   A real table rather than a grid of stacked cells: one row per metric,
+   with the label, the figure, and its qualifier each in their own aligned
+   column. Balance keeps its prominence through type weight (`lead`)
+   instead of through layout. */
+
+interface MetricRow {
+  label: string;
+  value: React.ReactNode;
+  detail?: React.ReactNode;
+  /** the page's headline figure, set larger and bolder than the rest */
+  lead?: boolean;
+}
+
+const TH = "px-5 py-2.5 font-mono text-[10px] font-normal uppercase tracking-[0.14em] text-zinc-400 md:px-6 dark:text-zinc-500";
+/* Vertical hairlines only between columns, so the last cell stays open to
+   the board edge and the rules read as a table rather than a set of boxes. */
+const RULE = "border-r border-zinc-200 dark:border-zinc-800";
+
+function MetricTable({ rows }: { rows: MetricRow[] }) {
   return (
-    <span className="font-mono text-xl tabular-nums tracking-tight text-zinc-900 sm:text-2xl md:text-[1.75rem] dark:text-zinc-50">
-      {value}
-      {unit && <span className="ml-1.5 text-sm text-zinc-400 dark:text-zinc-500">{unit}</span>}
-    </span>
+    <Board divide={false} className="overflow-x-auto">
+      <table className="w-full border-collapse text-left">
+        <thead>
+          <tr className="border-b border-zinc-200 dark:border-zinc-800">
+            <th scope="col" className={cn(TH, RULE, "w-[26%]")}>
+              Metric
+            </th>
+            <th scope="col" className={cn(TH, RULE, "w-[34%]")}>
+              Value
+            </th>
+            <th scope="col" className={TH}>
+              Detail
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+          {rows.map((r) => (
+            <tr key={r.label}>
+              <th
+                scope="row"
+                className={cn(
+                  RULE,
+                  "px-5 py-3 align-top font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-zinc-500 md:px-6 dark:text-zinc-400",
+                )}
+              >
+                {r.label}
+              </th>
+              <td
+                className={cn(
+                  RULE,
+                  "px-5 py-3 align-top font-mono tabular-nums tracking-tight text-zinc-900 md:px-6 dark:text-zinc-50",
+                  r.lead ? "text-lg font-bold md:text-xl" : "text-[13px]",
+                )}
+              >
+                {r.value}
+              </td>
+              <td className="px-5 py-3 align-top font-mono text-[11px] tabular-nums text-zinc-400 md:px-6 dark:text-zinc-500">
+                {r.detail}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Board>
   );
 }
 
@@ -79,6 +134,67 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
     : [];
   const usd = a ? formatUsd(a.balance.total, avaxUsd) : undefined;
 
+  // Rows are assembled rather than hand-written so the optional ones (USD off
+  // testnet, provenance on an address the indexer has no funding tx for) drop
+  // out without leaving an empty row behind.
+  const metricRows: MetricRow[] = [];
+  if (a) {
+    metricRows.push({
+      label: "Balance",
+      lead: true,
+      value: (
+        <>
+          {formatAvax(a.balance.total, { symbol: false })}
+          <span className="ml-1.5 text-sm font-normal text-zinc-400 dark:text-zinc-500">AVAX</span>
+        </>
+      ),
+      // lead with whatever is at work rather than with the unlocked share: on
+      // a validator's payout address that reads "0.0% unlocked", which is true
+      // and tells the reader nothing
+      detail:
+        stakedRaw > 0
+          ? `${((stakedRaw / totalRaw) * 100).toFixed(1)}% staked`
+          : lockedRaw > 0
+            ? `${((lockedRaw / totalRaw) * 100).toFixed(1)}% locked`
+            : "all unlocked",
+    });
+    if (usd) {
+      metricRows.push({ label: "In USD", value: usd, detail: `at $${avaxUsd?.toFixed(2)}/AVAX` });
+    }
+    metricRows.push({
+      label: "Unspent UTXOs",
+      value: formatNumber(a.utxoCount),
+      // the API returns the newest 1,000; say so rather than letting the list
+      // below quietly disagree with this count
+      detail: a.utxos.length < a.utxoCount ? `${formatNumber(a.utxos.length)} newest indexed` : undefined,
+    });
+    if (a.fundedBy) {
+      metricRows.push({
+        label: "First funded",
+        value: timeAgo(a.fundedBy.blockTimestamp),
+        detail: (
+          <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            {formatAvax(a.fundedBy.amount)}
+            <span aria-hidden>·</span>
+            <HashChip value={a.fundedBy.txHash} href={`${base}/tx/${a.fundedBy.txHash}`} len={16} />
+          </span>
+        ),
+      });
+      if (a.fundedBy.funders.length > 0) {
+        metricRows.push({
+          label: "Funded from",
+          value: (
+            <span className="flex flex-col gap-1">
+              {a.fundedBy.funders.map((f) => (
+                <HashChip key={f} value={f} href={`${base}/address/${f}`} len={18} />
+              ))}
+            </span>
+          ),
+        });
+      }
+    }
+  }
+
   return (
     <ExplorerShell chain={chain} network={network}>
       {loading && <DetailSkeleton label="Address" />}
@@ -91,63 +207,8 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
             <SubjectHeadline value={a.address} copyLabel="Copy address" />
           </section>
 
-          {/* ---------------- the ledger strip ---------------- */}
-          <StatStrip cols={usd ? 4 : 3}>
-            <StatCell
-              label="Balance"
-              sub={
-                // lead with whatever is at work rather than with the unlocked
-                // share: on a validator's payout address that reads "0.0%
-                // unlocked", which is true and tells the reader nothing
-                stakedRaw > 0
-                  ? `${((stakedRaw / totalRaw) * 100).toFixed(1)}% staked`
-                  : lockedRaw > 0
-                    ? `${((lockedRaw / totalRaw) * 100).toFixed(1)}% locked`
-                    : "all unlocked"
-              }
-            >
-              <Figure value={formatAvax(a.balance.total, { symbol: false })} unit="AVAX" />
-            </StatCell>
-            {usd && (
-              <StatCell label="In USD" sub={`at $${avaxUsd?.toFixed(2)}/AVAX`}>
-                <Figure value={usd} />
-              </StatCell>
-            )}
-            <StatCell
-              label="Unspent UTXOs"
-              sub={
-                // the API returns the newest 1,000; say so rather than
-                // letting the list quietly disagree with the count
-                a.utxos.length < a.utxoCount
-                  ? `${formatNumber(a.utxos.length)} newest indexed`
-                  : undefined
-              }
-            >
-              <Figure value={formatNumber(a.utxoCount)} />
-            </StatCell>
-            <StatCell
-              label="First funded"
-              sub={a.fundedBy ? `${formatAvax(a.fundedBy.amount)} · view tx` : undefined}
-              href={a.fundedBy ? `${base}/tx/${a.fundedBy.txHash}` : undefined}
-            >
-              {a.fundedBy ? (
-                <Figure value={timeAgo(a.fundedBy.blockTimestamp).replace(" ago", "")} unit="ago" />
-              ) : (
-                <Figure value="—" />
-              )}
-            </StatCell>
-          </StatStrip>
-
-          {/* provenance as one hairline line, not the five-row plate it was:
-              the funders matter for tracing, but not at plate weight */}
-          {a.fundedBy && a.fundedBy.funders.length > 0 && (
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 font-mono text-[11px] text-zinc-400 dark:text-zinc-500">
-              <span className="uppercase tracking-[0.16em]">Funded from</span>
-              {a.fundedBy.funders.map((f) => (
-                <HashChip key={f} value={f} href={`${base}/address/${f}`} len={20} />
-              ))}
-            </div>
-          )}
+          {/* ---------------- the summary table ---------------- */}
+          <MetricTable rows={metricRows} />
 
           {/* balance composition, only when there is a split to show */}
           {isSplit && (

--- a/components/explorer-v2/pchain/PchainAddress.tsx
+++ b/components/explorer-v2/pchain/PchainAddress.tsx
@@ -13,8 +13,8 @@ import {
   TxTypePill,
   idInk,
 } from "@/components/explorer-v2/ui";
-import { formatAvax, formatNumber, formatTime, timeAgo, truncate } from "@/components/explorer-v2/format";
-import { usePchainData } from "./hooks";
+import { formatAvax, formatNumber, formatTime, formatUsd, timeAgo, truncate } from "@/components/explorer-v2/format";
+import { useAvaxUsd, usePchainData } from "./hooks";
 import { NotFound } from "./PchainTx";
 import type { Address, AddressTxs } from "@/lib/pchain-explorer";
 
@@ -33,6 +33,8 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
   const base = `/explorer/${network}/${chain}`;
   const { data: a, loading, error } = usePchainData<Address>(network, `address/${addr}`);
   const { data: history } = usePchainData<AddressTxs>(network, `address/${addr}/txs`, { limit: 50 });
+  // mainnet only: Fuji AVAX has no market value to quote
+  const avaxUsd = useAvaxUsd(network === "mainnet");
 
   const totalRaw = a ? Number(a.balance.total) : 0;
   const composition = a
@@ -89,11 +91,23 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
             <section className="flex flex-col gap-4">
               <SectionHeader label="Balance" />
               <Board divide={false} className="flex flex-col gap-5 px-5 py-5 md:px-6">
-                <div className="flex flex-wrap items-baseline gap-2">
-                  <span className="font-mono text-3xl tabular-nums tracking-tight text-zinc-900 md:text-[2.25rem] dark:text-zinc-50">
-                    {formatAvax(a.balance.total, { symbol: false })}
-                  </span>
-                  <span className="font-mono text-sm text-zinc-400 dark:text-zinc-500">AVAX</span>
+                <div className="flex flex-col gap-1">
+                  <div className="flex flex-wrap items-baseline gap-2">
+                    <span className="font-mono text-3xl tabular-nums tracking-tight text-zinc-900 md:text-[2.25rem] dark:text-zinc-50">
+                      {formatAvax(a.balance.total, { symbol: false })}
+                    </span>
+                    <span className="font-mono text-sm text-zinc-400 dark:text-zinc-500">AVAX</span>
+                  </div>
+                  {/* the fiat line rides under the hero figure, never replaces
+                      it: AVAX is the ledger unit, USD is the gloss */}
+                  {formatUsd(a.balance.total, avaxUsd) && (
+                    <span className="font-mono text-[13px] tabular-nums text-zinc-500 dark:text-zinc-400">
+                      {formatUsd(a.balance.total, avaxUsd)}
+                      <span className="ml-2 text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                        at ${avaxUsd?.toFixed(2)}/AVAX
+                      </span>
+                    </span>
+                  )}
                 </div>
                 {totalRaw > 0 && (
                   <div className="flex h-2 w-full overflow-hidden" aria-hidden>
@@ -116,7 +130,14 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
                         {p.label}
                       </dt>
                       <dd className="flex items-baseline gap-3 text-[13.5px] font-medium tabular-nums text-zinc-900 dark:text-zinc-50">
-                        {formatAvax(p.raw)}
+                        <span className="flex flex-col items-end">
+                          {formatAvax(p.raw)}
+                          {formatUsd(p.raw, avaxUsd) && (
+                            <span className="font-mono text-[10px] tabular-nums text-zinc-400 dark:text-zinc-500">
+                              {formatUsd(p.raw, avaxUsd)}
+                            </span>
+                          )}
+                        </span>
                         <span className="font-mono text-[10px] tabular-nums text-zinc-400 dark:text-zinc-500">
                           {totalRaw > 0 ? `${((p.raw / totalRaw) * 100).toFixed(1)}%` : "—"}
                         </span>

--- a/components/explorer-v2/pchain/PchainBlock.tsx
+++ b/components/explorer-v2/pchain/PchainBlock.tsx
@@ -6,7 +6,7 @@ import { Board, DetailSkeleton, HashChip, SectionHeader, SpecPlate, SpecRow, Sub
 import { formatBytes, formatNumber, formatTime, timeAgo } from "@/components/explorer-v2/format";
 import { usePchainData } from "./hooks";
 import { NotFound } from "./PchainTx";
-import type { Block } from "@/lib/pchain-explorer";
+import { txTypeLabel, type Block } from "@/lib/pchain-explorer";
 
 export function PchainBlock({ chain, network, id }: { chain: string; network: string; id: string }) {
   const base = `/explorer/${network}/${chain}`;
@@ -69,7 +69,7 @@ export function PchainBlock({ chain, network, id }: { chain: string; network: st
                   <span className={`min-w-0 truncate font-mono text-[12px] ${idInk}`}>
                     {t.txHash}
                   </span>
-                  <TxTypePill type={t.txType.replace(/Tx$/, "")} />
+                  <TxTypePill type={t.txType} label={txTypeLabel(t.txType)} />
                 </Link>
               ))}
             </Board>

--- a/components/explorer-v2/pchain/PchainHome.tsx
+++ b/components/explorer-v2/pchain/PchainHome.tsx
@@ -31,7 +31,7 @@ import { formatAvax, formatNumber, timeAgo, truncate } from "@/components/explor
 import { usePchainData, LIVE_REFRESH_MS } from "./hooks";
 import { PRIMARY_SUBNET_ID } from "@/lib/pchain-node";
 import { useValidatorStats } from "@/components/explorer-v2/validator-stats";
-import type { Stats, TxSummary, BlockSummary } from "@/lib/pchain-explorer";
+import { txTypeLabel, type Stats, type TxSummary, type BlockSummary } from "@/lib/pchain-explorer";
 
 /* The /api/pchain-activity contract: staking money-flow, not tx counts.
    Rewards paid ride red (stake moving = the chain alive); stake about to
@@ -511,7 +511,7 @@ export function PchainHome({ chain, network }: { chain: string; network: string 
                       {truncate(t.txHash, 22)}
                     </span>
                     <span className="min-w-0 text-left">
-                      <TxTypePill type={t.txType.replace(/Tx$/, "")} />
+                      <TxTypePill type={t.txType} label={txTypeLabel(t.txType)} />
                     </span>
                     <span className="text-right font-mono text-[11px] tabular-nums text-zinc-500 dark:text-zinc-400">
                       {timeAgo(t.blockTimestamp)}

--- a/components/explorer-v2/pchain/PchainNode.tsx
+++ b/components/explorer-v2/pchain/PchainNode.tsx
@@ -34,7 +34,7 @@ import {
   getPrimaryTotalStake,
   type CurrentValidator,
 } from "@/lib/pchain-node";
-import type { NodeResponse, ValidationsResponse } from "@/lib/pchain-explorer";
+import { txTypeLabel, type NodeResponse, type ValidationsResponse } from "@/lib/pchain-explorer";
 
 /* The node page as one instrument, not an endless scroll: a bold summary
    strip, then two split views — what the validator IS (the spec plate)
@@ -364,37 +364,11 @@ export function PchainNode({
                     sub="gross minus the fee"
                   />
                 </div>
-                {/* where the validator's take comes from, as one bar */}
-                {stake.totalTake > 0 && (
-                  <div className="flex flex-col gap-2 border-t border-zinc-200 px-5 py-4 md:px-6 dark:border-zinc-800">
-                    <div className="flex h-2 w-full overflow-hidden">
-                      <div
-                        className="bg-zinc-900 dark:bg-zinc-100"
-                        style={{ width: `${(n.validator.potentialReward / stake.totalTake) * 100}%` }}
-                      />
-                      <div className="flex-1 bg-[#E6212F]" />
-                    </div>
-                    <div className="flex justify-between font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-                      <span>
-                        ■ own stake{" "}
-                        <span className="font-bold text-zinc-900 dark:text-zinc-100">
-                          {((n.validator.potentialReward / stake.totalTake) * 100).toFixed(1)}%
-                        </span>
-                      </span>
-                      <span>
-                        delegation fees{" "}
-                        <span className="font-bold text-[#E6212F]">
-                          {((stake.feeTake / stake.totalTake) * 100).toFixed(1)}%
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                )}
+                {/* No own-stake-vs-fees split bar here. On any validator whose
+                    own stake dominates it renders as a solid block reading
+                    "99.8% / 0.2%", which is arithmetic the two tiles above
+                    already state and not a number anyone acts on. */}
               </Board>
-              <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
-                Projected payouts at the end of the term, assuming the validator keeps meeting the
-                uptime requirement. Delegator rewards are shown gross; the fee comes out at payout.
-              </p>
             </section>
           )}
 
@@ -528,26 +502,36 @@ export function PchainNode({
                   ) : (
                     <p className="font-mono text-[11px] text-zinc-400 dark:text-zinc-500">Not enough samples</p>
                   )}
-                  {n.uptime.sampleCount > 0 && (
-                    <div className="grid grid-cols-5 gap-4">
-                      {[
-                        { l: "MIN", v: n.uptime.min },
-                        { l: "AVG", v: n.uptime.avg },
-                        { l: "P50", v: n.uptime.p50 },
-                        { l: "P95", v: n.uptime.p95 },
-                        { l: "MAX", v: n.uptime.max },
-                      ].map((s) => (
-                        <div key={s.l} className="flex flex-col gap-1">
-                          <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
-                            {s.l}
-                          </span>
-                          <span className="font-mono text-[13px] font-bold tabular-nums text-zinc-900 dark:text-zinc-100">
-                            {s.v.toFixed(1)}%
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
+                  {/* A five-across MIN/AVG/P50/P95/MAX strip is five copies of
+                      the same number on any healthy validator. Show the spread
+                      only when there is one; otherwise one figure says it. */}
+                  {n.uptime.sampleCount > 0 &&
+                    (n.uptime.max - n.uptime.min < 0.1 ? (
+                      <p className="font-mono text-[11px] text-zinc-400 dark:text-zinc-500">
+                        <span className="font-bold text-zinc-900 dark:text-zinc-100">
+                          {n.uptime.avg.toFixed(1)}%
+                        </span>{" "}
+                        flat across {formatNumber(n.uptime.sampleCount)} samples
+                      </p>
+                    ) : (
+                      <div className="grid grid-cols-4 gap-4">
+                        {[
+                          { l: "MIN", v: n.uptime.min },
+                          { l: "AVG", v: n.uptime.avg },
+                          { l: "P95", v: n.uptime.p95 },
+                          { l: "MAX", v: n.uptime.max },
+                        ].map((s) => (
+                          <div key={s.l} className="flex flex-col gap-1">
+                            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
+                              {s.l}
+                            </span>
+                            <span className="font-mono text-[13px] font-bold tabular-nums text-zinc-900 dark:text-zinc-100">
+                              {s.v.toFixed(1)}%
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    ))}
 
                   {/* block production, proposed vs missed */}
                   {blocksSeries.length > 1 && (
@@ -594,7 +578,10 @@ export function PchainNode({
                     </div>
                   )}
 
-                  {/* proposal timing: how often it lands its first slot */}
+                  {/* Proposal timing. A three-segment bar is worth drawing only
+                      when the node actually misses its first slot; at 99.9%
+                      slot 0 it is a solid block with a legend under it, so the
+                      healthy case gets one line instead. */}
                   {slots && (
                     <div className="flex flex-col gap-2 border-t border-zinc-200 pt-4 dark:border-zinc-800">
                       <div className="flex items-center justify-between">
@@ -602,31 +589,43 @@ export function PchainNode({
                           Proposal timing
                         </span>
                         <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-                          slot 0 <span className="font-bold text-zinc-900 dark:text-zinc-100">{((slots.slot0 / slots.total) * 100).toFixed(1)}%</span>
+                          slot 0{" "}
+                          <span className="font-bold text-zinc-900 dark:text-zinc-100">
+                            {((slots.slot0 / slots.total) * 100).toFixed(1)}%
+                          </span>
                         </span>
                       </div>
-                      <div className="flex h-2 w-full overflow-hidden">
-                        <div
-                          className="bg-zinc-900 dark:bg-zinc-100"
-                          style={{ width: `${(slots.slot0 / slots.total) * 100}%` }}
-                          title={`Slot 0 · ${formatNumber(slots.slot0)}`}
-                        />
-                        <div
-                          className="bg-[#A2AFB2]"
-                          style={{ width: `${(slots.slot1 / slots.total) * 100}%` }}
-                          title={`Slot 1 · ${formatNumber(slots.slot1)}`}
-                        />
-                        <div
-                          className="bg-[#E6212F]"
-                          style={{ width: `${(slots.slot2plus / slots.total) * 100}%` }}
-                          title={`Slot 2+ · ${formatNumber(slots.slot2plus)}`}
-                        />
-                      </div>
-                      <div className="flex gap-4 font-mono text-[9px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
-                        <span>■ slot 0 first try</span>
-                        <span>slot 1</span>
-                        <span className="text-[#E6212F]">slot 2+</span>
-                      </div>
+                      {slots.slot0 / slots.total < 0.95 ? (
+                        <>
+                          <div className="flex h-2 w-full overflow-hidden">
+                            <div
+                              className="bg-zinc-900 dark:bg-zinc-100"
+                              style={{ width: `${(slots.slot0 / slots.total) * 100}%` }}
+                              title={`Slot 0 · ${formatNumber(slots.slot0)}`}
+                            />
+                            <div
+                              className="bg-[#A2AFB2]"
+                              style={{ width: `${(slots.slot1 / slots.total) * 100}%` }}
+                              title={`Slot 1 · ${formatNumber(slots.slot1)}`}
+                            />
+                            <div
+                              className="bg-[#E6212F]"
+                              style={{ width: `${(slots.slot2plus / slots.total) * 100}%` }}
+                              title={`Slot 2+ · ${formatNumber(slots.slot2plus)}`}
+                            />
+                          </div>
+                          <div className="flex gap-4 font-mono text-[9px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                            <span>■ slot 0 first try</span>
+                            <span>slot 1</span>
+                            <span className="text-[#E6212F]">slot 2+</span>
+                          </div>
+                        </>
+                      ) : (
+                        <p className="font-mono text-[11px] text-zinc-400 dark:text-zinc-500">
+                          lands its first slot on {formatNumber(slots.slot0)} of{" "}
+                          {formatNumber(slots.total)} proposals
+                        </p>
+                      )}
                     </div>
                   )}
                 </Board>
@@ -723,7 +722,7 @@ export function PchainNode({
                         <span className={`truncate font-mono text-[12px] ${idInk}`}>
                           {truncate(h.txHash, 16)}
                         </span>
-                        <TxTypePill type={h.txType.replace(/Tx$/, "")} />
+                        <TxTypePill type={h.txType} label={txTypeLabel(h.txType)} />
                       </div>
                       <span className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-500 dark:text-zinc-400">
                         {timeAgo(h.blockTimestamp)}
@@ -780,7 +779,14 @@ function ValidationHistory({ data, base }: { data: ValidationsResponse; base: st
             </span>
           }
         />
-        <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
+        {/* Two tiles, not four. "Terms completed" restated the header chip and
+            the row count below it; "Delegations served" was the weakest figure
+            on the page. Both survivors say something the table does not.
+            (Also deliberately no "terms unrewarded" tile: across 200 sampled
+            mainnet terms from 2020 to 2026 the Data API has never returned a
+            completed term with a zero reward, so it would read 0 forever. The
+            count is in the header, on the only occasion it means anything.) */}
+        <div className="grid grid-cols-1 divide-y divide-zinc-200 sm:grid-cols-2 sm:divide-y-0 sm:divide-x dark:divide-zinc-800">
           <Tile
             label="Validating since"
             value={totals.firstStart ? formatTime(totals.firstStart).slice(0, 10) : "—"}
@@ -790,23 +796,12 @@ function ValidationHistory({ data, base }: { data: ValidationsResponse; base: st
                 : undefined
             }
           />
-          <Tile label="Terms completed" value={formatNumber(totals.periods)} />
           <Tile
             label="Rewards earned"
             value={formatAvax(lifetimeReward.toString(), { compact: true })}
             strong
             tone="good"
-            sub="own stake plus fee take"
-          />
-          {/* Deliberately not a "terms unrewarded" tile: across 200 sampled
-              mainnet terms from 2020 to 2026 the Data API has never returned a
-              completed term with a zero reward, so that figure would read 0
-              forever. The count is called out in the header instead, on the
-              only occasion it means anything. */}
-          <Tile
-            label="Delegations served"
-            value={formatNumber(delegationsServed)}
-            sub="across every term"
+            sub="own stake plus fee take, across every term"
           />
         </div>
         <div className="sticky top-0 z-10 hidden grid-cols-[1.5fr_0.6fr_1fr_0.8fr_1fr] gap-4 border-t border-zinc-200 bg-white px-5 py-2.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 md:grid md:px-6 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-500">
@@ -877,12 +872,6 @@ function ValidationHistory({ data, base }: { data: ValidationsResponse; base: st
           />
         )}
       </Board>
-      <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
-        Every staking term this node has completed, with the reward it was actually paid. A term pays
-        out only if the node met the uptime requirement over that term, so a paid term is a term the
-        node saw through. Per-term uptime itself is not retained once a term closes; the live figures
-        above cover the current one.
-      </p>
     </section>
   );
 }

--- a/components/explorer-v2/pchain/PchainNode.tsx
+++ b/components/explorer-v2/pchain/PchainNode.tsx
@@ -15,6 +15,7 @@ import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
 import {
   Board,
   BoardHeader,
+  CellLabel,
   DetailSkeleton,
   HashChip,
   SectionHeader,
@@ -33,7 +34,7 @@ import {
   getPrimaryTotalStake,
   type CurrentValidator,
 } from "@/lib/pchain-node";
-import type { NodeResponse } from "@/lib/pchain-explorer";
+import type { NodeResponse, ValidationsResponse } from "@/lib/pchain-explorer";
 
 /* The node page as one instrument, not an endless scroll: a bold summary
    strip, then two split views — what the validator IS (the spec plate)
@@ -64,6 +65,29 @@ function useP2PDetail(nodeId: string, enabled: boolean) {
       .catch(() => {});
     return () => controller.abort();
   }, [nodeId, enabled]);
+  return data;
+}
+
+/* --- the track record: past validation terms and what they paid --- */
+
+/* The node document's `history` cannot answer this. Upstream caps it at 100
+   recent staking txs and honours no filter, so on a validator with thousands
+   of delegators every row is a delegator addition and the node's own past
+   terms fall off the end. The Data API indexes the terms themselves. */
+function useValidationHistory(network: string, nodeId: string): ValidationsResponse | null {
+  const [data, setData] = useState<ValidationsResponse | null>(null);
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(`/api/pchain-validations/${network}/${encodeURIComponent(nodeId)}`, {
+      signal: controller.signal,
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: ValidationsResponse | null) => d?.periods && setData(d))
+      .catch(() => {
+        /* a node with no closed terms just doesn't get the section */
+      });
+    return () => controller.abort();
+  }, [network, nodeId]);
   return data;
 }
 
@@ -115,6 +139,9 @@ export function PchainNode({
   const p2p = useP2PDetail(nodeId, network === "mainnet" && Boolean(n?.hasSnapshot));
   // payout owners + BLS identity + the network-share denominator, live
   const { identity, networkStake } = useStakeContext(network, nodeId, Boolean(n?.hasSnapshot));
+  // past terms: asked for unconditionally, since the nodes where the track
+  // record matters most are the ones no longer in the current snapshot
+  const validations = useValidationHistory(network, nodeId);
 
   // the stake story, derived once: share of the network, delegation
   // headroom, the validator's total take, how far through the term it is
@@ -369,6 +396,14 @@ export function PchainNode({
                 uptime requirement. Delegator rewards are shown gross; the fee comes out at payout.
               </p>
             </section>
+          )}
+
+          {/* the track record, next to the projection above it: every closed
+              term and what it actually paid. This is the question a delegator
+              is really asking before committing stake, and the one the
+              rebuilt page had lost. */}
+          {validations && validations.periods.length > 0 && (
+            <ValidationHistory data={validations} base={base} />
           )}
 
           {/* split view: what it IS | how it's PERFORMING */}
@@ -673,7 +708,10 @@ export function PchainNode({
 
             {n.history.length > 0 && (
               <section className="flex min-w-0 flex-col gap-4">
-                <SectionHeader label={`History · ${n.history.length}`} />
+                {/* not the validation record (that's Past Validation Terms
+                    above): this is the raw recent staking-tx feed, which on a
+                    busy validator is all delegator additions */}
+                <SectionHeader label={`Recent staking activity · ${n.history.length}`} />
                 <Board>
                   {(showAllHistory ? n.history : n.history.slice(0, LIST_CAP)).map((h) => (
                     <Link
@@ -706,6 +744,146 @@ export function PchainNode({
         </div>
       )}
     </ExplorerShell>
+  );
+}
+
+/* Past validation terms: the node's track record.
+ *
+ * Deliberately shows rewards PAID rather than a historical uptime figure. The
+ * Data API keeps no per-period uptime, and inventing one would be worse than
+ * omitting it: a term only pays out when the node met the uptime requirement,
+ * so the payout already answers "did it do the job". An unrewarded term is
+ * called out in red, since that is the one row a delegator must not miss.
+ */
+function ValidationHistory({ data, base }: { data: ValidationsResponse; base: string }) {
+  const [showAll, setShowAll] = useState(false);
+  const { periods, totals } = data;
+  const lifetimeReward = BigInt(totals.validationReward) + BigInt(totals.delegationReward);
+  // delegations, not people: the same delegator re-staking across two terms
+  // counts twice, which is the honest reading of "how much work has this node
+  // taken on" rather than a unique-holder count the API can't give us
+  const delegationsServed = periods.reduce((s, p) => s + p.delegatorCount, 0);
+  const rows = showAll ? periods : periods.slice(0, LIST_CAP);
+
+  return (
+    <section className="flex flex-col gap-3">
+      <Board divide={false} className="border">
+        <BoardHeader
+          label="Past Validation Terms"
+          display
+          action={
+            <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+              {formatNumber(totals.periods)} completed
+              {totals.unrewarded > 0 && (
+                <span className="text-[#E6212F]"> · {formatNumber(totals.unrewarded)} unrewarded</span>
+              )}
+            </span>
+          }
+        />
+        <div className="grid grid-cols-2 divide-x divide-y divide-zinc-200 max-lg:[&>*:nth-child(odd)]:border-l-0 lg:grid-cols-4 lg:divide-y-0 dark:divide-zinc-800">
+          <Tile
+            label="Validating since"
+            value={totals.firstStart ? formatTime(totals.firstStart).slice(0, 10) : "—"}
+            sub={
+              totals.firstStart
+                ? `${formatNumber(Math.floor((Date.now() / 1000 - totals.firstStart) / 86400))} days on record`
+                : undefined
+            }
+          />
+          <Tile label="Terms completed" value={formatNumber(totals.periods)} />
+          <Tile
+            label="Rewards earned"
+            value={formatAvax(lifetimeReward.toString(), { compact: true })}
+            strong
+            tone="good"
+            sub="own stake plus fee take"
+          />
+          {/* Deliberately not a "terms unrewarded" tile: across 200 sampled
+              mainnet terms from 2020 to 2026 the Data API has never returned a
+              completed term with a zero reward, so that figure would read 0
+              forever. The count is called out in the header instead, on the
+              only occasion it means anything. */}
+          <Tile
+            label="Delegations served"
+            value={formatNumber(delegationsServed)}
+            sub="across every term"
+          />
+        </div>
+        <div className="sticky top-0 z-10 hidden grid-cols-[1.5fr_0.6fr_1fr_0.8fr_1fr] gap-4 border-t border-zinc-200 bg-white px-5 py-2.5 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 md:grid md:px-6 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-500">
+          <span>Term</span>
+          <span className="text-right">Days</span>
+          <span className="text-right">Stake</span>
+          <span className="text-right">Delegators</span>
+          <span className="text-right">Reward paid</span>
+        </div>
+        <div className="divide-y divide-zinc-200 border-t border-zinc-200 md:border-t-0 dark:divide-zinc-800 dark:border-zinc-800">
+          {rows.map((p) => {
+            const days = Math.round((p.endTimestamp - p.startTimestamp) / 86400);
+            const paid = BigInt(p.validationReward) + BigInt(p.delegationReward);
+            return (
+              <div
+                key={p.txHash}
+                className="grid grid-cols-2 gap-x-4 gap-y-1 px-5 py-3 md:grid-cols-[1.5fr_0.6fr_1fr_0.8fr_1fr] md:items-center md:px-6"
+              >
+                <div className="flex min-w-0 flex-col gap-0.5">
+                  <span className="font-mono text-[11.5px] tabular-nums text-zinc-900 dark:text-zinc-100">
+                    {formatTime(p.startTimestamp).slice(0, 10)} → {formatTime(p.endTimestamp).slice(0, 10)}
+                  </span>
+                  <span className="font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+                    ended {timeAgo(p.endTimestamp)}
+                  </span>
+                </div>
+                <div className="font-mono text-[11px] tabular-nums text-zinc-500 md:text-right dark:text-zinc-400">
+                  <CellLabel>Days</CellLabel>
+                  {formatNumber(days)}
+                </div>
+                <div className="font-mono text-[11px] tabular-nums text-zinc-900 md:text-right dark:text-zinc-100">
+                  <CellLabel>Stake</CellLabel>
+                  {formatAvax(p.amountStaked, { compact: true })}
+                </div>
+                <div className="font-mono text-[11px] tabular-nums text-zinc-500 md:text-right dark:text-zinc-400">
+                  <CellLabel>Delegators</CellLabel>
+                  {formatNumber(p.delegatorCount)}
+                </div>
+                <div className="font-mono text-[11px] tabular-nums md:text-right">
+                  <CellLabel>Reward paid</CellLabel>
+                  {p.rewarded ? (
+                    // the reward tx is the receipt; pre-Banff payouts have none
+                    p.rewardTxHash ? (
+                      <Link
+                        href={`${base}/tx/${p.rewardTxHash}`}
+                        className="text-emerald-600 hover:underline dark:text-emerald-400"
+                      >
+                        +{formatAvax(paid.toString(), { compact: true })}
+                      </Link>
+                    ) : (
+                      <span className="text-emerald-600 dark:text-emerald-400">
+                        +{formatAvax(paid.toString(), { compact: true })}
+                      </span>
+                    )
+                  ) : (
+                    <span className="text-[#E6212F]">no reward</span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        {periods.length > LIST_CAP && (
+          <ExpandRow
+            expanded={showAll}
+            count={periods.length - LIST_CAP}
+            onClick={() => setShowAll((v) => !v)}
+          />
+        )}
+      </Board>
+      <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+        Every staking term this node has completed, with the reward it was actually paid. A term pays
+        out only if the node met the uptime requirement over that term, so a paid term is a term the
+        node saw through. Per-term uptime itself is not retained once a term closes; the live figures
+        above cover the current one.
+      </p>
+    </section>
   );
 }
 

--- a/components/explorer-v2/pchain/PchainTxsList.tsx
+++ b/components/explorer-v2/pchain/PchainTxsList.tsx
@@ -7,23 +7,26 @@ import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
 import { Board, CellLabel, SectionHeader, TxTypePill, TypeFilterRail, idInk } from "@/components/explorer-v2/ui";
 import { formatNumber, timeAgo, truncate } from "@/components/explorer-v2/format";
 import { usePchainData, LIVE_REFRESH_MS } from "./hooks";
-import type { TxSummary } from "@/lib/pchain-explorer";
+import { txTypeLabel, type TxSummary } from "@/lib/pchain-explorer";
 
+/* Deliberate order (validator business first, plumbing last), with the
+   display names coming from the shared map so this rail and the one on the
+   address page can't drift apart. */
 const TYPE_OPTIONS: { value: string; label: string }[] = [
-  { value: "", label: "All types" },
-  { value: "AddPermissionlessValidatorTx", label: "Add Validator" },
-  { value: "AddPermissionlessDelegatorTx", label: "Add Delegator" },
-  { value: "RewardValidatorTx", label: "Reward" },
-  { value: "AddAutoRenewedValidatorTx", label: "Add Auto-Renew Validator" },
-  { value: "SetAutoRenewedValidatorConfigTx", label: "Auto-Renew Config" },
-  { value: "RewardAutoRenewedValidatorTx", label: "Auto-Renew Reward" },
-  { value: "ImportTx", label: "Import" },
-  { value: "ExportTx", label: "Export" },
-  { value: "BaseTx", label: "Transfer" },
-  { value: "CreateSubnetTx", label: "Create Subnet" },
-  { value: "CreateChainTx", label: "Create Chain" },
-  { value: "ConvertSubnetToL1Tx", label: "Convert to L1" },
-];
+  "",
+  "AddPermissionlessValidatorTx",
+  "AddPermissionlessDelegatorTx",
+  "RewardValidatorTx",
+  "AddAutoRenewedValidatorTx",
+  "SetAutoRenewedValidatorConfigTx",
+  "RewardAutoRenewedValidatorTx",
+  "ImportTx",
+  "ExportTx",
+  "BaseTx",
+  "CreateSubnetTx",
+  "CreateChainTx",
+  "ConvertSubnetToL1Tx",
+].map((value) => ({ value, label: value ? txTypeLabel(value) : "All types" }));
 
 export function PchainTxsList({ chain, network }: { chain: string; network: string }) {
   const base = `/explorer/${network}/${chain}`;

--- a/components/explorer-v2/pchain/PchainTxsList.tsx
+++ b/components/explorer-v2/pchain/PchainTxsList.tsx
@@ -80,7 +80,7 @@ export function PchainTxsList({ chain, network }: { chain: string; network: stri
                 {truncate(t.txHash, 16)}
               </span>
               <span className="justify-self-start">
-                <TxTypePill type={t.txType.replace(/Tx$/, "")} />
+                <TxTypePill type={t.txType} label={txTypeLabel(t.txType)} />
               </span>
               <div className="font-mono text-[11px] tabular-nums text-zinc-500 md:text-right dark:text-zinc-400">
                 <CellLabel>Block</CellLabel>

--- a/components/explorer-v2/pchain/hooks.ts
+++ b/components/explorer-v2/pchain/hooks.ts
@@ -19,6 +19,34 @@ export const LIVE_REFRESH_MS = 12_000;
  * a failed background poll keeps the last-good data on screen. Polling pauses
  * while the tab is hidden.
  */
+/**
+ * AVAX spot price in USD, for the fiat line on balance surfaces.
+ *
+ * Reuses `/api/avax-supply` (CoinGecko behind a 60s revalidate) rather than
+ * adding a second price path. Returns null until it lands and on any failure,
+ * so a dead price feed hides the USD line instead of printing "$0.00".
+ *
+ * Pass enabled=false on testnets: Fuji AVAX has no market value, and pricing
+ * it against mainnet AVAX would be actively misleading.
+ */
+export function useAvaxUsd(enabled: boolean): number | null {
+  const [price, setPrice] = useState<number | null>(null);
+  useEffect(() => {
+    if (!enabled) return;
+    const controller = new AbortController();
+    fetch("/api/avax-supply", { signal: controller.signal })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: { price?: number } | null) => {
+        if (typeof d?.price === "number" && d.price > 0) setPrice(d.price);
+      })
+      .catch(() => {
+        /* no price, no USD line */
+      });
+    return () => controller.abort();
+  }, [enabled]);
+  return price;
+}
+
 export function usePchainData<T>(
   network: string,
   resource: string,

--- a/components/explorer-v2/ui.tsx
+++ b/components/explorer-v2/ui.tsx
@@ -588,7 +588,20 @@ function pillTone(type: string): keyof typeof PILL_TONES {
   return "neutral";
 }
 
-export function TxTypePill({ type, className }: { type: string; className?: string }) {
+export function TxTypePill({
+  type,
+  label,
+  className,
+}: {
+  /** the raw type: what the tone is derived from */
+  type: string;
+  /** friendly display text; defaults to `type`. Kept separate because
+   *  `pillTone` matches on substrings of the raw type, so rendering a label
+   *  through `type` would silently retone some pills (a "Auto-Renew Config"
+   *  label loses the "validator" that puts it in the stake family). */
+  label?: string;
+  className?: string;
+}) {
   const tone = pillTone(type);
   return (
     <span
@@ -599,7 +612,7 @@ export function TxTypePill({ type, className }: { type: string; className?: stri
       )}
     >
       <span className="size-1 shrink-0 bg-current opacity-80" aria-hidden />
-      <span className="truncate">{type}</span>
+      <span className="truncate">{label ?? type}</span>
     </span>
   );
 }

--- a/lib/pchain-explorer.ts
+++ b/lib/pchain-explorer.ts
@@ -294,6 +294,37 @@ export interface Address {
   utxos: AddressUtxo[];
 }
 
+/* Display names for P-Chain tx types, shared by every surface that offers a
+   type filter so the chip on the list page and the chip on an address page
+   can't drift apart. Keys are the raw `txType` the API returns. */
+export const TX_TYPE_LABELS: Record<string, string> = {
+  AddPermissionlessValidatorTx: "Add Validator",
+  AddPermissionlessDelegatorTx: "Add Delegator",
+  AddValidatorTx: "Add Validator (legacy)",
+  AddDelegatorTx: "Add Delegator (legacy)",
+  AddSubnetValidatorTx: "Add Subnet Validator",
+  RemoveSubnetValidatorTx: "Remove Subnet Validator",
+  RewardValidatorTx: "Reward",
+  AddAutoRenewedValidatorTx: "Add Auto-Renew Validator",
+  SetAutoRenewedValidatorConfigTx: "Auto-Renew Config",
+  RewardAutoRenewedValidatorTx: "Auto-Renew Reward",
+  ImportTx: "Import",
+  ExportTx: "Export",
+  BaseTx: "Transfer",
+  CreateSubnetTx: "Create Subnet",
+  CreateChainTx: "Create Chain",
+  ConvertSubnetToL1Tx: "Convert to L1",
+  RegisterL1ValidatorTx: "Register L1 Validator",
+  SetL1ValidatorWeightTx: "Set L1 Validator Weight",
+  IncreaseL1ValidatorBalanceTx: "Increase L1 Balance",
+  DisableL1ValidatorTx: "Disable L1 Validator",
+};
+
+/** Display name for a tx type, falling back to the raw type minus its `Tx`. */
+export function txTypeLabel(txType: string): string {
+  return TX_TYPE_LABELS[txType] ?? txType.replace(/Tx$/, "");
+}
+
 export interface AddressTx {
   txHash: string;
   txType: string;

--- a/lib/pchain-explorer.ts
+++ b/lib/pchain-explorer.ts
@@ -368,6 +368,42 @@ export interface NodeResponse {
   nodeInfo?: { version: string; publicIp: string; benched: string[]; observedUptime: number };
 }
 
+/* Completed validation periods come from the Data API, not the explorer API
+   (whose node document caps `history` at 100 recent staking txs, which on a
+   busy validator are all delegator additions). Served by
+   app/api/pchain-validations/[network]/[nodeId]. */
+
+export interface ValidationPeriod {
+  txHash: string;
+  startTimestamp: number;
+  endTimestamp: number;
+  amountStaked: string;
+  delegationFeePercent: number;
+  delegatorCount: number;
+  amountDelegated: string;
+  /** nAVAX actually paid for the validator's own stake */
+  validationReward: string;
+  /** nAVAX actually paid out of the delegators' rewards as this node's fee */
+  delegationReward: string;
+  rewardTxHash?: string;
+  /** a term that closed without paying missed the uptime requirement */
+  rewarded: boolean;
+}
+
+export interface ValidationsResponse {
+  nodeId: string;
+  periods: ValidationPeriod[];
+  totals: {
+    periods: number;
+    validationReward: string;
+    delegationReward: string;
+    /** start of the earliest term on record: "validating since" */
+    firstStart: number | null;
+    /** terms that closed without a reward */
+    unrewarded: number;
+  };
+}
+
 export interface ValidatorSummary {
   nodeId: string;
   subnetId: string;


### PR DESCRIPTION
Four changes to the P-Chain explorer: two data gaps closed, two readability passes.

## 1. Past validation terms on node pages

The rebuilt node page lost the historical track record the old one showed. Not a UI regression: the explorer API's node document caps `history` at 100 recent staking txs and honours no filter or limit param (`limit`, `txType`, `kind`, `historyLimit` all ignored). On a validator with thousands of delegators all 100 rows are delegator additions, so the node's own past terms fall off the end of the payload.

Adds `app/api/pchain-validations/[network]/[nodeId]` against the Data API's `validationStatus=completed`, and a section listing each closed term with its dates, duration, stake, delegator count, and the reward actually paid, plus a "validating since" date and lifetime rewards.

Shows rewards paid rather than per-term uptime, because the Data API retains none once a term closes (`CompletedValidatorDetails` has no `uptimePerformance`, unlike the active shape). A term only pays out when the node met the uptime requirement, so the payout is the record.

## 2. USD value on address pages

Reuses the existing `/api/avax-supply` price feed rather than adding a second price path. Mainnet only: quoting Fuji AVAX against the mainnet price would be misleading. `formatUsd` returns `undefined` rather than a string when there is no price or the amount is zero, so a dead feed hides the line instead of printing `$0.00`.

## 3. Address page rebuild

The page had no visible subject: the address sat truncated at 12px inside a spec plate, while every other detail page opens on its subject at headline weight. The balance, the reason anyone opens the page, was below the fold under a five-row provenance plate.

Now: the address as a `SubjectHeadline`, a two-column summary table with labels left and figures right-aligned, provenance folded into it, and both long lists full width. Balance composition renders only when something is actually locked or staked, since most addresses are 100% unlocked and the bar plus its three-row legend was restating the hero figure three times.

Transactions get the type filter rail from the `/txs` page. Two differences, both forced by the API: the address txs endpoint ignores a `type` param, so the filter runs client-side over loaded rows, and it clamps `limit` to 200, so Load more stops there. Options are derived from the types this address has actually used, counts ride in each chip, and a line under the table says how many rows are being filtered.

Two fixes here are not cosmetic:

- the UTXO list mounted every row the API returned (1,000 for a 4,373-UTXO address) into a box showing eight. It now pages 50 at a time and discloses the 1,000 cap rather than letting the list silently disagree with the count.
- the transactions board dropped its internal max-height scroll, which clipped a half row at its top edge under the sticky header.

## 4. Node page redundancy pass, and readable tx pills

The node page had grown to state figures two and three times and to draw bars that only render as solid blocks. Cut: the own-stake vs delegation-fees split bar (arithmetic the tiles above already state), the MIN/AVG/P50/P95/MAX strip when the spread is under 0.1pp (five copies of one percentage), the proposal-timing bar above 95% slot 0, both explanatory paragraphs (each restating its own header chip), and two of the four Past Validation Terms tiles. The collapsed cases each become one line, and the bars return when a node is actually unhealthy.

Separately, tx pills across all five P-Chain surfaces rendered the raw type minus its `Tx`, uppercased, so `AddPermissionlessDelegatorTx` read `ADDPERMISSIONLESSDELEGATOR`. They now use a shared `TX_TYPE_LABELS` map. `TxTypePill` takes a new optional `label` prop rather than receiving nicer text through `type`, because `pillTone` derives the colour family from substrings of that same prop, so passing a label would silently retone some pills.

## Verification

- `tsc --noEmit` clean, enforced by the pre-commit hook on every commit
- Route tested live: mainnet 200 (10 terms for `NodeID-DaKj4jky…`, back to 2021-05-29), Fuji 200, unknown network 404, malformed NodeID 400, unknown node returns empty `periods` so the section self-hides
- Address page checked against three shapes: an all-unlocked exchange address (4,373 UTXOs, discloses the 1,000 cap, no composition section, 50 rows mounted instead of 1,000), a fully staked validator payout address (composition renders, reads "100.0% staked"), and a Fuji address (no USD row)
- Table alignment verified by measurement, not by eye: every value and detail line ends on a single pixel column
- Filter verified: chips derive from real types with counts, selecting one narrows 50 rows to 25, header and clear-filter update, Load more raises the count and the disclosure line follows
- Node page cleanup verified against 12 assertions on the rendered page; `/p-chain`, `/txs` and `/blocks` re-checked after the pill change. Zero console errors on every page

## Notes for review

- **No "terms unrewarded" tile on purpose.** Across 200 sampled mainnet terms from 2020 to 2026 the Data API never returns a completed term with a zero reward, so it would read 0 forever. Unrewarded early exits land in `validationStatus: "removed"`, which turns out to be subnet/L1 owner removals (non-primary `subnetId`s, weight not AVAX) rather than the uptime-failure case. The count surfaces in the section header only when nonzero, and the `rewarded: false` render path is defensive and untested because no such record appears to exist.
- **Possible overlap with an upstream fix.** The cleaner long-term fix for both API gaps is raising or filtering the explorer API's own caps. This works around them from the Data API and client side, so the two can coexist, but worth confirming nobody is building the same thing upstream before merge.

## Known, not fixed here

- Block type pills on `/blocks` have the same jamming problem (`BANFFCOMMIT`, `BANFFPROPOSAL`). Different enum, needs its own label map.
- The node page's uptime chart uses a `["dataMin", 100]` y-axis, which magnifies sub-0.1% variance into a visual cliff. Worth a look, though the chart reads the hourly P2P feed while the collapsed stats read the indexer snapshot, so the variance may be real.
- Per-term uptime history. Not retained anywhere readable; would need the explorer API to persist a snapshot per term.
