### PR TITLE
fix(explorer): surface state-minted reward UTXOs on P-Chain reward txs

### DIFF
--- a/app/api/pchain-rpc/[network]/route.ts
+++ b/app/api/pchain-rpc/[network]/route.ts
@@ -19,6 +19,9 @@ const ALLOWED_METHODS = new Set([
   "platform.getTotalStake",
   // the L1s tab's continuous-fee price (ACP-77 fee market)
   "platform.getValidatorFeeState",
+  // reward UTXOs are minted directly into state, never as tx outputs, so
+  // the indexer can't see them: the tx page reads them off the node
+  "platform.getRewardUTXOs",
 ]);
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ network: string }> }) {

--- a/components/explorer-v2/pchain/FundFlowDiagram.tsx
+++ b/components/explorer-v2/pchain/FundFlowDiagram.tsx
@@ -131,9 +131,9 @@ export function NoFundMovement({ txType }: { txType: string }) {
 function explainNoMovement(type: string): string {
   const t = type.toLowerCase();
   if (t.includes("rewardautorenew"))
-    return "Settles an auto-renewed staking cycle: the earned reward is compounded back into the validator's stake (or the cycle is closed out) as on-chain state. No UTXOs are created or spent.";
+    return "Settles an auto-renewed staking cycle: the earned reward compounds back into the validator's stake, and any non-compounded share is minted directly into state as a reward UTXO (see Reward Payout). Nothing flows through the transaction itself.";
   if (t.includes("reward"))
-    return "Marks the end of a validation period and settles its staking reward. When the reward is compounded or the period is aborted, the outcome is recorded as state and no UTXOs move.";
+    return "Marks the end of a validation period and settles its staking reward. Payouts are minted directly into state as reward UTXOs rather than moving through the transaction; an aborted vote mints nothing.";
   if (t.includes("setautorenew") || t.includes("config"))
     return "Updates a validator's auto-renew configuration: staking period and compounding. It changes on-chain state only and moves no funds.";
   if (t.includes("advancetime"))

--- a/components/explorer-v2/pchain/PchainTx.tsx
+++ b/components/explorer-v2/pchain/PchainTx.tsx
@@ -8,10 +8,12 @@ import {
   bytesToHex,
   decodeL1WarpMessage,
   getPlatformTx,
+  getRewardUtxos,
   hexToNodeId,
   type DecodedL1WarpMessage,
   type L1InitialValidator,
   type PlatformUnsignedTx,
+  type RewardUtxo,
 } from "@/lib/pchain-node";
 import { ExplorerShell } from "@/components/explorer-v2/ExplorerShell";
 import {
@@ -77,6 +79,24 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
   // and the full-width initial-validator-set table); on a 404 it doubles
   // as the authoritative "does this tx exist on-chain at all?" check
   const platformOp = usePlatformTx(network, txHash, isConvert || isWarpOp || isCreateChain || notFound);
+
+  // Reward payouts are minted directly into P-Chain state keyed by this
+  // tx — never as tx outputs — so the indexer's emittedUtxos is always
+  // empty here and only the node knows about them
+  const isRewardTx =
+    tx?.txType === "RewardValidatorTx" || tx?.txType === "RewardAutoRenewedValidatorTx";
+  const [rewardUtxos, setRewardUtxos] = useState<RewardUtxo[] | null>(null);
+  useEffect(() => {
+    if (!isRewardTx) return;
+    let cancelled = false;
+    getRewardUtxos(network, txHash).then((utxos) => {
+      if (!cancelled) setRewardUtxos(utxos);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isRewardTx, network, txHash]);
+  const rewardTotal = rewardUtxos?.reduce((sum, u) => sum + u.amount, 0) ?? 0;
 
   return (
     <ExplorerShell chain={chain} network={network}>
@@ -181,9 +201,25 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
                   <SpecRow label="End">{formatTime(tx.endTimestamp)}</SpecRow>
                 )}
                 {tx.estimatedReward && <SpecRow label="Est. Reward">{formatAvax(tx.estimatedReward)}</SpecRow>}
-                {tx.details?.rewardPaid !== undefined && (
-                  <SpecRow label="Reward Paid">{tx.details.rewardPaid ? "Yes (committed)" : "No (aborted)"}</SpecRow>
-                )}
+                {/* A continuous validator's reward never commits/aborts:
+                    it restakes on every renewal, with any non-compounded
+                    share minted straight into state (the board below).
+                    The indexer's rewardPaid flag only means something for
+                    the legacy end-of-stake commit/abort vote. */}
+                {tx.details?.rewardPaid !== undefined &&
+                  (tx.txType === "RewardAutoRenewedValidatorTx" ? (
+                    <SpecRow label="Reward">
+                      {rewardUtxos === null
+                        ? "Restaked · compounds into the stake"
+                        : rewardUtxos.length
+                          ? `Restaked · ${formatAvax(rewardTotal)} paid out`
+                          : "Restaked · fully compounded"}
+                    </SpecRow>
+                  ) : (
+                    <SpecRow label="Reward Paid">
+                      {tx.details.rewardPaid ? "Yes (committed)" : "No (aborted)"}
+                    </SpecRow>
+                  ))}
                 {tx.details?.stakingTxId && (
                   <SpecRow label="Staking Tx">
                     <HashChip value={tx.details.stakingTxId} href={`${base}/tx/${tx.details.stakingTxId}`} len={20} />
@@ -196,6 +232,29 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
                 ) : null}
               </SpecPlate>
             </Section>
+          )}
+
+          {/* the payout itself: state-minted UTXOs keyed by this tx */}
+          {isRewardTx && rewardUtxos !== null && rewardUtxos.length > 0 && (
+            <section className="flex flex-col gap-3">
+              <Section label="Reward Payout">
+                <SpecPlate>
+                  {rewardUtxos.map((u) => (
+                    <SpecRow key={u.outputIndex} label={`UTXO #${u.outputIndex}`} align="start">
+                      <div className="flex flex-col items-end gap-1">
+                        <span>{formatAvax(u.amount)}</span>
+                        <AddrList base={base} addrs={u.addresses} />
+                      </div>
+                    </SpecRow>
+                  ))}
+                </SpecPlate>
+              </Section>
+              <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+                Reward UTXOs are minted directly into P-Chain state under this transaction&apos;s
+                ID: they are not outputs of the transaction itself, so they come from the node
+                rather than the indexer.
+              </p>
+            </section>
           )}
 
           {/* Continuous staking (Granite auto-renew family) */}

--- a/lib/pchain-node.ts
+++ b/lib/pchain-node.ts
@@ -1,7 +1,9 @@
 // Client helpers for the AvalancheGo P-Chain RPC (via /api/pchain-rpc).
 // These fill the gaps the indexer leaves: decoded platform-op inputs
 // (ConvertSubnetToL1Tx validator sets, manager pointers), subnet/L1
-// conversion state, and live L1 validator sets.
+// conversion state, live L1 validator sets, and state-minted reward UTXOs.
+
+import { bech32 } from "@scure/base";
 
 export interface PchainOwner {
   threshold: number | string;
@@ -89,6 +91,72 @@ async function rpc<T>(network: string, method: string, params: object): Promise<
   } catch {
     return null;
   }
+}
+
+/* ------------------------------------------------------------------ */
+/* Reward UTXOs. Staking rewards are minted directly into P-Chain state
+   keyed by the reward tx: they are never outputs OF a transaction, so
+   the indexer's emittedUtxos is always empty for reward txs and the only
+   source is platform.getRewardUTXOs. The method refuses encoding=json,
+   so the hex payload is decoded here: codec(2) txID(32) outputIndex(4)
+   assetID(32) typeID(4) amount(8) locktime(8) threshold(4) nAddrs(4)
+   addr(20)×n checksum(4).                                              */
+
+export interface RewardUtxo {
+  outputIndex: number;
+  /** nAVAX */
+  amount: number;
+  locktime: number;
+  threshold: number;
+  /** bech32 P-chain addresses (P-avax1… / P-fuji1…) */
+  addresses: string[];
+}
+
+const BECH32_HRP: Record<string, string> = { mainnet: "avax", fuji: "fuji" };
+
+function decodeRewardUtxo(hex: string, hrp: string): RewardUtxo | null {
+  try {
+    const raw = hex.startsWith("0x") ? hex.slice(2) : hex;
+    const bytes = new Uint8Array(raw.length / 2);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = parseInt(raw.slice(i * 2, i * 2 + 2), 16);
+    const view = new DataView(bytes.buffer);
+    let o = 2 + 32; // codec version + txID
+    const outputIndex = view.getUint32(o);
+    o += 4 + 32; // output index + assetID
+    const typeID = view.getUint32(o);
+    o += 4;
+    if (typeID !== 7) return null; // only secp256k1 transfer outputs expected
+    const amount = Number(view.getBigUint64(o));
+    o += 8;
+    const locktime = Number(view.getBigUint64(o));
+    o += 8;
+    const threshold = view.getUint32(o);
+    o += 4;
+    const nAddrs = view.getUint32(o);
+    o += 4;
+    const addresses: string[] = [];
+    for (let i = 0; i < nAddrs; i++) {
+      const addr = bytes.slice(o, o + 20);
+      o += 20;
+      addresses.push(`P-${bech32.encode(hrp, bech32.toWords(addr))}`);
+    }
+    return { outputIndex, amount, locktime, threshold, addresses };
+  } catch {
+    return null;
+  }
+}
+
+export async function getRewardUtxos(network: string, txID: string): Promise<RewardUtxo[] | null> {
+  const r = await rpc<{ utxos?: string[] }>(network, "platform.getRewardUTXOs", {
+    txID,
+    encoding: "hex",
+  });
+  if (!r?.utxos) return null;
+  const hrp = BECH32_HRP[network] ?? network;
+  return r.utxos
+    .map((u) => decodeRewardUtxo(u, hrp))
+    .filter((u): u is RewardUtxo => u !== null)
+    .sort((a, b) => a.outputIndex - b.outputIndex);
 }
 
 export async function getPlatformTx(network: string, txID: string): Promise<PlatformUnsignedTx | null> {


### PR DESCRIPTION
## What changed

A continuous (restaking) validator's reward tx read "Reward Paid: No (aborted)" and showed no UTXOs, both wrong: reward payouts are minted directly into P-Chain state keyed by the reward tx, never as tx outputs, so the indexer's emittedUtxos is always empty and its rewardPaid flag only means something for the legacy commit/abort vote.

- lib/pchain-node: getRewardUtxos() reads platform.getRewardUTXOs off the node (the method refuses encoding=json, so the hex UTXO layout is decoded here, addresses bech32-encoded via @scure/base). /api/pchain-rpc allowlist extended accordingly.
- P-Chain tx page: RewardAutoRenewedValidatorTx now reads "Restaked · {amount} paid out" (or "fully compounded"); legacy RewardValidatorTx keeps commit/abort semantics. New "Reward Payout" board lists the state-minted UTXOs (output index, amount, owner address linked to its address page) with a footnote explaining they come from the node, not the indexer.
- Fund-flow blurbs for reward types no longer claim "no UTXOs are created".

Example: /explorer/fuji/p-chain/tx/21ncmjkeDQg1XzJynfcA7PZRzgEKieZUFMeKn81tFtcm5b6xdL now shows "Restaked · 0.000105525 AVAX paid out" and UTXO #0 to P-fuji19j5wc4t...9gny, matching platform.getRewardUTXOs.

## Verification

- tsc --noEmit clean.
- Decoder verified against the live Fuji payload (amount 0x19c35 = 105,525 nAVAX, address matches).
- Rendered on localhost in headless Chromium: reward row, payout board, and updated fund-flow copy all present, no console errors.