### PR TITLE
fix(console): actionable guidance for initializeValidatorSet reverts

### DIFF
--- a/components/toolbox/console/permissioned-l1s/validator-manager-setup/InitValidatorSet.tsx
+++ b/components/toolbox/console/permissioned-l1s/validator-manager-setup/InitValidatorSet.tsx
@@ -38,6 +38,7 @@ import {
   parseAggregationError,
   type RemediationLink,
 } from '@/components/toolbox/hooks/contracts/parseAggregationError';
+import { parseInitValidatorSetError } from '@/components/toolbox/hooks/contracts/parseInitValidatorSetError';
 
 type ConversionData = ExtractSubnetToL1ConversionDataResult & { signingSubnetId: string };
 
@@ -208,6 +209,7 @@ function InitValidatorSet({ onSuccess }: BaseConsoleToolProps) {
 
     setIsInitializing(true);
     setError(null);
+    setAggRemediation(null);
 
     try {
       const txArgs = buildTxArgs(conversionResult);
@@ -250,7 +252,12 @@ function InitValidatorSet({ onSuccess }: BaseConsoleToolProps) {
       setTxSuccess(true);
       onSuccess?.();
     } catch (err) {
-      setError((err as Error).message);
+      // The SDK simulates before sending and throws the raw viem revert
+      // dump; map the unambiguous reverts to actionable guidance instead
+      // of showing the dump (issue #4464).
+      const mapped = parseInitValidatorSetError(err, conversionResult?.managerAddress ?? managerAddress ?? null);
+      setAggRemediation(mapped?.remediation?.length ? mapped.remediation : null);
+      setError(mapped?.message ?? (err as Error).message);
     } finally {
       setIsInitializing(false);
     }

--- a/components/toolbox/console/permissioned-l1s/validator-manager-setup/Initialize.tsx
+++ b/components/toolbox/console/permissioned-l1s/validator-manager-setup/Initialize.tsx
@@ -229,6 +229,19 @@ function Initialize({ onSuccess }: BaseConsoleToolProps) {
                     <RefreshCw className={`w-3.5 h-3.5 text-zinc-500 ${isChecking ? 'animate-spin' : ''}`} />
                   </button>
                 </div>
+                {vmcData.validatorManagerAddress &&
+                  managerAddress &&
+                  vmcData.validatorManagerAddress.toLowerCase() !== managerAddress.toLowerCase() && (
+                    <div className="mt-2 p-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+                      <p className="text-xs text-amber-700 dark:text-amber-400">
+                        The conversion for this subnet records the validator manager at{' '}
+                        <span className="font-mono break-all">{vmcData.validatorManagerAddress}</span>. Initializing{' '}
+                        <span className="font-mono break-all">{managerAddress}</span> stores settings at a different
+                        address, and initializing the validator set against the recorded manager will fail. Use the
+                        recorded address unless you know why they differ.
+                      </p>
+                    </div>
+                  )}
                 {isInitialized !== null && (
                   <div
                     className={`mt-2 text-xs flex items-center gap-1 ${isInitialized ? 'text-amber-600' : 'text-green-600'}`}

--- a/components/toolbox/hooks/contracts/parseContractError.ts
+++ b/components/toolbox/hooks/contracts/parseContractError.ts
@@ -9,9 +9,12 @@ const KNOWN_ERRORS: Record<string, string> = {
     'Exceeds the maximum churn rate. The network limits how much weight can change at once (typically 20% of total weight). Try a smaller amount or wait.',
   MaxChurnRateExceeded:
     'Exceeds the maximum churn rate. The network limits how much weight can change at once (typically 20% of total weight). Try a smaller amount or wait.',
-  '0x3e1a7851': 'Invalid total weight. The resulting total weight would be zero or exceed limits.',
-  '0xe8e82e76': 'Invalid total weight. The resulting total weight would be zero or exceed limits.',
-  InvalidTotalWeight: 'Invalid total weight. The resulting total weight would be zero or exceed limits.',
+  '0x3e1a7851':
+    'Invalid total weight. During validator set initialization this means the manager at the called address was never initialized (its churn settings read zero); run Initialize against the manager (proxy) address recorded in the conversion. Otherwise the resulting total weight would exceed limits.',
+  '0xe8e82e76':
+    'Invalid total weight. During validator set initialization this means the manager at the called address was never initialized (its churn settings read zero); run Initialize against the manager (proxy) address recorded in the conversion. Otherwise the resulting total weight would exceed limits.',
+  InvalidTotalWeight:
+    'Invalid total weight. During validator set initialization this means the manager at the called address was never initialized (its churn settings read zero); run Initialize against the manager (proxy) address recorded in the conversion. Otherwise the resulting total weight would exceed limits.',
   '0xdaa3fc0a': 'Maximum weight exceeded. The validator or delegation weight exceeds the allowed limit for this L1.',
   MaxWeightExceeded:
     'Maximum weight exceeded. The validator or delegation weight exceeds the allowed limit for this L1.',

--- a/components/toolbox/hooks/contracts/parseInitValidatorSetError.test.ts
+++ b/components/toolbox/hooks/contracts/parseInitValidatorSetError.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { parseInitValidatorSetError } from './parseInitValidatorSetError';
+
+// Shape of the real failure from issue #4464: the SDK simulates first and
+// throws the raw viem revert dump as an Error message.
+const INVALID_TOTAL_WEIGHT_DUMP =
+  'initializeValidatorSet would revert: The contract function "initializeValidatorSet" reverted. ' +
+  'Error: InvalidTotalWeight(uint64 weight) (100) Contract Call: address: 0xfacade0000000000000000000000000000000000';
+
+describe('parseInitValidatorSetError', () => {
+  it('maps InvalidTotalWeight to uninitialized-manager guidance with the called address', () => {
+    const mapped = parseInitValidatorSetError(
+      new Error(INVALID_TOTAL_WEIGHT_DUMP),
+      '0xfacade0000000000000000000000000000000000',
+    );
+    expect(mapped).not.toBeNull();
+    expect(mapped!.message).toContain('0xfacade0000000000000000000000000000000000');
+    expect(mapped!.message).toMatch(/never been initialized/i);
+    expect(mapped!.remediation[0].href).toBe('/console/permissioned-l1s/validator-manager-setup');
+  });
+
+  it('falls back to a generic address phrase when the manager address is unknown', () => {
+    const mapped = parseInitValidatorSetError(new Error(INVALID_TOTAL_WEIGHT_DUMP), null);
+    expect(mapped!.message).toContain('recorded in the conversion');
+  });
+
+  it('maps InvalidWarpMessage to ProposerVM guidance with the advance tool link', () => {
+    const mapped = parseInitValidatorSetError(new Error('Error: InvalidWarpMessage()'), '0xfacade');
+    expect(mapped!.message).toMatch(/ProposerVM/);
+    expect(mapped!.remediation.map((r) => r.href)).toContain('/console/layer-1/advance-pchain-view');
+  });
+
+  it('maps InvalidInitializationStatus to an already-initialized message', () => {
+    const mapped = parseInitValidatorSetError(new Error('Error: InvalidInitializationStatus()'), '0xfacade');
+    expect(mapped!.message).toMatch(/already initialized/i);
+  });
+
+  it('returns null for everything else so the raw error still surfaces', () => {
+    expect(parseInitValidatorSetError(new Error('fetch failed'), '0xfacade')).toBeNull();
+    expect(parseInitValidatorSetError(undefined, '0xfacade')).toBeNull();
+  });
+});

--- a/components/toolbox/hooks/contracts/parseInitValidatorSetError.ts
+++ b/components/toolbox/hooks/contracts/parseInitValidatorSetError.ts
@@ -1,0 +1,67 @@
+import type { MappedAggregationError, RemediationLink } from './parseAggregationError';
+
+const SETUP_REMEDIATION: RemediationLink[] = [
+  {
+    label: 'Validator Manager Setup (Initialize step)',
+    href: '/console/permissioned-l1s/validator-manager-setup',
+  },
+];
+
+const DELIVERY_REMEDIATION: RemediationLink[] = [
+  {
+    label: 'Advance P-Chain View',
+    href: '/console/layer-1/advance-pchain-view',
+  },
+  {
+    label: 'ProposerVM troubleshooting',
+    href: '/docs/nodes/architecture/proposervm#troubleshooting-warp-delivery-fails-on-an-idle-chain',
+  },
+];
+
+/**
+ * Maps initializeValidatorSet reverts to actionable guidance, or null when
+ * the error is not one of the unambiguous shapes (caller shows the raw
+ * message).
+ *
+ * InvalidTotalWeight during initialization is a misdirection: the contract
+ * checks `totalWeight * maximumChurnPercentage < 100`, and initialize()
+ * rejects a churn percentage of zero, so a zero product means initialize()
+ * never ran at the CALLED address. The conversion records the proxy
+ * (0xfacade...) as the manager, while the setup flow can leave the user
+ * initializing the freshly deployed implementation instead (issue #4464).
+ */
+export function parseInitValidatorSetError(err: unknown, managerAddress: string | null): MappedAggregationError | null {
+  const message = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+
+  if (message.includes('InvalidTotalWeight')) {
+    const target = managerAddress ?? 'the manager address recorded in the conversion';
+    return {
+      message:
+        `The ValidatorManager at ${target} has never been initialized: its churn settings read zero, and ` +
+        'initialize() rejects zero, so initialize() cannot have run at this address. This usually means the ' +
+        'Initialize step ran against a different address, for example the implementation contract instead of ' +
+        `the proxy. Run the Initialize step against ${target}, then retry.`,
+      remediation: SETUP_REMEDIATION,
+    };
+  }
+
+  if (message.includes('InvalidWarpMessage')) {
+    return {
+      message:
+        "The chain rejected the signed conversion message. The usual cause is the L1's ProposerVM view of the " +
+        'P-Chain: it only advances when the chain produces blocks, so on an idle chain it can pin a P-Chain ' +
+        'height from before your conversion. Produce a block (a zero-value transfer works), then retry.',
+      remediation: DELIVERY_REMEDIATION,
+    };
+  }
+
+  if (message.includes('InvalidInitializationStatus')) {
+    return {
+      message:
+        'The validator set is already initialized on this manager. Refresh the page to re-check the on-chain status.',
+      remediation: [],
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Fixes the UX behind #4464. The reported `InvalidTotalWeight(uint64 weight) (100)` is a misdirection, and it is not the ProposerVM staleness class: the contract checks `totalWeight * maximumChurnPercentage < 100`, and `initialize()` rejects a zero churn percentage, so a zero product means `initialize()` never ran at the called address. The conversion records the proxy (`0xfacade...`) as the manager, while DeployValidatorManager stores the freshly deployed implementation address, so the Initialize step can run against the implementation and leave the proxy's storage untouched. A stale ProposerVM view fails earlier with `InvalidWarpMessage`.

- New `parseInitValidatorSetError` maps `InvalidTotalWeight` (manager never initialized at the called address, with the address named), `InvalidWarpMessage` (ProposerVM view, links the Advance P-Chain View tool), and `InvalidInitializationStatus` (already initialized) to short messages with remediation links. Everything else passes through as the raw error.
- Initialize step warns when the entered manager address differs from the address the conversion recorded (Glacier VMC lookup), which is the mistake that produces this revert.
- Shared `parseContractError` copy for `InvalidTotalWeight` corrected; the old text ("would be zero or exceed limits") described neither failure mode.

## Test plan

- 5 new vitest tests against the exact error shape from the issue, green
- `yarn tsc --noEmit` clean; `eslint --max-warnings 0` clean on touched files
- `./scripts/check-console-design.sh` passes

Fixes #4464