### PR TITLE
feat(explorer): all-time tick on the shared page clock

### DIFF
--- a/components/explorer-v2/ExplorerSubnav.tsx
+++ b/components/explorer-v2/ExplorerSubnav.tsx
@@ -187,7 +187,9 @@ function ChainSwitcher({
             />
           )
         )}
-        <span className="max-w-28 truncate font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-zinc-900 sm:max-w-40 md:max-w-56 dark:text-zinc-100">
+        {/* below sm the name would starve the section tabs — the mark and
+            chevron carry the switcher, the page header names the surface */}
+        <span className="hidden truncate font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-zinc-900 sm:block sm:max-w-40 md:max-w-56 dark:text-zinc-100">
           {(chainSlug === "c-chain" ? "C-Chain" : chainName) ?? "All Networks"}
         </span>
         <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-zinc-400 transition-colors group-hover:text-zinc-900 dark:text-zinc-500 dark:group-hover:text-zinc-100" />
@@ -614,7 +616,7 @@ export function ExplorerSubnav({
         className,
       )}
     >
-      <div className="flex min-w-0 items-stretch gap-x-4 md:gap-x-5">
+      <div className="flex min-w-0 items-stretch gap-x-3 sm:gap-x-4 md:gap-x-5">
         <ChainSwitcher network={network} chainSlug={chainSlug} chainName={chainName} chainLogoURI={chainLogoURI} />
         {tabs.length > 0 && <div className="my-3.5 w-px shrink-0 bg-zinc-200 dark:bg-zinc-800" />}
         {tabs.length > 0 && (
@@ -623,7 +625,7 @@ export function ExplorerSubnav({
             aria-label="Explorer sections"
             onScroll={onRailScroll}
             style={railMask}
-            className="scrollbar-hide flex items-stretch gap-x-4 overflow-x-auto md:gap-x-5"
+            className="scrollbar-hide flex items-stretch gap-x-3 overflow-x-auto sm:gap-x-4 md:gap-x-5"
           >
             {tabs.map((tab) => {
               const active = tab.isActive(pathname);

--- a/components/explorer-v2/evm/EvmAccounts.tsx
+++ b/components/explorer-v2/evm/EvmAccounts.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { EvmShell } from "@/components/explorer-v2/EvmShell";
 import { Board, BoardHeader, ChartBoard, StatDash, idInk } from "@/components/explorer-v2/ui";
 import { ChartEmpty, Stat } from "@/components/explorer-v2/staking/bits";
-import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
+import { RANGE_DAYS, rangeWindowLabel, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import { useContractNames } from "@/lib/sourcify-client";
 import { useChainContext } from "@/app/(home)/explorer/[network]/[chain]/layout.client";
 import type { AccountsActivity, AccountLeader } from "@/lib/explorer-clickhouse";
@@ -162,7 +162,7 @@ export function EvmAccounts({ network }: { network: string }) {
 
   const clock = useExplorerTimeRange();
   const range = RANGE_DAYS[clock];
-  const rangeLabel = RANGE_LABEL[clock];
+  const rangeLabel = rangeWindowLabel(clock);
 
   // fetch double the window so every reading can face its previous window
   const { metrics, failed } = useChainMetrics(c.chainId, Math.min(range * 2, 365), METRICS);
@@ -200,7 +200,7 @@ export function EvmAccounts({ network }: { network: string }) {
             display
             action={
               <span className="shrink-0 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
-                Last {rangeLabel}
+                {rangeLabel}
               </span>
             }
           />

--- a/components/explorer-v2/evm/EvmActivity.tsx
+++ b/components/explorer-v2/evm/EvmActivity.tsx
@@ -48,6 +48,7 @@ const ACTIVITY_DAYS: Record<ExplorerRange, 7 | 30 | 90> = {
   month: 30,
   quarter: 90,
   year: 90,
+  all: 90,
 };
 
 const AXIS_TICK = { fontSize: 10, fill: "#a1a1aa", fontFamily: "monospace" } as const;
@@ -56,7 +57,11 @@ export function CchainActivityChart({ href }: { href?: string }) {
   const clock = useExplorerTimeRange();
   const served = ACTIVITY_DAYS[clock];
   const exception =
-    clock === "day" ? "· 7 days" : clock === "year" ? "· 90 days · longest computed" : null;
+    clock === "day"
+      ? "· 7 days"
+      : clock === "year" || clock === "all"
+        ? "· 90 days · longest computed"
+        : null;
 
   const [activity, setActivity] = useState<CchainActivityDay[] | null>(null);
   const [servedDays, setServedDays] = useState<number | null>(null);

--- a/components/explorer-v2/evm/EvmOverviewStats.tsx
+++ b/components/explorer-v2/evm/EvmOverviewStats.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Board, BoardHeader, StatCell, StatDash } from "@/components/explorer-v2/ui";
-import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange, type ExplorerRange } from "@/components/explorer-v2/time-range";
+import { RANGE_DAYS, rangeWindowLabel, useExplorerTimeRange, type ExplorerRange } from "@/components/explorer-v2/time-range";
 import {
   Delta,
   fmtCompact,
@@ -85,9 +85,15 @@ export function EvmOverviewStats({
   // the page clock: window sums/averages and their vs-prev move all ride it
   const clock = useExplorerTimeRange();
   const n = RANGE_DAYS[clock];
-  const windowLabel = RANGE_LABEL[clock];
-  // fetch double the window so the previous window is comparable
-  const { metrics, failed } = useChainMetrics(chainId, Math.min(n * 2, 365), METRICS);
+  const windowLabel = rangeWindowLabel(clock);
+  // fetch double the window so the previous window is comparable; the
+  // all-time tick fetches the genesis window as-is (there is no previous
+  // window to face, so the deltas sit out)
+  const { metrics, failed } = useChainMetrics(
+    chainId,
+    clock === "all" ? n : Math.min(n * 2, 365),
+    METRICS,
+  );
   const util = useUtilization(chainId, n);
 
   const m = metrics ?? {};
@@ -148,7 +154,7 @@ export function EvmOverviewStats({
         display
         action={
           <span className="shrink-0 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
-            Last {windowLabel}
+            {windowLabel}
           </span>
         }
       />

--- a/components/explorer-v2/evm/EvmStats.tsx
+++ b/components/explorer-v2/evm/EvmStats.tsx
@@ -12,7 +12,7 @@ import {
 import { Board, BoardHeader, StatDash } from "@/components/explorer-v2/ui";
 import { ChartEmpty, Stat, TipPlate } from "@/components/explorer-v2/staking/bits";
 import { thin, windowSeries } from "@/components/explorer-v2/staking/data";
-import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
+import { RANGE_DAYS, rangeWindowLabel, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import {
   ChartSection,
   Delta,
@@ -66,7 +66,7 @@ export function EvmStats({
   // the page clock in the subnav — every chart and figure below rides it
   const clock = useExplorerTimeRange();
   const range = RANGE_DAYS[clock];
-  const rangeLabel = RANGE_LABEL[clock];
+  const rangeLabel = rangeWindowLabel(clock);
   // fetch double the window so every reading can face its previous window
   const { metrics, failed } = useChainMetrics(chainId, Math.min(range * 2, 365), METRICS);
 
@@ -144,7 +144,7 @@ export function EvmStats({
               display
               action={
                 <span className="shrink-0 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
-                  Last {rangeLabel}
+                  {rangeLabel}
                 </span>
               }
             />

--- a/components/explorer-v2/evm/metric-charts.tsx
+++ b/components/explorer-v2/evm/metric-charts.tsx
@@ -157,7 +157,9 @@ export function metricSeries(
 export function useChainMetrics(chainId: string, range: number, metricKeys: string) {
   const [metrics, setMetrics] = useState<Metrics | null>(null);
   const [failed, setFailed] = useState(false);
-  const timeRange = range <= 30 ? "30d" : range <= 90 ? "90d" : "1y";
+  // "all" rides the API's genesis-anchored window (STATS_CONFIG.TIME_RANGES
+  // pins it to September 2020), so the widest clock tick is true all-time
+  const timeRange = range <= 30 ? "30d" : range <= 90 ? "90d" : range <= 365 ? "1y" : "all";
 
   useEffect(() => {
     let cancelled = false;

--- a/components/explorer-v2/network/NetworkIcm.tsx
+++ b/components/explorer-v2/network/NetworkIcm.tsx
@@ -13,8 +13,7 @@ import {
 } from "recharts";
 import { cn } from "@/lib/utils";
 import {
-  RANGE_DAYS,
-  RANGE_LABEL,
+  rangeWindowLabel,
   useExplorerTimeRange,
   type ExplorerRange,
 } from "@/components/explorer-v2/time-range";
@@ -58,6 +57,9 @@ const ICM_TIME_RANGE: Record<ExplorerRange, string> = {
   month: "30d",
   quarter: "90d",
   year: "1y",
+  // the route's widest window (730 days) predates the first ICM message,
+  // so this tick really is all-time here
+  all: "all",
 };
 
 const QUIET = "#A2AFB2";
@@ -239,7 +241,9 @@ export function NetworkIcm() {
     [metrics],
   );
   const dailyICM = metrics?.aggregatedData?.[0]?.totalMessageCount ?? 0;
-  const avgDailyICM = Math.round(totalICMMessages / RANGE_DAYS[range]);
+  // divide by the days the feed actually returned, not the clock's nominal
+  // span: the all-time window would otherwise dilute the average to noise
+  const avgDailyICM = Math.round(totalICMMessages / Math.max(1, metrics?.aggregatedData?.length ?? 1));
 
   const topChains = useMemo(() => {
     if (!metrics?.aggregatedData) return [];
@@ -305,7 +309,7 @@ export function NetworkIcm() {
           <BoardHeader
             label="Interchain Messaging"
             display
-            action={<Chip>Last {RANGE_LABEL[range]}</Chip>}
+            action={<Chip>{rangeWindowLabel(range)}</Chip>}
           />
           <div className="grid grid-cols-3 divide-x divide-zinc-200 dark:divide-zinc-800">
             <StatCell label="Total ICM">

--- a/components/explorer-v2/network/NetworkOverview.tsx
+++ b/components/explorer-v2/network/NetworkOverview.tsx
@@ -92,6 +92,16 @@ interface SupplyData {
   priceChange24h: number;
 }
 
+/* the overview aggregate's longest upstream window is a year: the ALL
+   tick clamps to it, and the pulse labels say so */
+function overviewWindow(range: ExplorerRange): Exclude<ExplorerRange, "all"> {
+  return range === "all" ? "year" : range;
+}
+
+function overviewWindowLabel(range: ExplorerRange): string {
+  return range === "all" ? `${RANGE_LABEL.year} · longest window` : RANGE_LABEL[range];
+}
+
 function useOverviewStats(timeRange: ExplorerRange) {
   const [data, setData] = useState<OverviewData | null>(null);
   // when the figures landed — the anchor the live tx counter counts from
@@ -243,7 +253,7 @@ export function NetworkOverview() {
   // the shared clock: registers this page as a consumer, so the subnav
   // surfaces its range control and every reading below tracks the one pick
   const range = useExplorerTimeRange();
-  const { data, fetchedAt, refreshing } = useOverviewStats(range);
+  const { data, fetchedAt, refreshing } = useOverviewStats(overviewWindow(range));
   const supply = useAvaxSupply();
 
   const agg = data?.aggregated;
@@ -380,7 +390,7 @@ export function NetworkOverview() {
 
         {/* the ecosystem's ledger strip */}
         <section className="flex flex-col gap-4">
-          <SectionHeader label={`Network pulse · ${RANGE_LABEL[range]}`} />
+          <SectionHeader label={`Network pulse · ${overviewWindowLabel(range)}`} />
           <Board
             divide={false}
             className={cn("overflow-hidden transition-opacity", refreshing && data && "opacity-60")}
@@ -454,7 +464,7 @@ export function NetworkOverview() {
         <div className="grid items-start gap-x-8 gap-y-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,27rem)]">
         <section className="flex min-w-0 flex-col gap-4">
           <SectionHeader
-            label={`Top chains · ${RANGE_LABEL[range]}`}
+            label={`Top chains · ${overviewWindowLabel(range)}`}
             action={<BoardLink href="/explorer/mainnet/chains">All chains</BoardLink>}
           />
           <Board divide={false} className="overflow-x-auto">

--- a/components/explorer-v2/network/NetworkToken.tsx
+++ b/components/explorer-v2/network/NetworkToken.tsx
@@ -67,7 +67,7 @@ export function NetworkToken() {
   // follows it (daily bars up to a month, weekly for a quarter, monthly
   // for a year) so the chart stays readable at every window
   const clock = useExplorerTimeRange();
-  const period: Period = clock === "year" ? "M" : clock === "quarter" ? "W" : "D";
+  const period: Period = clock === "year" || clock === "all" ? "M" : clock === "quarter" ? "W" : "D";
   const [brushIndexes, setBrushIndexes] = useState<{
     startIndex: number;
     endIndex: number;
@@ -613,7 +613,8 @@ export function NetworkToken() {
                     <div>
                       <h2 className="text-lg font-medium text-black dark:text-white">Network Fees Paid</h2>
                       <p className="text-xs text-muted-foreground mt-0.5">
-                        C-Chain and ICM contract fees · {RANGE_LABEL[clock]}
+                        C-Chain and ICM contract fees ·{" "}
+                        {clock === "all" ? `${RANGE_LABEL.year} · longest window` : RANGE_LABEL[clock]}
                       </p>
                     </div>
                   </div>

--- a/components/explorer-v2/pchain/PchainHome.tsx
+++ b/components/explorer-v2/pchain/PchainHome.tsx
@@ -19,7 +19,7 @@ import {
   idInk,
   txToneText,
 } from "@/components/explorer-v2/ui";
-import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
+import { RANGE_DAYS, rangeWindowLabel, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import {
   usePrimaryMetrics,
   toSeries,
@@ -94,8 +94,10 @@ interface StatDef {
    in the metric's own unit — absolute heads, not percents */
 function levelDiff(points: SeriesPoint[], n: number): number | null {
   const cur = points[points.length - 1];
-  const prev = points[points.length - 1 - n];
-  if (!cur || !prev) return null;
+  // a window wider than the history (the ALL tick) reads from the first
+  // point: the diff becomes "since the series began"
+  const prev = points[Math.max(0, points.length - 1 - n)];
+  if (!cur || !prev || cur === prev) return null;
   return cur.value - prev.value;
 }
 
@@ -237,7 +239,7 @@ function MainnetChainStats({
     <ChainStatsBoard
       action={
         <span className="shrink-0 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
-          Last {RANGE_LABEL[clock]}
+          {rangeWindowLabel(clock)}
         </span>
       }
       cells={buildStatCells(s, totalStake, stakingRatio, base, {

--- a/components/explorer-v2/staking/StakingMetricPage.tsx
+++ b/components/explorer-v2/staking/StakingMetricPage.tsx
@@ -469,7 +469,8 @@ function ApySheet({ base, network }: { base: string; network: string }) {
 function RewardsSheet({ base, network }: { base: string; network: string }) {
   const clock = useExplorerTimeRange();
   const range = RANGE_DAYS[clock];
-  const rangeLabel = RANGE_LABEL[clock];
+  // the money-flow feed's longest window is a year: ALL clamps and says so
+  const rangeLabel = clock === "all" ? `${RANGE_LABEL.year} · longest window` : RANGE_LABEL[clock];
   const { data: metrics, failed } = usePrimaryMetrics();
   const { flow, failed: flowFailed } = useMoneyFlow(network, range);
 
@@ -675,7 +676,8 @@ function RewardsSheet({ base, network }: { base: string; network: string }) {
 function ExpirySheet({ base, network }: { base: string; network: string }) {
   const clock = useExplorerTimeRange();
   const range = RANGE_DAYS[clock];
-  const rangeLabel = RANGE_LABEL[clock];
+  // the unlock schedule reaches a year ahead at most: ALL clamps and says so
+  const rangeLabel = clock === "all" ? `${RANGE_LABEL.year} · longest window` : RANGE_LABEL[clock];
   const { data: metrics } = usePrimaryMetrics();
   const { flow, failed } = useMoneyFlow(network, range);
 

--- a/components/explorer-v2/time-range.tsx
+++ b/components/explorer-v2/time-range.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 /* a provider through four different shells.                            */
 /* ------------------------------------------------------------------ */
 
-export type ExplorerRange = "day" | "week" | "month" | "quarter" | "year";
+export type ExplorerRange = "day" | "week" | "month" | "quarter" | "year" | "all";
 
 export const EXPLORER_RANGES: { value: ExplorerRange; label: string; title: string }[] = [
   { value: "day", label: "1D", title: "Last day" },
@@ -20,16 +20,22 @@ export const EXPLORER_RANGES: { value: ExplorerRange; label: string; title: stri
   { value: "month", label: "1M", title: "Last month" },
   { value: "quarter", label: "3M", title: "Last quarter" },
   { value: "year", label: "1Y", title: "Last year" },
+  { value: "all", label: "ALL", title: "All time" },
 ];
 
 /* Every consumer vocabulary the old surfaces used, derived from the one
-   range so no page needs its own mapping table. */
+   range so no page needs its own mapping table. "All" is a finite
+   sentinel (ten years, older than every chain here) so window arithmetic
+   stays finite: slices return everything, deltas clamp to the first
+   point. Feeds with a shorter maximum window clamp to it and say so with
+   a "longest window" label, the gas page's rule. */
 export const RANGE_DAYS: Record<ExplorerRange, number> = {
   day: 1,
   week: 7,
   month: 30,
   quarter: 90,
   year: 365,
+  all: 3650,
 };
 
 /* the window spelled out, for chart headers ("Transactions · 30 days") */
@@ -39,7 +45,13 @@ export const RANGE_LABEL: Record<ExplorerRange, string> = {
   month: "30 days",
   quarter: "90 days",
   year: "1 year",
+  all: "all time",
 };
+
+/* the lead-board chip's copy: "Last 30 days", but never "Last all time" */
+export function rangeWindowLabel(range: ExplorerRange): string {
+  return range === "all" ? "All time" : `Last ${RANGE_LABEL[range]}`;
+}
 
 const DEFAULT_RANGE: ExplorerRange = "month";
 const STORAGE_KEY = "explorer-time-range";

--- a/components/explorer-v2/time-range.tsx
+++ b/components/explorer-v2/time-range.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useSyncExternalStore } from "react";
+import { ChevronsUpDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 /* ------------------------------------------------------------------ */
@@ -126,11 +127,34 @@ export function ExplorerRangeControl({ className }: { className?: string }) {
   const present = useRangeConsumersPresent();
   if (!present) return null;
   return (
-    <div
-      role="radiogroup"
-      aria-label="Time range for all stats on this page"
-      className={cn("inline-flex self-center border border-zinc-200 dark:border-zinc-800", className)}
-    >
+    <>
+      {/* narrow viewports: six segments would squeeze the section tabs out
+          of the rail entirely, so the clock folds into the native picker */}
+      <label className={cn("relative self-center sm:hidden", className)}>
+        <span className="sr-only">Time range for all stats on this page</span>
+        <select
+          value={current}
+          onChange={(e) => setExplorerRange(e.target.value as ExplorerRange)}
+          className="appearance-none border border-zinc-200 bg-transparent py-1.5 pl-2.5 pr-7 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-zinc-900 outline-none dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100"
+        >
+          {/* label only: the closed control renders the selected option's
+              full text, so anything longer would re-widen the rail */}
+          {EXPLORER_RANGES.map(({ value, label }) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+        <ChevronsUpDown className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-zinc-400 dark:text-zinc-500" />
+      </label>
+      <div
+        role="radiogroup"
+        aria-label="Time range for all stats on this page"
+        className={cn(
+          "hidden self-center border border-zinc-200 sm:inline-flex dark:border-zinc-800",
+          className,
+        )}
+      >
       {EXPLORER_RANGES.map(({ value, label, title }) => {
         const active = value === current;
         return (
@@ -152,7 +176,8 @@ export function ExplorerRangeControl({ className }: { className?: string }) {
           </button>
         );
       })}
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/components/explorer/GasMetricPage.tsx
+++ b/components/explorer/GasMetricPage.tsx
@@ -360,7 +360,11 @@ function BaseFeeSheet({ catalog, base }: { catalog: L1Chain; base: string }) {
 
   const windowed = useMemo(() => (daily ?? []).slice(-RANGE_DAYS[range]), [daily, range]);
   const isHourly = range === "day";
-  const windowLabel = isHourly ? "last 48 hours" : RANGE_LABEL[range];
+  const windowLabel = isHourly
+    ? "last 48 hours"
+    : range === "all"
+      ? `${RANGE_LABEL.year} · longest window`
+      : RANGE_LABEL[range];
 
   // the window's story in three numbers: typical, spike, floor
   const stats = useMemo(() => {

--- a/components/explorer/IcmMessagesPage.tsx
+++ b/components/explorer/IcmMessagesPage.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/explorer/L1ExplorerPage";
 import { Board, BoardHeader, ChartBoard, StatDash } from "@/components/explorer-v2/ui";
 import { Stat, TipPlate } from "@/components/explorer-v2/staking/bits";
-import { RANGE_DAYS, RANGE_LABEL, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
+import { RANGE_DAYS, rangeWindowLabel, useExplorerTimeRange } from "@/components/explorer-v2/time-range";
 import { ChainChip } from "@/components/stats/ChainChip";
 import { buildTxUrl } from "@/utils/eip3091";
 import { formatTokenValue } from "@/utils/formatTokenValue";
@@ -85,7 +85,7 @@ function fmtCount(v: number): string {
 function useIcmSeries(chainId: string, windowDays: number): { days: IcmDay[] | null; failed: boolean } {
   const [days, setDays] = useState<IcmDay[] | null>(null);
   const [failed, setFailed] = useState(false);
-  const timeRange = windowDays <= 30 ? "30d" : windowDays <= 90 ? "90d" : "1y";
+  const timeRange = windowDays <= 30 ? "30d" : windowDays <= 90 ? "90d" : windowDays <= 365 ? "1y" : "all";
   useEffect(() => {
     let cancelled = false;
     setDays(null);
@@ -238,7 +238,7 @@ export function IcmMessagesPage({
   // the daily chart floors at a week (one bar says nothing) and labels it
   const clock = useExplorerTimeRange();
   const rangeDays = RANGE_DAYS[clock];
-  const rangeLabel = RANGE_LABEL[clock];
+  const rangeLabel = rangeWindowLabel(clock);
   const chartDays = Math.max(7, rangeDays);
 
   const { days, failed: seriesFailed } = useIcmSeries(chainId, rangeDays);
@@ -303,7 +303,7 @@ export function IcmMessagesPage({
           display
           action={
             <span className="shrink-0 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
-              Last {rangeLabel}
+              {rangeLabel}
             </span>
           }
         />


### PR DESCRIPTION
## What changed

Adds an ALL segment to the explorer's shared time range control (1D/1W/1M/3M/1Y/ALL) and teaches every stats surface to handle it.

- time-range.tsx: new `all` range (finite 10-year sentinel so window arithmetic stays finite) plus a `rangeWindowLabel` helper so chips read "All time" instead of "Last all time".
- True all-time where the feed supports it: chain metrics (`/api/chain-stats` already pins `all` to the September 2020 genesis timestamp), ICM stats (route's `all` window predates the first ICM message), P-Chain primary metrics, ICM per-chain feeds.
- Labeled clamps where it does not, following the gas page's "longest window / longest computed" rule: overview aggregate (year), token fee history (year), gas history (year/90d), staking money-flow and expiry sheets (year), C-Chain activity classification (90d).
- Small correctness fixes surfaced by the sweep: NetworkIcm's daily average now divides by the days the feed returned rather than the clock's nominal span, and PchainHome's level deltas clamp to the series start so ALL reads "since inception".

## Verification

- tsc --noEmit clean.
- Headless smoke test of all 14 clock-consuming pages with the ALL tick active: zero page errors; every page shows either "All time" (genuine) or a "longest window/computed" clamp label; no "Last all time" anywhere.

## Open questions

- The C-Chain overview's utilization cell clamps to a year under ALL (gas-history API cap) while its strip chip says "All time"; the utilization detail sheet it links to labels its own window. Can add a per-cell note if wanted.