### PR TITLE
docs(platform-cli): apply Simplified Technical English writing rules

### DIFF
--- a/content/docs/tooling/platform-cli/chains.mdx
+++ b/content/docs/tooling/platform-cli/chains.mdx
@@ -3,7 +3,7 @@ title: Chains
 description: Deploy new blockchains on existing subnets
 ---
 
-Deploy a new blockchain on an existing subnet using the `chain create` command.
+Use the `chain create` command to deploy a new blockchain on an existing subnet.
 
 ## Create a Chain
 

--- a/content/docs/tooling/platform-cli/command-reference.mdx
+++ b/content/docs/tooling/platform-cli/command-reference.mdx
@@ -94,7 +94,7 @@ platform-cli keys delete --name <name> [--force]
 platform-cli keys default [--name <name>]
 ```
 
-Shows current default if `--name` is omitted. Sets default if `--name` is provided.
+Shows the current default if you omit `--name`. Sets the default if you provide `--name`.
 
 ## wallet
 
@@ -190,7 +190,7 @@ platform-cli validator add-permissionless --node-id <id> --stake <avax>
 | `--node-id` | Node ID (required) | |
 | `--stake` | Stake in AVAX (required) | |
 | `--duration` | Validation duration | `336h` |
-| `--start` | Start time (RFC3339 or `now`). Ignored post-Durango; validation starts at tx acceptance | `now` |
+| `--start` | Start time (RFC3339 or `now`). The network ignores this flag after Durango. Validation starts at tx acceptance | `now` |
 | `--delegation-fee` | Fee percentage (0.02 = 2%) | `0.02` |
 | `--reward-address` | Reward address | own address |
 | `--bls-public-key` | BLS public key hex (recommended) | |
@@ -208,7 +208,7 @@ platform-cli validator add-permissionless-delegator --node-id <id> --stake <avax
 | `--node-id` | Node ID to delegate to (required) | |
 | `--stake` | Stake in AVAX (required) | |
 | `--duration` | Delegation duration | `336h` |
-| `--start` | Start time (RFC3339 or `now`). Ignored post-Durango; validation starts at tx acceptance | `now` |
+| `--start` | Start time (RFC3339 or `now`). The network ignores this flag after Durango. Validation starts at tx acceptance | `now` |
 | `--reward-address` | Reward address | own address |
 
 ### validator add-auto-renewed
@@ -238,7 +238,7 @@ Adds an auto-renewed validator (`AddAutoRenewedValidatorTx`, ACP-236) that resta
 platform-cli validator set-auto-renewed-config --tx-id <id> --period <dur> --auto-compound <frac>
 ```
 
-Updates the next-cycle config of an auto-renewed validator (`SetAutoRenewedValidatorConfigTx`). Must be signed by the owner address set at add time.
+Updates the next-cycle config of an auto-renewed validator (`SetAutoRenewedValidatorConfigTx`). The owner address set at add time must sign the transaction.
 
 | Flag | Description |
 |------|-------------|
@@ -255,7 +255,7 @@ Updates the next-cycle config of an auto-renewed validator (`SetAutoRenewedValid
 platform-cli subnet create
 ```
 
-Creates a new subnet owned by the wallet address. No additional flags required.
+Creates a new subnet that the wallet address owns. This command needs no additional flags.
 
 ### subnet transfer-ownership
 
@@ -304,7 +304,7 @@ Adds a validator to a permissioned subnet (`AddSubnetValidatorTx`). The node mus
 | `--subnet-id` | Subnet ID (required) | |
 | `--node-id` | Validator node ID, must already validate the primary network (required) | |
 | `--weight` | Validator sampling weight on the subnet (required, > 0) | |
-| `--start` | Start time (RFC3339 or `now`). Ignored post-Durango; validation starts at tx acceptance | `now` |
+| `--start` | Start time (RFC3339 or `now`). The network ignores this flag after Durango. Validation starts at tx acceptance | `now` |
 | `--duration` | Validation duration (must fall within the node's primary network validation period) | `336h` |
 
 ## l1
@@ -358,7 +358,7 @@ Sign and submit partially signed transactions for multisig owners. See [Multisig
 
 ### tx sign
 
-Add signatures with locally available keys; existing signatures are preserved and the file is updated in place.
+Add signatures with locally available keys. The CLI keeps existing signatures and updates the file in place.
 
 ```bash
 platform-cli tx sign --tx-path <file>
@@ -370,7 +370,7 @@ platform-cli tx sign --tx-path <file>
 
 ### tx commit
 
-Submit a fully signed transaction and wait for acceptance. Refuses under-signed transactions and lists the missing signers. No key is needed.
+Submit a fully signed transaction and wait for acceptance. Refuses under-signed transactions and lists the missing signers. This command needs no key.
 
 ```bash
 platform-cli tx commit --tx-path <file>

--- a/content/docs/tooling/platform-cli/installation.mdx
+++ b/content/docs/tooling/platform-cli/installation.mdx
@@ -31,7 +31,7 @@ platform-cli --help
 
 ## Build from Source
 
-Requires **Go 1.24+** ([install Go](https://go.dev/dl/)).
+Building from source requires **Go 1.24+** ([install Go](https://go.dev/dl/)).
 
 ```bash
 git clone https://github.com/ava-labs/platform-cli.git
@@ -49,7 +49,7 @@ go build -tags ledger -o platform .
 
 ## Global Flags
 
-These flags are available on all commands:
+All commands accept these flags:
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
@@ -103,7 +103,7 @@ platform-cli wallet balance --key-name mykey --rpc-url http://127.0.0.1:9650
 platform-cli wallet balance --key-name mykey --rpc-url https://my-node.example.com:9650 --network-id 5
 ```
 
-When using `--rpc-url`, the network ID is auto-detected from the node unless `--network-id` is specified.
+If you use `--rpc-url` without `--network-id`, Platform CLI auto-detects the network ID from the node.
 
 ## Next Steps
 

--- a/content/docs/tooling/platform-cli/key-management.mdx
+++ b/content/docs/tooling/platform-cli/key-management.mdx
@@ -3,7 +3,7 @@ title: Key Management
 description: Generate, import, export, and encrypt private keys with Platform CLI
 ---
 
-Platform CLI stores keys in `~/.platform/keys/` with AES-256-GCM encryption enabled by default. Keys are encrypted using Argon2id key derivation with a user-provided password.
+Platform CLI stores keys in `~/.platform/keys/` with AES-256-GCM encryption enabled by default. The encryption uses Argon2id key derivation and a password that you provide.
 
 ## Generating Keys
 
@@ -84,7 +84,7 @@ platform-cli keys export --name mykey --format hex --output-file ./mykey.hex
 platform-cli keys export --name mykey --unsafe-stdout
 ```
 
-If the key is encrypted, you'll be prompted for the password. Set `PLATFORM_CLI_KEY_PASSWORD` to skip the prompt in scripts.
+If the key is encrypted, Platform CLI prompts you for the password. Set `PLATFORM_CLI_KEY_PASSWORD` to skip the prompt in scripts.
 
 ## Deleting Keys
 
@@ -96,7 +96,7 @@ platform-cli keys delete --name mykey
 platform-cli keys delete --name mykey --force
 ```
 
-Deletion is irreversible. Ensure you have a backup first.
+Deletion cannot be undone. Make sure that you have a backup first.
 
 ## Default Key
 
@@ -122,7 +122,7 @@ The ewoq key is pre-funded on local networks. Platform CLI blocks its use on mai
 
 ## Ledger Hardware Wallet
 
-Build with Ledger support and use the `--ledger` flag:
+Build the CLI with Ledger support. Then use the `--ledger` flag:
 
 ```bash
 go build -tags ledger -o platform .
@@ -137,7 +137,7 @@ platform-cli wallet balance --ledger --ledger-index 1
 
 ## Security Best Practices
 
-1. **Keys are encrypted by default** - only use `--encrypt=false` for throwaway test keys
+1. **Platform CLI encrypts keys by default**: only use `--encrypt=false` for throwaway test keys
 2. **Use strong passwords** (minimum 8 characters required)
 3. **Back up keys** immediately after generation
 4. **Use environment variables** (`AVALANCHE_PRIVATE_KEY`, `PLATFORM_CLI_KEY_PASSWORD`) for CI/CD

--- a/content/docs/tooling/platform-cli/l1-validators.mdx
+++ b/content/docs/tooling/platform-cli/l1-validators.mdx
@@ -3,7 +3,7 @@ title: L1 Validators
 description: Register, manage, and disable validators on L1 blockchains
 ---
 
-Once a subnet is converted to an L1, manage its validators with the `l1` commands. These operations use hex-encoded Warp messages for authorization.
+After you convert a subnet to an L1, manage its validators with the `l1` commands. These operations use hex-encoded Warp messages for authorization.
 
 ## Register Validator
 
@@ -35,7 +35,7 @@ platform-cli l1 set-validator-weight \
 
 ## Increase Validator Balance
 
-Top up a validator's balance for continuous fee payments:
+Add AVAX to a validator's balance for continuous fee payments:
 
 ```bash
 platform-cli l1 increase-validator-balance \
@@ -51,7 +51,7 @@ platform-cli l1 increase-validator-balance \
 
 ## Disable Validator
 
-Disable a validator and return remaining funds:
+Disable a validator and return its remaining funds:
 
 ```bash
 platform-cli l1 disable-validator \

--- a/content/docs/tooling/platform-cli/staking.mdx
+++ b/content/docs/tooling/platform-cli/staking.mdx
@@ -91,7 +91,7 @@ Validators charge a fee as a percentage of delegator rewards:
 ```
 
 <Callout type="info">
-Post-Durango, the P-Chain ignores the transaction start time — validation begins when the transaction is accepted. `--start` is retained for compatibility but has no on-chain effect on current networks.
+Post-Durango, the P-Chain ignores the transaction start time. Validation begins when the network accepts the transaction. Platform CLI keeps `--start` for compatibility, but the flag has no on-chain effect on current networks.
 </Callout>
 
 ### Duration
@@ -115,7 +115,7 @@ By default, rewards go to your P-Chain address. Specify a different address with
 
 ## Auto-Renewed Staking (ACP-236)
 
-An auto-renewed validator automatically restakes at the end of each cycle instead of expiring, optionally compounding its rewards. The configuration for the *next* cycle can be updated at any time by the owner address set when the validator was added.
+An auto-renewed validator automatically restakes at the end of each cycle instead of expiring, optionally compounding its rewards. The owner address can update the configuration for the *next* cycle at any time. You set this owner address when you add the validator.
 
 ### Add an Auto-Renewed Validator
 
@@ -147,7 +147,7 @@ platform-cli validator add-auto-renewed \
 
 ### Update the Next-Cycle Config
 
-Change the next cycle's period and auto-compound rate, or stop auto-renewal. Must be signed by the `--owner-address` set at add time, and references the original `add-auto-renewed` transaction ID.
+Change the next cycle's period and auto-compound rate, or stop auto-renewal. Sign this transaction with the `--owner-address` that you set at add time. The transaction references the original `add-auto-renewed` transaction ID.
 
 ```bash
 platform-cli validator set-auto-renewed-config \

--- a/content/docs/tooling/platform-cli/subnets.mdx
+++ b/content/docs/tooling/platform-cli/subnets.mdx
@@ -19,7 +19,7 @@ Subnet created successfully!
 Subnet ID: 2QYfFcfZ9...
 ```
 
-The subnet owner is the wallet address used to create it. You need P-Chain AVAX balance to create subnets.
+The subnet owner is the wallet address that created it. You need P-Chain AVAX balance to create subnets.
 
 ## Transfer Subnet Ownership
 
@@ -46,7 +46,7 @@ See [Multisig Owners](/docs/tooling/platform-cli/multisig) for signing later own
 
 ## Add a Validator (Permissioned Subnet)
 
-Add a validator to a permissioned subnet (`AddSubnetValidatorTx`). The node must **already be a primary network validator**, and the subnet owner key authorizes the transaction.
+Add a validator to a permissioned subnet (`AddSubnetValidatorTx`). The node must **already be a primary network validator**. The subnet owner key authorizes the transaction.
 
 ```bash
 platform-cli subnet add-validator \
@@ -57,15 +57,15 @@ platform-cli subnet add-validator \
   --key-name mykey
 ```
 
-The validation period must fall within the node's primary network validation window. `--weight` is the validator's sampling weight on the subnet (not a stake amount). To add validators to a subnet that has already been converted to an L1, use [`l1 register-validator`](/docs/tooling/platform-cli/l1-validators) instead.
+The validation period must fall within the node's primary network validation window. `--weight` is the validator's sampling weight on the subnet (not a stake amount). If the subnet is already an L1, use [`l1 register-validator`](/docs/tooling/platform-cli/l1-validators) instead.
 
 ## Convert Subnet to L1
 
-Convert a permissioned subnet to an L1 blockchain. This operation is **irreversible**.
+Convert a permissioned subnet to an L1 blockchain. This operation **cannot be undone**.
 
 ### Auto-Discovery Mode
 
-Provide validator node addresses and let the CLI fetch NodeID and BLS credentials:
+Provide validator node addresses. The CLI fetches the NodeID and BLS credentials:
 
 ```bash
 platform-cli subnet convert-to-l1 \
@@ -79,7 +79,7 @@ platform-cli subnet convert-to-l1 \
 
 ### Manual Mode
 
-Provide validator data explicitly (all lists must be comma-separated and aligned by index):
+Provide validator data explicitly. Comma-separate every list. Align the lists by index:
 
 ```bash
 platform-cli subnet convert-to-l1 \

--- a/content/docs/tooling/platform-cli/transfers.mdx
+++ b/content/docs/tooling/platform-cli/transfers.mdx
@@ -30,7 +30,7 @@ platform-cli transfer send --to P-avax1abc123... --amount 100 --network mainnet 
 
 ## Cross-Chain: P-Chain to C-Chain
 
-Transfer AVAX from P-Chain to C-Chain in one step (handles export + import automatically):
+Transfer AVAX from P-Chain to C-Chain in one step. Platform CLI does the export and the import for you:
 
 ```bash
 platform-cli transfer p-to-c --amount 10 --key-name mykey


### PR DESCRIPTION
Stacked on #4453. Prose-only style sweep of all platform-cli docs pages.

## What changed

- Sentences shortened to STE limits (20 words for instructions, 25 for descriptions), long compounds split.
- Passive voice converted to active; instructions converted to imperative mood, one instruction per sentence.
- Simpler vocabulary where meaning is unchanged ("irreversible" -> "cannot be undone", etc.). Domain terms kept.
- No changes to commands, flags, defaults, tables' structure, code blocks, headings, or facts. index.mdx already complied and is untouched.

## Verification

- Full diff reviewed line by line: 30 changed lines, all prose.
- Em/en dash sweep clean (also removed one pre-existing em dash in staking.mdx).
- Not strict ASD-STE100: the approved-word dictionary is not applied; domain vocabulary (multisig, keystore, bech32) stays.