### PR TITLE
fix(quick-l1): fall back to canonical prod origin when BUILDER_HUB_URL is unset

### DIFF
--- a/app/api/quick-l1/deploy/route.ts
+++ b/app/api/quick-l1/deploy/route.ts
@@ -124,7 +124,14 @@ async function handlePost(
     // header (request.nextUrl.origin). On Vercel the Host header is forwarded
     // verbatim, so a request with a spoofed Host would leak the shared secret
     // to an attacker-controlled callback origin.
-    const builderHubUrl = process.env.BUILDER_HUB_URL;
+    //
+    // Production falls back to the canonical origin so a missing env var
+    // cannot 503 every prod deploy. Previews still require the env var:
+    // falling back to prod there would point their register-node callbacks
+    // at the wrong origin.
+    const builderHubUrl =
+      process.env.BUILDER_HUB_URL ??
+      (process.env.VERCEL_ENV === 'production' ? 'https://build.avax.network' : undefined);
     if (!builderHubUrl) {
       return NextResponse.json(
         { error: 'BUILDER_HUB_URL not configured on this server' },


### PR DESCRIPTION
## What changed
`/api/quick-l1/deploy` 503s with "BUILDER_HUB_URL not configured on this server" when the env var is missing. In production the route now falls back to `https://build.avax.network` (the same canonical origin quick-l1 pins as `PROD_BUILDER_HUB_URL`). Previews still require the env var explicitly, so their register-node callbacks are never pointed at prod. The Host header remains untrusted.

## Verification
- `tsc --noEmit`: no errors in the touched file (worktree-only errors are from fumadocs generated sources)
- Confirmed live 503s on this route in Vercel runtime logs before the fix

## Notes
The env var has been added to the Vercel project; merging this triggers the prod deployment that picks it up.