### PR TITLE
feat(console): editable RPC URL in network list and My L1 details

### DIFF
--- a/app/console/my-l1/_components/NetworkDetailsCard.tsx
+++ b/app/console/my-l1/_components/NetworkDetailsCard.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { Check, ChevronRight, Copy } from 'lucide-react';
+import { Check, ChevronRight, Copy, Pencil } from 'lucide-react';
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
+import { useEditRpcUrlModal } from '@/components/toolbox/providers/modals/EditRpcUrlModal';
 import type { CombinedL1 } from '@/lib/console/my-l1/types';
 import type { L1ValidatorManagerInfo } from '@/lib/console/my-l1/useL1ValidatorManager';
 
@@ -25,6 +26,21 @@ export function NetworkDetailsCard({
   validatorManager?: L1ValidatorManagerInfo;
 }) {
   const { copiedId, copyToClipboard } = useCopyToClipboard();
+  const { openEditRpcUrl } = useEditRpcUrlModal();
+
+  // Managed L1s get their RPC URL from the server-side node registration,
+  // which wins over the wallet store in the dashboard merge, so an edit
+  // there would not show up here. Only wallet-sourced entries are editable.
+  const canEditRpc = l1.source === 'wallet' && l1.evmChainId !== null;
+  const handleEditRpc = () => {
+    if (l1.evmChainId === null) return;
+    void openEditRpcUrl({
+      evmChainId: l1.evmChainId,
+      name: l1.chainName,
+      rpcUrl: l1.rpcUrl,
+      isTestnet: l1.isTestnet,
+    });
+  };
 
   // Order chosen to keep the 2-col grid tidy:
   //   row 1: RPC URL          | Subnet ID
@@ -43,9 +59,12 @@ export function NetworkDetailsCard({
      *  hasn't been deployed yet but the user can configure it via the
      *  prominent banner above. */
     placeholder?: boolean;
+    /** Opens an editor for this value. Only the RPC URL of wallet-sourced
+     *  L1s is editable today (issue #4450). */
+    onEdit?: () => void;
   };
   const items: Item[] = [
-    { label: 'RPC URL', value: l1.rpcUrl, id: 'rpc-url' },
+    { label: 'RPC URL', value: l1.rpcUrl, id: 'rpc-url', onEdit: canEditRpc ? handleEditRpc : undefined },
     { label: 'Subnet ID', value: l1.subnetId, id: 'subnet-id' },
     { label: 'Blockchain ID', value: l1.blockchainId, id: 'blockchain-id' },
   ];
@@ -152,6 +171,20 @@ export function NetworkDetailsCard({
                   >
                     {item.value}
                   </code>
+                  {item.onEdit && (
+                    <button
+                      type="button"
+                      aria-label={`Edit ${item.label}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        item.onEdit?.();
+                      }}
+                      onMouseDown={(e) => e.stopPropagation()}
+                      className="p-1.5 shrink-0 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+                    >
+                      <Pencil className="w-3.5 h-3.5" />
+                    </button>
+                  )}
                   <span
                     className="p-1.5 shrink-0 text-muted-foreground group-hover/item:text-foreground transition-colors"
                     aria-hidden="true"

--- a/components/toolbox/components/console-header/evm-network-wallet/components/NetworkList.tsx
+++ b/components/toolbox/components/console-header/evm-network-wallet/components/NetworkList.tsx
@@ -8,6 +8,7 @@ interface NetworkListProps {
   isNetworkActive: (network: L1ListItem) => boolean;
   onNetworkSelect: (network: L1ListItem) => void;
   onNetworkRemove?: (network: L1ListItem) => void;
+  onNetworkEditRpc?: (network: L1ListItem) => void;
   isEditMode: boolean;
 }
 
@@ -17,6 +18,7 @@ export function NetworkList({
   isNetworkActive,
   onNetworkSelect,
   onNetworkRemove,
+  onNetworkEditRpc,
   isEditMode,
 }: NetworkListProps) {
   return (
@@ -34,6 +36,7 @@ export function NetworkList({
           onSelect={onNetworkSelect}
           isEditMode={isEditMode}
           onRemove={onNetworkRemove}
+          onEditRpc={onNetworkEditRpc}
           balance={getNetworkBalance(network)}
         />
       ))}

--- a/components/toolbox/components/console-header/evm-network-wallet/components/NetworkMenuItem.tsx
+++ b/components/toolbox/components/console-header/evm-network-wallet/components/NetworkMenuItem.tsx
@@ -1,5 +1,5 @@
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
-import { Check, Trash2 } from 'lucide-react';
+import { Check, Pencil, Trash2 } from 'lucide-react';
 import { L1ListItem } from '@/components/toolbox/stores/l1ListStore';
 import { ChainLogo } from './ChainLogo';
 
@@ -9,6 +9,7 @@ interface NetworkMenuItemProps {
   onSelect: (network: L1ListItem, tokenAddress?: string | null) => void;
   isEditMode?: boolean;
   onRemove?: (network: L1ListItem) => void;
+  onEditRpc?: (network: L1ListItem) => void;
   /** null = balance could not be fetched for this network. */
   balance?: number | string | null;
 }
@@ -23,6 +24,7 @@ export function NetworkMenuItem({
   onSelect,
   isEditMode = false,
   onRemove,
+  onEditRpc,
   balance = 0,
 }: NetworkMenuItemProps) {
   const formatBalance = (balance: number | string | null) => {
@@ -74,6 +76,21 @@ export function NetworkMenuItem({
         </div>
       </div>
       {!isEditMode && isActive && <Check className="w-4 h-4 text-green-600" />}
+      {isEditMode && !isCChain(network.evmChainId) && onEditRpc && (
+        <button
+          type="button"
+          aria-label={`Edit RPC URL for ${network.name}`}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onEditRpc(network);
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          className="p-1.5 rounded-md text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+        >
+          <Pencil className="w-3.5 h-3.5" />
+        </button>
+      )}
     </DropdownMenuItem>
   );
 }

--- a/components/toolbox/components/console-header/evm-network-wallet/index.tsx
+++ b/components/toolbox/components/console-header/evm-network-wallet/index.tsx
@@ -9,6 +9,7 @@ import { Wallet } from 'lucide-react';
 
 import { useNetworkData } from './hooks/useNetworkData';
 import { useNetworkActions } from './hooks/useNetworkActions';
+import { useEditRpcUrlModal } from '@/components/toolbox/providers/modals/EditRpcUrlModal';
 import { NetworkList } from './components/NetworkList';
 import { NetworkActions } from './components/NetworkActions';
 import { WalletInfo } from './components/WalletInfo';
@@ -34,6 +35,16 @@ export function EvmNetworkWallet() {
 
   const handleRemoveNetwork = (network: any) => {
     removeL1(network.id);
+  };
+
+  const { openEditRpcUrl } = useEditRpcUrlModal();
+  const handleEditRpc = (network: any) => {
+    void openEditRpcUrl({
+      evmChainId: network.evmChainId,
+      name: network.name,
+      rpcUrl: network.rpcUrl,
+      isTestnet: network.isTestnet,
+    });
   };
 
   if (!walletEVMAddress) {
@@ -72,6 +83,7 @@ export function EvmNetworkWallet() {
             isNetworkActive={isNetworkActive}
             onNetworkSelect={handleNetworkChange}
             onNetworkRemove={handleRemoveNetwork}
+            onNetworkEditRpc={handleEditRpc}
             isEditMode={isEditMode}
           />
 

--- a/components/toolbox/lib/editRpcUrl.test.ts
+++ b/components/toolbox/lib/editRpcUrl.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { decideRpcEdit, validateRpcUrlInput } from './editRpcUrl';
+
+describe('validateRpcUrlInput', () => {
+  it('rejects empty input', () => {
+    expect(validateRpcUrlInput('   ')).toMatch(/enter/i);
+  });
+
+  it('rejects non-URL garbage', () => {
+    expect(validateRpcUrlInput('not a url')).toMatch(/valid URL/i);
+  });
+
+  it('rejects non-http schemes', () => {
+    expect(validateRpcUrlInput('ws://localhost:9650/ext/bc/C/ws')).toMatch(/http/i);
+  });
+
+  it('accepts http and https URLs', () => {
+    expect(validateRpcUrlInput('http://localhost:9650/ext/bc/abc/rpc')).toBeNull();
+    expect(validateRpcUrlInput('https://node.example.com/ext/bc/abc/rpc')).toBeNull();
+  });
+});
+
+describe('decideRpcEdit', () => {
+  it('saves without friction when preflight passes', () => {
+    expect(decideRpcEdit({ ok: true, chainId: 10637 }, 10637)).toEqual({
+      save: true,
+      allowForce: false,
+      message: null,
+    });
+  });
+
+  it('never allows forcing a chain-identity mismatch', () => {
+    const decision = decideRpcEdit({ ok: false, reason: 'chain-mismatch', actualChainId: 43113 }, 10637);
+    expect(decision.save).toBe(false);
+    expect(decision.allowForce).toBe(false);
+    expect(decision.message).toContain('43113');
+    expect(decision.message).toContain('10637');
+  });
+
+  it('allows forcing an unreachable endpoint and surfaces the detail', () => {
+    const decision = decideRpcEdit({ ok: false, reason: 'unreachable', detail: 'fetch failed' }, 10637);
+    expect(decision.save).toBe(false);
+    expect(decision.allowForce).toBe(true);
+    expect(decision.message).toContain('fetch failed');
+  });
+
+  it('allows forcing past a mixed-content block and points at the proxy fix', () => {
+    const decision = decideRpcEdit({ ok: false, reason: 'mixed-content-blocked' }, 10637);
+    expect(decision.allowForce).toBe(true);
+    expect(decision.message).toMatch(/reverse proxy/i);
+  });
+
+  it('allows forcing a non-RPC response', () => {
+    const decision = decideRpcEdit({ ok: false, reason: 'bad-response', detail: 'HTTP 404' }, 10637);
+    expect(decision.allowForce).toBe(true);
+    expect(decision.message).toContain('HTTP 404');
+  });
+});

--- a/components/toolbox/lib/editRpcUrl.ts
+++ b/components/toolbox/lib/editRpcUrl.ts
@@ -1,0 +1,63 @@
+import type { RpcPreflightResult } from './rpcPreflight';
+
+/**
+ * Decision logic for the Edit RPC URL modal, kept pure for tests.
+ *
+ * A chain-identity mismatch is never overridable: the URL provably serves
+ * a different chain, so saving it can only break every tool that reads it.
+ * Reachability failures are overridable because the node may be down right
+ * now, or reachable by the wallet extension but not by the page (mixed
+ * content), and the user may still want to store the correct URL.
+ */
+export type EditRpcDecision = {
+  save: boolean;
+  allowForce: boolean;
+  message: string | null;
+};
+
+export function validateRpcUrlInput(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return 'Enter an RPC URL.';
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return 'This is not a valid URL.';
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return 'The RPC URL must start with http:// or https://.';
+  }
+  return null;
+}
+
+export function decideRpcEdit(result: RpcPreflightResult, expectedChainId: number): EditRpcDecision {
+  if (result.ok) return { save: true, allowForce: false, message: null };
+
+  switch (result.reason) {
+    case 'chain-mismatch':
+      return {
+        save: false,
+        allowForce: false,
+        message: `This URL serves chain ID ${result.actualChainId}, but this network is chain ID ${expectedChainId}. Check that the blockchain ID in the URL path belongs to this chain.`,
+      };
+    case 'mixed-content-blocked':
+      return {
+        save: false,
+        allowForce: true,
+        message:
+          'The browser blocks this http:// URL from an https page, so console tools cannot reach it. Use an https reverse proxy URL for a remote node. Save anyway only if you know the endpoint works outside the browser.',
+      };
+    case 'unreachable':
+      return {
+        save: false,
+        allowForce: true,
+        message: `Could not reach this RPC endpoint${result.detail ? ` (${result.detail})` : ''}. The node may be down or the URL may be wrong. You can save anyway and retry later.`,
+      };
+    case 'bad-response':
+      return {
+        save: false,
+        allowForce: true,
+        message: `The endpoint responded but not like an EVM RPC${result.detail ? ` (${result.detail})` : ''}. Check that the URL ends with the chain's /rpc path. You can save anyway if you know it is correct.`,
+      };
+  }
+}

--- a/components/toolbox/providers/WalletProvider.tsx
+++ b/components/toolbox/providers/WalletProvider.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { AddChainModal } from './modals/AddChainModal';
 import { SwitchNetworkModal } from './modals/SwitchNetworkModal';
+import { EditRpcUrlModal } from './modals/EditRpcUrlModal';
 import { WalletSync } from '../components/console-header/WalletSync';
 import { Web3Provider } from './Web3Provider';
 
@@ -13,6 +14,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       <WalletSync />
       <AddChainModal />
       <SwitchNetworkModal />
+      <EditRpcUrlModal />
     </Web3Provider>
   );
 }

--- a/components/toolbox/providers/modals/EditRpcUrlModal.tsx
+++ b/components/toolbox/providers/modals/EditRpcUrlModal.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Dialog, DialogOverlay, DialogContent, DialogTitle } from '../../components/ui/dialog';
+import { Button } from '../../components/Button';
+import { Input } from '../../components/Input';
+import { getL1ListStore } from '@/components/toolbox/stores/l1ListStore';
+import { rpcUrlsEquivalent } from '@/components/toolbox/lib/rpcUrl';
+import { preflightRpc } from '@/components/toolbox/lib/rpcPreflight';
+import { decideRpcEdit, validateRpcUrlInput } from '@/components/toolbox/lib/editRpcUrl';
+import { toast } from '@/lib/toast';
+import { AlertCircle } from 'lucide-react';
+
+/**
+ * Focused editor for one network's RPC URL, discoverable from the header
+ * network list and the My L1 dashboard. Issue #4450 showed the gap: the
+ * only way to correct a stale URL was re-adding the chain through the Add
+ * Chain modal's repair path, which nobody found.
+ */
+export interface EditRpcUrlOptions {
+  evmChainId: number;
+  name: string;
+  rpcUrl: string;
+  isTestnet: boolean;
+}
+
+let editRpcModalState: {
+  isOpen: boolean;
+  options: EditRpcUrlOptions | null;
+  resolve: ((result: { success: boolean }) => void) | null;
+} = {
+  isOpen: false,
+  options: null,
+  resolve: null,
+};
+
+const editRpcListeners = new Set<() => void>();
+
+const notifyEditRpcChange = () => {
+  editRpcListeners.forEach((listener) => listener());
+};
+
+export function useEditRpcUrlModal() {
+  const openEditRpcUrl = (options: EditRpcUrlOptions): Promise<{ success: boolean }> => {
+    return new Promise((resolve) => {
+      editRpcModalState = { isOpen: true, options, resolve };
+      notifyEditRpcChange();
+    });
+  };
+
+  return { openEditRpcUrl };
+}
+
+function useEditRpcModalState() {
+  const [, forceUpdate] = useState({});
+
+  React.useEffect(() => {
+    const listener = () => forceUpdate({});
+    editRpcListeners.add(listener);
+    return () => {
+      editRpcListeners.delete(listener);
+    };
+  }, []);
+
+  const closeModal = (result: { success: boolean } = { success: false }) => {
+    if (editRpcModalState.resolve) {
+      editRpcModalState.resolve(result);
+    }
+    editRpcModalState = { isOpen: false, options: null, resolve: null };
+    notifyEditRpcChange();
+  };
+
+  return {
+    isOpen: editRpcModalState.isOpen,
+    options: editRpcModalState.options,
+    closeModal,
+  };
+}
+
+export function EditRpcUrlModal() {
+  const { isOpen, options, closeModal } = useEditRpcModalState();
+  if (!isOpen || !options) return null;
+  // Inner component mounts fresh on every open so form state never leaks
+  // between networks (same pattern as AddChainModal).
+  return <EditRpcUrlModalInner options={options} closeModal={closeModal} />;
+}
+
+function EditRpcUrlModalInner({
+  options,
+  closeModal,
+}: {
+  options: EditRpcUrlOptions;
+  closeModal: (result?: { success: boolean }) => void;
+}) {
+  const [url, setUrl] = useState(options.rpcUrl);
+  const [isChecking, setIsChecking] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [allowForce, setAllowForce] = useState(false);
+
+  const commit = (nextUrl: string) => {
+    getL1ListStore(options.isTestnet).getState().updateL1(options.evmChainId, { rpcUrl: nextUrl });
+    toast.success(`RPC URL updated for ${options.name}`);
+    closeModal({ success: true });
+  };
+
+  const handleSave = async () => {
+    const trimmed = url.trim();
+    setMessage(null);
+    setAllowForce(false);
+
+    const inputError = validateRpcUrlInput(trimmed);
+    if (inputError) {
+      setMessage(inputError);
+      return;
+    }
+    if (rpcUrlsEquivalent(trimmed, options.rpcUrl)) {
+      closeModal({ success: false });
+      return;
+    }
+
+    setIsChecking(true);
+    try {
+      const result = await preflightRpc(trimmed, options.evmChainId, {
+        pageProtocol: typeof window !== 'undefined' ? window.location.protocol : undefined,
+      });
+      const decision = decideRpcEdit(result, options.evmChainId);
+      if (decision.save) {
+        commit(trimmed);
+        return;
+      }
+      setMessage(decision.message);
+      setAllowForce(decision.allowForce);
+    } finally {
+      setIsChecking(false);
+    }
+  };
+
+  return (
+    <Dialog.Root open={true} onOpenChange={() => closeModal({ success: false })}>
+      <Dialog.Portal>
+        <DialogOverlay />
+        <DialogContent className="max-w-md">
+          <DialogTitle>Edit RPC URL</DialogTitle>
+
+          <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-4">
+            {options.name} (chain ID {options.evmChainId}). Console tools read this URL for balances, deployments, and
+            receipts.
+          </p>
+
+          <Input
+            label="RPC URL"
+            value={url}
+            onChange={(value: string) => {
+              setUrl(value);
+              setMessage(null);
+              setAllowForce(false);
+            }}
+            placeholder="https://your-node.example.com/ext/bc/<blockchainID>/rpc"
+          />
+
+          {message && (
+            <div className="mt-3 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+              <div className="flex items-start gap-2">
+                <AlertCircle className="w-4 h-4 text-amber-500 mt-0.5 shrink-0" />
+                <p className="text-sm text-amber-700 dark:text-amber-400">{message}</p>
+              </div>
+            </div>
+          )}
+
+          <p className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
+            Your wallet keeps its own copy of this URL. If the wallet also has a stale URL, update it in the
+            wallet&apos;s network settings.
+          </p>
+
+          <div className="mt-4 flex gap-2 justify-end">
+            <Button variant="secondary" onClick={() => closeModal({ success: false })}>
+              Cancel
+            </Button>
+            {allowForce && (
+              <Button variant="secondary" onClick={() => commit(url.trim())}>
+                Save anyway
+              </Button>
+            )}
+            <Button variant="primary" onClick={handleSave} loading={isChecking} disabled={isChecking}>
+              Check and save
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}


### PR DESCRIPTION
## Summary

Follow-up to #4450: the reporter's fix was changing the RPC URL, but the console had no visible way to edit it (the Add Chain modal's same-chain repair path exists since #4461 but is undiscoverable).

- New Edit RPC URL modal: runs the existing `preflightRpc` (eth_chainId probe, mixed-content classification) before saving via `updateL1`. A chain-ID mismatch can never be saved; unreachable / mixed-content / bad-response can be saved with an explicit "Save anyway". Notes that the wallet keeps its own copy of the URL.
- Pencil affordance in the header network dropdown's edit mode (non C-Chain rows).
- Pencil on the RPC URL cell of the My L1 network identifiers card, wallet-sourced entries only (managed entries keep the server-side URL, which wins in the dashboard merge).

## Test plan

- 9 new vitest tests for input validation and the save/force decision logic, green
- `yarn tsc --noEmit` clean; `eslint --max-warnings 0` clean on touched toolbox files
- `./scripts/check-console-design.sh` passes

Refs #4450