### PR TITLE
feat(console): advance p-chain view tool, delivery preflight, aggregation retries

### DIFF
--- a/app/console/layer-1/advance-pchain-view/page.tsx
+++ b/app/console/layer-1/advance-pchain-view/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import AdvancePChainView from '@/components/toolbox/console/layer-1/AdvancePChainView';
+
+export default function AdvancePChainViewPage() {
+  return <AdvancePChainView />;
+}

--- a/components/console/breadcrumbs-mapping.ts
+++ b/components/console/breadcrumbs-mapping.ts
@@ -14,6 +14,7 @@ export const pathToBreadcrumb = {
   "/console/layer-1/upgrade": ["Console", "Layer 1", "Upgrade JSON"],
   "/console/layer-1/l1-node-setup": ["Console", "Layer 1", "L1 Node Setup"],
   "/console/layer-1/explorer-setup": ["Console", "Layer 1", "Explorer Setup"],
+  "/console/layer-1/advance-pchain-view": ["Console", "Layer 1", "Advance P-Chain View"],
 
   // L1 Tokenomics
   "/console/l1-tokenomics/fee-manager": ["Console", "L1 Tokenomics", "Transaction Fee Parameters"],

--- a/components/toolbox/console/layer-1/AdvancePChainView.tsx
+++ b/components/toolbox/console/layer-1/AdvancePChainView.tsx
@@ -1,0 +1,336 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { FastForward, Loader2, RefreshCw } from 'lucide-react';
+import Link from 'next/link';
+import { Alert } from '@/components/toolbox/components/Alert';
+import { Button } from '@/components/toolbox/components/Button';
+import { Input } from '@/components/toolbox/components/Input';
+import {
+  BaseConsoleToolProps,
+  ConsoleToolMetadata,
+  withConsoleToolMetadata,
+} from '@/components/toolbox/components/WithConsoleToolMetadata';
+import { WalletRequirementsConfigKey } from '@/components/toolbox/hooks/useWalletRequirements';
+import { generateConsoleToolGitHubUrl } from '@/components/toolbox/utils/githubUrl';
+import { useSelectedL1 } from '@/components/toolbox/stores/l1ListStore';
+import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import { getPChainTxBlockHeight } from '@/components/toolbox/coreViem/utils/glacier';
+import { useProposerVMStatus } from '@/components/toolbox/hooks/useProposerVMStatus';
+import { useAdvanceProposerVM, type AdvancePhase } from '@/components/toolbox/hooks/useAdvanceProposerVM';
+
+const metadata: ConsoleToolMetadata = {
+  title: 'Advance P-Chain View',
+  description:
+    'Produce blocks on an idle L1 so its ProposerVM epoch catches up with the P-Chain and pending warp deliveries can verify against the current validator set.',
+  toolRequirements: [WalletRequirementsConfigKey.WalletConnected],
+  githubUrl: generateConsoleToolGitHubUrl(import.meta.url),
+};
+
+// Vocabulary mirrors the heights ruler on /docs/nodes/architecture/proposervm.
+// Copied as literals on purpose: console tools must not import the docs
+// figure's layout module.
+const HEIGHTS_FOOTER = 'EPOCH HEIGHT ≤ TIP EMBEDS ≤ P-CHAIN HEIGHT';
+
+const C_CHAIN_EVM_IDS = [43113, 43114];
+
+const RUNNING_PHASES: AdvancePhase[] = ['countdown', 'sending', 'confirming', 'verifying'];
+
+function formatHeight(height: bigint | null): string {
+  return height === null ? 'unknown' : Number(height).toLocaleString('en-US');
+}
+
+function formatAge(sec: number): string {
+  if (sec < 90) return `${sec}s`;
+  const minutes = Math.floor(sec / 60);
+  if (minutes < 90) return `${minutes}m ${sec % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h ${minutes % 60}m`;
+  return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+}
+
+function formatCountdown(sec: number): string {
+  return `${Math.floor(sec / 60)}:${String(sec % 60).padStart(2, '0')}`;
+}
+
+function AdvancePChainView({ onSuccess }: BaseConsoleToolProps) {
+  const selectedL1 = useSelectedL1();
+  const isTestnet = useWalletStore((s) => s.isTestnet);
+  const [targetInput, setTargetInput] = useState('');
+  const [txResolution, setTxResolution] = useState<{ txId: string; height: bigint | null } | null>(null);
+
+  const parsedTarget = useMemo((): {
+    kind: 'empty' | 'height' | 'txid' | 'invalid';
+    normalized: string;
+    height: bigint | null;
+    error: string | null;
+  } => {
+    const normalized = targetInput.trim().replace(/[,_\s]/g, '');
+    if (!normalized) return { kind: 'empty', normalized, height: null, error: null };
+    if (/^\d+$/.test(normalized)) return { kind: 'height', normalized, height: BigInt(normalized), error: null };
+    if (/^[1-9A-HJ-NP-Za-km-z]{40,60}$/.test(normalized))
+      return { kind: 'txid', normalized, height: null, error: null };
+    return { kind: 'invalid', normalized, height: null, error: 'Enter a block height or a P-Chain txID' };
+  }, [targetInput]);
+
+  useEffect(() => {
+    if (parsedTarget.kind !== 'txid') return;
+    const txId = parsedTarget.normalized;
+    let cancelled = false;
+    void getPChainTxBlockHeight(txId, isTestnet ? 'testnet' : 'mainnet').then((height) => {
+      if (!cancelled) setTxResolution({ txId, height });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [parsedTarget.kind, parsedTarget.normalized, isTestnet]);
+
+  const txResolved = parsedTarget.kind === 'txid' && txResolution?.txId === parsedTarget.normalized;
+  const isResolvingTx = parsedTarget.kind === 'txid' && !txResolved;
+  const explicitTarget = parsedTarget.height ?? (txResolved ? txResolution.height : null);
+  const targetError =
+    parsedTarget.error ??
+    (txResolved && txResolution.height === null
+      ? 'Transaction not found on the P-Chain (a very recent tx may not be indexed yet)'
+      : null);
+
+  const status = useProposerVMStatus({ requiredHeight: explicitTarget });
+  // No explicit target: catch up to wherever the live P-Chain is right now.
+  const advanceTarget = explicitTarget ?? status.liveHeight ?? null;
+  const advance = useAdvanceProposerVM({ status, requiredHeight: advanceTarget, onAdvanced: onSuccess });
+
+  const isCChain = selectedL1 ? C_CHAIN_EVM_IDS.includes(selectedL1.evmChainId) : false;
+  const isRunning = RUNNING_PHASES.includes(advance.phase);
+  const tipAge = status.status.tipAgeSec;
+
+  const curlSnippet = `curl -X POST -H 'content-type: application/json' \\\n  --data '{"jsonrpc":"2.0","id":1,"method":"proposervm.getCurrentEpoch","params":{}}' \\\n  ${status.proposerVMUrl ?? 'https://<your-node>/ext/bc/<blockchainID>/proposervm'}`;
+
+  const progressLine = (() => {
+    switch (advance.phase) {
+      case 'countdown':
+        return advance.countdownSecRemaining !== null
+          ? `The current epoch opened less than 5 minutes ago, so a new block cannot seal it yet. Sending in ${formatCountdown(advance.countdownSecRemaining)}.`
+          : 'Waiting for the epoch to become sealable.';
+      case 'sending':
+        return `Sending block-producing transaction ${advance.attempt} of ${advance.maxAttempts}. Confirm it in your wallet.`;
+      case 'confirming':
+        return 'Waiting for the transaction to land in a block.';
+      case 'verifying':
+        return 'Reading the epoch state.';
+      default:
+        return null;
+    }
+  })();
+
+  return (
+    <div className="space-y-4 w-full">
+      <Alert variant="info">
+        <span>
+          A chain&apos;s ProposerVM records a view of the P-Chain that{' '}
+          <strong>only advances when the chain produces blocks</strong>. On an idle L1 that view goes stale, and warp
+          message delivery (<code>initializeValidatorSet</code>, <code>completeValidatorRegistration</code>, ...) fails
+          because it verifies against the validator set at the stale epoch height. This tool produces blocks by sending
+          0-value transfers from your wallet to itself. It fixes <strong>delivery</strong> readiness only; it cannot fix
+          signature <em>aggregation</em> failures, which depend on the signing validators themselves.{' '}
+          <Link href="/docs/nodes/architecture/proposervm" className="underline" target="_blank">
+            How this works
+          </Link>
+        </span>
+      </Alert>
+
+      {isCChain ? (
+        <Alert variant="success">
+          The C-Chain produces blocks continuously, so its P-Chain view never goes stale. There is nothing to advance
+          here. Select an L1 to use this tool.
+        </Alert>
+      ) : (
+        <>
+          {/* The three heights, in the docs page's vocabulary */}
+          <div className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50 p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <h4 className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                {selectedL1 ? `${selectedL1.name}: P-Chain view` : 'P-Chain view'}
+              </h4>
+              <Button
+                variant="secondary"
+                onClick={() => void status.refresh()}
+                disabled={status.isLoading || isRunning}
+                className="text-xs py-1 px-2"
+              >
+                <RefreshCw className={`w-3 h-3 mr-1 inline ${status.isLoading ? 'animate-spin' : ''}`} />
+                Refresh
+              </Button>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
+              <div>
+                <div className="text-xs text-zinc-500 dark:text-zinc-400">EPOCH HEIGHT</div>
+                <div className="font-mono text-zinc-900 dark:text-zinc-100">
+                  {formatHeight(status.epoch?.pChainHeight ?? null)}
+                </div>
+                <div className="text-xs text-zinc-500 dark:text-zinc-400">pins what warp verifies</div>
+              </div>
+              <div>
+                <div className="text-xs text-zinc-500 dark:text-zinc-400">TIP EMBEDS</div>
+                <div className="font-mono text-zinc-900 dark:text-zinc-100">
+                  {tipAge === null ? 'unknown' : `last block ${formatAge(tipAge)} ago`}
+                </div>
+                <div className="text-xs text-zinc-500 dark:text-zinc-400">
+                  sets who may build next (no RPC exposes the value)
+                </div>
+              </div>
+              <div>
+                <div className="text-xs text-zinc-500 dark:text-zinc-400">P-CHAIN HEIGHT</div>
+                <div className="font-mono text-zinc-900 dark:text-zinc-100">{formatHeight(status.liveHeight)}</div>
+                <div className="text-xs text-zinc-500 dark:text-zinc-400">live registry, climbing</div>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between flex-wrap gap-2">
+              <div className="text-xs text-zinc-400 dark:text-zinc-500 font-mono">{HEIGHTS_FOOTER}</div>
+              {status.status.state === 'satisfied' && (
+                <span className="text-xs px-2 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">
+                  {explicitTarget !== null ? 'covers your target' : 'current'}
+                </span>
+              )}
+              {(status.status.state === 'stale-sealable' || status.status.state === 'stale-waiting') && (
+                <span className="text-xs px-2 py-0.5 rounded bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400">
+                  stale
+                  {status.status.heightLag !== null ? `, ${formatHeight(status.status.heightLag)} blocks behind` : ''}
+                </span>
+              )}
+              {status.status.state === 'unknown' && (
+                <span className="text-xs px-2 py-0.5 rounded bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300">
+                  unknown
+                </span>
+              )}
+            </div>
+          </div>
+
+          {status.unreachable && !status.isLoading && (
+            <Alert variant="warning">
+              <div className="space-y-2">
+                <span>
+                  This RPC endpoint does not expose the chain&apos;s <code>/proposervm</code> API (public gateways never
+                  do), so the epoch state cannot be read here. You can still advance blind: the tool sends 2
+                  block-producing transactions without verifying the result. To read the state yourself, run this
+                  against your own node:
+                </span>
+                <pre className="text-xs font-mono bg-zinc-100 dark:bg-zinc-800 rounded p-2 overflow-x-auto whitespace-pre">
+                  {curlSnippet}
+                </pre>
+              </div>
+            </Alert>
+          )}
+
+          <Input
+            label="Target P-Chain height or txID (optional)"
+            value={targetInput}
+            onChange={setTargetInput}
+            placeholder={status.liveHeight !== null ? `current: ${status.liveHeight}` : 'height or P-Chain txID'}
+            error={targetError}
+            helperText={
+              isResolvingTx
+                ? 'Resolving the transaction height...'
+                : txResolved && txResolution.height !== null
+                  ? `Transaction landed at P-Chain height ${txResolution.height}.`
+                  : 'Leave empty to catch up to the current P-Chain height. Paste a height or a P-Chain txID when a pending action needs the epoch to cover the block that transaction landed in.'
+            }
+            disabled={isRunning}
+          />
+
+          <div className="flex gap-2">
+            <Button
+              variant="primary"
+              onClick={advance.start}
+              disabled={isRunning || !selectedL1 || targetError !== null || isResolvingTx}
+              loading={isRunning}
+              loadingText="Working"
+              icon={<FastForward className="w-4 h-4" />}
+            >
+              Produce blocks ({'≈'}2 transactions)
+            </Button>
+            {isRunning && (
+              <Button variant="outline" onClick={advance.cancel}>
+                Cancel
+              </Button>
+            )}
+          </div>
+
+          {isRunning && progressLine && (
+            <div className="flex items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400">
+              <Loader2 className="w-4 h-4 animate-spin shrink-0" />
+              {progressLine}
+            </div>
+          )}
+
+          {advance.phase === 'done' && advance.verified && (
+            <Alert variant="success">
+              The epoch now pins P-Chain height {formatHeight(status.epoch?.pChainHeight ?? null)}
+              {advance.txHashes.length > 0
+                ? ` after ${advance.txHashes.length} transaction(s)`
+                : ' (no transactions were needed)'}
+              . Warp deliveries that need a height at or below it will verify. Retry your pending action now.
+            </Alert>
+          )}
+
+          {advance.phase === 'done' && !advance.verified && (
+            <Alert variant="warning">
+              Sent {advance.txHashes.length} block-producing transactions, but the epoch state cannot be read through
+              this RPC, so the result is unverified. Retry your pending action; if it still fails, check the epoch with
+              the curl above and run this tool again.
+            </Alert>
+          )}
+
+          {advance.phase === 'gave-up' && (
+            <Alert variant="warning">
+              Sent {advance.maxAttempts} transactions and the epoch still pins{' '}
+              {formatHeight(status.epoch?.pChainHeight ?? null)}, below your target of {formatHeight(advanceTarget)}.
+              The view did advance, so retry your pending action first; it may already succeed. If not, run this tool
+              again.
+            </Alert>
+          )}
+
+          {advance.phase === 'error' && advance.error && (
+            <Alert variant="error">
+              <div className="space-y-1">
+                <span>{advance.error}</span>
+                {advance.errorKind === 'no-gas' && selectedL1?.externalFaucetUrl && (
+                  <div>
+                    <a
+                      href={selectedL1.externalFaucetUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs underline"
+                    >
+                      Get {selectedL1.coinName} from the chain&apos;s faucet
+                    </a>
+                  </div>
+                )}
+                {advance.errorKind === 'allowlist' && (
+                  <div>
+                    <Link href="/console/l1-access-restrictions/transactor-allowlist" className="text-xs underline">
+                      Manage the Transactor Allowlist
+                    </Link>
+                  </div>
+                )}
+              </div>
+            </Alert>
+          )}
+
+          {advance.txHashes.length > 0 && (
+            <div className="text-xs text-zinc-500 dark:text-zinc-400 space-y-1">
+              {advance.txHashes.map((hash, i) => (
+                <div key={hash} className="font-mono break-all">
+                  tx {i + 1}: {hash}
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default withConsoleToolMetadata(AdvancePChainView, metadata);

--- a/components/toolbox/console/layer-1/create/ConvertSubnetToL1.tsx
+++ b/components/toolbox/console/layer-1/create/ConvertSubnetToL1.tsx
@@ -21,6 +21,8 @@ import Link from 'next/link';
 import { AlertTriangle } from 'lucide-react';
 import { CoreWalletTransactionButton } from '@/components/toolbox/components/CoreWalletTransactionButton';
 import { useSubmitPChainTx } from '@/components/toolbox/hooks/useSubmitPChainTx';
+import { Alert } from '@/components/toolbox/components/Alert';
+import { waitForPChainConfirmation } from '@/components/toolbox/utils/pchainConfirmation';
 
 const metadata: ConsoleToolMetadata = {
   title: 'Convert Subnet to L1',
@@ -63,6 +65,8 @@ function ConvertToL1({ onSuccess }: BaseConsoleToolProps) {
   const coreWalletClient = useWalletStore((s) => s.coreWalletClient);
 
   const [isConverting, setIsConverting] = useState(false);
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [convertError, setConvertError] = useState<string | null>(null);
 
   const { notify } = useConsoleNotifications();
   const { submitPChainTx } = useSubmitPChainTx();
@@ -98,10 +102,12 @@ function ConvertToL1({ onSuccess }: BaseConsoleToolProps) {
     if (!coreWalletClient) return;
 
     setConvertToL1TxId('');
+    setConvertError(null);
     setIsConverting(true);
 
+    let txID: string | null = null;
     try {
-      const txID = await submitPChainTx(async (client) => {
+      txID = await submitPChainTx(async (client) => {
         const convertSubnetToL1Tx = client.convertToL1({
           subnetId: selection.subnetId,
           chainId: validatorManagerChainID,
@@ -115,9 +121,21 @@ function ConvertToL1({ onSuccess }: BaseConsoleToolProps) {
         return convertSubnetToL1Tx;
       });
 
+      // Don't advance until the P-Chain actually accepts the conversion:
+      // everything downstream (initializeValidatorSet, Glacier lookups)
+      // reads state that only exists once this tx is Committed.
+      setIsConfirming(true);
+      await waitForPChainConfirmation(txID, isTestnet);
+
       setConvertToL1TxId(txID);
       onSuccess?.();
+    } catch (err) {
+      // Keep an issued-but-unconfirmed txID visible so the user can track
+      // it and paste it into the initialize step once it commits.
+      if (txID) setConvertToL1TxId(txID);
+      setConvertError((err as Error).message);
     } finally {
+      setIsConfirming(false);
       setIsConverting(false);
     }
   }
@@ -207,11 +225,13 @@ function ConvertToL1({ onSuccess }: BaseConsoleToolProps) {
               !selection.subnetId || !validatorManagerAddress || validators.length === 0 || selection.subnet?.isL1
             }
             loading={isConverting}
+            loadingText={isConfirming ? 'Waiting for P-Chain confirmation...' : 'Converting...'}
             className="w-full"
             cliCommand={buildConvertCliCommand()}
           >
             {selection.subnet?.isL1 ? 'Already Converted' : 'Convert to L1'}
           </CoreWalletTransactionButton>
+          {convertError && <Alert variant="error">{convertError}</Alert>}
         </Step>
       </Steps>
     </div>

--- a/components/toolbox/console/permissioned-l1s/remove-validator/CompleteValidatorRemoval.tsx
+++ b/components/toolbox/console/permissioned-l1s/remove-validator/CompleteValidatorRemoval.tsx
@@ -22,6 +22,12 @@ import ValidatorManagerABI from '@/contracts/icm-contracts/compiled/ValidatorMan
 import { Check } from 'lucide-react';
 import { generateCastSendCommand } from '@/components/toolbox/utils/castCommand';
 import { CliAlternative } from '@/components/console/cli-alternative';
+import { ProposerVMPreflightCard } from '@/components/toolbox/console/shared/ProposerVMPreflightCard';
+import {
+  AggregationRemediation,
+  parseAggregationError,
+  type RemediationLink,
+} from '@/components/toolbox/hooks/contracts/parseAggregationError';
 
 interface CompleteValidatorRemovalProps {
   subnetIdL1: string;
@@ -73,6 +79,7 @@ const CompleteValidatorRemoval: React.FC<CompleteValidatorRemovalProps> = ({
 
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setErrorState] = useState<string | null>(null);
+  const [aggRemediation, setAggRemediation] = useState<RemediationLink[] | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [transactionHash, setTransactionHash] = useState<string | null>(null);
   const [pChainSignature, setPChainSignature] = useState<string | null>(null);
@@ -207,8 +214,11 @@ const CompleteValidatorRemoval: React.FC<CompleteValidatorRemovalProps> = ({
       onSuccess(successMsg);
     } catch (err: any) {
       const message = err instanceof Error ? err.message : String(err);
-      setErrorState(`Failed to complete validator removal: ${message}`);
-      onError(`Failed to complete validator removal: ${message}`);
+      const mapped = parseAggregationError(err);
+      setAggRemediation(mapped?.remediation ?? null);
+      const display = mapped?.message ?? `Failed to complete validator removal: ${message}`;
+      setErrorState(display);
+      onError(display);
     } finally {
       setIsProcessing(false);
     }
@@ -238,7 +248,15 @@ const CompleteValidatorRemoval: React.FC<CompleteValidatorRemovalProps> = ({
 
   return (
     <div className="space-y-3">
-      {error && <Alert variant="error">{error}</Alert>}
+      <ProposerVMPreflightCard requiredTxId={pChainTxId.trim() || null} />
+      {error && (
+        <Alert variant="error">
+          <div>
+            {error}
+            {aggRemediation && <AggregationRemediation items={aggRemediation} />}
+          </div>
+        </Alert>
+      )}
 
       {isLoadingOwnership && (
         <div className="text-sm text-zinc-500 dark:text-zinc-400">Checking contract ownership...</div>

--- a/components/toolbox/console/permissioned-l1s/validator-manager-setup/InitValidatorSet.tsx
+++ b/components/toolbox/console/permissioned-l1s/validator-manager-setup/InitValidatorSet.tsx
@@ -32,6 +32,12 @@ import { ContractFunctionViewer } from '@/components/console/contract-function-v
 import { Check, ChevronDown, ChevronRight } from 'lucide-react';
 import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
 import versions from '@/scripts/versions.json';
+import { ProposerVMPreflightCard } from '@/components/toolbox/console/shared/ProposerVMPreflightCard';
+import {
+  AggregationRemediation,
+  parseAggregationError,
+  type RemediationLink,
+} from '@/components/toolbox/hooks/contracts/parseAggregationError';
 
 type ConversionData = ExtractSubnetToL1ConversionDataResult & { signingSubnetId: string };
 
@@ -57,6 +63,7 @@ function InitValidatorSet({ onSuccess }: BaseConsoleToolProps) {
   const { aggregateSignature } = useAvalancheSDKChainkit();
   const [isInitializing, setIsInitializing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [aggRemediation, setAggRemediation] = useState<RemediationLink[] | null>(null);
   const [collectedData, setCollectedData] = useState<Record<string, any>>({});
   const [showDebugData, setShowDebugData] = useState(false);
   const selectedL1 = useSelectedL1();
@@ -116,7 +123,9 @@ function InitValidatorSet({ onSuccess }: BaseConsoleToolProps) {
     try {
       await aggPromise;
     } catch (err) {
-      setError((err as Error).message);
+      const mapped = parseAggregationError(err);
+      setAggRemediation(mapped?.remediation ?? null);
+      setError(mapped?.message ?? (err as Error).message);
     } finally {
       setIsAggregating(false);
     }
@@ -377,6 +386,8 @@ function InitValidatorSet({ onSuccess }: BaseConsoleToolProps) {
             </div>
           </div>
 
+          <ProposerVMPreflightCard requiredTxId={conversionTxID.trim() || null} />
+
           {/* Step 2: Initialize Validator Set */}
           <div
             className={`p-3 rounded-xl border transition-colors ${
@@ -456,6 +467,7 @@ function InitValidatorSet({ onSuccess }: BaseConsoleToolProps) {
           {error && (
             <div className="p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
               <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
+              {aggRemediation && <AggregationRemediation items={aggRemediation} />}
             </div>
           )}
 

--- a/components/toolbox/console/shared/CompletePChainRegistration.tsx
+++ b/components/toolbox/console/shared/CompletePChainRegistration.tsx
@@ -31,6 +31,12 @@ import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
 import { Check } from 'lucide-react';
 import { StepFlowCard } from '@/components/toolbox/components/StepCard';
 import { generateCastSendCommand } from '@/components/toolbox/utils/castCommand';
+import { ProposerVMPreflightCard } from '@/components/toolbox/console/shared/ProposerVMPreflightCard';
+import {
+  AggregationRemediation,
+  parseAggregationError,
+  type RemediationLink,
+} from '@/components/toolbox/hooks/contracts/parseAggregationError';
 
 export type ManagerType = 'PoA' | 'PoS-Native' | 'PoS-ERC20';
 export type OwnerType = 'PoAManager' | 'StakingManager' | 'EOA' | null;
@@ -84,6 +90,7 @@ const CompletePChainRegistration: React.FC<CompletePChainRegistrationProps> = ({
   const [pChainTxIdState, setPChainTxIdState] = useState(pChainTxId || '');
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setErrorState] = useState<string | null>(null);
+  const [aggRemediation, setAggRemediation] = useState<RemediationLink[] | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
   const [registrationComplete, setRegistrationComplete] = useState(false);
   const [pChainSignature, setPChainSignature] = useState<string | null>(null);
@@ -309,8 +316,11 @@ const CompletePChainRegistration: React.FC<CompletePChainRegistrationProps> = ({
     } catch (err: any) {
       const message = err instanceof Error ? err.message : String(err);
 
-      setErrorState(`Failed to complete validator registration: ${message}`);
-      onError(`Failed to complete validator registration: ${message}`);
+      const mapped = parseAggregationError(err);
+      setAggRemediation(mapped?.remediation ?? null);
+      const display = mapped?.message ?? `Failed to complete validator registration: ${message}`;
+      setErrorState(display);
+      onError(display);
     } finally {
       setIsProcessing(false);
     }
@@ -357,7 +367,15 @@ const CompletePChainRegistration: React.FC<CompletePChainRegistrationProps> = ({
 
   return (
     <div className="space-y-3">
-      {error && <Alert variant="error">{error}</Alert>}
+      <ProposerVMPreflightCard requiredTxId={pChainTxIdState.trim() || null} />
+      {error && (
+        <Alert variant="error">
+          <div>
+            {error}
+            {aggRemediation && <AggregationRemediation items={aggRemediation} />}
+          </div>
+        </Alert>
+      )}
 
       {/* Step 1: Enter P-Chain Transaction */}
       <StepFlowCard

--- a/components/toolbox/console/shared/CompletePChainWeightUpdate.tsx
+++ b/components/toolbox/console/shared/CompletePChainWeightUpdate.tsx
@@ -28,6 +28,12 @@ import { useViemChainStore } from '@/components/toolbox/stores/toolboxStore';
 import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
 import { Check } from 'lucide-react';
 import { generateCastSendCommand } from '@/components/toolbox/utils/castCommand';
+import { ProposerVMPreflightCard } from '@/components/toolbox/console/shared/ProposerVMPreflightCard';
+import {
+  AggregationRemediation,
+  parseAggregationError,
+  type RemediationLink,
+} from '@/components/toolbox/hooks/contracts/parseAggregationError';
 
 export type WeightUpdateType = 'ChangeWeight' | 'Delegation';
 export type OwnerType = 'PoAManager' | 'StakingManager' | 'EOA' | null;
@@ -89,6 +95,7 @@ const CompletePChainWeightUpdate: React.FC<CompletePChainWeightUpdateProps> = ({
   const [delegationIDState, setDelegationIDState] = useState(delegationID || '');
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setErrorState] = useState<string | null>(null);
+  const [aggRemediation, setAggRemediation] = useState<RemediationLink[] | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
   const [updateComplete, setUpdateComplete] = useState(false);
   const [pChainSignature, setPChainSignature] = useState<string | null>(null);
@@ -291,8 +298,11 @@ const CompletePChainWeightUpdate: React.FC<CompletePChainWeightUpdateProps> = ({
       const message = err instanceof Error ? err.message : String(err);
 
       const errorPrefix = isDelegation ? 'Failed to complete delegation' : 'Failed to complete weight change';
-      setErrorState(`${errorPrefix}: ${message}`);
-      onError(`${errorPrefix}: ${message}`);
+      const mapped = parseAggregationError(err);
+      setAggRemediation(mapped?.remediation ?? null);
+      const display = mapped?.message ?? `${errorPrefix}: ${message}`;
+      setErrorState(display);
+      onError(display);
     } finally {
       setIsProcessing(false);
     }
@@ -343,7 +353,15 @@ const CompletePChainWeightUpdate: React.FC<CompletePChainWeightUpdateProps> = ({
 
   return (
     <div className="space-y-3">
-      {error && <Alert variant="error">{error}</Alert>}
+      <ProposerVMPreflightCard requiredTxId={pChainTxIdState.trim() || null} />
+      {error && (
+        <Alert variant="error">
+          <div>
+            {error}
+            {aggRemediation && <AggregationRemediation items={aggRemediation} />}
+          </div>
+        </Alert>
+      )}
 
       {/* Step 1: Enter P-Chain Transaction */}
       <div

--- a/components/toolbox/console/shared/ProposerVMPreflightCard.tsx
+++ b/components/toolbox/console/shared/ProposerVMPreflightCard.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { FastForward, Loader2 } from 'lucide-react';
+import { Alert } from '@/components/toolbox/components/Alert';
+import { Button } from '@/components/toolbox/components/Button';
+import { useWalletStore } from '@/components/toolbox/stores/walletStore';
+import { useSelectedL1 } from '@/components/toolbox/stores/l1ListStore';
+import { getPChainTxBlockHeight } from '@/components/toolbox/coreViem/utils/glacier';
+import { useProposerVMStatus } from '@/components/toolbox/hooks/useProposerVMStatus';
+import { useAdvanceProposerVM, type AdvancePhase } from '@/components/toolbox/hooks/useAdvanceProposerVM';
+
+const C_CHAIN_EVM_IDS = [43113, 43114];
+const RUNNING_PHASES: AdvancePhase[] = ['countdown', 'sending', 'confirming', 'verifying'];
+
+interface ProposerVMPreflightCardProps {
+  /** P-Chain txID whose inclusion height the delivery chain's epoch must cover. */
+  requiredTxId?: string | null;
+  onAdvanced?: () => void;
+}
+
+/** Full cb58 txID only: the wired inputs are controlled fields, so anything
+ *  shorter is a keystroke in progress and must not hit Glacier. */
+const P_CHAIN_TXID_SHAPE = /^[1-9A-HJ-NP-Za-km-z]{40,60}$/;
+
+function formatHeight(height: bigint | null): string {
+  return height === null ? 'unknown' : Number(height).toLocaleString('en-US');
+}
+
+/**
+ * Advisory staleness check rendered above a warp-delivery action. Warns when
+ * the selected chain's epoch pins a P-Chain height below the one the pending
+ * delivery needs, and offers one-click block production. Never blocks or
+ * disables the host step's own buttons: the check can be wrong in the
+ * user's favor (gateway RPCs hide the epoch) and delivery is always allowed.
+ */
+export function ProposerVMPreflightCard({ requiredTxId, onAdvanced }: ProposerVMPreflightCardProps) {
+  const isTestnet = useWalletStore((s) => s.isTestnet);
+  const selectedL1 = useSelectedL1();
+  const [resolved, setResolved] = useState<{ txId: string; height: bigint | null } | null>(null);
+
+  const isCChain = selectedL1 ? C_CHAIN_EVM_IDS.includes(selectedL1.evmChainId) : false;
+  const validTxId = requiredTxId && P_CHAIN_TXID_SHAPE.test(requiredTxId) ? requiredTxId : null;
+  const active = !isCChain && validTxId !== null;
+
+  useEffect(() => {
+    if (!active || !validTxId) return;
+    let cancelled = false;
+    void getPChainTxBlockHeight(validTxId, isTestnet ? 'testnet' : 'mainnet').then((height) => {
+      if (!cancelled) setResolved({ txId: validTxId, height });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [active, validTxId, isTestnet]);
+
+  const target = resolved && resolved.txId === validTxId ? resolved.height : null;
+  const resolvingTarget = active && resolved?.txId !== validTxId;
+
+  const status = useProposerVMStatus({ requiredHeight: target, enabled: active });
+  const advance = useAdvanceProposerVM({ status, requiredHeight: target, onAdvanced });
+
+  // Hide only while idle: mid-run refreshes flip isLoading and must not
+  // unmount the progress line and its Cancel control.
+  if (!active || resolvingTarget || (status.isLoading && advance.phase === 'idle')) return null;
+
+  // With a resolved target this is exact; without one (Glacier lag or
+  // unknown tx) computeEpochStatus falls back to its idle-chain heuristic,
+  // so a healthy chain stays quiet instead of flashing a false hint.
+  const state = status.status.state;
+  const isRunning = RUNNING_PHASES.includes(advance.phase);
+
+  // Quietly out of the way when the epoch covers the requirement (or the
+  // chain is producing normally and no requirement could be resolved).
+  if (state === 'satisfied' && advance.phase === 'idle') return null;
+
+  if (state === 'unknown') {
+    // Epoch unreadable through this RPC. Worth one neutral line only when
+    // the user gave us a concrete requirement we could not check; otherwise
+    // stay silent and let the delivery's own error path link the tool.
+    if (target === null) return null;
+    return (
+      <Alert variant="info">
+        <span>
+          Could not verify this chain&apos;s P-Chain view: its RPC does not expose the epoch state. If the delivery
+          below fails warp verification, produce blocks with the{' '}
+          <Link href="/console/layer-1/advance-pchain-view" className="underline">
+            Advance P-Chain View
+          </Link>{' '}
+          tool and retry.
+        </span>
+      </Alert>
+    );
+  }
+
+  if (advance.phase === 'done') {
+    return (
+      <Alert variant="success">
+        The chain&apos;s view advanced: the epoch now pins P-Chain height{' '}
+        {formatHeight(status.epoch?.pChainHeight ?? null)}. Run the action below again.
+      </Alert>
+    );
+  }
+
+  if (advance.phase === 'gave-up') {
+    return (
+      <Alert variant="warning">
+        <span>
+          Sent {advance.maxAttempts} block-producing transactions and the epoch still pins{' '}
+          {formatHeight(status.epoch?.pChainHeight ?? null)}, below {formatHeight(target)}. The view did advance, so try
+          the action below anyway, or continue in the{' '}
+          <Link href="/console/layer-1/advance-pchain-view" className="underline">
+            Advance P-Chain View
+          </Link>{' '}
+          tool.
+        </span>
+      </Alert>
+    );
+  }
+
+  return (
+    <Alert variant="warning">
+      <div className="space-y-2">
+        <span>
+          <strong>This chain&apos;s P-Chain view is stale.</strong>{' '}
+          {target !== null ? (
+            <>
+              Its epoch pins height {formatHeight(status.epoch?.pChainHeight ?? null)}, but your transaction landed at
+              height {formatHeight(target)}, so delivering its warp message will fail verification until the chain
+              produces blocks.
+            </>
+          ) : (
+            <>
+              The chain looks idle: its epoch pins height {formatHeight(status.epoch?.pChainHeight ?? null)} while the
+              P-Chain is at {formatHeight(status.liveHeight)}. Warp delivery may fail verification until the chain
+              produces blocks.
+            </>
+          )}{' '}
+          This does not affect signature aggregation, only delivery.
+        </span>
+
+        {isRunning ? (
+          <div className="flex items-center gap-2 text-sm">
+            <Loader2 className="w-4 h-4 animate-spin shrink-0" />
+            {advance.phase === 'countdown' && advance.countdownSecRemaining !== null
+              ? `The current epoch opened less than 5 minutes ago; sending in ${Math.floor(advance.countdownSecRemaining / 60)}:${String(advance.countdownSecRemaining % 60).padStart(2, '0')}.`
+              : `Producing blocks (transaction ${Math.max(advance.attempt, 1)} of ${advance.maxAttempts}).`}
+            <Button variant="outline" size="sm" onClick={advance.cancel}>
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-3 flex-wrap">
+            <Button variant="primary" size="sm" onClick={advance.start} icon={<FastForward className="w-4 h-4" />}>
+              Produce blocks ({'≈'}2 transactions)
+            </Button>
+            <Link href="/docs/nodes/architecture/proposervm" className="text-xs underline" target="_blank">
+              Why this happens
+            </Link>
+          </div>
+        )}
+
+        {advance.phase === 'error' && advance.error && <span className="text-sm block">{advance.error}</span>}
+      </div>
+    </Alert>
+  );
+}

--- a/components/toolbox/console/toolbox/tools.ts
+++ b/components/toolbox/console/toolbox/tools.ts
@@ -16,6 +16,7 @@ import {
   Coins,
   Droplets,
   Eye,
+  FastForward,
   GitMerge,
   HandCoins,
   Hexagon,
@@ -366,6 +367,13 @@ const TOOLS_RAW: ToolCard[] = [
     path: '/console/layer-1/monitoring-setup',
     category: 'L1 Management',
     icon: Activity,
+  },
+  {
+    name: 'Advance P-Chain View',
+    description: 'Produce blocks on an idle L1 so warp message delivery can verify against a current validator set.',
+    path: '/console/layer-1/advance-pchain-view',
+    category: 'L1 Management',
+    icon: FastForward,
   },
   {
     name: 'Fee Parameters',

--- a/components/toolbox/coreViem/utils/glacier.ts
+++ b/components/toolbox/coreViem/utils/glacier.ts
@@ -324,3 +324,30 @@ export async function getNativeTokenBalance(chainId: string | number, address: s
   const data: GetNativeTokenBalanceResponse = await response.json();
   return data.nativeTokenBalance;
 }
+
+/**
+ * P-Chain block height a transaction landed in (Glacier `blockNumber` field),
+ * or null when it cannot be resolved (unknown tx, indexer lag, Glacier down).
+ * Callers treat null as "requirement unknown" and degrade, never throw.
+ */
+export async function getPChainTxBlockHeight(
+  txHash: string,
+  network: Network,
+  signal?: AbortSignal,
+): Promise<bigint | null> {
+  try {
+    const response = await fetch(`${endpoint}/v1/networks/${network}/blockchains/p-chain/transactions/${txHash}`, {
+      headers: { accept: 'application/json' },
+      signal,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { blockNumber?: number | string };
+    const blockNumber = data?.blockNumber;
+    if (typeof blockNumber !== 'number' && (typeof blockNumber !== 'string' || blockNumber === '')) {
+      return null;
+    }
+    return BigInt(blockNumber);
+  } catch {
+    return null;
+  }
+}

--- a/components/toolbox/hooks/contracts/parseAggregationError.test.ts
+++ b/components/toolbox/hooks/contracts/parseAggregationError.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { parseAggregationError } from './parseAggregationError';
+
+describe('parseAggregationError', () => {
+  it('maps a below-quorum error with the achieved percentage and remediation links', () => {
+    const mapped = parseAggregationError(new Error('signature weight is insufficient: 67*200 > 100*100'));
+    expect(mapped).not.toBeNull();
+    expect(mapped!.message).toContain('50%');
+    expect(mapped!.message).toContain('67%');
+    const hrefs = mapped!.remediation.map((r) => r.href);
+    expect(hrefs).toContain('/console/permissioned-l1s/remove-legacy-validators');
+    expect(hrefs).toContain('/console/layer-1/advance-pchain-view');
+    expect(hrefs.some((h) => h.startsWith('/docs/nodes/architecture/proposervm'))).toBe(true);
+  });
+
+  it('maps the threshold-of-stake message without a percentage', () => {
+    const mapped = parseAggregationError(new Error('failed to connect to a threshold of stake'));
+    expect(mapped).not.toBeNull();
+    expect(mapped!.message).toMatch(/67%/);
+    expect(mapped!.remediation.length).toBeGreaterThan(0);
+  });
+
+  it('returns null for transient failures so the raw error surfaces (the enclosing try may not be aggregation)', () => {
+    // The step catch blocks wrap whole flows: a viem receipt timeout or a
+    // Glacier fetch failure must never be relabelled as an aggregation
+    // service problem. Only quorum shapes are unambiguous.
+    expect(parseAggregationError(new TypeError('Failed to fetch'))).toBeNull();
+    expect(
+      parseAggregationError(new Error('Timed out while waiting for transaction with hash 0xabc to be confirmed')),
+    ).toBeNull();
+  });
+
+  it('returns null for wallet rejections and other unrelated errors', () => {
+    expect(parseAggregationError(new Error('User rejected the request'))).toBeNull();
+  });
+
+  it('returns null for invalid-request errors so the raw message surfaces', () => {
+    const err = new Error('invalid hex string') as Error & { statusCode: number };
+    err.statusCode = 400;
+    expect(parseAggregationError(err)).toBeNull();
+  });
+});

--- a/components/toolbox/hooks/contracts/parseAggregationError.tsx
+++ b/components/toolbox/hooks/contracts/parseAggregationError.tsx
@@ -1,0 +1,82 @@
+import Link from 'next/link';
+import { classifyAggregationError } from '@/components/toolbox/utils/aggregationRetry';
+
+export interface RemediationLink {
+  label: string;
+  href: string;
+}
+
+export interface MappedAggregationError {
+  message: string;
+  remediation: RemediationLink[];
+}
+
+const QUORUM_REMEDIATION: RemediationLink[] = [
+  {
+    label: 'Remove Legacy Subnet Validators',
+    href: '/console/permissioned-l1s/remove-legacy-validators',
+  },
+  {
+    label: 'Advance P-Chain View (fixes delivery, not aggregation)',
+    href: '/console/layer-1/advance-pchain-view',
+  },
+  {
+    label: 'ProposerVM troubleshooting',
+    href: '/docs/nodes/architecture/proposervm#troubleshooting-warp-delivery-fails-on-an-idle-chain',
+  },
+];
+
+/**
+ * Turns a signature-aggregation failure into a user-actionable message, or
+ * null when the error is not aggregation-shaped (caller falls through to
+ * its existing error path).
+ *
+ * The two below-quorum causes look identical in a single attempt and need
+ * opposite remedies, so the message names both instead of guessing:
+ * validators whose own P-Chain view lags (heals in minutes, just retry) vs
+ * offline legacy Subnet validators still counted in the signing set
+ * (permanent until removed).
+ */
+export function parseAggregationError(err: unknown): MappedAggregationError | null {
+  const classified = classifyAggregationError(err);
+
+  if (classified.kind === 'below-quorum') {
+    const reached =
+      classified.achievedPercent !== undefined
+        ? `Signature aggregation reached only ${classified.achievedPercent}% of the required 67% of stake.`
+        : 'Signature aggregation could not reach the required 67% of stake.';
+    return {
+      message:
+        `${reached} Two causes look identical: validators whose own P-Chain view has not caught up with your ` +
+        'transaction yet (heals within minutes; retry), and offline legacy Subnet validators still counted in ' +
+        'the signing set (permanent until they are removed).',
+      remediation: QUORUM_REMEDIATION,
+    };
+  }
+
+  // Everything else returns null on purpose. The catch blocks feeding this
+  // mapper wrap whole multi-step flows, so generic shapes (fetch failures,
+  // timeouts) may come from viem, Glacier, or the P-Chain rather than the
+  // aggregator; relabelling them would hide the real error. Only the
+  // quorum shapes above are unambiguous.
+  return null;
+}
+
+/** Compact link row rendered under an aggregation error message. */
+export function AggregationRemediation({ items }: { items: RemediationLink[] }) {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-1 mt-1.5">
+      {items.map((item) => (
+        <Link
+          key={item.href}
+          href={item.href}
+          className="text-xs underline"
+          target={item.href.startsWith('/docs') ? '_blank' : undefined}
+        >
+          {item.label}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/components/toolbox/hooks/contracts/parseContractError.ts
+++ b/components/toolbox/hooks/contracts/parseContractError.ts
@@ -46,8 +46,10 @@ const KNOWN_ERRORS: Record<string, string> = {
   NodeAlreadyRegistered: 'This node is already registered as a validator.',
   '0x11327166': 'Invalid validation ID. The validator may not have been registered on the P-Chain yet.',
   InvalidValidationID: 'Invalid validation ID. The validator may not have been registered on the P-Chain yet.',
-  '0x6b2f19e9': 'Invalid warp message. Ensure the P-Chain transaction was successful and wait for confirmation.',
-  InvalidWarpMessage: 'Invalid warp message. Ensure the P-Chain transaction was successful and wait for confirmation.',
+  '0x6b2f19e9':
+    'Invalid warp message. The block was built against a P-Chain view that predates your transaction: confirm the P-Chain transaction succeeded, then produce blocks with the Advance P-Chain View tool (/console/layer-1/advance-pchain-view) and retry.',
+  InvalidWarpMessage:
+    'Invalid warp message. The block was built against a P-Chain view that predates your transaction: confirm the P-Chain transaction succeeded, then produce blocks with the Advance P-Chain View tool (/console/layer-1/advance-pchain-view) and retry.',
   '0x756b3ca9': 'This validator has already been registered.',
   ValidatorAlreadyRegistered: 'This validator has already been registered.',
   '0x1f0a1ec4': 'This validator cannot be removed in its current state.',

--- a/components/toolbox/hooks/useAdvanceProposerVM.ts
+++ b/components/toolbox/hooks/useAdvanceProposerVM.ts
@@ -1,0 +1,231 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useWalletStore } from '../stores/walletStore';
+import { useViemChainStore } from '../stores/toolboxStore';
+import { useChainPublicClient } from './useChainPublicClient';
+import { useResolvedWalletClient } from './useResolvedWalletClient';
+import useConsoleNotifications from '@/hooks/useConsoleNotifications';
+import { decideAdvanceAction } from '../utils/proposervm';
+import type { ProposerVMStatusResult } from './useProposerVMStatus';
+
+/** Hard cap on block-producing transactions per run. A long-idle chain needs
+ *  2 (seal the old epoch, start the new one); more than 4 means something
+ *  else is wrong and the user should retry their delivery instead. */
+export const MAX_ADVANCE_TXS = 4;
+/** Sends when the epoch cannot be read at all ("blind" mode): enough blocks
+ *  to seal and re-pin, with no way to verify. */
+const BLIND_ADVANCE_TXS = 2;
+
+export type AdvancePhase = 'idle' | 'countdown' | 'sending' | 'confirming' | 'verifying' | 'done' | 'gave-up' | 'error';
+
+export type AdvanceErrorKind = 'no-gas' | 'allowlist' | 'wallet' | 'rpc';
+
+class AdvanceError extends Error {
+  readonly kind: AdvanceErrorKind;
+  constructor(kind: AdvanceErrorKind, message: string) {
+    super(message);
+    this.kind = kind;
+  }
+}
+
+function classifySendError(err: unknown): AdvanceError {
+  const message = err instanceof Error ? err.message : String(err);
+  if (/allow ?list|not authorized|non-allowlisted|is not authorized/i.test(message)) {
+    return new AdvanceError(
+      'allowlist',
+      'This chain restricts who may send transactions (Transactor Allowlist), and the connected wallet is not on the list.',
+    );
+  }
+  if (/user rejected|denied|cancelled|canceled/i.test(message)) {
+    return new AdvanceError('wallet', 'Transaction rejected in the wallet.');
+  }
+  return new AdvanceError('rpc', message);
+}
+
+/**
+ * Produces blocks on the selected L1 (0-value self-transfers from the
+ * connected wallet) until the chain's epoch pins a P-Chain height at or past
+ * `requiredHeight`. One user click per run; nothing is ever sent silently.
+ *
+ * This advances warp DELIVERY readiness only. It cannot fix signature
+ * aggregation failures, which depend on the signing validators themselves.
+ */
+export function useAdvanceProposerVM(opts: {
+  status: ProposerVMStatusResult;
+  requiredHeight?: bigint | null;
+  onAdvanced?: () => void;
+}): {
+  start: () => void;
+  cancel: () => void;
+  phase: AdvancePhase;
+  /** 1-based count of block-producing transactions sent this run. */
+  attempt: number;
+  maxAttempts: number;
+  countdownSecRemaining: number | null;
+  txHashes: `0x${string}`[];
+  verified: boolean;
+  error: string | null;
+  errorKind: AdvanceErrorKind | null;
+} {
+  const { requiredHeight = null, onAdvanced } = opts;
+  const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
+  const viemChain = useViemChainStore();
+  const publicClient = useChainPublicClient();
+  const walletClient = useResolvedWalletClient();
+  const { notify } = useConsoleNotifications();
+
+  const [phase, setPhase] = useState<AdvancePhase>('idle');
+  const [attempt, setAttempt] = useState(0);
+  const [countdownSecRemaining, setCountdownSecRemaining] = useState<number | null>(null);
+  const [txHashes, setTxHashes] = useState<`0x${string}`[]>([]);
+  const [verified, setVerified] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [errorKind, setErrorKind] = useState<AdvanceErrorKind | null>(null);
+
+  const cancelledRef = useRef(false);
+  const runningRef = useRef(false);
+  // The loop must call the latest refresh (its identity changes with the
+  // selected L1), not the one captured when start() was created.
+  const statusRef = useRef(opts.status);
+  useEffect(() => {
+    statusRef.current = opts.status;
+  }, [opts.status]);
+
+  useEffect(() => {
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, []);
+
+  const waitUntilSealable = useCallback(async (sealableAtMs: number) => {
+    setPhase('countdown');
+    while (Date.now() < sealableAtMs && !cancelledRef.current) {
+      setCountdownSecRemaining(Math.ceil((sealableAtMs - Date.now()) / 1000));
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+    setCountdownSecRemaining(null);
+  }, []);
+
+  const start = useCallback(() => {
+    if (runningRef.current) return;
+    runningRef.current = true;
+    cancelledRef.current = false;
+    setTxHashes([]);
+    setVerified(false);
+    setError(null);
+    setErrorKind(null);
+    setAttempt(0);
+
+    void (async () => {
+      try {
+        if (!walletClient || !publicClient || !viemChain || !walletEVMAddress) {
+          throw new AdvanceError('wallet', 'Connect a wallet on the selected chain first.');
+        }
+        const account = walletEVMAddress as `0x${string}`;
+
+        const balance = await publicClient.getBalance({ address: account });
+        if (balance === 0n) {
+          throw new AdvanceError(
+            'no-gas',
+            'The connected wallet holds no funds on this chain, so it cannot pay for the block-producing transactions.',
+          );
+        }
+
+        let sends = 0;
+        setPhase('verifying');
+        let snapshot = await statusRef.current.refresh();
+        // Latched once: a run that started with a readable epoch never
+        // downgrades to blind completion on a later transient read failure.
+        const blindRun = snapshot.epoch === null;
+
+        for (;;) {
+          if (cancelledRef.current) {
+            setPhase('idle');
+            return;
+          }
+
+          const decision = decideAdvanceAction({
+            epoch: snapshot.epoch,
+            liveHeight: snapshot.liveHeight,
+            tipTimestampSec: snapshot.tipTimestampSec,
+            nowMs: Date.now(),
+            requiredHeight,
+            blindRun,
+            sends,
+            maxSends: MAX_ADVANCE_TXS,
+            blindSends: BLIND_ADVANCE_TXS,
+          });
+
+          if (decision.action === 'done-verified' || decision.action === 'done-unverified') {
+            setVerified(decision.action === 'done-verified');
+            setPhase('done');
+            onAdvanced?.();
+            return;
+          }
+          if (decision.action === 'give-up') {
+            setPhase('gave-up');
+            return;
+          }
+          if (decision.action === 'wait') {
+            await waitUntilSealable(decision.untilMs);
+            if (cancelledRef.current) {
+              setPhase('idle');
+              return;
+            }
+            setPhase('verifying');
+            snapshot = await statusRef.current.refresh();
+            continue;
+          }
+
+          sends += 1;
+          setAttempt(sends);
+          setPhase('sending');
+          const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+          const txPromise = walletClient
+            .sendTransaction({
+              to: account,
+              value: 0n,
+              account,
+              chain: viemChain,
+              nonce,
+            })
+            .catch((err) => {
+              throw classifySendError(err);
+            });
+          notify({ type: 'transfer', name: 'Advance P-Chain View' }, txPromise, viemChain);
+          const hash = await txPromise;
+          setPhase('confirming');
+          await publicClient.waitForTransactionReceipt({ hash });
+          setTxHashes((prev) => [...prev, hash]);
+          setPhase('verifying');
+          snapshot = await statusRef.current.refresh();
+        }
+      } catch (err) {
+        const advanceErr = err instanceof AdvanceError ? err : classifySendError(err);
+        setError(advanceErr.message);
+        setErrorKind(advanceErr.kind);
+        setPhase('error');
+      } finally {
+        runningRef.current = false;
+      }
+    })();
+  }, [walletClient, publicClient, viemChain, walletEVMAddress, requiredHeight, notify, onAdvanced, waitUntilSealable]);
+
+  const cancel = useCallback(() => {
+    cancelledRef.current = true;
+  }, []);
+
+  return {
+    start,
+    cancel,
+    phase,
+    attempt,
+    maxAttempts: MAX_ADVANCE_TXS,
+    countdownSecRemaining,
+    txHashes,
+    verified,
+    error,
+    errorKind,
+  };
+}

--- a/components/toolbox/hooks/useProposerVMStatus.ts
+++ b/components/toolbox/hooks/useProposerVMStatus.ts
@@ -1,0 +1,120 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useWalletStore } from '../stores/walletStore';
+import { useSelectedL1 } from '../stores/l1ListStore';
+import { useChainPublicClient } from './useChainPublicClient';
+import { getPChainRpcUrl } from '../utils/avalancheEndpoints';
+import {
+  computeEpochStatus,
+  deriveProposerVMUrl,
+  fetchCurrentEpoch,
+  fetchLivePChainHeight,
+  type EpochStatus,
+  type ProposerVMEpoch,
+} from '../utils/proposervm';
+
+export interface ProposerVMSnapshot {
+  epoch: ProposerVMEpoch | null;
+  liveHeight: bigint | null;
+  tipTimestampSec: number | null;
+  readAtMs: number;
+}
+
+export interface ProposerVMStatusResult {
+  epoch: ProposerVMEpoch | null;
+  liveHeight: bigint | null;
+  status: EpochStatus;
+  /** True when the chain's /proposervm endpoint could not be read (gateway
+   *  RPCs don't proxy it; some operators disable it). Not an error state. */
+  unreachable: boolean;
+  proposerVMUrl: string | null;
+  isLoading: boolean;
+  refresh: () => Promise<ProposerVMSnapshot>;
+}
+
+/**
+ * Reads how stale the selected L1's ProposerVM view of the P-Chain is.
+ *
+ * `refresh()` resolves to the snapshot it just read so async callers (the
+ * advance loop) can act on fresh values instead of stale closure state; the
+ * hook's state fields exist for rendering.
+ */
+export function useProposerVMStatus(
+  opts: { requiredHeight?: bigint | null; enabled?: boolean } = {},
+): ProposerVMStatusResult {
+  const { requiredHeight = null, enabled = true } = opts;
+  const selectedL1 = useSelectedL1();
+  const isTestnet = useWalletStore((s) => s.isTestnet);
+  const publicClient = useChainPublicClient();
+
+  const rpcUrl = selectedL1?.rpcUrl ?? null;
+  const proposerVMUrl = useMemo(() => (rpcUrl ? deriveProposerVMUrl(rpcUrl) : null), [rpcUrl]);
+
+  const [snapshot, setSnapshot] = useState<ProposerVMSnapshot | null>(null);
+  const [unreachable, setUnreachable] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  // Discards responses from a superseded refresh (e.g. after switching L1s).
+  const requestIdRef = useRef(0);
+
+  const refresh = useCallback(async (): Promise<ProposerVMSnapshot> => {
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    setIsLoading(true);
+
+    const [epochResult, liveResult, tipResult] = await Promise.allSettled([
+      proposerVMUrl
+        ? fetchCurrentEpoch(proposerVMUrl)
+        : Promise.reject(new Error('no proposervm URL derivable from this RPC URL')),
+      fetchLivePChainHeight(getPChainRpcUrl(isTestnet)),
+      publicClient
+        ? publicClient.getBlock({ blockTag: 'latest' })
+        : Promise.reject(new Error('no public client for the selected chain')),
+    ]);
+
+    const next: ProposerVMSnapshot = {
+      epoch: epochResult.status === 'fulfilled' ? epochResult.value : null,
+      liveHeight: liveResult.status === 'fulfilled' ? liveResult.value : null,
+      tipTimestampSec: tipResult.status === 'fulfilled' ? Number(tipResult.value.timestamp) : null,
+      readAtMs: Date.now(),
+    };
+
+    if (requestIdRef.current === requestId) {
+      setSnapshot(next);
+      setUnreachable(next.epoch === null);
+      setIsLoading(false);
+    }
+    return next;
+  }, [proposerVMUrl, isTestnet, publicClient]);
+
+  useEffect(() => {
+    setSnapshot(null);
+    setUnreachable(false);
+    if (!enabled || !rpcUrl) return;
+    void refresh().catch(() => {
+      // refresh never rejects (allSettled), but keep the effect noise-free
+    });
+  }, [enabled, rpcUrl, refresh]);
+
+  const status = useMemo(
+    () =>
+      computeEpochStatus({
+        epoch: snapshot?.epoch ?? null,
+        liveHeight: snapshot?.liveHeight ?? null,
+        tipTimestampSec: snapshot?.tipTimestampSec ?? null,
+        nowMs: snapshot?.readAtMs ?? Date.now(),
+        requiredHeight,
+      }),
+    [snapshot, requiredHeight],
+  );
+
+  return {
+    epoch: snapshot?.epoch ?? null,
+    liveHeight: snapshot?.liveHeight ?? null,
+    status,
+    unreachable,
+    proposerVMUrl,
+    isLoading,
+    refresh,
+  };
+}

--- a/components/toolbox/stores/useAvalancheSDKChainkit.ts
+++ b/components/toolbox/stores/useAvalancheSDKChainkit.ts
@@ -1,6 +1,7 @@
 import { useMemo, useCallback } from 'react';
 import { Avalanche } from '@avalanche-sdk/chainkit';
 import { useWalletStore } from './walletStore';
+import { aggregateWithRetry } from '../utils/aggregationRetry';
 
 // Types for signature aggregation
 interface SignatureAggregationParams {
@@ -9,6 +10,11 @@ interface SignatureAggregationParams {
   signingSubnetId?: string;
   quorumPercentage?: number;
 }
+
+/** Per-attempt cap; the SDK itself has no timeout configured. Generous on
+ *  purpose (healthy aggregations take seconds): when it fires, the attempt
+ *  is not retried, because the raced request may still be in flight. */
+const AGGREGATION_ATTEMPT_TIMEOUT_MS = 60_000;
 
 interface SignatureAggregationResult {
   signedMessage: string;
@@ -72,8 +78,24 @@ export const useAvalancheSDKChainkit = (customNetwork?: 'mainnet' | 'fuji') => {
           signatureAggregatorRequest.signingSubnetId = signingSubnetId;
         }
 
-        const result = await sdk.data.signatureAggregator.aggregate({
-          signatureAggregatorRequest,
+        // Below-quorum results right after a P-Chain tx usually mean some
+        // validators' own P-Chain views lag; they self-heal, so retry a few
+        // times before surfacing the failure (see aggregationRetry.ts).
+        const result = await aggregateWithRetry(() => {
+          let timer: ReturnType<typeof setTimeout> | undefined;
+          const timeout = new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () =>
+                reject(
+                  new Error(`signature aggregation attempt timed out after ${AGGREGATION_ATTEMPT_TIMEOUT_MS / 1000}s`),
+                ),
+              AGGREGATION_ATTEMPT_TIMEOUT_MS,
+            );
+          });
+          return Promise.race([
+            sdk.data.signatureAggregator.aggregate({ signatureAggregatorRequest }),
+            timeout,
+          ]).finally(() => clearTimeout(timer));
         });
         return { signedMessage: result.signedMessage };
       } catch (error) {

--- a/components/toolbox/utils/aggregationRetry.test.ts
+++ b/components/toolbox/utils/aggregationRetry.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { aggregateWithRetry, classifyAggregationError } from './aggregationRetry';
+
+function statusError(statusCode: number, message: string): Error {
+  const err = new Error(message) as Error & { statusCode: number };
+  err.statusCode = statusCode;
+  return err;
+}
+
+describe('classifyAggregationError', () => {
+  it('classifies the aggregator threshold message as below-quorum and retryable', () => {
+    const result = classifyAggregationError(new Error('failed to connect to a threshold of stake'));
+    expect(result.kind).toBe('below-quorum');
+    expect(result.retryable).toBe(true);
+    expect(result.achievedPercent).toBeUndefined();
+  });
+
+  it('extracts the achieved percentage from the signature-weight message', () => {
+    const result = classifyAggregationError(new Error('signature weight is insufficient: 67*200 > 100*100'));
+    expect(result.kind).toBe('below-quorum');
+    expect(result.retryable).toBe(true);
+    expect(result.achievedPercent).toBe(50);
+  });
+
+  it('classifies network failures as transient', () => {
+    const result = classifyAggregationError(new TypeError('Failed to fetch'));
+    expect(result.kind).toBe('transient');
+    expect(result.retryable).toBe(true);
+  });
+
+  it('classifies our attempt timeout as transient but NOT retryable (the request may still be in flight)', () => {
+    const result = classifyAggregationError(new Error('signature aggregation attempt timed out after 60s'));
+    expect(result.kind).toBe('transient');
+    expect(result.retryable).toBe(false);
+  });
+
+  it('classifies 5xx responses as transient', () => {
+    const result = classifyAggregationError(statusError(500, 'Internal Server Error'));
+    expect(result.kind).toBe('transient');
+    expect(result.retryable).toBe(true);
+  });
+
+  it('classifies 4xx responses as invalid-request and not retryable', () => {
+    const result = classifyAggregationError(statusError(400, 'invalid hex string'));
+    expect(result.kind).toBe('invalid-request');
+    expect(result.retryable).toBe(false);
+  });
+
+  it('leaves unrecognized errors as unknown and not retryable', () => {
+    const result = classifyAggregationError(new Error('User rejected the request'));
+    expect(result.kind).toBe('unknown');
+    expect(result.retryable).toBe(false);
+  });
+});
+
+describe('aggregateWithRetry', () => {
+  it('retries retryable failures with the configured delays and succeeds', async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const onAttempt = vi.fn();
+    let calls = 0;
+    const run = vi.fn().mockImplementation(() => {
+      calls += 1;
+      if (calls < 3) return Promise.reject(new Error('failed to connect to a threshold of stake'));
+      return Promise.resolve('signed');
+    });
+
+    const result = await aggregateWithRetry(run, { onAttempt, sleep });
+
+    expect(result).toBe('signed');
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(sleep.mock.calls.map((c) => c[0])).toEqual([5000, 10000]);
+    expect(onAttempt.mock.calls.map((c) => [c[0], c[1]])).toEqual([
+      [2, 4],
+      [3, 4],
+    ]);
+  });
+
+  it('throws immediately on a non-retryable error without sleeping', async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const run = vi.fn().mockRejectedValue(statusError(400, 'invalid hex string'));
+
+    await expect(aggregateWithRetry(run, { sleep })).rejects.toThrow('invalid hex string');
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('rethrows the last error after exhausting all attempts', async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    let calls = 0;
+    const run = vi.fn().mockImplementation(() => {
+      calls += 1;
+      return Promise.reject(new Error(`transient failure, fetch failed (${calls})`));
+    });
+
+    await expect(aggregateWithRetry(run, { sleep })).rejects.toThrow('transient failure, fetch failed (4)');
+    expect(run).toHaveBeenCalledTimes(4);
+    expect(sleep.mock.calls.map((c) => c[0])).toEqual([5000, 10000, 20000]);
+  });
+
+  it('honors a custom attempt budget', async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const run = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+
+    await expect(aggregateWithRetry(run, { attempts: 2, sleep })).rejects.toThrow('Failed to fetch');
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(sleep.mock.calls.map((c) => c[0])).toEqual([5000]);
+  });
+});

--- a/components/toolbox/utils/aggregationRetry.ts
+++ b/components/toolbox/utils/aggregationRetry.ts
@@ -1,0 +1,106 @@
+/**
+ * Retry policy for BLS signature aggregation calls.
+ *
+ * Below-quorum failures are usually transient: right after a P-Chain
+ * transaction, some validators' own P-Chain replicas have not seen it yet
+ * and refuse to sign, so the aggregate lands under the 67% threshold and
+ * heals by itself within seconds to minutes. A bounded retry turns most of
+ * those "failures" into successes. Malformed requests never retry.
+ *
+ * Permanent quorum shortfalls (offline legacy Subnet validators still in
+ * the signing set) look identical per attempt: those exhaust the retries
+ * and surface through parseAggregationError with remediation links.
+ */
+
+export type AggErrorKind = 'below-quorum' | 'transient' | 'invalid-request' | 'unknown';
+
+export interface AggregationErrorClass {
+  kind: AggErrorKind;
+  retryable: boolean;
+  /** Share of stake that actually signed, when the error message carries it. */
+  achievedPercent?: number;
+}
+
+const DEFAULT_ATTEMPTS = 4;
+const RETRY_DELAYS_MS = [5000, 10000, 20000];
+
+function extractStatusCode(err: unknown): number | null {
+  if (err && typeof err === 'object') {
+    const candidate = (err as { statusCode?: unknown }).statusCode ?? (err as { status?: unknown }).status;
+    if (typeof candidate === 'number') return candidate;
+  }
+  return null;
+}
+
+export function classifyAggregationError(err: unknown): AggregationErrorClass {
+  const message = err instanceof Error ? err.message : String(err);
+
+  // The aggregator's below-quorum shapes: icm-services' "failed to connect
+  // to a threshold of stake" and the P-Chain's "signature weight is
+  // insufficient: 67*<total> > 100*<signed>".
+  if (/threshold of stake/i.test(message) || /signature weight is insufficient/i.test(message)) {
+    const match = message.match(/(\d+)\s*\*\s*(\d+)\s*>\s*100\s*\*\s*(\d+)/);
+    let achievedPercent: number | undefined;
+    if (match) {
+      const total = Number(match[2]);
+      const signed = Number(match[3]);
+      if (total > 0) achievedPercent = Math.round((signed / total) * 1000) / 10;
+    }
+    return { kind: 'below-quorum', retryable: true, achievedPercent };
+  }
+
+  // Our own per-attempt timeout races the SDK call but cannot cancel it, so
+  // the request may still be in flight. Retrying would stack concurrent
+  // aggregations against the service: transient, but never retried.
+  if (/signature aggregation attempt timed out/i.test(message)) {
+    return { kind: 'transient', retryable: false };
+  }
+
+  const statusCode = extractStatusCode(err);
+  if (statusCode !== null) {
+    if (statusCode >= 500 || statusCode === 408 || statusCode === 429) {
+      return { kind: 'transient', retryable: true };
+    }
+    if (statusCode >= 400) return { kind: 'invalid-request', retryable: false };
+  }
+
+  // These shapes mean the request itself terminated, so a retry cannot
+  // stack a duplicate in-flight call.
+  if (/failed to fetch|fetch failed|network|timed out|timeout|aborted|econnreset|socket/i.test(message)) {
+    return { kind: 'transient', retryable: true };
+  }
+
+  return { kind: 'unknown', retryable: false };
+}
+
+export async function aggregateWithRetry<T>(
+  run: () => Promise<T>,
+  opts: {
+    attempts?: number;
+    delaysMs?: number[];
+    /** Fires before each retry with the upcoming attempt number and the error that caused it. */
+    onAttempt?: (attempt: number, maxAttempts: number, lastError: unknown) => void;
+    /** Injectable for tests. */
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<T> {
+  const {
+    attempts = DEFAULT_ATTEMPTS,
+    delaysMs = RETRY_DELAYS_MS,
+    onAttempt,
+    sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
+  } = opts;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    if (attempt > 1) onAttempt?.(attempt, attempts, lastError);
+    try {
+      return await run();
+    } catch (err) {
+      lastError = err;
+      if (!classifyAggregationError(err).retryable || attempt === attempts) throw err;
+      await sleep(delaysMs[Math.min(attempt - 1, delaysMs.length - 1)]);
+    }
+  }
+  throw lastError;
+}

--- a/components/toolbox/utils/proposervm.test.ts
+++ b/components/toolbox/utils/proposervm.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EPOCH_DURATION_MS,
+  computeEpochStatus,
+  decideAdvanceAction,
+  deriveProposerVMUrl,
+  parseCurrentEpochResponse,
+  parsePlatformHeightResponse,
+  type ProposerVMEpoch,
+} from './proposervm';
+
+const NOW_MS = 1_754_600_000_000;
+const NOW_SEC = NOW_MS / 1000;
+
+function epochAt(startTimeSec: number, pChainHeight: bigint): ProposerVMEpoch {
+  return { number: 7n, startTimeSec, pChainHeight };
+}
+
+describe('deriveProposerVMUrl', () => {
+  it('swaps the trailing rpc segment on a node URL', () => {
+    expect(deriveProposerVMUrl('https://node.example:9650/ext/bc/2ALtzRYgRpRWnTgjdrMArkMvU6RTpcjs/rpc')).toBe(
+      'https://node.example:9650/ext/bc/2ALtzRYgRpRWnTgjdrMArkMvU6RTpcjs/proposervm',
+    );
+  });
+
+  it('swaps the trailing rpc segment on a gateway URL', () => {
+    expect(deriveProposerVMUrl('https://subnets.avax.network/echo/testnet/rpc')).toBe(
+      'https://subnets.avax.network/echo/testnet/proposervm',
+    );
+  });
+
+  it('tolerates a trailing slash', () => {
+    expect(deriveProposerVMUrl('https://node.example/ext/bc/XYZ/rpc/')).toBe(
+      'https://node.example/ext/bc/XYZ/proposervm',
+    );
+  });
+
+  it('preserves a query string (provider auth tokens)', () => {
+    expect(deriveProposerVMUrl('https://host.example/ext/bc/XYZ/rpc?token=abc')).toBe(
+      'https://host.example/ext/bc/XYZ/proposervm?token=abc',
+    );
+  });
+
+  it('returns null when the last path segment is not rpc', () => {
+    expect(deriveProposerVMUrl('https://rpc.ankr.com/avalanche')).toBeNull();
+  });
+
+  it('returns null for an unparseable URL', () => {
+    expect(deriveProposerVMUrl('not a url')).toBeNull();
+  });
+});
+
+describe('parseCurrentEpochResponse', () => {
+  it('parses the string-encoded fields avalanchego returns', () => {
+    const parsed = parseCurrentEpochResponse({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { number: '56', startTime: '1754500000', pChainHeight: '291012' },
+    });
+    expect(parsed).toEqual({ number: 56n, startTimeSec: 1754500000, pChainHeight: 291012n });
+  });
+
+  it('parses the pre-Granite all-zeros response without throwing', () => {
+    const parsed = parseCurrentEpochResponse({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { number: '0', startTime: '0', pChainHeight: '0' },
+    });
+    expect(parsed).toEqual({ number: 0n, startTimeSec: 0, pChainHeight: 0n });
+  });
+
+  it('throws the RPC error message when the node returns an error', () => {
+    expect(() =>
+      parseCurrentEpochResponse({ jsonrpc: '2.0', id: 1, error: { message: 'proposervm API not enabled' } }),
+    ).toThrow(/proposervm API not enabled/);
+  });
+
+  it('throws on a malformed result', () => {
+    expect(() =>
+      parseCurrentEpochResponse({ jsonrpc: '2.0', id: 1, result: { number: 'x', startTime: '1', pChainHeight: '2' } }),
+    ).toThrow();
+    expect(() => parseCurrentEpochResponse({ jsonrpc: '2.0', id: 1 })).toThrow();
+  });
+});
+
+describe('parsePlatformHeightResponse', () => {
+  it('parses the string-encoded platform.getHeight result', () => {
+    expect(parsePlatformHeightResponse({ jsonrpc: '2.0', id: 1, result: { height: '302171' } })).toBe(302_171n);
+  });
+
+  it('throws the RPC error message when the node returns an error', () => {
+    expect(() => parsePlatformHeightResponse({ jsonrpc: '2.0', id: 1, error: { message: 'rate limited' } })).toThrow(
+      /rate limited/,
+    );
+  });
+
+  it('throws on a malformed result', () => {
+    expect(() => parsePlatformHeightResponse({ jsonrpc: '2.0', id: 1, result: {} })).toThrow(/platform\.getHeight/);
+  });
+});
+
+describe('computeEpochStatus', () => {
+  it('is unknown when the epoch could not be read', () => {
+    const status = computeEpochStatus({
+      epoch: null,
+      liveHeight: 302_171n,
+      tipTimestampSec: NOW_SEC - 120,
+      nowMs: NOW_MS,
+    });
+    expect(status.state).toBe('unknown');
+    expect(status.heightLag).toBeNull();
+    expect(status.sealableAtMs).toBeNull();
+    expect(status.tipAgeSec).toBe(120);
+  });
+
+  it('is satisfied when the pinned height covers the required height, even on an idle chain', () => {
+    const status = computeEpochStatus({
+      epoch: epochAt(NOW_SEC - 42 * 86_400, 302_170n),
+      liveHeight: 302_171n,
+      tipTimestampSec: null,
+      nowMs: NOW_MS,
+      requiredHeight: 302_168n,
+    });
+    expect(status.state).toBe('satisfied');
+    expect(status.heightLag).toBe(1n);
+  });
+
+  it('is stale-sealable when required exceeds pinned and the epoch is past its duration', () => {
+    const startSec = NOW_SEC - 42 * 86_400;
+    const status = computeEpochStatus({
+      epoch: epochAt(startSec, 291_012n),
+      liveHeight: 302_171n,
+      tipTimestampSec: null,
+      nowMs: NOW_MS,
+      requiredHeight: 302_168n,
+    });
+    expect(status.state).toBe('stale-sealable');
+    expect(status.sealableAtMs).toBe(startSec * 1000 + EPOCH_DURATION_MS);
+  });
+
+  it('is stale-waiting with the seal moment when the epoch is younger than its duration', () => {
+    const startSec = NOW_SEC - 90;
+    const status = computeEpochStatus({
+      epoch: epochAt(startSec, 291_012n),
+      liveHeight: 302_171n,
+      tipTimestampSec: null,
+      nowMs: NOW_MS,
+      requiredHeight: 302_168n,
+    });
+    expect(status.state).toBe('stale-waiting');
+    expect(status.sealableAtMs).toBe(startSec * 1000 + EPOCH_DURATION_MS);
+  });
+
+  it('treats the exact seal boundary as sealable', () => {
+    const startSec = NOW_SEC - EPOCH_DURATION_MS / 1000;
+    const status = computeEpochStatus({
+      epoch: epochAt(startSec, 291_012n),
+      liveHeight: 302_171n,
+      tipTimestampSec: null,
+      nowMs: NOW_MS,
+      requiredHeight: 302_168n,
+    });
+    expect(status.state).toBe('stale-sealable');
+  });
+
+  it('does not call a healthy chain stale while its epoch is current (no required height)', () => {
+    const status = computeEpochStatus({
+      epoch: epochAt(NOW_SEC - 240, 302_100n),
+      liveHeight: 302_171n,
+      tipTimestampSec: NOW_SEC - 3,
+      nowMs: NOW_MS,
+    });
+    expect(status.state).toBe('satisfied');
+  });
+
+  it('grants an actively producing chain one epoch of grace before calling it stale (no required height)', () => {
+    const status = computeEpochStatus({
+      epoch: epochAt(NOW_SEC - 7 * 60, 302_100n),
+      liveHeight: 302_171n,
+      tipTimestampSec: NOW_SEC - 30,
+      nowMs: NOW_MS,
+    });
+    expect(status.state).toBe('satisfied');
+  });
+
+  it('flags a chain a full extra epoch overdue as stale (no required height)', () => {
+    const startSec = NOW_SEC - (2 * EPOCH_DURATION_MS) / 1000;
+    const status = computeEpochStatus({
+      epoch: epochAt(startSec, 291_012n),
+      liveHeight: 302_171n,
+      tipTimestampSec: NOW_SEC - 600,
+      nowMs: NOW_MS,
+    });
+    expect(status.state).toBe('stale-sealable');
+    expect(status.heightLag).toBe(11_159n);
+  });
+
+  it('clamps the height lag at zero when RPC views skew', () => {
+    const status = computeEpochStatus({
+      epoch: epochAt(NOW_SEC - 60, 302_172n),
+      liveHeight: 302_171n,
+      tipTimestampSec: null,
+      nowMs: NOW_MS,
+    });
+    expect(status.heightLag).toBe(0n);
+  });
+
+  it('leaves heightLag and tipAgeSec null when their inputs are missing', () => {
+    const status = computeEpochStatus({
+      epoch: epochAt(NOW_SEC - 60, 302_100n),
+      liveHeight: null,
+      tipTimestampSec: null,
+      nowMs: NOW_MS,
+    });
+    expect(status.heightLag).toBeNull();
+    expect(status.tipAgeSec).toBeNull();
+  });
+});
+
+describe('decideAdvanceAction', () => {
+  const caps = { maxSends: 4, blindSends: 2 };
+  const staleEpoch = epochAt(NOW_SEC - 42 * 86_400, 291_012n);
+
+  function decide(overrides: Partial<Parameters<typeof decideAdvanceAction>[0]>) {
+    return decideAdvanceAction({
+      epoch: staleEpoch,
+      liveHeight: 302_171n,
+      tipTimestampSec: null,
+      nowMs: NOW_MS,
+      requiredHeight: 302_168n,
+      blindRun: false,
+      sends: 0,
+      ...caps,
+      ...overrides,
+    });
+  }
+
+  it('sends in a blind run until the blind budget is spent, then finishes unverified', () => {
+    expect(decide({ blindRun: true, epoch: null, sends: 0 })).toEqual({ action: 'send' });
+    expect(decide({ blindRun: true, epoch: null, sends: 1 })).toEqual({ action: 'send' });
+    expect(decide({ blindRun: true, epoch: null, sends: 2 })).toEqual({ action: 'done-unverified' });
+  });
+
+  it('finishes verified as soon as the pinned height covers the requirement', () => {
+    expect(decide({ epoch: epochAt(NOW_SEC - 42 * 86_400, 302_170n), sends: 1 })).toEqual({
+      action: 'done-verified',
+    });
+  });
+
+  it('keeps sending when a mid-run epoch read fails in a run that started verifiable', () => {
+    expect(decide({ epoch: null, sends: 1 })).toEqual({ action: 'send' });
+  });
+
+  it('gives up instead of finishing when reads stay failed at the send cap', () => {
+    expect(decide({ epoch: null, sends: 4 })).toEqual({ action: 'give-up' });
+  });
+
+  it('waits for the seal moment when the epoch is younger than its duration', () => {
+    const startSec = NOW_SEC - 90;
+    const decision = decide({ epoch: epochAt(startSec, 291_012n) });
+    expect(decision).toEqual({ action: 'wait', untilMs: startSec * 1000 + EPOCH_DURATION_MS });
+  });
+
+  it('sends when the epoch is sealable and the target is unmet', () => {
+    expect(decide({ sends: 3 })).toEqual({ action: 'send' });
+  });
+
+  it('gives up at the send cap when the target stays unmet', () => {
+    expect(decide({ sends: 4 })).toEqual({ action: 'give-up' });
+  });
+
+  it('treats the no-target heuristic as the goal when no required height is given', () => {
+    expect(decide({ requiredHeight: null, epoch: epochAt(NOW_SEC - 240, 302_100n) })).toEqual({
+      action: 'done-verified',
+    });
+    expect(decide({ requiredHeight: null, epoch: staleEpoch })).toEqual({ action: 'send' });
+  });
+});

--- a/components/toolbox/utils/proposervm.ts
+++ b/components/toolbox/utils/proposervm.ts
@@ -1,0 +1,216 @@
+/**
+ * ProposerVM epoch staleness primitives.
+ *
+ * Every block an L1 produces carries an ACP-181 epoch (number, start time,
+ * pinned P-Chain height). Warp message delivery verifies signatures against
+ * the validator set at the CURRENT epoch's pinned height, and that height
+ * only advances when the chain produces blocks: the first block at or past
+ * `startTime + D` seals the epoch, and the next block adopts the sealer's
+ * embedded height. An idle chain's view therefore stands still while the
+ * P-Chain moves on, and deliveries (initializeValidatorSet,
+ * completeValidatorRegistration, ...) fail until blocks are produced.
+ * Reference: /docs/nodes/architecture/proposervm
+ *
+ * These helpers only diagnose DELIVERY readiness (the epoch's pinned
+ * height). They say nothing about signature AGGREGATION, which depends on
+ * each validator's own P-Chain view and the signing set's online quorum.
+ */
+
+/** Epoch duration D on both Fuji and Mainnet (ACP-181, Granite activation).
+ *  Changing D requires a network upgrade. Used for countdown UX only; the
+ *  advance loop's correctness never depends on it. */
+export const EPOCH_DURATION_MS = 5 * 60_000;
+
+export interface ProposerVMEpoch {
+  number: bigint;
+  startTimeSec: number;
+  pChainHeight: bigint;
+}
+
+export type EpochAdvanceState = 'satisfied' | 'stale-sealable' | 'stale-waiting' | 'unknown';
+
+export interface EpochStatus {
+  state: EpochAdvanceState;
+  /** Live P-Chain height minus the epoch's pinned height, clamped at zero. */
+  heightLag: bigint | null;
+  tipAgeSec: number | null;
+  /** The moment a new block may seal the current epoch (startTime + D). */
+  sealableAtMs: number | null;
+}
+
+/**
+ * Derive the chain's proposervm API URL from its JSON-RPC URL. Both live on
+ * the same host: `/ext/bc/<blockchainID>/rpc` vs `/ext/bc/<blockchainID>/proposervm`.
+ * Returns null when the URL does not end in an `rpc` segment; callers treat
+ * that as "epoch state unreadable", not as an error.
+ */
+export function deriveProposerVMUrl(rpcUrl: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(rpcUrl);
+  } catch {
+    return null;
+  }
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (segments.length === 0 || segments[segments.length - 1] !== 'rpc') return null;
+  const swapped = [...segments.slice(0, -1), 'proposervm'];
+  return `${url.origin}/${swapped.join('/')}${url.search}`;
+}
+
+function toBigIntField(value: unknown, field: string): bigint {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    throw new Error(`proposervm.getCurrentEpoch: missing ${field}`);
+  }
+  try {
+    return BigInt(value);
+  } catch {
+    throw new Error(`proposervm.getCurrentEpoch: non-numeric ${field} "${String(value)}"`);
+  }
+}
+
+function toIntField(value: unknown, field: string): number {
+  const parsed = Number(value);
+  if (typeof value === 'undefined' || value === null || !Number.isFinite(parsed)) {
+    throw new Error(`proposervm.getCurrentEpoch: non-numeric ${field} "${String(value)}"`);
+  }
+  return parsed;
+}
+
+/** avalanchego returns number/startTime/pChainHeight as string-encoded ints. */
+export function parseCurrentEpochResponse(body: unknown): ProposerVMEpoch {
+  const envelope = body as {
+    result?: { number?: unknown; startTime?: unknown; pChainHeight?: unknown };
+    error?: { message?: string };
+  } | null;
+  if (envelope?.error) {
+    throw new Error(envelope.error.message || 'proposervm.getCurrentEpoch returned an error');
+  }
+  const result = envelope?.result;
+  if (!result) throw new Error('proposervm.getCurrentEpoch returned no result');
+  return {
+    number: toBigIntField(result.number, 'number'),
+    startTimeSec: toIntField(result.startTime, 'startTime'),
+    pChainHeight: toBigIntField(result.pChainHeight, 'pChainHeight'),
+  };
+}
+
+/** `platform.getHeight` also returns its height as a string-encoded int. */
+export function parsePlatformHeightResponse(body: unknown): bigint {
+  const envelope = body as { result?: { height?: unknown }; error?: { message?: string } } | null;
+  if (envelope?.error) {
+    throw new Error(envelope.error.message || 'platform.getHeight returned an error');
+  }
+  const height = envelope?.result?.height;
+  if (typeof height !== 'string' && typeof height !== 'number') {
+    throw new Error('platform.getHeight returned no height');
+  }
+  try {
+    return BigInt(height);
+  } catch {
+    throw new Error(`platform.getHeight returned a non-numeric height "${String(height)}"`);
+  }
+}
+
+async function postJsonRpc(url: string, method: string, timeoutMs: number): Promise<unknown> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params: {} }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) throw new Error(`${method} request failed with HTTP ${res.status}`);
+  return res.json();
+}
+
+export async function fetchCurrentEpoch(proposerVMUrl: string, timeoutMs = 8000): Promise<ProposerVMEpoch> {
+  return parseCurrentEpochResponse(await postJsonRpc(proposerVMUrl, 'proposervm.getCurrentEpoch', timeoutMs));
+}
+
+export async function fetchLivePChainHeight(pChainRpcUrl: string, timeoutMs = 8000): Promise<bigint> {
+  return parsePlatformHeightResponse(await postJsonRpc(pChainRpcUrl, 'platform.getHeight', timeoutMs));
+}
+
+/**
+ * The one decision function.
+ *
+ * With `requiredHeight` (the P-Chain height a pending warp delivery needs
+ * the epoch to cover): satisfied iff the pinned height already covers it;
+ * otherwise the chain needs blocks, and the state says whether a block sent
+ * now could seal the epoch or the seal moment is still in the future.
+ *
+ * Without `requiredHeight` (display only): a chain gets one full epoch of
+ * grace past its seal moment before it reads as stale, so an actively
+ * producing chain never flashes a false warning between D elapsing and the
+ * next block landing.
+ */
+export function computeEpochStatus(input: {
+  epoch: ProposerVMEpoch | null;
+  liveHeight: bigint | null;
+  tipTimestampSec: number | null;
+  nowMs: number;
+  requiredHeight?: bigint | null;
+}): EpochStatus {
+  const { epoch, liveHeight, tipTimestampSec, nowMs, requiredHeight } = input;
+  const tipAgeSec = tipTimestampSec == null ? null : Math.max(0, Math.floor(nowMs / 1000) - tipTimestampSec);
+
+  if (!epoch) return { state: 'unknown', heightLag: null, tipAgeSec, sealableAtMs: null };
+
+  const rawLag = liveHeight == null ? null : liveHeight - epoch.pChainHeight;
+  const heightLag = rawLag == null ? null : rawLag < 0n ? 0n : rawLag;
+  const sealableAtMs = epoch.startTimeSec * 1000 + EPOCH_DURATION_MS;
+
+  if (requiredHeight != null) {
+    if (epoch.pChainHeight >= requiredHeight) {
+      return { state: 'satisfied', heightLag, tipAgeSec, sealableAtMs };
+    }
+    const state = nowMs >= sealableAtMs ? 'stale-sealable' : 'stale-waiting';
+    return { state, heightLag, tipAgeSec, sealableAtMs };
+  }
+
+  const state = nowMs - sealableAtMs >= EPOCH_DURATION_MS ? 'stale-sealable' : 'satisfied';
+  return { state, heightLag, tipAgeSec, sealableAtMs };
+}
+
+export type AdvanceAction =
+  | { action: 'done-verified' }
+  | { action: 'done-unverified' }
+  | { action: 'wait'; untilMs: number }
+  | { action: 'send' }
+  | { action: 'give-up' };
+
+/**
+ * One iteration of the advance loop, as a pure decision.
+ *
+ * `blindRun` is latched from the run's FIRST snapshot: a run that started
+ * with a readable epoch must never downgrade to blind completion because a
+ * single mid-run read failed. Such a failure keeps producing blocks (they
+ * are what the chain needs anyway) and verifies on a later read; if reads
+ * never recover before the send cap, the run gives up instead of claiming
+ * success.
+ */
+export function decideAdvanceAction(input: {
+  epoch: ProposerVMEpoch | null;
+  liveHeight: bigint | null;
+  tipTimestampSec: number | null;
+  nowMs: number;
+  requiredHeight: bigint | null;
+  blindRun: boolean;
+  sends: number;
+  maxSends: number;
+  blindSends: number;
+}): AdvanceAction {
+  const { epoch, liveHeight, tipTimestampSec, nowMs, requiredHeight, blindRun, sends, maxSends, blindSends } = input;
+
+  if (blindRun) {
+    return sends >= blindSends ? { action: 'done-unverified' } : { action: 'send' };
+  }
+
+  const status = computeEpochStatus({ epoch, liveHeight, tipTimestampSec, nowMs, requiredHeight });
+  if (epoch !== null && status.state === 'satisfied') return { action: 'done-verified' };
+  if (sends >= maxSends) return { action: 'give-up' };
+  if (epoch === null) return { action: 'send' };
+  if (status.state === 'stale-waiting' && status.sealableAtMs !== null && status.sealableAtMs > nowMs) {
+    return { action: 'wait', untilMs: status.sealableAtMs };
+  }
+  return { action: 'send' };
+}

--- a/content/blog/granite-upgrade.mdx
+++ b/content/blog/granite-upgrade.mdx
@@ -167,10 +167,10 @@ A new struct has been added as part of ACP-181 to support epoched P-Chain views:
 Three new API methods have been added to support the Granite upgrade features:
 
 1. **`proposervm.GetProposedHeight`** - Returns this node's current proposer VM height.
-   - [Documentation](https://build.avax.network/docs/api-reference/proposervm-api#proposervmgetproposedheight)
+   - [Documentation](https://build.avax.network/docs/rpcs/other/proposervm-rpc#proposervmgetproposedheight)
 
 2. **`proposervm.GetCurrentEpoch`** - Returns the current epoch information.
-   - [Documentation](https://build.avax.network/docs/api-reference/proposervm-api#proposervmgetcurrentepoch)
+   - [Documentation](https://build.avax.network/docs/rpcs/other/proposervm-rpc#proposervmgetcurrentepoch)
 
 3. **`platform.GetAllValidatorsAt`** - Get the validators and their weights of all L1s and the Primary Network at a given P-Chain height.
    - [Documentation](https://build.avax.network/docs/api-reference/p-chain/api#platformgetallvalidatorsat)

--- a/content/docs/avalanche-l1s/validator-manager/registration-flow.mdx
+++ b/content/docs/avalanche-l1s/validator-manager/registration-flow.mdx
@@ -81,7 +81,7 @@ Every failure below is real: each one has occurred in production support cases.
 
 **Cause:** the block proposer built the block against a P-Chain height that predates the registration, so predicate verification ran against an older validator set view.
 
-**Fix:** wait for the chain to progress and resend the identical transaction. The same calldata and access list succeed once the proposer's P-Chain view includes the registration.
+**Fix:** produce blocks so the chain's epoch catches up, then resend the identical transaction. The same calldata and access list succeed once the pinned P-Chain height includes the registration. Follow [the procedure on the ProposerVM page](/docs/nodes/architecture/proposervm#troubleshooting-warp-delivery-fails-on-an-idle-chain), or use the console's [Advance P-Chain View](/console/layer-1/advance-pchain-view) tool.
 
 </Accordion>
 </Accordions>

--- a/content/docs/nodes/architecture/proposervm.mdx
+++ b/content/docs/nodes/architecture/proposervm.mdx
@@ -272,7 +272,7 @@ All numbers are illustrative.
 
 **Cause:** verification runs against the P-Chain height pinned by the verifying chain's epoch, which can trail the live P-Chain. If the validator set changed after that pinned height, the fresh signature does not match the set the verifier resolves. ACP-181 states it directly: the message constructor must account for the verifying chain's epoch height, which may be arbitrarily far behind.
 
-**Fix:** wait for the verifying chain to produce blocks past the change (the epoch advances one block after the seal). Then resend the identical message. The [validator registration flow](/docs/avalanche-l1s/validator-manager/registration-flow) documents the same failure shape on the registration completion path.
+**Fix:** produce blocks past the change, then resend the identical message. The procedure is in [warp delivery fails on an idle chain](#troubleshooting-warp-delivery-fails-on-an-idle-chain). The [validator registration flow](/docs/avalanche-l1s/validator-manager/registration-flow) documents the same failure shape on the registration completion path.
 
 </Accordion>
 </Accordions>
@@ -286,6 +286,50 @@ All numbers are illustrative.
 - Alert on production silence: `block_building_slot` climbs while `build_block_count` stays flat, and the tip age grows. These alerts catch this class in minutes instead of days.
 - Keep validator continuous fee balances funded: inactive weight cannot sign but still counts against every quorum.
 - Run current releases: the v1.15.0 line logs the offending parent P-Chain height when a node cannot determine its proposer slot.
+
+## Troubleshooting: warp delivery fails on an idle chain
+
+The frozen-chain deadlock above is the extreme case. A milder version hits chains that are alive but quiet: block production works, yet warp message delivery fails.
+
+**Symptom signature:**
+
+- `initializeValidatorSet` reverts, or a `completeValidatorRegistration` / weight update / removal call rejects a freshly aggregated message with `InvalidWarpMessage` (`0x6b2f19e9`).
+- The P-Chain transaction it depends on is confirmed.
+- The signature aggregation itself succeeded.
+
+**The rule:** delivery verifies signatures against the validator set at the height pinned by the receiving chain's current epoch. That epoch advances only when the chain produces blocks. On a quiet chain the pinned height predates your P-Chain transaction, so the verifier resolves a validator set that does not match the fresh signature.
+
+### Produce blocks to advance the view
+
+Any transaction produces a block. A zero-value transfer to your own address is the cheapest one:
+
+```bash
+cast send $YOUR_ADDRESS --value 0 \
+  --rpc-url https://<node>/ext/bc/<blockchainID>/rpc \
+  --private-key $PRIVATE_KEY
+```
+
+Two blocks are enough on a long-quiet chain. The first block seals the old epoch, whose duration D elapsed long ago. The next block starts a new epoch and adopts the sealer's embedded height. Your retried delivery transaction can be that next block: one self-transfer plus the retry often completes the pair.
+
+One case needs patience instead of transactions: an epoch that opened less than D ago (5 minutes on Fuji and Mainnet) cannot seal yet. Wait out the remainder, then send.
+
+Verify before and after with the epoch read from [the RPC surface](#the-rpc-surface):
+
+```bash
+curl -s -X POST -H 'content-type: application/json' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"proposervm.getCurrentEpoch","params":{}}' \
+  https://<node>/ext/bc/<blockchainID>/proposervm
+```
+
+The pinned `pChainHeight` must reach or pass the height your P-Chain transaction landed in. Then resend the identical warp message.
+
+**Prerequisites and caveats:**
+
+- The sending account needs gas on the chain, and the Transactor Allowlist precompile (when enabled) must include it.
+- This advances **delivery** readiness only. It cannot fix signature **aggregation** failures: those depend on the signing validators' own P-Chain views and their online weight (see the legacy-validator pitfall above).
+- A ValidatorManager hosted on the C-Chain needs none of this. The C-Chain always produces blocks.
+
+The [Builder Console](/console/layer-1/advance-pchain-view) automates this procedure: it reads the epoch, computes the wait, sends the self-transfers, and verifies the result.
 
 ## Related
 

--- a/content/docs/tooling/avalanche-sdk/client/methods/public-methods/api.mdx
+++ b/content/docs/tooling/avalanche-sdk/client/methods/public-methods/api.mdx
@@ -1508,7 +1508,7 @@ console.log("C-Chain proposed height:", cChainHeight.height);
 
 **Related:**
 
-- [API Reference](https://build.avax.network/docs/api-reference/proposervm-api#proposervmgetproposedheight)
+- [API Reference](https://build.avax.network/docs/rpcs/other/proposervm-rpc#proposervmgetproposedheight)
 
 ---
 
@@ -1553,7 +1553,7 @@ console.log("P-Chain height at epoch start:", epoch.pChainHeight);
 
 **Related:**
 
-- [API Reference](https://build.avax.network/docs/api-reference/proposervm-api#proposervmgetcurrentepoch)
+- [API Reference](https://build.avax.network/docs/rpcs/other/proposervm-rpc#proposervmgetcurrentepoch)
 
 ---
 

--- a/lib/chat/tools-search.ts
+++ b/lib/chat/tools-search.ts
@@ -101,6 +101,13 @@ export const consoleTools: ConsoleTool[] = [
     description: 'Set up Prometheus and Grafana monitoring for your AvalancheGo nodes',
     keywords: ['monitoring', 'grafana', 'prometheus', 'metrics', 'health', 'node', 'tps', 'uptime', 'dashboard', 'docker', 'terraform', 'kubernetes'],
   },
+  {
+    title: 'Advance P-Chain View',
+    url: '/console/layer-1/advance-pchain-view',
+    category: 'Layer 1',
+    description: 'Produce blocks on an idle L1 so its ProposerVM epoch catches up and warp delivery verifies',
+    keywords: ['proposervm', 'epoch', 'stale', 'advance', 'self transfer', 'produce blocks', 'warp', 'InvalidWarpMessage', 'initializeValidatorSet', 'p-chain height', 'not enough blocks', 'idle chain'],
+  },
 
   // Testnet Infrastructure
   {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2338,7 +2338,7 @@ const config = {
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: blob: https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://abs.twimg.com https://*.public.blob.vercel-storage.com https://images.ctfassets.net https://f005.backblazeb2.com https://explorer-binaryholdings.cogitus.io https://cdn.prod.website-files.com https://developers.avacloud.io https://dashboard-assets.dappradar.com",
               "font-src 'self'",
-              "connect-src 'self' https://us.i.posthog.com https://app.posthog.com https://api.openai.com https://api.github.com https://www.googleapis.com https://api.hubapi.com https://api.dune.com https://glacier-api.avax.network https://accounts.google.com https://api.avax.network https://api.avax-test.network",
+              "connect-src 'self' https://us.i.posthog.com https://app.posthog.com https://api.openai.com https://api.github.com https://www.googleapis.com https://api.hubapi.com https://api.dune.com https://glacier-api.avax.network https://data-api.avax.network https://accounts.google.com https://api.avax.network https://api.avax-test.network",
               "frame-src 'self' https://calendar.google.com https://www.google.com https://chromewebstore.google.com",
               "frame-ancestors 'none'",
               "base-uri 'self'",


### PR DESCRIPTION
## Summary

Console UX for the ProposerVM staleness class reported by Zeeve (init-after-convert failures, validator add/remove failures, signature aggregation failures). Root cause: a chain's epoch pins the P-Chain height that warp delivery verifies against, and that height only advances when the chain produces blocks (ACP-181). The console had zero awareness of this.

- **Advance P-Chain View tool** (`/console/layer-1/advance-pchain-view`): reads `proposervm.getCurrentEpoch`, shows epoch height / tip age / live P-Chain height, and produces blocks via 0-value self-transfers (max 4) with epoch-seal countdown. Accepts a height or a P-Chain txID as target. Degrades honestly when the RPC does not expose `/proposervm` (gateways never do): blind mode sends exactly 2 and reports unverified.
- **Preflight card** in the four warp-delivery steps (InitValidatorSet, complete registration / weight update / removal): warns when the epoch pins a height below the block the pending P-Chain tx landed in (resolved via Glacier `blockNumber`), with one-click block production. Advisory only, never disables the step's own actions. Self-skips on C-Chain.
- **ConvertSubnetToL1 waits for P-Chain acceptance** before advancing the wizard (previously fire-and-forget, which fed "cannot initialize after converting").
- **Aggregation resilience**: bounded retry (4 attempts, 5/10/20s backoff) in `useAvalancheSDKChainkit` for below-quorum and terminated-request failures; 60s per-attempt cap (a timed-out attempt is never retried since the raced request may still be in flight). Quorum failures now show the achieved percentage and link Remove Legacy Subnet Validators + the advance tool. `InvalidWarpMessage` contract error text explains the stale-view cause. CSP report-only `connect-src` gains `data-api.avax.network` (the host the chainkit SDK actually calls).
- **Docs**: `proposervm.mdx` gains the missing "produce blocks to advance the view" procedure (self-transfer, the 2-block rule, the start+D wait, before/after `getCurrentEpoch` verification); registration-flow's InvalidWarpMessage fix links it; dead `/docs/api-reference/proposervm-api` links fixed in the Granite blog post and the SDK api reference.

Design rule kept everywhere: advancing the view fixes **delivery** (epoch pinned height); it never fixes **aggregation** (validators' own P-Chain views and online quorum). Copy, error mapper, and docs keep the two separated.

## Test plan

- [x] 47 new vitest tests (URL derivation, epoch parsing, staleness decision, advance-loop decision function, retry classifier/backoff, error mapper), all green
- [x] `yarn tsc --noEmit` clean; `eslint --max-warnings 0` clean on `components/toolbox`
- [x] `check-console-design.sh`, `check-render-safety.sh` green; `check-cli-coverage.sh` at its pre-existing 5-error baseline (none from this PR)
- [x] Tool page, add-validator complete step, convert step, and both docs pages render on dev
- [x] `proposervm.getCurrentEpoch` response shape verified live against Fuji; Glacier `blockNumber` verified against a real conversion tx
- [ ] Fuji end-to-end with a connected wallet: idle L1 shows the preflight card, advance flips `getCurrentEpoch`, delivery succeeds
- [ ] Mainnet smoke of the tool against an operator node RPC

Pre-existing on master, not addressed here: 2 failing `convertWarp.test.ts` tests (validator ordering in conversion marshaling), 5 `check-cli-coverage.sh` errors, vitest collecting `e2e/*.spec.ts`.
