### PR TITLE
fix(console): preflight min stake duration before validator removal

### DIFF
--- a/components/toolbox/console/remove-validator/PosInitiateRemoval.tsx
+++ b/components/toolbox/console/remove-validator/PosInitiateRemoval.tsx
@@ -278,7 +278,7 @@ function ProbeBanner({ probe, onRetry }: { probe: ProbeState; onRetry: () => voi
       ? "The contract says this validator hasn't met the rewards threshold."
       : probe.reason === 'not-found'
         ? "The L1 node's /validators endpoint didn't return this validator."
-        : "The L1 node's /validators endpoint is unreachable.";
+        : "The L1 node's /validators endpoint is unreachable. Public RPC gateways don't proxy this API; it's only served directly by a node (http://<node-ip>:9650/ext/bc/<blockchainID>/validators).";
 
   return (
     <div className="flex items-start gap-3 rounded-2xl border border-amber-500/30 bg-amber-500/5 dark:bg-amber-500/10 px-4 py-3">

--- a/components/toolbox/hooks/useValidatorPreflight.ts
+++ b/components/toolbox/hooks/useValidatorPreflight.ts
@@ -143,7 +143,15 @@ function deriveChecks(
       ? notMetCheck(
           'There is a pending P-Chain operation for this validator (nonce mismatch). Complete the current operation before starting a new one. If you recently submitted a P-Chain transaction, wait for it to be confirmed.',
         )
-      : deriveInitiateRemovalCheck(status, stakingData, walletAddress, churn, totalWeight, validatorWeight),
+      : deriveInitiateRemovalCheck(
+          status,
+          stakingData,
+          walletAddress,
+          churn,
+          totalWeight,
+          validatorWeight,
+          validatorData,
+        ),
     completeRemoval: deriveCompleteRemovalCheck(status),
     completeRegistration: deriveCompleteRegistrationCheck(status),
   };
@@ -192,6 +200,7 @@ function deriveInitiateRemovalCheck(
   churn: ValidatorPreflightResult['churn'],
   totalWeight: bigint,
   validatorWeight: bigint,
+  validatorData: ValidatorPreflightResult['validatorData'],
 ): PreflightCheck {
   if (status !== ValidatorStatus.Active) {
     if (status === ValidatorStatus.PendingAdded) {
@@ -220,6 +229,21 @@ function deriveInitiateRemovalCheck(
     const isOwner = stakingData.owner.toLowerCase() === walletAddress.toLowerCase();
     if (!isOwner) {
       return notMetCheck(`Connected wallet is not the validator owner. Owner: ${stakingData.owner}`);
+    }
+  }
+
+  // Check minimum stake duration (PoS only). The StakingManager enforces
+  // startTime + minStakeDuration on BOTH initiateValidatorRemoval and
+  // forceInitiateValidatorRemoval, so an early removal reverts with
+  // MinStakeDurationNotPassed even in force mode.
+  if (stakingData && validatorData && validatorData.startTime > 0n && stakingData.minStakeDuration > 0n) {
+    const removableAt = validatorData.startTime + stakingData.minStakeDuration;
+    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+    if (nowSeconds < removableAt) {
+      const removableAtDate = new Date(Number(removableAt) * 1000);
+      return notMetCheck(
+        `Minimum stake duration has not passed. Removal (including force removal) becomes possible at ${removableAtDate.toLocaleString()}.`,
+      );
     }
   }
 


### PR DESCRIPTION
## What changed

- `useValidatorPreflight`: new initiate-removal check comparing `getValidator().startTime + getStakingValidator().minStakeDuration` against now. The StakingManager enforces this on both `initiateValidatorRemoval` and `forceInitiateValidatorRemoval`, so early removals reverted with `MinStakeDurationNotPassed` after every visible preflight check passed. The checklist now blocks with the exact time removal becomes possible.
- `PosInitiateRemoval`: the uptime-unavailable banner now explains that public RPC gateways don't proxy the `/validators` API and shows the node URL shape to use in the custom URL field.

## Verification

- `tsc --noEmit` clean (after syncing node_modules; pre-existing Stake.tsx errors were stale deps, not repo errors).
- Reproduced the failure mode from a user report: re-registered validator, preflight all green, force removal reverts on simulation.

## Open questions

None.