### PR TITLE
fix(academy): restore the Avalanche9000 page so quiz 1202 has a lesson again

### DIFF
--- a/content/academy/avalanche-l1/avalanche-fundamentals/03-multi-chain-architecture-intro/03a-etna-upgrade.mdx
+++ b/content/academy/avalanche-l1/avalanche-fundamentals/03-multi-chain-architecture-intro/03a-etna-upgrade.mdx
@@ -1,0 +1,13 @@
+---
+title: Avalanche9000 Upgrade
+description: Learn about how the Avalanche9000 upgrade changes the network architecture.
+updated: 2024-05-31
+authors: [ashucoder9]
+icon: BookOpen
+---
+
+import EtnaUpgradeMotivation from '@/content/common/multi-chain-architecture/etna-upgrade-motivation.mdx';
+
+<EtnaUpgradeMotivation />
+
+<Quiz quizId="1202"/>


### PR DESCRIPTION
## What happened

`quizId 1202` ("What were the main changes the Avalanche9000 upgrade brought?") is defined in `components/quizzes/data/courses/avalanche-fundamentals.json`, but no page under `content/academy/` renders it.

It used to. The quiz lived on `03a-etna-upgrade.mdx`, a 13 line page that imported the shared Avalanche9000 write-up and embedded the quiz right after it. That page was deleted in 312bee14 ("feat: multi-chain chapter", 2026-02-05) while the chapter was being restructured, and the quiz record stayed behind in the data file.

Two things follow from that:

1. The quiz still appears on the certificate page, grouped under "Avalanche Fundamentals", but it is no longer attached to any lesson. A learner is asked about a topic the course never covers.
2. "Avalanche9000" does not appear anywhere in the course content now, even though `CreateSubnetTx` shows up later in *Creating an L1*. The Subnet to L1 renaming is never explained, so a learner meets the old term with no context.

The write-up itself was never deleted. `content/common/multi-chain-architecture/etna-upgrade-motivation.mdx` is still in the repo and still maintained. Today only `content/blog/` imports it.

## Fix

Restores `03a-etna-upgrade.mdx` exactly as it stood before 312bee14. One new file, 13 lines: it imports the existing shared content and embeds `<Quiz quizId="1202"/>`. No other page is touched and nothing is renumbered, since the `03a` prefix was already the file's original position in this chapter.

## Correction to the earlier version of this PR

The first version of this PR claimed the certificate could not be obtained by anyone, and added a short hand written Avalanche9000 section to `03-L1.mdx` instead of restoring the page. Both were wrong, and I would rather say so here than have a reviewer find it:

- I tested it on the live site. The certificate page renders every quiz of a course inside accordions, so 1202 was answerable there all along and the certificate does come out. The problem is not a blocked certificate.
- Hand writing a summary ignored the maintained write-up that was already in the repo. Importing it is both smaller and more accurate.

The reachability check that found this is generic, so it may be worth having as a test: comparing the quiz IDs in `components/quizzes/data/courses/*.json` against the `<Quiz quizId>` tags in `content/` surfaces the same class of problem in other published courses. Happy to open that separately if it is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
