### PR TITLE
docs(platform-cli): multisig owners, multi-key signing, partial signing

### DIFF
--- a/content/docs/tooling/platform-cli/chains.mdx
+++ b/content/docs/tooling/platform-cli/chains.mdx
@@ -3,7 +3,7 @@ title: Chains
 description: Deploy new blockchains on existing subnets
 ---
 
-Deploy a new blockchain on an existing subnet using the `chain create` command.
+Use the `chain create` command to deploy a new blockchain on an existing subnet.
 
 ## Create a Chain
 

--- a/content/docs/tooling/platform-cli/command-reference.mdx
+++ b/content/docs/tooling/platform-cli/command-reference.mdx
@@ -94,7 +94,7 @@ platform-cli keys delete --name <name> [--force]
 platform-cli keys default [--name <name>]
 ```
 
-Shows current default if `--name` is omitted. Sets default if `--name` is provided.
+Shows the current default if you omit `--name`. Sets the default if you provide `--name`.
 
 ## wallet
 
@@ -190,7 +190,7 @@ platform-cli validator add-permissionless --node-id <id> --stake <avax>
 | `--node-id` | Node ID (required) | |
 | `--stake` | Stake in AVAX (required) | |
 | `--duration` | Validation duration | `336h` |
-| `--start` | Start time (RFC3339 or `now`). Ignored post-Durango; validation starts at tx acceptance | `now` |
+| `--start` | Start time (RFC3339 or `now`). The network ignores this flag after Durango. Validation starts at tx acceptance | `now` |
 | `--delegation-fee` | Fee percentage (0.02 = 2%) | `0.02` |
 | `--reward-address` | Reward address | own address |
 | `--bls-public-key` | BLS public key hex (recommended) | |
@@ -208,7 +208,7 @@ platform-cli validator add-permissionless-delegator --node-id <id> --stake <avax
 | `--node-id` | Node ID to delegate to (required) | |
 | `--stake` | Stake in AVAX (required) | |
 | `--duration` | Delegation duration | `336h` |
-| `--start` | Start time (RFC3339 or `now`). Ignored post-Durango; validation starts at tx acceptance | `now` |
+| `--start` | Start time (RFC3339 or `now`). The network ignores this flag after Durango. Validation starts at tx acceptance | `now` |
 | `--reward-address` | Reward address | own address |
 
 ### validator add-auto-renewed
@@ -238,7 +238,7 @@ Adds an auto-renewed validator (`AddAutoRenewedValidatorTx`, ACP-236) that resta
 platform-cli validator set-auto-renewed-config --tx-id <id> --period <dur> --auto-compound <frac>
 ```
 
-Updates the next-cycle config of an auto-renewed validator (`SetAutoRenewedValidatorConfigTx`). Must be signed by the owner address set at add time.
+Updates the next-cycle config of an auto-renewed validator (`SetAutoRenewedValidatorConfigTx`). The owner address set at add time must sign the transaction.
 
 | Flag | Description |
 |------|-------------|
@@ -255,7 +255,7 @@ Updates the next-cycle config of an auto-renewed validator (`SetAutoRenewedValid
 platform-cli subnet create
 ```
 
-Creates a new subnet owned by the wallet address. No additional flags required.
+Creates a new subnet that the wallet address owns. This command needs no additional flags.
 
 ### subnet transfer-ownership
 
@@ -304,7 +304,7 @@ Adds a validator to a permissioned subnet (`AddSubnetValidatorTx`). The node mus
 | `--subnet-id` | Subnet ID (required) | |
 | `--node-id` | Validator node ID, must already validate the primary network (required) | |
 | `--weight` | Validator sampling weight on the subnet (required, > 0) | |
-| `--start` | Start time (RFC3339 or `now`). Ignored post-Durango; validation starts at tx acceptance | `now` |
+| `--start` | Start time (RFC3339 or `now`). The network ignores this flag after Durango. Validation starts at tx acceptance | `now` |
 | `--duration` | Validation duration (must fall within the node's primary network validation period) | `336h` |
 
 ## l1
@@ -358,7 +358,7 @@ Sign and submit partially signed transactions for multisig owners. See [Multisig
 
 ### tx sign
 
-Add signatures with locally available keys; existing signatures are preserved and the file is updated in place.
+Add signatures with locally available keys. The CLI keeps existing signatures and updates the file in place.
 
 ```bash
 platform-cli tx sign --tx-path <file>
@@ -370,7 +370,7 @@ platform-cli tx sign --tx-path <file>
 
 ### tx commit
 
-Submit a fully signed transaction and wait for acceptance. Refuses under-signed transactions and lists the missing signers. No key is needed.
+Submit a fully signed transaction and wait for acceptance. Refuses under-signed transactions and lists the missing signers. This command needs no key.
 
 ```bash
 platform-cli tx commit --tx-path <file>

--- a/content/docs/tooling/platform-cli/command-reference.mdx
+++ b/content/docs/tooling/platform-cli/command-reference.mdx
@@ -10,7 +10,7 @@ Available on all commands:
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
 | `--network` | `-n` | Network: `fuji` or `mainnet` | `fuji` |
-| `--key-name` | | Load key from keystore by name | |
+| `--key-name` | | Load key from keystore by name (repeat or comma-separate to sign with multiple keys) | |
 | `--ledger` | | Use Ledger hardware wallet | `false` |
 | `--ledger-index` | | Ledger BIP44 address index | `0` |
 | `--rpc-url` | | Custom RPC URL (overrides `--network`) | |
@@ -260,13 +260,17 @@ Creates a new subnet owned by the wallet address. No additional flags required.
 ### subnet transfer-ownership
 
 ```bash
-platform-cli subnet transfer-ownership --subnet-id <id> --new-owner <address>
+platform-cli subnet transfer-ownership --subnet-id <id> --new-owner <address> [--new-owner <address> ...] [--threshold <n>] [--output-tx-path <file>]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--subnet-id` | Subnet ID (required) |
-| `--new-owner` | New owner P-Chain address (required) |
+| `--new-owner` | New owner P-Chain address, bech32 or CB58 (required; repeat or comma-separate for a multisig owner) |
+| `--threshold` | Owner signatures required for future subnet changes (default `1`) |
+| `--output-tx-path` | Write a partially signed tx file instead of submitting (complete with `tx sign` / `tx commit`) |
+
+See [Multisig Owners](/docs/tooling/platform-cli/multisig) for multisig workflows.
 
 ### subnet convert-to-l1
 
@@ -347,6 +351,34 @@ platform-cli l1 disable-validator --validation-id <id>
 | Flag | Description |
 |------|-------------|
 | `--validation-id` | Validation ID to disable (required) |
+
+## tx
+
+Sign and submit partially signed transactions for multisig owners. See [Multisig Owners](/docs/tooling/platform-cli/multisig).
+
+### tx sign
+
+Add signatures with locally available keys; existing signatures are preserved and the file is updated in place.
+
+```bash
+platform-cli tx sign --tx-path <file>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--tx-path` | Transaction file to sign (required) |
+
+### tx commit
+
+Submit a fully signed transaction and wait for acceptance. Refuses under-signed transactions and lists the missing signers. No key is needed.
+
+```bash
+platform-cli tx commit --tx-path <file>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--tx-path` | Transaction file to submit (required) |
 
 ## chain
 

--- a/content/docs/tooling/platform-cli/installation.mdx
+++ b/content/docs/tooling/platform-cli/installation.mdx
@@ -31,7 +31,7 @@ platform-cli --help
 
 ## Build from Source
 
-Requires **Go 1.25+** ([install Go](https://go.dev/dl/)).
+Building from source requires **Go 1.25+** ([install Go](https://go.dev/dl/)).
 
 ```bash
 git clone https://github.com/ava-labs/platform-cli.git
@@ -49,7 +49,7 @@ go build -tags ledger -o platform-cli .
 
 ## Global Flags
 
-These flags are available on all commands:
+All commands accept these flags:
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
@@ -103,7 +103,7 @@ platform-cli wallet balance --key-name mykey --rpc-url http://127.0.0.1:9650
 platform-cli wallet balance --key-name mykey --rpc-url https://my-node.example.com:9650 --network-id 5
 ```
 
-When using `--rpc-url`, the network ID is auto-detected from the node unless `--network-id` is specified.
+If you use `--rpc-url` without `--network-id`, Platform CLI auto-detects the network ID from the node.
 
 ## Next Steps
 

--- a/content/docs/tooling/platform-cli/key-management.mdx
+++ b/content/docs/tooling/platform-cli/key-management.mdx
@@ -3,7 +3,7 @@ title: Key Management
 description: Generate, import, export, and encrypt private keys with Platform CLI
 ---
 
-Platform CLI stores keys in `~/.platform/keys/` with AES-256-GCM encryption enabled by default. Keys are encrypted using Argon2id key derivation with a user-provided password.
+Platform CLI stores keys in `~/.platform/keys/` with AES-256-GCM encryption enabled by default. The encryption uses Argon2id key derivation and a password that you provide.
 
 ## Generating Keys
 
@@ -84,7 +84,7 @@ platform-cli keys export --name mykey --format hex --output-file ./mykey.hex
 platform-cli keys export --name mykey --unsafe-stdout
 ```
 
-If the key is encrypted, you'll be prompted for the password. Set `PLATFORM_CLI_KEY_PASSWORD` to skip the prompt in scripts.
+If the key is encrypted, Platform CLI prompts you for the password. Set `PLATFORM_CLI_KEY_PASSWORD` to skip the prompt in scripts.
 
 ## Deleting Keys
 
@@ -96,7 +96,7 @@ platform-cli keys delete --name mykey
 platform-cli keys delete --name mykey --force
 ```
 
-Deletion is irreversible. Ensure you have a backup first.
+Deletion cannot be undone. Make sure that you have a backup first.
 
 ## Default Key
 
@@ -122,7 +122,7 @@ The ewoq key is pre-funded on local networks. Platform CLI blocks its use on mai
 
 ## Ledger Hardware Wallet
 
-Build with Ledger support and use the `--ledger` flag:
+Build the CLI with Ledger support. Then use the `--ledger` flag:
 
 ```bash
 go build -tags ledger -o platform-cli .
@@ -137,7 +137,7 @@ platform-cli wallet balance --ledger --ledger-index 1
 
 ## Security Best Practices
 
-1. **Keys are encrypted by default** - only use `--encrypt=false` for throwaway test keys
+1. **Platform CLI encrypts keys by default**: only use `--encrypt=false` for throwaway test keys
 2. **Use strong passwords** (minimum 8 characters required)
 3. **Back up keys** immediately after generation
 4. **Use environment variables** (`AVALANCHE_PRIVATE_KEY`, `PLATFORM_CLI_KEY_PASSWORD`) for CI/CD

--- a/content/docs/tooling/platform-cli/l1-validators.mdx
+++ b/content/docs/tooling/platform-cli/l1-validators.mdx
@@ -3,7 +3,7 @@ title: L1 Validators
 description: Register, manage, and disable validators on L1 blockchains
 ---
 
-Once a subnet is converted to an L1, manage its validators with the `l1` commands. These operations use hex-encoded Warp messages for authorization.
+After you convert a subnet to an L1, manage its validators with the `l1` commands. These operations use hex-encoded Warp messages for authorization.
 
 ## Register Validator
 
@@ -35,7 +35,7 @@ platform-cli l1 set-validator-weight \
 
 ## Increase Validator Balance
 
-Top up a validator's balance for continuous fee payments:
+Add AVAX to a validator's balance for continuous fee payments:
 
 ```bash
 platform-cli l1 increase-validator-balance \
@@ -51,7 +51,7 @@ platform-cli l1 increase-validator-balance \
 
 ## Disable Validator
 
-Disable a validator and return remaining funds:
+Disable a validator and return its remaining funds:
 
 ```bash
 platform-cli l1 disable-validator \

--- a/content/docs/tooling/platform-cli/meta.json
+++ b/content/docs/tooling/platform-cli/meta.json
@@ -11,6 +11,7 @@
     "---Network Operations---",
     "staking",
     "subnets",
+    "multisig",
     "l1-validators",
     "chains",
     "---Reference---",

--- a/content/docs/tooling/platform-cli/multisig.mdx
+++ b/content/docs/tooling/platform-cli/multisig.mdx
@@ -1,0 +1,111 @@
+---
+title: Multisig Owners
+description: Transfer a subnet to a multisig owner and authorize owner-gated transactions with multiple keys or partial signing
+---
+
+When you create a subnet, one P-Chain key owns it. This key controls the validator set, chain creation, and the conversion to an L1. If you lose the key, or if an attacker gets it, you lose the subnet. Platform CLI can transfer the subnet to a multisig owner: a set of addresses with a signature threshold. It can then authorize owner-gated transactions with multiple keys on one machine, or with a transaction file that signers pass between machines.
+
+<Callout title="Availability">
+Multisig owner flags, multi-key signing, and the `tx` command ship in the release after v2.0.1. Earlier versions support a single owner only.
+</Callout>
+
+## Transfer a Subnet to a Multisig Owner
+
+Repeat `--new-owner` for each address. Set `--threshold` to the number of required signatures. Only the current owner key signs this transaction:
+
+```bash
+platform-cli subnet transfer-ownership \
+  --subnet-id 2QYfFcfZ9... \
+  --new-owner P-avax1aaa... \
+  --new-owner P-avax1bbb... \
+  --new-owner P-avax1ccc... \
+  --threshold 2 \
+  --key-name mykey \
+  --network mainnet
+```
+
+After this transaction, every owner-gated operation requires 2 of the 3 owner keys. The owner-gated operations are: add or remove a validator, create a chain, convert to an L1, and transfer ownership again.
+
+<Callout type="warn">
+A transfer to an owner set you do not control cannot be undone. Check each address carefully. Do a test run on Fuji first.
+</Callout>
+
+Verify the on-chain owner set at any time:
+
+```bash
+curl -X POST --data '{
+  "jsonrpc": "2.0",
+  "method": "platform.getSubnet",
+  "params": {"subnetID": "2QYfFcfZ9..."},
+  "id": 1
+}' -H 'content-type:application/json' https://api.avax.network/ext/bc/P
+```
+
+The response lists `controlKeys` and `threshold`.
+
+## Sign with Multiple Keys on One Machine
+
+Sometimes one operator holds enough owner keys. Examples: key separation, a hot/warm split, or CI. In that case, load all keys in one invocation. Repeat `--key-name`, or set `AVALANCHE_PRIVATE_KEY` to a comma-separated list. The first key pays the transaction fee:
+
+```bash
+platform-cli subnet add-validator \
+  --subnet-id 2QYfFcfZ9... \
+  --node-id NodeID-... \
+  --weight 20 \
+  --key-name owner1 --key-name owner2
+```
+
+Commands that operate on one key, such as `wallet address`, reject multi-key configurations.
+
+## Partial Signing Across Machines
+
+When different people hold the owner keys, pass the transaction between machines instead of the keys. Keys never leave a signer's machine.
+
+**1. The first signer builds and signs the transaction.** The `--output-tx-path` flag writes a transaction file. The CLI does not submit the transaction:
+
+```bash
+platform-cli subnet transfer-ownership \
+  --subnet-id 2QYfFcfZ9... \
+  --new-owner P-avax1ddd... \
+  --key-name owner1 \
+  --output-tx-path transfer.json
+```
+
+```
+Wrote partially signed tx to transfer.json
+Signatures: 1 of 2 collected
+  Signed:    P-avax1aaa...
+  Remaining: P-avax1bbb...
+Next signer runs: platform-cli tx sign --tx-path transfer.json
+```
+
+**2. Send the file to the next signer.** The next signer adds their signature. The CLI keeps the existing signatures and updates the file in place:
+
+```bash
+platform-cli tx sign --tx-path transfer.json --key-name owner2
+```
+
+```
+Signatures: 2 of 2 collected
+Fully signed. Submit with: platform-cli tx commit --tx-path transfer.json
+```
+
+**3. Submit the fully signed transaction.** Any machine can submit it. This step needs no key:
+
+```bash
+platform-cli tx commit --tx-path transfer.json
+```
+
+`tx commit` refuses a transaction that does not have enough signatures. It lists the owner addresses that still must sign. The transaction file contains the network ID and a checksum. A file made for Fuji fails on mainnet. A corrupted file fails with a clear error.
+
+<Callout>
+The first signer pays the transaction fee. Their P-Chain balance funds the fee even when they are not in the owner set. Partial signing supports `TransferSubnetOwnershipTx` only. Other owner-gated transactions need all keys on one machine.
+</Callout>
+
+## Which Flow to Use
+
+| Situation | Flow |
+|-----------|------|
+| Move a single-key subnet to a multisig | `subnet transfer-ownership` with the current owner key |
+| One operator holds enough owner keys | Multi-key signing (`--key-name` repeated) |
+| Owner keys are held by different people | Partial signing (`--output-tx-path`, `tx sign`, `tx commit`) |

--- a/content/docs/tooling/platform-cli/staking.mdx
+++ b/content/docs/tooling/platform-cli/staking.mdx
@@ -91,7 +91,7 @@ Validators charge a fee as a percentage of delegator rewards:
 ```
 
 <Callout type="info">
-Post-Durango, the P-Chain ignores the transaction start time — validation begins when the transaction is accepted. `--start` is retained for compatibility but has no on-chain effect on current networks.
+Post-Durango, the P-Chain ignores the transaction start time. Validation begins when the network accepts the transaction. Platform CLI keeps `--start` for compatibility, but the flag has no on-chain effect on current networks.
 </Callout>
 
 ### Duration
@@ -115,7 +115,7 @@ By default, rewards go to your P-Chain address. Specify a different address with
 
 ## Auto-Renewed Staking (ACP-236)
 
-An auto-renewed validator automatically restakes at the end of each cycle instead of expiring, optionally compounding its rewards. The configuration for the *next* cycle can be updated at any time by the owner address set when the validator was added.
+An auto-renewed validator automatically restakes at the end of each cycle instead of expiring, optionally compounding its rewards. The owner address can update the configuration for the *next* cycle at any time. You set this owner address when you add the validator.
 
 ### Add an Auto-Renewed Validator
 
@@ -147,7 +147,7 @@ platform-cli validator add-auto-renewed \
 
 ### Update the Next-Cycle Config
 
-Change the next cycle's period and auto-compound rate, or stop auto-renewal. Must be signed by the `--owner-address` set at add time, and references the original `add-auto-renewed` transaction ID.
+Change the next cycle's period and auto-compound rate, or stop auto-renewal. Sign this transaction with the `--owner-address` that you set at add time. The transaction references the original `add-auto-renewed` transaction ID.
 
 ```bash
 platform-cli validator set-auto-renewed-config \

--- a/content/docs/tooling/platform-cli/subnets.mdx
+++ b/content/docs/tooling/platform-cli/subnets.mdx
@@ -32,6 +32,18 @@ platform-cli subnet transfer-ownership \
   --key-name mykey
 ```
 
+The new owner can also be a multisig. Repeat `--new-owner` for each address. Set `--threshold` to require multiple signatures for future subnet changes (for example, 2-of-3). Addresses can be bech32 (`P-avax1...`, `P-fuji1...`) or CB58. A transfer to an owner set you do not control cannot be undone.
+
+```bash
+platform-cli subnet transfer-ownership \
+  --subnet-id 2QYfFcfZ9... \
+  --new-owner P-fuji1aaa... --new-owner P-fuji1bbb... --new-owner P-fuji1ccc... \
+  --threshold 2 \
+  --key-name mykey
+```
+
+See [Multisig Owners](/docs/tooling/platform-cli/multisig) for signing later owner-gated transactions with multiple keys, including partial signing across machines.
+
 ## Add a Validator (Permissioned Subnet)
 
 Add a validator to a permissioned subnet (`AddSubnetValidatorTx`). The node must **already be a primary network validator**, and the subnet owner key authorizes the transaction.

--- a/content/docs/tooling/platform-cli/subnets.mdx
+++ b/content/docs/tooling/platform-cli/subnets.mdx
@@ -19,7 +19,7 @@ Subnet created successfully!
 Subnet ID: 2QYfFcfZ9...
 ```
 
-The subnet owner is the wallet address used to create it. You need P-Chain AVAX balance to create subnets.
+The subnet owner is the wallet address that created it. You need P-Chain AVAX balance to create subnets.
 
 ## Transfer Subnet Ownership
 
@@ -46,7 +46,7 @@ See [Multisig Owners](/docs/tooling/platform-cli/multisig) for signing later own
 
 ## Add a Validator (Permissioned Subnet)
 
-Add a validator to a permissioned subnet (`AddSubnetValidatorTx`). The node must **already be a primary network validator**, and the subnet owner key authorizes the transaction.
+Add a validator to a permissioned subnet (`AddSubnetValidatorTx`). The node must **already be a primary network validator**. The subnet owner key authorizes the transaction.
 
 ```bash
 platform-cli subnet add-validator \
@@ -57,15 +57,15 @@ platform-cli subnet add-validator \
   --key-name mykey
 ```
 
-The validation period must fall within the node's primary network validation window. `--weight` is the validator's sampling weight on the subnet (not a stake amount). To add validators to a subnet that has already been converted to an L1, use [`l1 register-validator`](/docs/tooling/platform-cli/l1-validators) instead.
+The validation period must fall within the node's primary network validation window. `--weight` is the validator's sampling weight on the subnet (not a stake amount). If the subnet is already an L1, use [`l1 register-validator`](/docs/tooling/platform-cli/l1-validators) instead.
 
 ## Convert Subnet to L1
 
-Convert a permissioned subnet to an L1 blockchain. This operation is **irreversible**.
+Convert a permissioned subnet to an L1 blockchain. This operation **cannot be undone**.
 
 ### Auto-Discovery Mode
 
-Provide validator node addresses and let the CLI fetch NodeID and BLS credentials:
+Provide validator node addresses. The CLI fetches the NodeID and BLS credentials:
 
 ```bash
 platform-cli subnet convert-to-l1 \
@@ -79,7 +79,7 @@ platform-cli subnet convert-to-l1 \
 
 ### Manual Mode
 
-Provide validator data explicitly (all lists must be comma-separated and aligned by index):
+Provide validator data explicitly. Comma-separate every list. Align the lists by index:
 
 ```bash
 platform-cli subnet convert-to-l1 \

--- a/content/docs/tooling/platform-cli/transfers.mdx
+++ b/content/docs/tooling/platform-cli/transfers.mdx
@@ -30,7 +30,7 @@ platform-cli transfer send --to P-avax1abc123... --amount 100 --network mainnet 
 
 ## Cross-Chain: P-Chain to C-Chain
 
-Transfer AVAX from P-Chain to C-Chain in one step (handles export + import automatically):
+Transfer AVAX from P-Chain to C-Chain in one step. Platform CLI does the export and the import for you:
 
 ```bash
 platform-cli transfer p-to-c --amount 10 --key-name mykey


### PR DESCRIPTION
## What changed

- New page: Multisig Owners (transfer a subnet to a multisig, multi-key signing on one machine, partial signing across machines with `tx sign`/`tx commit`, flow-selection table).
- Subnets page: multisig example under Transfer Subnet Ownership with a link to the new page.
- Command reference: updated `subnet transfer-ownership` flags, repeatable `--key-name` note, new `tx` section.

## Verification

Commands and outputs match the behavior verified on Fuji in ava-labs/platform-cli#46 through #50 (stack #51).

## Open questions

- Draft until the platform-cli release containing the stack ships; the availability callout says "the release after v2.0.1" and should be updated to the actual version number at publish time.