### PR TITLE
fix(explorer): monthly active-address buckets need a 65-day lookback

### DIFF
--- a/app/api/overview-stats/route.ts
+++ b/app/api/overview-stats/route.ts
@@ -148,12 +148,17 @@ async function getTxCountData(chainId: string, timeRange: TimeRangeKey): Promise
 async function getActiveAddressesData(chainId: string, timeRange: TimeRangeKey): Promise<number> {
   try {
     const endTimestamp = Math.floor(Date.now() / 1000);
-    const startTimestamp = endTimestamp - (30 * SECONDS_PER_DAY);
 
     // active addresses is a distinct count, not a sum — the metrics-api only
     // buckets it by day/week/month, so quarter and year (no wider bucket
     // exists) read the monthly figure rather than an unsupported interval.
-    const interval = timeRange === 'quarter' || timeRange === 'year' ? 'month' : timeRange;
+    const isMonthly = timeRange === 'quarter' || timeRange === 'year';
+    const interval = isMonthly ? 'month' : timeRange;
+    // monthly buckets are stamped at month START and only complete months
+    // are served: a 30-day lookback contains none for most of the month
+    // (every chain read 0 from the 2nd onward), so the monthly read
+    // reaches back 65 days to always cover one full bucket
+    const startTimestamp = endTimestamp - ((isMonthly ? 65 : 30) * SECONDS_PER_DAY);
 
     const url = new URL(`${METRICS_API_URL}/v2/chains/${chainId}/metrics/activeAddresses`);
     url.searchParams.set('timeInterval', interval);


### PR DESCRIPTION
## What changed

The All Networks overview reads active addresses at the monthly interval for quarter/year windows, but always looked back only 30 days. The metrics API stamps monthly buckets at month START and serves only complete months, so for most of the month the window contains no bucket and every chain reads 0 (prod shows this now at /explorer/mainnet with 3M/1Y selected; it self-heals for a day or two after each month boundary, which is how it slipped through). The monthly read now looks back 65 days so one complete bucket is always in range.

## Verification

- Reproduced upstream: metrics.avax.network activeAddresses with timeInterval=month over a 30-day window returns empty; 65 days returns the June bucket.
- Prod /api/overview-stats?timeRange=quarter: 0 of 65 chains nonzero. Local with fix: 29 of 68 nonzero (the rest have no activity), C-Chain 8.9M.

Data source note: this page reads the public metrics API only; no Glacier/Data API involved.