### PR TITLE
refactor(explorer): reward split in staking panel, payout UTXOs in the fund flow

### DIFF
--- a/components/explorer-v2/pchain/PchainTx.tsx
+++ b/components/explorer-v2/pchain/PchainTx.tsx
@@ -7,6 +7,7 @@ import {
   PRIMARY_SUBNET_ID,
   bytesToHex,
   decodeL1WarpMessage,
+  getCurrentValidators,
   getPlatformTx,
   getRewardUtxos,
   hexToNodeId,
@@ -81,7 +82,7 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
   const platformOp = usePlatformTx(network, txHash, isConvert || isWarpOp || isCreateChain || notFound);
 
   // Reward payouts are minted directly into P-Chain state keyed by this
-  // tx — never as tx outputs — so the indexer's emittedUtxos is always
+  // tx, never as tx outputs, so the indexer's emittedUtxos is always
   // empty here and only the node knows about them
   const isRewardTx =
     tx?.txType === "RewardValidatorTx" || tx?.txType === "RewardAutoRenewedValidatorTx";
@@ -96,7 +97,84 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
       cancelled = true;
     };
   }, [isRewardTx, network, txHash]);
-  const rewardTotal = rewardUtxos?.reduce((sum, u) => sum + u.amount, 0) ?? 0;
+  const rewardWithdrawn = rewardUtxos?.reduce((sum, u) => sum + u.amount, 0) ?? 0;
+
+  // the split needs the staker's compound ratio: withdrawn is the
+  // (1 - c) share minted to the owner, so restaked = withdrawn * c/(1-c)
+  const stakingTxId = tx?.details?.stakingTxId;
+  const [compoundShares, setCompoundShares] = useState<number | null>(null);
+  useEffect(() => {
+    if (tx?.txType !== "RewardAutoRenewedValidatorTx" || !stakingTxId) return;
+    let cancelled = false;
+    fetch(`/api/pchain/${network}/tx/${stakingTxId}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((staker: Tx | null) => {
+        if (!cancelled && typeof staker?.autoCompoundRewardShares === "number") {
+          setCompoundShares(staker.autoCompoundRewardShares);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [tx?.txType, stakingTxId, network]);
+  // avalanchego's PercentDenominator for reward shares
+  const SHARES_DENOM = 1_000_000;
+  const rewardRestaked =
+    compoundShares !== null && compoundShares > 0 && compoundShares < SHARES_DENOM && rewardWithdrawn > 0
+      ? Math.round((rewardWithdrawn * compoundShares) / (SHARES_DENOM - compoundShares))
+      : null;
+
+  // a live continuous validator carries its compounded stake in the
+  // current validator set: weight minus the original stake is every
+  // renewal's restake to date
+  const isContinuousStaker = tx?.txType === "AddAutoRenewedValidatorTx";
+  const [liveWeight, setLiveWeight] = useState<number | null>(null);
+  useEffect(() => {
+    if (!isContinuousStaker || !tx?.nodeId) return;
+    let cancelled = false;
+    getCurrentValidators(network, PRIMARY_SUBNET_ID, [tx.nodeId]).then((validators) => {
+      if (cancelled || !validators?.length) return;
+      const weight = Number(validators[0].weight);
+      if (Number.isFinite(weight) && weight > 0) setLiveWeight(weight);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isContinuousStaker, network, tx?.nodeId]);
+  const initialStake = tx?.amountStaked?.reduce((sum, a) => sum + Number(a.amount || 0), 0) ?? 0;
+  const restakedToDate =
+    liveWeight !== null && initialStake > 0 && liveWeight > initialStake ? liveWeight - initialStake : null;
+
+  // reward UTXOs join the fund flow as emitted outputs (the diagram
+  // already tones Reward* txs' outputs as rewards)
+  const rewardEmitted: Utxo[] =
+    tx && rewardUtxos?.length
+      ? rewardUtxos.map((u) => ({
+          addresses: u.addresses.map((a) => a.replace(/^P-/, "")),
+          utxoId: `${tx.txHash}:${u.outputIndex}`,
+          txHash: tx.txHash,
+          outputIndex: u.outputIndex,
+          blockTimestamp: tx.blockTimestamp,
+          blockNumber: tx.blockNumber,
+          assetId: "",
+          asset: {
+            assetId: "",
+            name: "Avalanche",
+            symbol: "AVAX",
+            denomination: 9,
+            amount: String(u.amount),
+          },
+          utxoType: "reward",
+          amount: String(u.amount),
+          platformLocktime: u.locktime,
+          threshold: u.threshold,
+          createdOnChainId: "",
+          consumedOnChainId: "",
+          staked: false,
+        }))
+      : [];
+  const flowEmitted = tx ? (rewardEmitted.length ? [...tx.emittedUtxos, ...rewardEmitted] : tx.emittedUtxos) : [];
 
   return (
     <ExplorerShell chain={chain} network={network}>
@@ -202,18 +280,20 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
                 )}
                 {tx.estimatedReward && <SpecRow label="Est. Reward">{formatAvax(tx.estimatedReward)}</SpecRow>}
                 {/* A continuous validator's reward never commits/aborts:
-                    it restakes on every renewal, with any non-compounded
-                    share minted straight into state (the board below).
-                    The indexer's rewardPaid flag only means something for
-                    the legacy end-of-stake commit/abort vote. */}
+                    each renewal restakes the compound share and mints the
+                    rest straight into state (shown in the fund flow). The
+                    indexer's rewardPaid flag only means something for the
+                    legacy end-of-stake commit/abort vote. */}
                 {tx.details?.rewardPaid !== undefined &&
                   (tx.txType === "RewardAutoRenewedValidatorTx" ? (
                     <SpecRow label="Reward">
                       {rewardUtxos === null
                         ? "Restaked · compounds into the stake"
-                        : rewardUtxos.length
-                          ? `Restaked · ${formatAvax(rewardTotal)} paid out`
-                          : "Restaked · fully compounded"}
+                        : rewardUtxos.length === 0
+                          ? "Fully compounded into the stake"
+                          : rewardRestaked !== null
+                            ? `${formatAvax(rewardRestaked)} restaked · ${formatAvax(rewardWithdrawn)} withdrawn`
+                            : `Restaked · ${formatAvax(rewardWithdrawn)} withdrawn`}
                     </SpecRow>
                   ) : (
                     <SpecRow label="Reward Paid">
@@ -232,29 +312,6 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
                 ) : null}
               </SpecPlate>
             </Section>
-          )}
-
-          {/* the payout itself: state-minted UTXOs keyed by this tx */}
-          {isRewardTx && rewardUtxos !== null && rewardUtxos.length > 0 && (
-            <section className="flex flex-col gap-3">
-              <Section label="Reward Payout">
-                <SpecPlate>
-                  {rewardUtxos.map((u) => (
-                    <SpecRow key={u.outputIndex} label={`UTXO #${u.outputIndex}`} align="start">
-                      <div className="flex flex-col items-end gap-1">
-                        <span>{formatAvax(u.amount)}</span>
-                        <AddrList base={base} addrs={u.addresses} />
-                      </div>
-                    </SpecRow>
-                  ))}
-                </SpecPlate>
-              </Section>
-              <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
-                Reward UTXOs are minted directly into P-Chain state under this transaction&apos;s
-                ID: they are not outputs of the transaction itself, so they come from the node
-                rather than the indexer.
-              </p>
-            </section>
           )}
 
           {/* Continuous staking (Granite auto-renew family) */}
@@ -284,6 +341,16 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
                       ? "0% — rewards are fully paid out, nothing restakes"
                       : `${autoCompoundPct(tx)}% of each reward restakes`}
                   </SpecRow>
+                )}
+                {/* compounding shows up as stake weight: the live set's
+                    weight above the original stake is every renewal's
+                    restake so far (only visible while the validator is
+                    in the current set) */}
+                {liveWeight !== null && (
+                  <SpecRow label="Current Stake">{formatAvax(liveWeight)}</SpecRow>
+                )}
+                {restakedToDate !== null && (
+                  <SpecRow label="Restaked To Date">{formatAvax(restakedToDate)}</SpecRow>
                 )}
                 {tx.validatorAuthority?.length ? (
                   <SpecRow label="Config Authority" align="start">
@@ -431,7 +498,7 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
             />
             {!hasFundMovement({
               consumed: tx.consumedUtxos,
-              emitted: tx.emittedUtxos,
+              emitted: flowEmitted,
               burned: tx.amountBurned,
               importedFrom: tx.importedFrom,
               sourceChain: tx.details?.sourceChain,
@@ -444,7 +511,7 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
               <Board divide={false} className="px-5 py-6 md:px-6">
                 <FundFlowDiagram
                   consumed={tx.consumedUtxos}
-                  emitted={tx.emittedUtxos}
+                  emitted={flowEmitted}
                   burned={tx.amountBurned}
                   txType={tx.txType}
                   base={base}
@@ -456,8 +523,15 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
             ) : (
               <div className="grid gap-6 lg:grid-cols-2">
                 <UtxoColumn base={base} title={`Consumed · ${tx.consumedUtxos.length}`} utxos={tx.consumedUtxos} side="in" />
-                <UtxoColumn base={base} title={`Emitted · ${tx.emittedUtxos.length}`} utxos={tx.emittedUtxos} side="out" />
+                <UtxoColumn base={base} title={`Emitted · ${flowEmitted.length}`} utxos={flowEmitted} side="out" />
               </div>
+            )}
+            {rewardEmitted.length > 0 && (
+              <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+                Reward UTXOs are minted directly into P-Chain state under this transaction&apos;s
+                ID rather than as transaction outputs, so they are read from the node, not the
+                indexer.
+              </p>
             )}
           </section>
         </div>


### PR DESCRIPTION
## What changed

Follow-up to #4434, reshaping how a P-Chain reward tx presents its payout:

- The Staking panel's Reward row now shows the full split: "{restaked} restaked · {withdrawn} withdrawn". Withdrawn is the sum of the state-minted reward UTXOs; restaked is derived from the staker's autoCompoundRewardShares (withdrawn x c/(1-c), staker fetched via the cached tx endpoint). Fully-compounded cycles read "Fully compounded into the stake".
- The reward UTXOs moved out of the separate "Reward Payout" board and into the Fund Flow, where they render as outputs with the existing green reward tone in both the diagram and table views. The state-minting explanation is now a footnote under the fund flow.
- Staking tx pages (AddAutoRenewedValidatorTx) show the compounding through stake weight: "Current Stake" and "Restaked To Date" rows in the Continuous Staking panel, read live from platform.getCurrentValidators while the validator is in the current set.

## Verification

- tsc --noEmit clean.
- Rendered on localhost against Fuji tx 21ncmjkeDQg1XzJynfcA7PZRzgEKieZUFMeKn81tFtcm5b6xdL: Reward reads "0.000011725 AVAX restaked · 0.000105525 AVAX withdrawn" and the fund flow shows the reward ribbon to fuji19j5wc4tue...9gny; no console errors.