### PR TITLE
P-Chain explorer: resolve NodeID on L1 balance/disable tx pages

### DIFF
--- a/app/(home)/explorer/[network]/[chain]/layout.tsx
+++ b/app/(home)/explorer/[network]/[chain]/layout.tsx
@@ -1,8 +1,18 @@
 import { ReactNode } from "react";
-import { notFound } from "next/navigation";
 import l1ChainsData from "@/constants/l1-chains.json";
 import { L1Chain } from "@/types/stats";
+import { Board } from "@/components/explorer-v2/ui";
 import { ChainExplorerLayoutClient } from "./layout.client";
+
+function ChainNotIndexed() {
+  return (
+    <Board divide={false} className="px-6 py-16 text-center">
+      <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-zinc-400 dark:text-zinc-500">
+        No data indexed yet for this chain
+      </p>
+    </Board>
+  );
+}
 
 interface ChainExplorerLayoutProps {
   children: ReactNode;
@@ -23,7 +33,8 @@ export default async function ChainExplorerLayout({
   const wantTestnet = network === "fuji" || network === "testnet";
   const candidates = l1ChainsData.filter((c) => c.slug === chainSlug) as L1Chain[];
   const chain = candidates.find((c) => (c.isTestnet === true) === wantTestnet) ?? candidates[0];
-  
+  const unindexed = chain?.isIndexed === false;
+
   // If chain found in static data, render with server-known props
   if (chain) {
     return (
@@ -41,7 +52,7 @@ export default async function ChainExplorerLayout({
         blockchainId={chain.blockchainId}
         sourcifySupport={(chain as L1Chain & { sourcifySupport?: boolean }).sourcifySupport}
       >
-        {children}
+        {unindexed ? <ChainNotIndexed /> : children}
       </ChainExplorerLayoutClient>
     );
   }

--- a/app/api/pchain-rpc/[network]/route.ts
+++ b/app/api/pchain-rpc/[network]/route.ts
@@ -22,6 +22,9 @@ const ALLOWED_METHODS = new Set([
   // reward UTXOs are minted directly into state, never as tx outputs, so
   // the indexer can't see them: the tx page reads them off the node
   "platform.getRewardUTXOs",
+  // resolves an ACP-77 validationID to the seat's nodeID — the indexer's
+  // balance/disable tx rows carry only the validationID
+  "platform.getL1Validator",
 ]);
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ network: string }> }) {

--- a/components/explorer-v2/network/NetworkChains.tsx
+++ b/components/explorer-v2/network/NetworkChains.tsx
@@ -198,9 +198,10 @@ export function NetworkChains() {
                 ))}
               {(live || failed || showInactive) && chains.map((c) => {
                 const liveCount = (c.subnetId && live?.get(c.subnetId)) || 0;
-                const explorerHref = c.rpcUrl
-                  ? `/explorer/${c.isTestnet ? "fuji" : "mainnet"}/${c.slug}`
-                  : null;
+                const explorerHref =
+                  c.rpcUrl && c.isIndexed !== false
+                    ? `/explorer/${c.isTestnet ? "fuji" : "mainnet"}/${c.slug}`
+                    : null;
                 return (
                   <tr key={`${c.slug}-${c.chainId}`} className="transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-900/50">
                     <td className={TD}>

--- a/components/explorer-v2/pchain/PchainAddress.tsx
+++ b/components/explorer-v2/pchain/PchainAddress.tsx
@@ -48,9 +48,9 @@ const UTXO_PAGE = 50;
 /* Transaction paging. The type filter runs client-side because the address
    txs endpoint ignores a `type` param (unlike the /txs list endpoint), so
    the filter can only see what has been loaded, and the UI says so.
-   TX_MAX is the API's own ceiling: it clamps `limit` to 200. */
+   Paging is cursor-based (?before=<blockHeight> from the response's
+   nextBefore), so history walks arbitrarily far back — no fixed ceiling. */
 const TX_PAGE = 50;
-const TX_MAX = 200;
 
 /* ---- the summary table ----------------------------------------------
    A real table rather than a grid of stacked cells: labels in their own
@@ -112,18 +112,40 @@ function MetricTable({ rows }: { rows: MetricRow[] }) {
 export function PchainAddress({ chain, network, addr }: { chain: string; network: string; addr: string }) {
   const base = `/explorer/${network}/${chain}`;
   const { data: a, loading, error } = usePchainData<Address>(network, `address/${addr}`);
-  const [txLimit, setTxLimit] = useState(TX_PAGE);
   const { data: history, loading: txsLoading } = usePchainData<AddressTxs>(
     network,
     `address/${addr}/txs`,
-    { limit: txLimit },
+    { limit: TX_PAGE },
   );
+  // older pages appended via the nextBefore cursor; each page is a stable URL
+  const [olderPages, setOlderPages] = useState<AddressTxs[]>([]);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const lastPage = olderPages.length ? olderPages[olderPages.length - 1] : history;
+  const nextCursor = lastPage?.nextBefore;
+  const loadMoreTxs = async () => {
+    if (nextCursor === undefined || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const res = await fetch(
+        `/api/pchain/${network}/address/${addr}/txs?limit=${TX_PAGE}&before=${nextCursor}`,
+      );
+      if (res.ok) {
+        const page: AddressTxs = await res.json();
+        setOlderPages((ps) => [...ps, page]);
+      }
+    } finally {
+      setLoadingMore(false);
+    }
+  };
   // mainnet only: Fuji AVAX has no market value to quote
   const avaxUsd = useAvaxUsd(network === "mainnet");
   const [utxoLimit, setUtxoLimit] = useState(UTXO_PAGE);
   const [txType, setTxType] = useState("");
 
-  const txs = history?.txs ?? [];
+  const txs = useMemo(
+    () => [...(history?.txs ?? []), ...olderPages.flatMap((p) => p.txs)],
+    [history, olderPages],
+  );
 
   /* Filter options are derived from what this address has actually done,
      not from the global list of P-Chain tx types. Offering "Create Chain"
@@ -142,7 +164,7 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
 
   const shownTxs = txType ? txs.filter((t) => t.txType === txType) : txs;
   // more to fetch, and headroom under the API's 200-row ceiling
-  const canLoadMore = Boolean(history?.truncated) && txLimit < TX_MAX;
+  const canLoadMore = nextCursor !== undefined;
 
   const totalRaw = a ? Number(a.balance.total) : 0;
   const lockedRaw = a ? Number(a.balance.locked) : 0;
@@ -355,11 +377,12 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
             {/* The filter is client-side, so "42 Export" means 42 of the rows
                 loaded so far, not of the address's whole history. Say that
                 plainly rather than letting a filtered count read as a total. */}
-            {history?.truncated && (
+            {(canLoadMore || history?.truncated) && (
               <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
                 {canLoadMore && (
                   <button
-                    onClick={() => setTxLimit((n) => Math.min(TX_MAX, n + TX_PAGE))}
+                    onClick={loadMoreTxs}
+                    disabled={loadingMore}
                     className="border border-zinc-200 px-5 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-zinc-600 transition-colors hover:border-zinc-900 hover:text-zinc-900 dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-100 dark:hover:text-zinc-100"
                   >
                     Load more
@@ -367,7 +390,7 @@ export function PchainAddress({ chain, network, addr }: { chain: string; network
                 )}
                 <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
                   {txType ? "filtering the" : "showing the"} newest {formatNumber(txs.length)}
-                  {!canLoadMore && ", the most this endpoint returns"}
+                  {!canLoadMore && ", the full recorded history"}
                 </span>
               </div>
             )}

--- a/components/explorer-v2/pchain/PchainNode.tsx
+++ b/components/explorer-v2/pchain/PchainNode.tsx
@@ -34,7 +34,7 @@ import {
   getPrimaryTotalStake,
   type CurrentValidator,
 } from "@/lib/pchain-node";
-import { txTypeLabel, type NodeResponse, type ValidationsResponse } from "@/lib/pchain-explorer";
+import { txTypeLabel, type NodeResponse, type NodeStakingTx, type TxSummary, type ValidationsResponse } from "@/lib/pchain-explorer";
 
 /* The node page as one instrument, not an endless scroll: a bold summary
    strip, then two split views — what the validator IS (the spec plate)
@@ -201,6 +201,47 @@ export function PchainNode({
 
   const [showAllDelegators, setShowAllDelegators] = useState(false);
   const [showAllHistory, setShowAllHistory] = useState(false);
+
+  const [olderHistory, setOlderHistory] = useState<NodeStakingTx[]>([]);
+  const [historyCursor, setHistoryCursor] = useState<number | undefined>(undefined);
+  const [historyDone, setHistoryDone] = useState(false);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const loadOlderHistory = async () => {
+    if (historyDone || loadingOlder || !n) return;
+    setLoadingOlder(true);
+    try {
+      const seen = new Set([...n.history.map((h) => h.txHash), ...olderHistory.map((h) => h.txHash)]);
+      let cursor = historyCursor;
+      for (let hop = 0; hop < 4; hop++) {
+        const qs = new URLSearchParams({ node: nodeId, limit: "100" });
+        if (cursor !== undefined) qs.set("before", String(cursor));
+        const res = await fetch(`/api/pchain/${network}/txs?${qs}`);
+        const page: TxSummary[] = res.ok ? await res.json() : [];
+        if (page.length === 0) {
+          setHistoryDone(true);
+          break;
+        }
+        cursor = page[page.length - 1].blockHeight;
+        const fresh = page.filter((t) => !seen.has(t.txHash));
+        if (fresh.length > 0) {
+          setOlderHistory((o) => [
+            ...o,
+            ...fresh.map((t) => ({
+              txHash: t.txHash,
+              txType: t.txType,
+              blockTimestamp: t.blockTimestamp,
+              period: t.period,
+            })),
+          ]);
+          break;
+        }
+      }
+      setHistoryCursor(cursor);
+    } finally {
+      setLoadingOlder(false);
+    }
+  };
+  const fullHistory = n ? [...n.history, ...olderHistory] : [];
 
   const uptimeSeries = useMemo(
     () =>
@@ -710,9 +751,9 @@ export function PchainNode({
                 {/* not the validation record (that's Past Validation Terms
                     above): this is the raw recent staking-tx feed, which on a
                     busy validator is all delegator additions */}
-                <SectionHeader label={`Recent staking activity · ${n.history.length}`} />
+                <SectionHeader label={`Recent staking activity · ${fullHistory.length}`} />
                 <Board>
-                  {(showAllHistory ? n.history : n.history.slice(0, LIST_CAP)).map((h) => (
+                  {(showAllHistory ? fullHistory : fullHistory.slice(0, LIST_CAP)).map((h) => (
                     <Link
                       key={h.txHash}
                       href={`${base}/tx/${h.txHash}`}
@@ -729,14 +770,23 @@ export function PchainNode({
                       </span>
                     </Link>
                   ))}
-                  {n.history.length > LIST_CAP && (
+                  {fullHistory.length > LIST_CAP && (
                     <ExpandRow
                       expanded={showAllHistory}
-                      count={n.history.length - LIST_CAP}
+                      count={fullHistory.length - LIST_CAP}
                       onClick={() => setShowAllHistory((v) => !v)}
                     />
                   )}
                 </Board>
+                {showAllHistory && !historyDone && (
+                  <button
+                    onClick={loadOlderHistory}
+                    disabled={loadingOlder}
+                    className="mx-auto border border-zinc-200 px-5 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-zinc-600 transition-colors hover:border-zinc-900 hover:text-zinc-900 disabled:opacity-50 dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-100 dark:hover:text-zinc-100"
+                  >
+                    {loadingOlder ? "Loading…" : "Load older activity"}
+                  </button>
+                )}
               </section>
             )}
           </div>

--- a/components/explorer-v2/pchain/PchainTx.tsx
+++ b/components/explorer-v2/pchain/PchainTx.tsx
@@ -57,7 +57,7 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
       tx.details?.stakingTxId ||
       tx.details?.rewardPaid !== undefined)
   );
-  // continuous staking (Granite): the stake renews itself on a period,
+  // continuous staking (Helicon): the stake renews itself on a period,
   // optionally compounding rewards back in
   const hasContinuous = !!(
     tx &&
@@ -88,22 +88,26 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
   // empty here and only the node knows about them
   const isRewardTx =
     tx?.txType === "RewardValidatorTx" || tx?.txType === "RewardAutoRenewedValidatorTx";
+  const isClassicRewardTx = tx?.txType === "RewardValidatorTx";
+  const stakingTxId = tx?.details?.stakingTxId;
   const [rewardUtxos, setRewardUtxos] = useState<RewardUtxo[] | null>(null);
   useEffect(() => {
     if (!isRewardTx) return;
+    // classic reward UTXOs are minted under the staking tx they reward;
+    // Helicon auto-renew payouts are keyed by the reward tx itself
+    const key = isClassicRewardTx ? (stakingTxId ?? txHash) : txHash;
     let cancelled = false;
-    getRewardUtxos(network, txHash).then((utxos) => {
+    getRewardUtxos(network, key).then((utxos) => {
       if (!cancelled) setRewardUtxos(utxos);
     });
     return () => {
       cancelled = true;
     };
-  }, [isRewardTx, network, txHash]);
+  }, [isRewardTx, isClassicRewardTx, stakingTxId, network, txHash]);
   const rewardWithdrawn = rewardUtxos?.reduce((sum, u) => sum + u.amount, 0) ?? 0;
 
   // the split needs the staker's compound ratio: withdrawn is the
   // (1 - c) share minted to the owner, so restaked = withdrawn * c/(1-c)
-  const stakingTxId = tx?.details?.stakingTxId;
   const [compoundShares, setCompoundShares] = useState<number | null>(null);
   useEffect(() => {
     if (tx?.txType !== "RewardAutoRenewedValidatorTx" || !stakingTxId) return;
@@ -160,6 +164,51 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
       cancelled = true;
     };
   }, [validationId, tx?.nodeId, isWarpOp, network]);
+
+  // a classic staking tx's own reward: once the period ends the payout is
+  // minted as reward UTXOs keyed by THIS tx; while the stake is live only
+  // the node's current validator set knows the potential reward
+  const isDelegatorTx =
+    tx?.txType === "AddDelegatorTx" || tx?.txType === "AddPermissionlessDelegatorTx";
+  const isPrimaryStaker =
+    (isDelegatorTx || tx?.txType === "AddValidatorTx" || tx?.txType === "AddPermissionlessValidatorTx") &&
+    tx?.subnetId === PRIMARY_SUBNET_ID;
+  const stakeEnded = !!tx?.endTimestamp && tx.endTimestamp <= Date.now() / 1000;
+  const [stakeRewardUtxos, setStakeRewardUtxos] = useState<RewardUtxo[] | null>(null);
+  useEffect(() => {
+    setStakeRewardUtxos(null);
+    if (!isPrimaryStaker || !stakeEnded) return;
+    let cancelled = false;
+    getRewardUtxos(network, txHash).then((utxos) => {
+      if (!cancelled) setStakeRewardUtxos(utxos);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isPrimaryStaker, stakeEnded, network, txHash]);
+  const stakeRewardPaid = stakeRewardUtxos?.reduce((sum, u) => sum + u.amount, 0) ?? 0;
+
+  const [potentialReward, setPotentialReward] = useState<number | null>(null);
+  useEffect(() => {
+    setPotentialReward(null);
+    if (!isPrimaryStaker || stakeEnded || !tx?.nodeId) return;
+    let cancelled = false;
+    getCurrentValidators(network, PRIMARY_SUBNET_ID, [tx.nodeId]).then((validators) => {
+      if (cancelled) return;
+      const v = validators?.[0];
+      if (!v) return;
+      const raw = isDelegatorTx
+        ? v.delegators?.find((d) => d.txID === txHash)?.potentialReward
+        : v.txID === txHash
+          ? v.potentialReward
+          : undefined;
+      const n = raw !== undefined ? Number(raw) : NaN;
+      if (Number.isFinite(n) && n > 0) setPotentialReward(n);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isPrimaryStaker, stakeEnded, isDelegatorTx, network, txHash, tx?.nodeId]);
 
   const initialStake = tx?.amountStaked?.reduce((sum, a) => sum + Number(a.amount || 0), 0) ?? 0;
   const restakedToDate =
@@ -297,7 +346,17 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
                 {tx.endTimestamp !== undefined && tx.endTimestamp > 0 && (
                   <SpecRow label="End">{formatTime(tx.endTimestamp)}</SpecRow>
                 )}
-                {tx.estimatedReward && <SpecRow label="Est. Reward">{formatAvax(tx.estimatedReward)}</SpecRow>}
+                {/* the stake's own payout once it ended, the live potential
+                    reward until then, the indexer's estimate as fallback */}
+                {stakeRewardUtxos !== null ? (
+                  <SpecRow label="Reward">
+                    {stakeRewardUtxos.length ? formatAvax(stakeRewardPaid) : "None (aborted)"}
+                  </SpecRow>
+                ) : potentialReward !== null ? (
+                  <SpecRow label="Est. Reward">{formatAvax(potentialReward)}</SpecRow>
+                ) : tx.estimatedReward ? (
+                  <SpecRow label="Est. Reward">{formatAvax(tx.estimatedReward)}</SpecRow>
+                ) : null}
                 {/* A continuous validator's reward never commits/aborts:
                     each renewal restakes the compound share and mints the
                     rest straight into state (shown in the fund flow). The
@@ -333,7 +392,7 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
             </Section>
           )}
 
-          {/* Continuous staking (Granite auto-renew family) */}
+          {/* Continuous staking (Helicon auto-renew family) */}
           {hasContinuous && (
             <Section label="Continuous Staking">
               <SpecPlate>

--- a/components/explorer-v2/pchain/PchainTx.tsx
+++ b/components/explorer-v2/pchain/PchainTx.tsx
@@ -8,11 +8,13 @@ import {
   bytesToHex,
   decodeL1WarpMessage,
   getCurrentValidators,
+  getL1Validator,
   getPlatformTx,
   getRewardUtxos,
   hexToNodeId,
   type DecodedL1WarpMessage,
   type L1InitialValidator,
+  type L1ValidatorInfo,
   type PlatformUnsignedTx,
   type RewardUtxo,
 } from "@/lib/pchain-node";
@@ -142,6 +144,23 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
       cancelled = true;
     };
   }, [isContinuousStaker, network, tx?.nodeId]);
+  // an IncreaseL1ValidatorBalanceTx / DisableL1ValidatorTx row carries only
+  // the validationID — the node resolves it to the seat's nodeID while the
+  // validator is still active (removed seats error, and the row stays off)
+  const validationId = tx?.details?.validationId;
+  const [l1Seat, setL1Seat] = useState<L1ValidatorInfo | null>(null);
+  useEffect(() => {
+    setL1Seat(null);
+    if (!validationId || tx?.nodeId || isWarpOp) return;
+    let cancelled = false;
+    getL1Validator(network, validationId).then((v) => {
+      if (!cancelled) setL1Seat(v);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [validationId, tx?.nodeId, isWarpOp, network]);
+
   const initialStake = tx?.amountStaked?.reduce((sum, a) => sum + Number(a.amount || 0), 0) ?? 0;
   const restakedToDate =
     liveWeight !== null && initialStake > 0 && liveWeight > initialStake ? liveWeight - initialStake : null;
@@ -365,6 +384,16 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
           {hasL1Validation && !isWarpOp && (
             <Section label="L1 Validation">
               <SpecPlate>
+                {l1Seat?.nodeID && (
+                  <SpecRow label="Node ID">
+                    <HashChip value={l1Seat.nodeID} href={`${base}/node/${l1Seat.nodeID}`} len={32} />
+                  </SpecRow>
+                )}
+                {l1Seat?.subnetID && !tx.subnetId && (
+                  <SpecRow label="Subnet ID">
+                    <SubnetChip base={base} subnetId={l1Seat.subnetID} />
+                  </SpecRow>
+                )}
                 {tx.details?.validationId && (
                   <SpecRow label="Validation ID">
                     <HashChip value={tx.details.validationId} len={32} />

--- a/components/explorer-v2/pchain/PchainTx.tsx
+++ b/components/explorer-v2/pchain/PchainTx.tsx
@@ -1081,6 +1081,15 @@ function UtxoColumn({ base, title, utxos, side }: { base: string; title: string;
                 spent in {truncate(u.consumingTxHash, 12)} →
               </Link>
             )}
+            {/* walk any UTXO backward through delegations/transfers */}
+            {u.txHash && side === "in" && (
+              <Link
+                href={`${base}/tx/${u.txHash}`}
+                className="font-mono text-[10px] text-[#0061E2] hover:text-[#E6212F] dark:text-[#5f9dff]"
+              >
+                ← created in {truncate(u.txHash, 12)}
+              </Link>
+            )}
           </div>
         ))}
       </Board>

--- a/components/explorer-v2/pchain/PchainTx.tsx
+++ b/components/explorer-v2/pchain/PchainTx.tsx
@@ -83,9 +83,9 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
   // as the authoritative "does this tx exist on-chain at all?" check
   const platformOp = usePlatformTx(network, txHash, isConvert || isWarpOp || isCreateChain || notFound);
 
-  // Reward payouts are minted directly into P-Chain state keyed by this
-  // tx, never as tx outputs, so the indexer's emittedUtxos is always
-  // empty here and only the node knows about them
+  // Reward payouts are minted directly into P-Chain state, not as tx
+  // outputs. The indexer bridges them into emittedUtxos
+  // the node fetch remains the amount source here and fallback for pages this flow can't cover.
   const isRewardTx =
     tx?.txType === "RewardValidatorTx" || tx?.txType === "RewardAutoRenewedValidatorTx";
   const isClassicRewardTx = tx?.txType === "RewardValidatorTx";
@@ -188,9 +188,28 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
   }, [isPrimaryStaker, stakeEnded, network, txHash]);
   const stakeRewardPaid = stakeRewardUtxos?.reduce((sum, u) => sum + u.amount, 0) ?? 0;
 
+  // a delegation's payout mints two reward UTXOs: the delegator's NET reward
+  // (owned by the tx's reward addresses) and the validator's delegation-fee cut
+  // split by owner so the page can answer "what did I actually get, net of fee".
+  const rewardAddrSet = new Set((tx?.rewardAddresses ?? []).map((a) => a.replace(/^P-/, "")));
+  const stakeRewardNet =
+    isDelegatorTx && stakeRewardUtxos?.length && rewardAddrSet.size
+      ? stakeRewardUtxos
+          .filter((u) => u.addresses.some((a) => rewardAddrSet.has(a.replace(/^P-/, ""))))
+          .reduce((sum, u) => sum + u.amount, 0)
+      : null;
+  const stakeRewardFee =
+    stakeRewardNet !== null && stakeRewardNet > 0 && stakeRewardNet < stakeRewardPaid
+      ? stakeRewardPaid - stakeRewardNet
+      : null;
+
   const [potentialReward, setPotentialReward] = useState<number | null>(null);
+  // validator's fee percentage — turns the delegator's GROSS potential
+  // reward into the net estimate they'll actually receive
+  const [validatorFeePct, setValidatorFeePct] = useState<number | null>(null);
   useEffect(() => {
     setPotentialReward(null);
+    setValidatorFeePct(null);
     if (!isPrimaryStaker || stakeEnded || !tx?.nodeId) return;
     let cancelled = false;
     getCurrentValidators(network, PRIMARY_SUBNET_ID, [tx.nodeId]).then((validators) => {
@@ -204,6 +223,8 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
           : undefined;
       const n = raw !== undefined ? Number(raw) : NaN;
       if (Number.isFinite(n) && n > 0) setPotentialReward(n);
+      const fee = v.delegationFee !== undefined ? Number(v.delegationFee) : NaN;
+      if (isDelegatorTx && Number.isFinite(fee) && fee >= 0 && fee <= 100) setValidatorFeePct(fee);
     });
     return () => {
       cancelled = true;
@@ -359,11 +380,41 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
                 {/* the stake's own payout once it ended, the live potential
                     reward until then, the indexer's estimate as fallback */}
                 {stakeRewardUtxos !== null ? (
-                  <SpecRow label="Reward">
-                    {stakeRewardUtxos.length ? formatAvax(stakeRewardPaid) : "None (aborted)"}
-                  </SpecRow>
+                  stakeRewardUtxos.length === 0 ? (
+                    <SpecRow label="Reward">None (aborted)</SpecRow>
+                  ) : stakeRewardNet !== null && stakeRewardFee !== null ? (
+                    /* delegation payout split by UTXO owner: what the
+                       delegator actually received vs the validator's cut */
+                    <>
+                      <SpecRow label="Reward Received">
+                        {formatAvax(stakeRewardNet)}
+                        <span className="ml-2 text-zinc-400 dark:text-zinc-500">
+                          net of delegation fee
+                        </span>
+                      </SpecRow>
+                      <SpecRow label="Delegation Fee">
+                        {formatAvax(stakeRewardFee)}
+                        <span className="ml-2 text-zinc-400 dark:text-zinc-500">
+                          paid to the validator
+                        </span>
+                      </SpecRow>
+                    </>
+                  ) : (
+                    <SpecRow label="Reward">{formatAvax(stakeRewardPaid)}</SpecRow>
+                  )
                 ) : potentialReward !== null ? (
-                  <SpecRow label="Est. Reward">{formatAvax(potentialReward)}</SpecRow>
+                  <SpecRow label="Est. Reward">
+                    {validatorFeePct !== null && potentialReward > 0 ? (
+                      <>
+                        {formatAvax(Math.round(potentialReward * (1 - validatorFeePct / 100)))}
+                        <span className="ml-2 text-zinc-400 dark:text-zinc-500">
+                          net of {validatorFeePct}% delegation fee
+                        </span>
+                      </>
+                    ) : (
+                      formatAvax(potentialReward)
+                    )}
+                  </SpecRow>
                 ) : tx.estimatedReward ? (
                   <SpecRow label="Est. Reward">{formatAvax(tx.estimatedReward)}</SpecRow>
                 ) : null}

--- a/components/explorer-v2/pchain/PchainTx.tsx
+++ b/components/explorer-v2/pchain/PchainTx.tsx
@@ -7,6 +7,7 @@ import {
   PRIMARY_SUBNET_ID,
   bytesToHex,
   decodeL1WarpMessage,
+  getCurrentValidators,
   getPlatformTx,
   getRewardUtxos,
   hexToNodeId,
@@ -81,7 +82,7 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
   const platformOp = usePlatformTx(network, txHash, isConvert || isWarpOp || isCreateChain || notFound);
 
   // Reward payouts are minted directly into P-Chain state keyed by this
-  // tx — never as tx outputs — so the indexer's emittedUtxos is always
+  // tx, never as tx outputs, so the indexer's emittedUtxos is always
   // empty here and only the node knows about them
   const isRewardTx =
     tx?.txType === "RewardValidatorTx" || tx?.txType === "RewardAutoRenewedValidatorTx";
@@ -96,7 +97,84 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
       cancelled = true;
     };
   }, [isRewardTx, network, txHash]);
-  const rewardTotal = rewardUtxos?.reduce((sum, u) => sum + u.amount, 0) ?? 0;
+  const rewardWithdrawn = rewardUtxos?.reduce((sum, u) => sum + u.amount, 0) ?? 0;
+
+  // the split needs the staker's compound ratio: withdrawn is the
+  // (1 - c) share minted to the owner, so restaked = withdrawn * c/(1-c)
+  const stakingTxId = tx?.details?.stakingTxId;
+  const [compoundShares, setCompoundShares] = useState<number | null>(null);
+  useEffect(() => {
+    if (tx?.txType !== "RewardAutoRenewedValidatorTx" || !stakingTxId) return;
+    let cancelled = false;
+    fetch(`/api/pchain/${network}/tx/${stakingTxId}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((staker: Tx | null) => {
+        if (!cancelled && typeof staker?.autoCompoundRewardShares === "number") {
+          setCompoundShares(staker.autoCompoundRewardShares);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [tx?.txType, stakingTxId, network]);
+  // avalanchego's PercentDenominator for reward shares
+  const SHARES_DENOM = 1_000_000;
+  const rewardRestaked =
+    compoundShares !== null && compoundShares > 0 && compoundShares < SHARES_DENOM && rewardWithdrawn > 0
+      ? Math.round((rewardWithdrawn * compoundShares) / (SHARES_DENOM - compoundShares))
+      : null;
+
+  // a live continuous validator carries its compounded stake in the
+  // current validator set: weight minus the original stake is every
+  // renewal's restake to date
+  const isContinuousStaker = tx?.txType === "AddAutoRenewedValidatorTx";
+  const [liveWeight, setLiveWeight] = useState<number | null>(null);
+  useEffect(() => {
+    if (!isContinuousStaker || !tx?.nodeId) return;
+    let cancelled = false;
+    getCurrentValidators(network, PRIMARY_SUBNET_ID, [tx.nodeId]).then((validators) => {
+      if (cancelled || !validators?.length) return;
+      const weight = Number(validators[0].weight);
+      if (Number.isFinite(weight) && weight > 0) setLiveWeight(weight);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isContinuousStaker, network, tx?.nodeId]);
+  const initialStake = tx?.amountStaked?.reduce((sum, a) => sum + Number(a.amount || 0), 0) ?? 0;
+  const restakedToDate =
+    liveWeight !== null && initialStake > 0 && liveWeight > initialStake ? liveWeight - initialStake : null;
+
+  // reward UTXOs join the fund flow as emitted outputs (the diagram
+  // already tones Reward* txs' outputs as rewards)
+  const rewardEmitted: Utxo[] =
+    tx && rewardUtxos?.length
+      ? rewardUtxos.map((u) => ({
+          addresses: u.addresses.map((a) => a.replace(/^P-/, "")),
+          utxoId: `${tx.txHash}:${u.outputIndex}`,
+          txHash: tx.txHash,
+          outputIndex: u.outputIndex,
+          blockTimestamp: tx.blockTimestamp,
+          blockNumber: tx.blockNumber,
+          assetId: "",
+          asset: {
+            assetId: "",
+            name: "Avalanche",
+            symbol: "AVAX",
+            denomination: 9,
+            amount: String(u.amount),
+          },
+          utxoType: "reward",
+          amount: String(u.amount),
+          platformLocktime: u.locktime,
+          threshold: u.threshold,
+          createdOnChainId: "",
+          consumedOnChainId: "",
+          staked: false,
+        }))
+      : [];
+  const flowEmitted = tx ? (rewardEmitted.length ? [...tx.emittedUtxos, ...rewardEmitted] : tx.emittedUtxos) : [];
 
   return (
     <ExplorerShell chain={chain} network={network}>
@@ -202,18 +280,20 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
                 )}
                 {tx.estimatedReward && <SpecRow label="Est. Reward">{formatAvax(tx.estimatedReward)}</SpecRow>}
                 {/* A continuous validator's reward never commits/aborts:
-                    it restakes on every renewal, with any non-compounded
-                    share minted straight into state (the board below).
-                    The indexer's rewardPaid flag only means something for
-                    the legacy end-of-stake commit/abort vote. */}
+                    each renewal restakes the compound share and mints the
+                    rest straight into state (shown in the fund flow). The
+                    indexer's rewardPaid flag only means something for the
+                    legacy end-of-stake commit/abort vote. */}
                 {tx.details?.rewardPaid !== undefined &&
                   (tx.txType === "RewardAutoRenewedValidatorTx" ? (
                     <SpecRow label="Reward">
                       {rewardUtxos === null
                         ? "Restaked · compounds into the stake"
-                        : rewardUtxos.length
-                          ? `Restaked · ${formatAvax(rewardTotal)} paid out`
-                          : "Restaked · fully compounded"}
+                        : rewardUtxos.length === 0
+                          ? "Fully compounded into the stake"
+                          : rewardRestaked !== null
+                            ? `${formatAvax(rewardRestaked)} restaked · ${formatAvax(rewardWithdrawn)} withdrawn`
+                            : `Restaked · ${formatAvax(rewardWithdrawn)} withdrawn`}
                     </SpecRow>
                   ) : (
                     <SpecRow label="Reward Paid">
@@ -232,29 +312,6 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
                 ) : null}
               </SpecPlate>
             </Section>
-          )}
-
-          {/* the payout itself: state-minted UTXOs keyed by this tx */}
-          {isRewardTx && rewardUtxos !== null && rewardUtxos.length > 0 && (
-            <section className="flex flex-col gap-3">
-              <Section label="Reward Payout">
-                <SpecPlate>
-                  {rewardUtxos.map((u) => (
-                    <SpecRow key={u.outputIndex} label={`UTXO #${u.outputIndex}`} align="start">
-                      <div className="flex flex-col items-end gap-1">
-                        <span>{formatAvax(u.amount)}</span>
-                        <AddrList base={base} addrs={u.addresses} />
-                      </div>
-                    </SpecRow>
-                  ))}
-                </SpecPlate>
-              </Section>
-              <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
-                Reward UTXOs are minted directly into P-Chain state under this transaction&apos;s
-                ID: they are not outputs of the transaction itself, so they come from the node
-                rather than the indexer.
-              </p>
-            </section>
           )}
 
           {/* Continuous staking (Granite auto-renew family) */}
@@ -284,6 +341,16 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
                       ? "0% — rewards are fully paid out, nothing restakes"
                       : `${autoCompoundPct(tx)}% of each reward restakes`}
                   </SpecRow>
+                )}
+                {/* compounding shows up as stake weight: the live set's
+                    weight above the original stake is every renewal's
+                    restake so far (only visible while the validator is
+                    in the current set) */}
+                {liveWeight !== null && (
+                  <SpecRow label="Current Stake">{formatAvax(liveWeight)}</SpecRow>
+                )}
+                {restakedToDate !== null && (
+                  <SpecRow label="Restaked To Date">{formatAvax(restakedToDate)}</SpecRow>
                 )}
                 {tx.validatorAuthority?.length ? (
                   <SpecRow label="Config Authority" align="start">
@@ -431,7 +498,7 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
             />
             {!hasFundMovement({
               consumed: tx.consumedUtxos,
-              emitted: tx.emittedUtxos,
+              emitted: flowEmitted,
               burned: tx.amountBurned,
               importedFrom: tx.importedFrom,
               sourceChain: tx.details?.sourceChain,
@@ -444,7 +511,7 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
               <Board divide={false} className="px-5 py-6 md:px-6">
                 <FundFlowDiagram
                   consumed={tx.consumedUtxos}
-                  emitted={tx.emittedUtxos}
+                  emitted={flowEmitted}
                   burned={tx.amountBurned}
                   txType={tx.txType}
                   base={base}
@@ -456,8 +523,15 @@ export function PchainTx({ chain, network, txHash }: { chain: string; network: s
             ) : (
               <div className="grid gap-6 lg:grid-cols-2">
                 <UtxoColumn base={base} title={`Consumed · ${tx.consumedUtxos.length}`} utxos={tx.consumedUtxos} side="in" />
-                <UtxoColumn base={base} title={`Emitted · ${tx.emittedUtxos.length}`} utxos={tx.emittedUtxos} side="out" />
+                <UtxoColumn base={base} title={`Emitted · ${flowEmitted.length}`} utxos={flowEmitted} side="out" />
               </div>
+            )}
+            {rewardEmitted.length > 0 && (
+              <p className="text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+                Reward UTXOs are minted directly into P-Chain state under this transaction&apos;s
+                ID rather than as transaction outputs, so they are read from the node, not the
+                indexer.
+              </p>
             )}
           </section>
         </div>

--- a/components/explorer-v2/pchain/PchainTxsList.tsx
+++ b/components/explorer-v2/pchain/PchainTxsList.tsx
@@ -33,7 +33,29 @@ export function PchainTxsList({ chain, network }: { chain: string; network: stri
   const [limit, setLimit] = useState(50);
   const [type, setType] = useState("");
   const { data, loading } = usePchainData<TxSummary[]>(network, "txs", { limit, type: type || undefined }, { refreshMs: LIVE_REFRESH_MS });
-  const txs = data ?? [];
+  /* Cursor paging: the live page keeps refreshing at the tip; older pages
+     are fetched once with ?before=<lastBlockHeight> and appended. */
+  const [older, setOlder] = useState<TxSummary[]>([]);
+  const [pagedOut, setPagedOut] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const live = data ?? [];
+  const seenHashes = new Set(live.map((t) => t.txHash));
+  const txs = [...live, ...older.filter((t) => !seenHashes.has(t.txHash))];
+  const loadOlder = async () => {
+    const last = txs[txs.length - 1];
+    if (!last || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const qs = new URLSearchParams({ limit: "50", before: String(last.blockHeight) });
+      if (type) qs.set("type", type);
+      const res = await fetch(`/api/pchain/${network}/txs?${qs}`);
+      const page: TxSummary[] = res.ok ? await res.json() : [];
+      if (page.length === 0) setPagedOut(true);
+      setOlder((o) => [...o, ...page]);
+    } finally {
+      setLoadingMore(false);
+    }
+  };
   const activeLabel = TYPE_OPTIONS.find((o) => o.value === type)?.label ?? "All types";
 
   return (
@@ -47,6 +69,8 @@ export function PchainTxsList({ chain, network }: { chain: string; network: stri
                 onClick={() => {
                   setType("");
                   setLimit(50);
+                  setOlder([]);
+                  setPagedOut(false);
                 }}
                 className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 transition-colors hover:text-[#E6212F] dark:text-zinc-500"
               >
@@ -61,6 +85,8 @@ export function PchainTxsList({ chain, network }: { chain: string; network: stri
           onChange={(v) => {
             setType(v);
             setLimit(50);
+                  setOlder([]);
+                  setPagedOut(false);
           }}
         />
         <Board className={cn(loading && txs.length > 0 && "opacity-60 transition-opacity")}>
@@ -101,6 +127,8 @@ export function PchainTxsList({ chain, network }: { chain: string; network: stri
                   onClick={() => {
                     setType("");
                     setLimit(50);
+                  setOlder([]);
+                  setPagedOut(false);
                   }}
                   className="uppercase tracking-[0.12em] text-zinc-500 underline-offset-4 transition-colors hover:text-[#E6212F] hover:underline dark:text-zinc-400"
                 >
@@ -110,12 +138,13 @@ export function PchainTxsList({ chain, network }: { chain: string; network: stri
             </div>
           )}
         </Board>
-        {!loading && txs.length >= limit && (
+        {!loading && txs.length >= limit && !pagedOut && (
           <button
-            onClick={() => setLimit((l) => l + 50)}
-            className="mx-auto border border-zinc-200 px-5 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-zinc-600 transition-colors hover:border-zinc-900 hover:text-zinc-900 dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-100 dark:hover:text-zinc-100"
+            onClick={loadOlder}
+            disabled={loadingMore}
+            className="mx-auto border border-zinc-200 px-5 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-zinc-600 transition-colors hover:border-zinc-900 hover:text-zinc-900 disabled:opacity-50 dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-100 dark:hover:text-zinc-100"
           >
-            Load more
+            {loadingMore ? "Loading…" : "Load more"}
           </button>
         )}
       </section>

--- a/constants/l1-chains.json
+++ b/constants/l1-chains.json
@@ -803,7 +803,8 @@
       "logoUri": "https://images.ctfassets.net/gcj8jwzm6086/15KL2tZgiggSNEgHbrxG4C/5f9b3f91c0a7666cd3d26b4d273fa158/defikingdoms.png",
       "description": "JEWEL is the central token on the DFK Subnet and used to pay gas for all transactions. While it is not natively minted on the DFK Subnet, it is integral to the subnet's function."
     },
-    "isActive": true
+    "isActive": true,
+    "isIndexed": false
   },
   {
     "chainId": "96786",
@@ -3414,7 +3415,8 @@
       }
     ],
     "isTestnet": true,
-    "isActive": false
+    "isActive": false,
+    "isIndexed": false
   },
   {
     "chainId": "179202",

--- a/lib/pchain-node.ts
+++ b/lib/pchain-node.ts
@@ -69,6 +69,8 @@ export interface CurrentValidator {
   startTime?: string;
   /** nAVAX this validation earns if it serves its full period */
   potentialReward?: string;
+  /** percentage string (e.g. "2.0000") the validator keeps from delegator rewards */
+  delegationFee?: string;
   delegators?: CurrentDelegator[];
   publicKey?: string;
   remainingBalanceOwner?: PchainOwner;

--- a/lib/pchain-node.ts
+++ b/lib/pchain-node.ts
@@ -44,6 +44,18 @@ export interface SubnetInfo {
   managerAddress?: string | null;
 }
 
+/** A live delegation riding a Primary Network validator; only present
+ *  when platform.getCurrentValidators is asked about specific nodeIDs. */
+export interface CurrentDelegator {
+  txID: string;
+  startTime: string;
+  endTime: string;
+  weight?: string;
+  /** nAVAX this delegation earns if it serves its full period */
+  potentialReward?: string;
+  rewardOwner?: PchainOwner;
+}
+
 /** platform.getCurrentValidators entry — L1 validators carry validationID
  *  and balance; legacy subnet validators carry txID/start/end instead.
  *  Primary Network validators additionally carry the reward plumbing the
@@ -53,7 +65,11 @@ export interface CurrentValidator {
   weight: string;
   balance?: string; // nAVAX
   validationID?: string;
+  txID?: string;
   startTime?: string;
+  /** nAVAX this validation earns if it serves its full period */
+  potentialReward?: string;
+  delegators?: CurrentDelegator[];
   publicKey?: string;
   remainingBalanceOwner?: PchainOwner;
   deactivationOwner?: PchainOwner;

--- a/lib/pchain-node.ts
+++ b/lib/pchain-node.ts
@@ -171,6 +171,22 @@ export async function getSubnetInfo(network: string, subnetID: string): Promise<
   return rpc<SubnetInfo>(network, "platform.getSubnet", { subnetID });
 }
 
+export interface L1ValidatorInfo {
+  nodeID: string;
+  subnetID: string;
+  weight?: string | number;
+  /** nAVAX prepaid toward the continuous fee */
+  balance?: string | number;
+}
+
+/** Resolves an ACP-77 validationID to the seat's live nodeID/subnetID.
+ *  The node only answers while the seat is active — a removed validator
+ *  errors, which surfaces here as null. */
+export async function getL1Validator(network: string, validationID: string): Promise<L1ValidatorInfo | null> {
+  const r = await rpc<L1ValidatorInfo>(network, "platform.getL1Validator", { validationID });
+  return r?.nodeID ? r : null;
+}
+
 /** ACP-77 L1 validator fee market: `price` is the continuous fee every L1
  *  validator seat pays right now, in nAVAX per second, burned from the
  *  seat's prepaid balance. */


### PR DESCRIPTION
## What changed
- Added `platform.getL1Validator` to the P-Chain RPC proxy allowlist
- New `getL1Validator` helper in `lib/pchain-node.ts` (returns null once a seat is removed, since the node errors)
- `PchainTx` L1 Validation panel now shows a clickable Node ID (and the L1's Subnet ID) resolved from the validationID for IncreaseL1ValidatorBalanceTx / DisableL1ValidatorTx

## Verification
- `tsc --noEmit` clean
- Verified on Fuji: tx `pzzmvtVQxDNKbPnp3mkXua8TbV7N5f3HPHUL5MHttoQ5P8bwM` resolves to `NodeID-JkW6Fb7TcKTnCWgYGGcWQ8BqVUbTNhAvv`

## Open questions
- Historical txs whose validator was since removed still show only the validationID; showing NodeID there needs an indexer-side join