### PR TITLE
feat(academy): move quiz progress to the database, resync on login

### DIFF
--- a/app/api/quiz-progress/[quizId]/route.ts
+++ b/app/api/quiz-progress/[quizId]/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { withAuth, type RouteParams } from "@/lib/protectedRoute";
+import {
+  upsertQuizResponse,
+  QuizProgressValidationError,
+} from "@/server/services/quizProgress";
+
+export const PUT = withAuth<RouteParams<{ quizId: string }>>(
+  async (request, context, session) => {
+    const { quizId } = await context.params;
+
+    let body: any;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    try {
+      const response = await upsertQuizResponse(session.user.id, quizId, {
+        selectedAnswers: body?.selectedAnswers ?? [],
+        isAnswerChecked: Boolean(body?.isAnswerChecked),
+        isCorrect: Boolean(body?.isCorrect),
+        attemptCount: body?.attemptCount ?? 0,
+        lastAttemptAt: body?.lastAttemptAt ?? null,
+      });
+      return NextResponse.json({ response });
+    } catch (error) {
+      if (error instanceof QuizProgressValidationError) {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+      throw error;
+    }
+  }
+);

--- a/app/api/quiz-progress/[quizId]/route.ts
+++ b/app/api/quiz-progress/[quizId]/route.ts
@@ -1,29 +1,33 @@
 import { NextResponse } from "next/server";
 import { withAuth, type RouteParams } from "@/lib/protectedRoute";
+import { rateLimit } from "@/lib/rateLimit";
 import {
   upsertQuizResponse,
   QuizProgressValidationError,
 } from "@/server/services/quizProgress";
+import { quizResponseSchema } from "../schema";
 
-export const PUT = withAuth<RouteParams<{ quizId: string }>>(
-  async (request, context, session) => {
+export const PUT = rateLimit(
+  withAuth<RouteParams<{ quizId: string }>>(async (request, context, session) => {
     const { quizId } = await context.params;
 
-    let body: any;
+    let body: unknown;
     try {
       body = await request.json();
     } catch {
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
     }
 
+    const parsed = quizResponseSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid quiz response", issues: parsed.error.issues },
+        { status: 400 }
+      );
+    }
+
     try {
-      const response = await upsertQuizResponse(session.user.id, quizId, {
-        selectedAnswers: body?.selectedAnswers ?? [],
-        isAnswerChecked: Boolean(body?.isAnswerChecked),
-        isCorrect: Boolean(body?.isCorrect),
-        attemptCount: body?.attemptCount ?? 0,
-        lastAttemptAt: body?.lastAttemptAt ?? null,
-      });
+      const response = await upsertQuizResponse(session.user.id, quizId, parsed.data);
       return NextResponse.json({ response });
     } catch (error) {
       if (error instanceof QuizProgressValidationError) {
@@ -31,5 +35,6 @@ export const PUT = withAuth<RouteParams<{ quizId: string }>>(
       }
       throw error;
     }
-  }
+  }),
+  { windowMs: 60 * 1000, maxRequests: 30 }
 );

--- a/app/api/quiz-progress/route.ts
+++ b/app/api/quiz-progress/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/protectedRoute";
+import {
+  getQuizProgressForUser,
+  upsertQuizResponse,
+  QuizProgressValidationError,
+  type QuizResponseDTO,
+} from "@/server/services/quizProgress";
+
+// A user can hold at most one row per quiz; the whole catalog is a few
+// hundred quizzes, so anything beyond that in one backfill call is noise.
+const MAX_BULK_ITEMS = 500;
+
+export const GET = withAuth(async (_request, _context, session) => {
+  const responses = await getQuizProgressForUser(session.user.id);
+  return NextResponse.json({ responses });
+});
+
+/**
+ * Bulk upsert, used by the client-side backfill that pushes pre-existing
+ * IndexedDB progress up on the first signed-in visit. Invalid items are
+ * skipped (old browser data may reference quizzes that no longer exist) —
+ * a backfill must not fail wholesale because one row went stale.
+ */
+export const POST = withAuth(async (request, _context, session) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const items = Array.isArray(body) ? body : null;
+  if (!items) {
+    return NextResponse.json(
+      { error: "Expected an array of quiz responses" },
+      { status: 400 }
+    );
+  }
+  if (items.length > MAX_BULK_ITEMS) {
+    return NextResponse.json(
+      { error: `Too many items (max ${MAX_BULK_ITEMS})` },
+      { status: 400 }
+    );
+  }
+
+  const saved: QuizResponseDTO[] = [];
+  const skipped: { quizId: string; reason: string }[] = [];
+
+  for (const item of items) {
+    const quizId = typeof item?.quizId === "string" ? item.quizId : null;
+    if (!quizId) {
+      skipped.push({ quizId: String(item?.quizId ?? "?"), reason: "missing quizId" });
+      continue;
+    }
+    try {
+      saved.push(
+        await upsertQuizResponse(session.user.id, quizId, {
+          selectedAnswers: item.selectedAnswers ?? [],
+          isAnswerChecked: Boolean(item.isAnswerChecked),
+          isCorrect: Boolean(item.isCorrect),
+          attemptCount: item.attemptCount ?? 0,
+          lastAttemptAt: item.lastAttemptAt ?? null,
+        })
+      );
+    } catch (error) {
+      if (error instanceof QuizProgressValidationError) {
+        skipped.push({ quizId, reason: error.message });
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  return NextResponse.json({ saved, skipped });
+});

--- a/app/api/quiz-progress/route.ts
+++ b/app/api/quiz-progress/route.ts
@@ -11,7 +11,10 @@ import { bulkQuizResponseSchema } from "./schema";
 
 export const GET = withAuth(async (_request, _context, session) => {
   const responses = await getQuizProgressForUser(session.user.id);
-  return NextResponse.json({ responses });
+  // userId lets the client-side sync detect an account switch on a shared
+  // browser and drop the previous account's local rows instead of
+  // backfilling them into this one.
+  return NextResponse.json({ responses, userId: session.user.id });
 });
 
 /**

--- a/app/api/quiz-progress/route.ts
+++ b/app/api/quiz-progress/route.ts
@@ -1,15 +1,13 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/protectedRoute";
+import { rateLimit } from "@/lib/rateLimit";
 import {
   getQuizProgressForUser,
   upsertQuizResponse,
   QuizProgressValidationError,
   type QuizResponseDTO,
 } from "@/server/services/quizProgress";
-
-// A user can hold at most one row per quiz; the whole catalog is a few
-// hundred quizzes, so anything beyond that in one backfill call is noise.
-const MAX_BULK_ITEMS = 500;
+import { bulkQuizResponseSchema } from "./schema";
 
 export const GET = withAuth(async (_request, _context, session) => {
   const responses = await getQuizProgressForUser(session.user.id);
@@ -18,59 +16,45 @@ export const GET = withAuth(async (_request, _context, session) => {
 
 /**
  * Bulk upsert, used by the client-side backfill that pushes pre-existing
- * IndexedDB progress up on the first signed-in visit. Invalid items are
- * skipped (old browser data may reference quizzes that no longer exist) —
- * a backfill must not fail wholesale because one row went stale.
+ * IndexedDB progress up on the first signed-in visit. Items that fail
+ * quiz-content validation are skipped (old browser data may reference
+ * quizzes that no longer exist) — a backfill must not fail wholesale
+ * because one row went stale. Rate limited: the legitimate flow runs once
+ * per page load, and each item costs DB writes.
  */
-export const POST = withAuth(async (request, _context, session) => {
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const items = Array.isArray(body) ? body : null;
-  if (!items) {
-    return NextResponse.json(
-      { error: "Expected an array of quiz responses" },
-      { status: 400 }
-    );
-  }
-  if (items.length > MAX_BULK_ITEMS) {
-    return NextResponse.json(
-      { error: `Too many items (max ${MAX_BULK_ITEMS})` },
-      { status: 400 }
-    );
-  }
-
-  const saved: QuizResponseDTO[] = [];
-  const skipped: { quizId: string; reason: string }[] = [];
-
-  for (const item of items) {
-    const quizId = typeof item?.quizId === "string" ? item.quizId : null;
-    if (!quizId) {
-      skipped.push({ quizId: String(item?.quizId ?? "?"), reason: "missing quizId" });
-      continue;
-    }
+export const POST = rateLimit(
+  withAuth(async (request, _context, session) => {
+    let body: unknown;
     try {
-      saved.push(
-        await upsertQuizResponse(session.user.id, quizId, {
-          selectedAnswers: item.selectedAnswers ?? [],
-          isAnswerChecked: Boolean(item.isAnswerChecked),
-          isCorrect: Boolean(item.isCorrect),
-          attemptCount: item.attemptCount ?? 0,
-          lastAttemptAt: item.lastAttemptAt ?? null,
-        })
-      );
-    } catch (error) {
-      if (error instanceof QuizProgressValidationError) {
-        skipped.push({ quizId, reason: error.message });
-        continue;
-      }
-      throw error;
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
     }
-  }
 
-  return NextResponse.json({ saved, skipped });
-});
+    const parsed = bulkQuizResponseSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid quiz responses", issues: parsed.error.issues },
+        { status: 400 }
+      );
+    }
+
+    const saved: QuizResponseDTO[] = [];
+    const skipped: { quizId: string; reason: string }[] = [];
+
+    for (const { quizId, ...payload } of parsed.data) {
+      try {
+        saved.push(await upsertQuizResponse(session.user.id, quizId, payload));
+      } catch (error) {
+        if (error instanceof QuizProgressValidationError) {
+          skipped.push({ quizId, reason: error.message });
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    return NextResponse.json({ saved, skipped });
+  }),
+  { windowMs: 5 * 60 * 1000, maxRequests: 10 }
+);

--- a/app/api/quiz-progress/schema.ts
+++ b/app/api/quiz-progress/schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+// Shape validation for the quiz-progress endpoints. Quiz-content checks
+// (unknown id, option range, duplicates) live in the service, which owns the
+// quiz catalog. attemptCount's upper bound mirrors MAX_ATTEMPTS in
+// components/quizzes/quiz.tsx.
+export const quizResponseSchema = z.object({
+  selectedAnswers: z.array(z.number().int().min(0)).max(32).default([]),
+  isAnswerChecked: z.boolean().default(false),
+  isCorrect: z.boolean().default(false),
+  attemptCount: z.number().int().min(0).max(3).default(0),
+  lastAttemptAt: z.number().min(0).nullable().default(null),
+});
+
+export const bulkQuizResponseSchema = z
+  .array(quizResponseSchema.extend({ quizId: z.string().min(1) }))
+  .max(500);

--- a/components/quizzes/QuizProgress.tsx
+++ b/components/quizzes/QuizProgress.tsx
@@ -1,11 +1,13 @@
 "use client";
 import React, { useState, useEffect } from 'react';
 import { getQuizResponse } from '@/utils/quizzes/indexedDB';
+import { useQuizProgressSync } from '@/hooks/useQuizProgressSync';
 import quizData from './data';
 
 const QuizProgress: React.FC = () => {
   const [progress, setProgress] = useState<{ [quizId: string]: boolean }>({});
   const [isLoading, setIsLoading] = useState(true);
+  const syncVersion = useQuizProgressSync();
 
   useEffect(() => {
     async function loadProgress() {
@@ -21,7 +23,7 @@ const QuizProgress: React.FC = () => {
       setIsLoading(false);
     }
     loadProgress();
-  }, []);
+  }, [syncVersion]);
 
   if (isLoading) {
     return <div>Loading progress...</div>;

--- a/components/quizzes/certificates.tsx
+++ b/components/quizzes/certificates.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState, useEffect } from 'react';
 import { getQuizResponse } from '@/utils/quizzes/indexedDB';
+import { useQuizProgressSync } from '@/hooks/useQuizProgressSync';
 import { buttonVariants } from '@/components/ui/button';
 import { cn } from '@/utils/cn';
 import quizData from '@/components/quizzes/data';
@@ -31,6 +32,7 @@ const CertificatePage: React.FC<CertificatePageProps> = ({ courseId }) => {
   const [totalQuizzes, setTotalQuizzes] = useState(0);
   const [correctlyAnsweredQuizzes, setCorrectlyAnsweredQuizzes] = useState(0);
   const [shouldShowCertificate, setShouldShowCertificate] = useState(false);
+  const syncVersion = useQuizProgressSync();
 
   useEffect(() => {
     const fetchQuizzes = () => {
@@ -70,7 +72,7 @@ const CertificatePage: React.FC<CertificatePageProps> = ({ courseId }) => {
     if (quizzes.length > 0) {
       checkQuizCompletion();
     }
-  }, [quizzes]);
+  }, [quizzes, syncVersion]);
 
   useEffect(() => {
     if (totalQuizzes > 0 && correctlyAnsweredQuizzes === totalQuizzes) {

--- a/components/quizzes/quiz.tsx
+++ b/components/quizzes/quiz.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState, useEffect } from 'react';
 import { saveQuizResponse, getQuizResponse } from '@/utils/quizzes/indexedDB';
+import { useQuizProgressSync } from '@/hooks/useQuizProgressSync';
 import { parseTextWithLinks } from '../../utils/safeHtml';
 import Image from 'next/image';
 import { cn } from '@/utils/cn';
@@ -48,6 +49,7 @@ const Quiz: React.FC<QuizProps> = ({ quizId, onQuizCompleted }) => {
 
   const isLocked = attemptCount >= MAX_ATTEMPTS && !isCorrect;
   const isCoolingDown = cooldownRemaining > 0;
+  const syncVersion = useQuizProgressSync();
 
   // Cooldown countdown timer — only active after all attempts exhausted
   useEffect(() => {
@@ -75,7 +77,7 @@ const Quiz: React.FC<QuizProps> = ({ quizId, onQuizCompleted }) => {
     setIsClient(true);
     setQuizInfo(getVariant(quizId, 0));
     loadSavedResponse();
-  }, [quizId]);
+  }, [quizId, syncVersion]);
 
   const loadSavedResponse = async () => {
     const savedResponse = await getQuizResponse(quizId);

--- a/hooks/useCourseCompletion.ts
+++ b/hooks/useCourseCompletion.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { getQuizResponse } from '@/utils/quizzes/indexedDB';
+import { useQuizProgressSync } from '@/hooks/useQuizProgressSync';
 import quizData from '@/components/quizzes/data';
 
 export interface CourseCompletionEntry {
@@ -14,6 +15,7 @@ const quizCourses = quizData.courses;
 export function useCourseCompletion(courses: CourseCompletionEntry[]) {
   const [completionMap, setCompletionMap] = useState<Map<string, boolean>>(new Map());
   const [isLoading, setIsLoading] = useState(true);
+  const syncVersion = useQuizProgressSync();
 
   const coursesKey = JSON.stringify(courses);
 
@@ -49,7 +51,7 @@ export function useCourseCompletion(courses: CourseCompletionEntry[]) {
     checkAll();
 
     return () => { cancelled = true; };
-  }, [coursesKey]);
+  }, [coursesKey, syncVersion]);
 
   return { completionMap, isLoading };
 }

--- a/hooks/useQuizProgressSync.ts
+++ b/hooks/useQuizProgressSync.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { useLoginCompleteListener } from '@/hooks/useLoginModal';
+import { resyncQuizProgress } from '@/utils/quizzes/indexedDB';
+
+/**
+ * Signing in through the login modal closes it in place — there is no
+ * navigation, so the quiz sync layer's page-load cache never sees the new
+ * session (#4357: answers stay invisible and saves stop reaching the API
+ * until a manual refresh). This hook re-runs the account sync on login and
+ * returns a version number; consumers add it to their load effect's deps to
+ * re-read IndexedDB once the pull has landed.
+ *
+ * Two triggers, same as AlertDashboard's post-login refetch:
+ * - login-complete event: the full modal flow finished in this tab
+ * - unauthenticated → authenticated: logins that never fire that event
+ *   (e.g. the session broadcast from another tab of this browser)
+ */
+export function useQuizProgressSync(): number {
+  const [version, setVersion] = useState(0);
+
+  const resync = useCallback(() => {
+    resyncQuizProgress().then(() => setVersion((v) => v + 1));
+  }, []);
+
+  useLoginCompleteListener(resync);
+
+  const { status } = useSession();
+  const prevStatus = useRef(status);
+  useEffect(() => {
+    if (prevStatus.current === 'unauthenticated' && status === 'authenticated') {
+      resync();
+    }
+    prevStatus.current = status;
+  }, [status, resync]);
+
+  return version;
+}

--- a/prisma/migrations/20260806213500_add_quiz_response/migration.sql
+++ b/prisma/migrations/20260806213500_add_quiz_response/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "QuizResponse" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "quiz_id" TEXT NOT NULL,
+    "selected_answers" INTEGER[] DEFAULT ARRAY[]::INTEGER[],
+    "is_answer_checked" BOOLEAN NOT NULL DEFAULT false,
+    "is_correct" BOOLEAN NOT NULL DEFAULT false,
+    "attempt_count" INTEGER NOT NULL DEFAULT 0,
+    "last_attempt_at" TIMESTAMPTZ(3),
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "QuizResponse_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "QuizResponse_user_id_idx" ON "QuizResponse"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "QuizResponse_user_id_quiz_id_key" ON "QuizResponse"("user_id", "quiz_id");
+
+-- AddForeignKey
+ALTER TABLE "QuizResponse" ADD CONSTRAINT "QuizResponse_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,6 +105,7 @@ model User {
   statsPlaygrounds           StatsPlayground[]
   statsPlaygroundFavorites   StatsPlaygroundFavorite[] @relation("StatsPlaygroundFavorites")
   badges                     UserBadge[]
+  quizResponses              QuizResponse[]
   validatorAlerts            ValidatorAlert[]
   referralLinks              ReferralLink[]            @relation("ReferralLinkOwner")
   referralAttributionsMade   ReferralAttribution[]     @relation("ReferralAttributionReferrer")
@@ -757,5 +758,22 @@ model GrantApplication {
   project     Project  @relation("GrantApplicationProject", fields: [project_id], references: [id], onDelete: Cascade)
 
   @@unique([program_key, project_id])
+  @@index([user_id])
+}
+
+model QuizResponse {
+  id                String    @id @default(uuid())
+  user_id           String
+  quiz_id           String
+  selected_answers  Int[]     @default([])
+  is_answer_checked Boolean   @default(false)
+  is_correct        Boolean   @default(false)
+  attempt_count     Int       @default(0)
+  last_attempt_at   DateTime? @db.Timestamptz(3)
+  created_at        DateTime  @default(now()) @db.Timestamptz(3)
+  updated_at        DateTime  @updatedAt @db.Timestamptz(3)
+  user              User      @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@unique([user_id, quiz_id])
   @@index([user_id])
 }

--- a/server/services/badgeStrategy.ts
+++ b/server/services/badgeStrategy.ts
@@ -13,9 +13,26 @@ export interface BadgeAssignmentStrategy {
  */
 export class AcademyBadgeStrategy implements BadgeAssignmentStrategy {
   async assignBadge(body: AssignBadgeBody, awardedBy?: string): Promise<AssignBadgeResult> {
+    // Academy badges require no admin role, so verify the claim against the
+    // user's synced quiz progress instead of trusting the client (#4357).
+    if (body.courseId) {
+      const { hasCompletedCourse } = await import("./quizProgress");
+      const completed = await hasCompletedCourse(body.userId, body.courseId);
+      if (!completed) {
+        return {
+          success: false,
+          message:
+            "Course completion could not be verified: not every quiz of this course has a correct answer recorded for this account.",
+          badge_id: "",
+          user_id: body.userId,
+          badges: [],
+        };
+      }
+    }
+
     // Import the existing academy badge logic
     const { assignBadgeAcademy } = await import("./badge");
-    
+
     // Use the existing service
     return await assignBadgeAcademy(body);
   }

--- a/server/services/quizProgress.ts
+++ b/server/services/quizProgress.ts
@@ -15,6 +15,12 @@ export interface QuizResponsePayload {
 
 export interface QuizResponseDTO extends QuizResponsePayload {
   quizId: string;
+  /**
+   * Course ids this write completed (all quizzes now correct). Their academy
+   * badges have already been awarded server-side — completion no longer
+   * depends on the client making a separate badge call.
+   */
+  completedCourses?: string[];
 }
 
 export class QuizProgressValidationError extends Error {
@@ -149,27 +155,63 @@ export async function upsertQuizResponse(
     data,
   });
 
+  let row: Awaited<ReturnType<typeof prisma.quizResponse.findUnique>> = null;
   if (updated.count === 0) {
     // Either the row doesn't exist yet, or it exists and is frozen correct.
     try {
-      const created = await prisma.quizResponse.create({
+      row = await prisma.quizResponse.create({
         data: { user_id: userId, quiz_id: quizId, ...data },
       });
-      return toDTO(created);
     } catch (error) {
       if (!isUniqueViolation(error)) throw error;
       // Frozen row (or a concurrent create won the race): return what's stored.
     }
   }
 
-  const row = await prisma.quizResponse.findUnique({
-    where: { user_id_quiz_id: { user_id: userId, quiz_id: quizId } },
-  });
+  if (!row) {
+    row = await prisma.quizResponse.findUnique({
+      where: { user_id_quiz_id: { user_id: userId, quiz_id: quizId } },
+    });
+  }
   if (!row) {
     // Only reachable if the row was deleted between statements.
     throw new Error(`Quiz response disappeared during upsert: ${quizId}`);
   }
-  return toDTO(row);
+
+  const dto = toDTO(row);
+  if (row.is_correct) {
+    dto.completedCourses = await autoAwardCompletedCourses(userId, quizId);
+  }
+  return dto;
+}
+
+/**
+ * Server-driven course completion: after a correct write, award the academy
+ * badge for every course this quiz just completed. assignBadgeAcademy is
+ * transactional and idempotent (approved badges are skipped, concurrent
+ * writers race on the unique constraint inside its transaction), so the
+ * client's own badge call becomes a harmless duplicate rather than the
+ * mechanism completion depends on. A badge failure never fails the write —
+ * progress is stored either way and the award retries on the next correct
+ * write or the client call.
+ */
+async function autoAwardCompletedCourses(userId: string, quizId: string): Promise<string[]> {
+  const containingCourses = Object.entries(quizData.courses)
+    .filter(([, course]) => course.quizzes.includes(quizId))
+    .map(([courseId]) => courseId);
+
+  const completed: string[] = [];
+  for (const courseId of containingCourses) {
+    if (!(await hasCompletedCourse(userId, courseId))) continue;
+    completed.push(courseId);
+    try {
+      const { assignBadgeAcademy } = await import("./badge");
+      await assignBadgeAcademy({ userId, courseId } as Parameters<typeof assignBadgeAcademy>[0]);
+    } catch (error) {
+      console.error(`[quiz-progress] badge auto-award failed for ${courseId}:`, error);
+    }
+  }
+  return completed;
 }
 
 /**

--- a/server/services/quizProgress.ts
+++ b/server/services/quizProgress.ts
@@ -1,0 +1,171 @@
+import { prisma } from "@/prisma/prisma";
+import quizData from "@/components/quizzes/data";
+
+// Mirrors MAX_ATTEMPTS in components/quizzes/quiz.tsx — the client enforces the
+// attempt cap, the server only needs it to bound the accepted payload.
+const MAX_ATTEMPTS = 3;
+
+export interface QuizResponsePayload {
+  selectedAnswers: number[];
+  isAnswerChecked: boolean;
+  isCorrect: boolean;
+  attemptCount: number;
+  lastAttemptAt: number | null;
+}
+
+export interface QuizResponseDTO extends QuizResponsePayload {
+  quizId: string;
+}
+
+export class QuizProgressValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QuizProgressValidationError";
+  }
+}
+
+// Mirrors getVariant in components/quizzes/quiz.tsx: variant 0 is the base
+// question, variant N (N >= 1) is alternates[N - 1], out-of-range falls back
+// to the base question.
+function getVariant(quizId: string, variantIndex: number) {
+  const baseQuiz = quizData.quizzes[quizId];
+  if (!baseQuiz) return null;
+  if (variantIndex === 0 || !baseQuiz.alternates) return baseQuiz;
+  if (variantIndex - 1 < baseQuiz.alternates.length) {
+    return baseQuiz.alternates[variantIndex - 1];
+  }
+  return baseQuiz;
+}
+
+function setEquals(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false;
+  const bSet = new Set(b);
+  return a.every((x) => bSet.has(x));
+}
+
+/**
+ * The variant the user actually answered. quiz.tsx shows getVariant(quizId,
+ * attemptCount) and only increments attemptCount on a wrong answer — so a
+ * correct response was answered on variant `attemptCount`, a wrong one on
+ * `attemptCount - 1`.
+ */
+function answeredVariant(quizId: string, payload: QuizResponsePayload) {
+  const variantIndex = payload.isCorrect
+    ? payload.attemptCount
+    : Math.max(0, payload.attemptCount - 1);
+  return getVariant(quizId, variantIndex);
+}
+
+/**
+ * Server-side recompute of correctness. A client claiming `isCorrect` only
+ * gets a correct row if the selected answers actually match the answered
+ * variant's correctAnswers. A client claiming incorrect is never upgraded.
+ */
+function computeStoredCorrect(quizId: string, payload: QuizResponsePayload): boolean {
+  if (!payload.isCorrect) return false;
+  const variant = answeredVariant(quizId, payload);
+  if (!variant) return false;
+  return setEquals(payload.selectedAnswers, variant.correctAnswers);
+}
+
+function validatePayload(quizId: string, payload: QuizResponsePayload): void {
+  if (!quizData.quizzes[quizId]) {
+    throw new QuizProgressValidationError(`Unknown quiz id: ${quizId}`);
+  }
+  if (!Array.isArray(payload.selectedAnswers) ||
+      payload.selectedAnswers.some((x) => !Number.isInteger(x) || x < 0)) {
+    throw new QuizProgressValidationError("selectedAnswers must be non-negative integers");
+  }
+  const variant = answeredVariant(quizId, payload);
+  const optionCount = variant?.options.length ?? 0;
+  if (payload.selectedAnswers.some((x) => x >= optionCount)) {
+    throw new QuizProgressValidationError("selectedAnswers out of range for this quiz");
+  }
+  if (!Number.isInteger(payload.attemptCount) ||
+      payload.attemptCount < 0 || payload.attemptCount > MAX_ATTEMPTS) {
+    throw new QuizProgressValidationError(`attemptCount must be between 0 and ${MAX_ATTEMPTS}`);
+  }
+  if (payload.lastAttemptAt !== null &&
+      (typeof payload.lastAttemptAt !== "number" || payload.lastAttemptAt < 0)) {
+    throw new QuizProgressValidationError("lastAttemptAt must be a timestamp or null");
+  }
+}
+
+function toDTO(row: {
+  quiz_id: string;
+  selected_answers: number[];
+  is_answer_checked: boolean;
+  is_correct: boolean;
+  attempt_count: number;
+  last_attempt_at: Date | null;
+}): QuizResponseDTO {
+  return {
+    quizId: row.quiz_id,
+    selectedAnswers: row.selected_answers,
+    isAnswerChecked: row.is_answer_checked,
+    isCorrect: row.is_correct,
+    attemptCount: row.attempt_count,
+    lastAttemptAt: row.last_attempt_at ? row.last_attempt_at.getTime() : null,
+  };
+}
+
+export async function getQuizProgressForUser(userId: string): Promise<QuizResponseDTO[]> {
+  const rows = await prisma.quizResponse.findMany({
+    where: { user_id: userId },
+  });
+  return rows.map(toDTO);
+}
+
+/**
+ * Upsert one quiz response. Correctness is recomputed server-side, and a row
+ * that is already correct is frozen — later writes (including the client's
+ * 24h auto-reset) never downgrade it.
+ */
+export async function upsertQuizResponse(
+  userId: string,
+  quizId: string,
+  payload: QuizResponsePayload
+): Promise<QuizResponseDTO> {
+  validatePayload(quizId, payload);
+
+  const existing = await prisma.quizResponse.findUnique({
+    where: { user_id_quiz_id: { user_id: userId, quiz_id: quizId } },
+  });
+  if (existing?.is_correct) {
+    return toDTO(existing);
+  }
+
+  const data = {
+    selected_answers: payload.selectedAnswers,
+    is_answer_checked: payload.isAnswerChecked,
+    is_correct: computeStoredCorrect(quizId, payload),
+    attempt_count: payload.attemptCount,
+    last_attempt_at: payload.lastAttemptAt ? new Date(payload.lastAttemptAt) : null,
+  };
+
+  const row = await prisma.quizResponse.upsert({
+    where: { user_id_quiz_id: { user_id: userId, quiz_id: quizId } },
+    create: { user_id: userId, quiz_id: quizId, ...data },
+    update: data,
+  });
+  return toDTO(row);
+}
+
+/**
+ * True when every quiz currently belonging to the course has a correct row
+ * for this user. Course membership is read from the quiz JSON at call time,
+ * so course changes need no data migration.
+ */
+export async function hasCompletedCourse(userId: string, courseId: string): Promise<boolean> {
+  const courseQuizzes = quizData.courses[courseId]?.quizzes;
+  if (!courseQuizzes || courseQuizzes.length === 0) return false;
+
+  const correctCount = await prisma.quizResponse.count({
+    where: {
+      user_id: userId,
+      quiz_id: { in: courseQuizzes },
+      is_correct: true,
+    },
+  });
+  return correctCount === courseQuizzes.length;
+}

--- a/server/services/quizProgress.ts
+++ b/server/services/quizProgress.ts
@@ -68,26 +68,24 @@ function computeStoredCorrect(quizId: string, payload: QuizResponsePayload): boo
   return setEquals(payload.selectedAnswers, variant.correctAnswers);
 }
 
+/**
+ * Quiz-content validation only — shape validation (types, bounds) lives in
+ * the Zod schemas at the API boundary. What stays here is everything that
+ * needs the quiz catalog: the id must exist, and the selection must fit the
+ * answered variant's option list (no out-of-range indices, no duplicates,
+ * which also caps the stored array at the variant's option count).
+ */
 function validatePayload(quizId: string, payload: QuizResponsePayload): void {
   if (!quizData.quizzes[quizId]) {
     throw new QuizProgressValidationError(`Unknown quiz id: ${quizId}`);
-  }
-  if (!Array.isArray(payload.selectedAnswers) ||
-      payload.selectedAnswers.some((x) => !Number.isInteger(x) || x < 0)) {
-    throw new QuizProgressValidationError("selectedAnswers must be non-negative integers");
   }
   const variant = answeredVariant(quizId, payload);
   const optionCount = variant?.options.length ?? 0;
   if (payload.selectedAnswers.some((x) => x >= optionCount)) {
     throw new QuizProgressValidationError("selectedAnswers out of range for this quiz");
   }
-  if (!Number.isInteger(payload.attemptCount) ||
-      payload.attemptCount < 0 || payload.attemptCount > MAX_ATTEMPTS) {
-    throw new QuizProgressValidationError(`attemptCount must be between 0 and ${MAX_ATTEMPTS}`);
-  }
-  if (payload.lastAttemptAt !== null &&
-      (typeof payload.lastAttemptAt !== "number" || payload.lastAttemptAt < 0)) {
-    throw new QuizProgressValidationError("lastAttemptAt must be a timestamp or null");
+  if (new Set(payload.selectedAnswers).size !== payload.selectedAnswers.length) {
+    throw new QuizProgressValidationError("selectedAnswers must not contain duplicates");
   }
 }
 
@@ -116,10 +114,20 @@ export async function getQuizProgressForUser(userId: string): Promise<QuizRespon
   return rows.map(toDTO);
 }
 
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: string }).code === "P2002"
+  );
+}
+
 /**
  * Upsert one quiz response. Correctness is recomputed server-side, and a row
  * that is already correct is frozen — later writes (including the client's
- * 24h auto-reset) never downgrade it.
+ * 24h auto-reset) never downgrade it. The freeze is enforced atomically: the
+ * update carries `is_correct: false` in its WHERE, so a concurrent writer can
+ * never overwrite a just-written correct row (read-then-write would race).
  */
 export async function upsertQuizResponse(
   userId: string,
@@ -127,13 +135,6 @@ export async function upsertQuizResponse(
   payload: QuizResponsePayload
 ): Promise<QuizResponseDTO> {
   validatePayload(quizId, payload);
-
-  const existing = await prisma.quizResponse.findUnique({
-    where: { user_id_quiz_id: { user_id: userId, quiz_id: quizId } },
-  });
-  if (existing?.is_correct) {
-    return toDTO(existing);
-  }
 
   const data = {
     selected_answers: payload.selectedAnswers,
@@ -143,11 +144,31 @@ export async function upsertQuizResponse(
     last_attempt_at: payload.lastAttemptAt ? new Date(payload.lastAttemptAt) : null,
   };
 
-  const row = await prisma.quizResponse.upsert({
-    where: { user_id_quiz_id: { user_id: userId, quiz_id: quizId } },
-    create: { user_id: userId, quiz_id: quizId, ...data },
-    update: data,
+  const updated = await prisma.quizResponse.updateMany({
+    where: { user_id: userId, quiz_id: quizId, is_correct: false },
+    data,
   });
+
+  if (updated.count === 0) {
+    // Either the row doesn't exist yet, or it exists and is frozen correct.
+    try {
+      const created = await prisma.quizResponse.create({
+        data: { user_id: userId, quiz_id: quizId, ...data },
+      });
+      return toDTO(created);
+    } catch (error) {
+      if (!isUniqueViolation(error)) throw error;
+      // Frozen row (or a concurrent create won the race): return what's stored.
+    }
+  }
+
+  const row = await prisma.quizResponse.findUnique({
+    where: { user_id_quiz_id: { user_id: userId, quiz_id: quizId } },
+  });
+  if (!row) {
+    // Only reachable if the row was deleted between statements.
+    throw new Error(`Quiz response disappeared during upsert: ${quizId}`);
+  }
   return toDTO(row);
 }
 

--- a/tests/unit/quiz-progress/quizProgress.test.ts
+++ b/tests/unit/quiz-progress/quizProgress.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { dbMocks } = vi.hoisted(() => ({
+  dbMocks: {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+    upsert: vi.fn(),
+    count: vi.fn(),
+  },
+}));
+
+vi.mock('@/prisma/prisma', () => ({
+  prisma: {
+    quizResponse: {
+      findUnique: dbMocks.findUnique,
+      findMany: dbMocks.findMany,
+      upsert: dbMocks.upsert,
+      count: dbMocks.count,
+    },
+  },
+}));
+
+// Hermetic quiz fixture so tests do not depend on real course content.
+// q1: single-answer, no alternates. q2: multi-answer with one alternate —
+// mirrors the avalanche-fundamentals 1202 shape.
+vi.mock('@/components/quizzes/data', () => ({
+  default: {
+    quizzes: {
+      q1: {
+        question: 'base q1',
+        options: ['a', 'b', 'c', 'd'],
+        correctAnswers: [1],
+        hint: '',
+        explanation: '',
+        chapter: 'ch',
+      },
+      q2: {
+        question: 'base q2',
+        options: ['a', 'b', 'c', 'd', 'e', 'f'],
+        correctAnswers: [0, 2],
+        hint: '',
+        explanation: '',
+        chapter: 'ch',
+        alternates: [
+          {
+            question: 'alternate q2',
+            options: ['a', 'b', 'c', 'd'],
+            correctAnswers: [2],
+            hint: '',
+            explanation: '',
+          },
+        ],
+      },
+    },
+    courses: {
+      'course-a': { title: 'Course A', quizzes: ['q1', 'q2'] },
+      'course-empty': { title: 'Empty', quizzes: [] },
+    },
+  },
+}));
+
+import {
+  upsertQuizResponse,
+  getQuizProgressForUser,
+  hasCompletedCourse,
+  QuizProgressValidationError,
+} from '@/server/services/quizProgress';
+
+const upsertedRow = (over: Record<string, unknown> = {}) => ({
+  quiz_id: 'q1',
+  selected_answers: [1],
+  is_answer_checked: true,
+  is_correct: true,
+  attempt_count: 0,
+  last_attempt_at: null,
+  ...over,
+});
+
+beforeEach(() => {
+  Object.values(dbMocks).forEach((m) => m.mockReset());
+  dbMocks.findUnique.mockResolvedValue(null);
+  dbMocks.upsert.mockImplementation(async ({ create }: any) => ({
+    quiz_id: create.quiz_id,
+    ...create,
+  }));
+});
+
+describe('upsertQuizResponse — server-side correctness recompute', () => {
+  it('stores correct when the claim matches the base variant', async () => {
+    await upsertQuizResponse('user-1', 'q1', {
+      selectedAnswers: [1],
+      isAnswerChecked: true,
+      isCorrect: true,
+      attemptCount: 0,
+      lastAttemptAt: null,
+    });
+
+    expect(dbMocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ is_correct: true }),
+      }),
+    );
+  });
+
+  it('validates against the alternate variant when attemptCount says so', async () => {
+    // attemptCount 1 + correct claim → answered variant is alternates[0],
+    // whose correctAnswers are [2] (base would require [0, 2])
+    await upsertQuizResponse('user-1', 'q2', {
+      selectedAnswers: [2],
+      isAnswerChecked: true,
+      isCorrect: true,
+      attemptCount: 1,
+      lastAttemptAt: null,
+    });
+
+    expect(dbMocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ is_correct: true }),
+      }),
+    );
+  });
+
+  it('downgrades a correct claim whose answers do not match', async () => {
+    await upsertQuizResponse('user-1', 'q1', {
+      selectedAnswers: [0],
+      isAnswerChecked: true,
+      isCorrect: true, // client lies
+      attemptCount: 0,
+      lastAttemptAt: null,
+    });
+
+    expect(dbMocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ is_correct: false }),
+      }),
+    );
+  });
+
+  it('never upgrades an incorrect claim even if the answers happen to match', async () => {
+    await upsertQuizResponse('user-1', 'q1', {
+      selectedAnswers: [1],
+      isAnswerChecked: true,
+      isCorrect: false,
+      attemptCount: 1,
+      lastAttemptAt: null,
+    });
+
+    expect(dbMocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ is_correct: false }),
+      }),
+    );
+  });
+
+  it('freezes an already-correct row instead of overwriting it', async () => {
+    dbMocks.findUnique.mockResolvedValue(
+      upsertedRow({ is_correct: true, selected_answers: [1] }),
+    );
+
+    const result = await upsertQuizResponse('user-1', 'q1', {
+      selectedAnswers: [],
+      isAnswerChecked: false,
+      isCorrect: false,
+      attemptCount: 0,
+      lastAttemptAt: null,
+    });
+
+    expect(result.isCorrect).toBe(true);
+    expect(dbMocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown quiz ids', async () => {
+    await expect(
+      upsertQuizResponse('user-1', 'nope', {
+        selectedAnswers: [0],
+        isAnswerChecked: true,
+        isCorrect: false,
+        attemptCount: 1,
+        lastAttemptAt: null,
+      }),
+    ).rejects.toThrow(QuizProgressValidationError);
+  });
+
+  it('rejects selectedAnswers outside the answered variant option range', async () => {
+    // attemptCount 1 + incorrect → answered variant is base q2 (6 options is
+    // fine) — but for q1 (4 options) index 4 is out of range
+    await expect(
+      upsertQuizResponse('user-1', 'q1', {
+        selectedAnswers: [4],
+        isAnswerChecked: true,
+        isCorrect: false,
+        attemptCount: 1,
+        lastAttemptAt: null,
+      }),
+    ).rejects.toThrow(QuizProgressValidationError);
+  });
+
+  it('rejects attemptCount outside 0..3', async () => {
+    await expect(
+      upsertQuizResponse('user-1', 'q1', {
+        selectedAnswers: [1],
+        isAnswerChecked: true,
+        isCorrect: false,
+        attemptCount: 7,
+        lastAttemptAt: null,
+      }),
+    ).rejects.toThrow(QuizProgressValidationError);
+  });
+});
+
+describe('getQuizProgressForUser', () => {
+  it('maps rows to the client-facing shape', async () => {
+    const when = new Date('2026-08-06T12:00:00Z');
+    dbMocks.findMany.mockResolvedValue([
+      upsertedRow({ quiz_id: 'q2', attempt_count: 2, last_attempt_at: when }),
+    ]);
+
+    const result = await getQuizProgressForUser('user-1');
+
+    expect(result).toEqual([
+      {
+        quizId: 'q2',
+        selectedAnswers: [1],
+        isAnswerChecked: true,
+        isCorrect: true,
+        attemptCount: 2,
+        lastAttemptAt: when.getTime(),
+      },
+    ]);
+  });
+});
+
+describe('hasCompletedCourse', () => {
+  it('is true when every course quiz has a correct row', async () => {
+    dbMocks.count.mockResolvedValue(2);
+    await expect(hasCompletedCourse('user-1', 'course-a')).resolves.toBe(true);
+    expect(dbMocks.count).toHaveBeenCalledWith({
+      where: {
+        user_id: 'user-1',
+        quiz_id: { in: ['q1', 'q2'] },
+        is_correct: true,
+      },
+    });
+  });
+
+  it('is false when any course quiz is missing', async () => {
+    dbMocks.count.mockResolvedValue(1);
+    await expect(hasCompletedCourse('user-1', 'course-a')).resolves.toBe(false);
+  });
+
+  it('is false for unknown or empty courses', async () => {
+    await expect(hasCompletedCourse('user-1', 'course-empty')).resolves.toBe(false);
+    await expect(hasCompletedCourse('user-1', 'nope')).resolves.toBe(false);
+    expect(dbMocks.count).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/quiz-progress/quizProgress.test.ts
+++ b/tests/unit/quiz-progress/quizProgress.test.ts
@@ -4,7 +4,8 @@ const { dbMocks } = vi.hoisted(() => ({
   dbMocks: {
     findUnique: vi.fn(),
     findMany: vi.fn(),
-    upsert: vi.fn(),
+    updateMany: vi.fn(),
+    create: vi.fn(),
     count: vi.fn(),
   },
 }));
@@ -14,7 +15,8 @@ vi.mock('@/prisma/prisma', () => ({
     quizResponse: {
       findUnique: dbMocks.findUnique,
       findMany: dbMocks.findMany,
-      upsert: dbMocks.upsert,
+      updateMany: dbMocks.updateMany,
+      create: dbMocks.create,
       count: dbMocks.count,
     },
   },
@@ -66,7 +68,7 @@ import {
   QuizProgressValidationError,
 } from '@/server/services/quizProgress';
 
-const upsertedRow = (over: Record<string, unknown> = {}) => ({
+const dbRow = (over: Record<string, unknown> = {}) => ({
   quiz_id: 'q1',
   selected_answers: [1],
   is_answer_checked: true,
@@ -76,28 +78,31 @@ const upsertedRow = (over: Record<string, unknown> = {}) => ({
   ...over,
 });
 
+const payload = (over: Record<string, unknown> = {}) => ({
+  selectedAnswers: [1],
+  isAnswerChecked: true,
+  isCorrect: true,
+  attemptCount: 0,
+  lastAttemptAt: null,
+  ...over,
+});
+
 beforeEach(() => {
   Object.values(dbMocks).forEach((m) => m.mockReset());
+  // Default: no existing row — updateMany matches nothing, create succeeds
+  dbMocks.updateMany.mockResolvedValue({ count: 0 });
+  dbMocks.create.mockImplementation(async ({ data }: any) => data);
   dbMocks.findUnique.mockResolvedValue(null);
-  dbMocks.upsert.mockImplementation(async ({ create }: any) => ({
-    quiz_id: create.quiz_id,
-    ...create,
-  }));
 });
 
 describe('upsertQuizResponse — server-side correctness recompute', () => {
   it('stores correct when the claim matches the base variant', async () => {
-    await upsertQuizResponse('user-1', 'q1', {
-      selectedAnswers: [1],
-      isAnswerChecked: true,
-      isCorrect: true,
-      attemptCount: 0,
-      lastAttemptAt: null,
-    });
+    const result = await upsertQuizResponse('user-1', 'q1', payload());
 
-    expect(dbMocks.upsert).toHaveBeenCalledWith(
+    expect(result.isCorrect).toBe(true);
+    expect(dbMocks.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        create: expect.objectContaining({ is_correct: true }),
+        data: expect.objectContaining({ is_correct: true }),
       }),
     );
   });
@@ -105,105 +110,83 @@ describe('upsertQuizResponse — server-side correctness recompute', () => {
   it('validates against the alternate variant when attemptCount says so', async () => {
     // attemptCount 1 + correct claim → answered variant is alternates[0],
     // whose correctAnswers are [2] (base would require [0, 2])
-    await upsertQuizResponse('user-1', 'q2', {
+    const result = await upsertQuizResponse('user-1', 'q2', payload({
       selectedAnswers: [2],
-      isAnswerChecked: true,
-      isCorrect: true,
       attemptCount: 1,
-      lastAttemptAt: null,
-    });
+    }));
 
-    expect(dbMocks.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        create: expect.objectContaining({ is_correct: true }),
-      }),
-    );
+    expect(result.isCorrect).toBe(true);
   });
 
   it('downgrades a correct claim whose answers do not match', async () => {
-    await upsertQuizResponse('user-1', 'q1', {
-      selectedAnswers: [0],
-      isAnswerChecked: true,
-      isCorrect: true, // client lies
-      attemptCount: 0,
-      lastAttemptAt: null,
-    });
+    const result = await upsertQuizResponse('user-1', 'q1', payload({
+      selectedAnswers: [0], // client lies about isCorrect
+    }));
 
-    expect(dbMocks.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        create: expect.objectContaining({ is_correct: false }),
-      }),
-    );
+    expect(result.isCorrect).toBe(false);
   });
 
   it('never upgrades an incorrect claim even if the answers happen to match', async () => {
-    await upsertQuizResponse('user-1', 'q1', {
-      selectedAnswers: [1],
-      isAnswerChecked: true,
+    const result = await upsertQuizResponse('user-1', 'q1', payload({
       isCorrect: false,
       attemptCount: 1,
-      lastAttemptAt: null,
-    });
+    }));
 
-    expect(dbMocks.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        create: expect.objectContaining({ is_correct: false }),
-      }),
-    );
+    expect(result.isCorrect).toBe(false);
   });
 
-  it('freezes an already-correct row instead of overwriting it', async () => {
-    dbMocks.findUnique.mockResolvedValue(
-      upsertedRow({ is_correct: true, selected_answers: [1] }),
-    );
+  it('updates through a WHERE that excludes frozen-correct rows', async () => {
+    dbMocks.updateMany.mockResolvedValue({ count: 1 });
+    dbMocks.findUnique.mockResolvedValue(dbRow({ is_correct: false }));
 
-    const result = await upsertQuizResponse('user-1', 'q1', {
+    await upsertQuizResponse('user-1', 'q1', payload({ isCorrect: false }));
+
+    expect(dbMocks.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { user_id: 'user-1', quiz_id: 'q1', is_correct: false },
+      }),
+    );
+    expect(dbMocks.create).not.toHaveBeenCalled();
+  });
+
+  it('returns the frozen row when a concurrent/frozen write loses the race', async () => {
+    // updateMany matched nothing (row is frozen correct), create hits the
+    // unique constraint, the stored row is returned untouched
+    dbMocks.updateMany.mockResolvedValue({ count: 0 });
+    dbMocks.create.mockRejectedValue({ code: 'P2002' });
+    dbMocks.findUnique.mockResolvedValue(dbRow({ is_correct: true }));
+
+    const result = await upsertQuizResponse('user-1', 'q1', payload({
       selectedAnswers: [],
       isAnswerChecked: false,
       isCorrect: false,
-      attemptCount: 0,
-      lastAttemptAt: null,
-    });
+    }));
 
     expect(result.isCorrect).toBe(true);
-    expect(dbMocks.upsert).not.toHaveBeenCalled();
   });
 
   it('rejects unknown quiz ids', async () => {
     await expect(
-      upsertQuizResponse('user-1', 'nope', {
-        selectedAnswers: [0],
-        isAnswerChecked: true,
-        isCorrect: false,
-        attemptCount: 1,
-        lastAttemptAt: null,
-      }),
+      upsertQuizResponse('user-1', 'nope', payload({ isCorrect: false })),
     ).rejects.toThrow(QuizProgressValidationError);
   });
 
   it('rejects selectedAnswers outside the answered variant option range', async () => {
-    // attemptCount 1 + incorrect → answered variant is base q2 (6 options is
-    // fine) — but for q1 (4 options) index 4 is out of range
     await expect(
-      upsertQuizResponse('user-1', 'q1', {
-        selectedAnswers: [4],
-        isAnswerChecked: true,
+      upsertQuizResponse('user-1', 'q1', payload({
+        selectedAnswers: [4], // q1 has 4 options: valid indices 0-3
         isCorrect: false,
         attemptCount: 1,
-        lastAttemptAt: null,
-      }),
+      })),
     ).rejects.toThrow(QuizProgressValidationError);
   });
 
-  it('rejects attemptCount outside 0..3', async () => {
+  it('rejects duplicate selectedAnswers', async () => {
     await expect(
-      upsertQuizResponse('user-1', 'q1', {
-        selectedAnswers: [1],
-        isAnswerChecked: true,
+      upsertQuizResponse('user-1', 'q1', payload({
+        selectedAnswers: [1, 1],
         isCorrect: false,
-        attemptCount: 7,
-        lastAttemptAt: null,
-      }),
+      })),
     ).rejects.toThrow(QuizProgressValidationError);
   });
 });
@@ -212,7 +195,7 @@ describe('getQuizProgressForUser', () => {
   it('maps rows to the client-facing shape', async () => {
     const when = new Date('2026-08-06T12:00:00Z');
     dbMocks.findMany.mockResolvedValue([
-      upsertedRow({ quiz_id: 'q2', attempt_count: 2, last_attempt_at: when }),
+      dbRow({ quiz_id: 'q2', attempt_count: 2, last_attempt_at: when }),
     ]);
 
     const result = await getQuizProgressForUser('user-1');

--- a/tests/unit/quiz-progress/quizProgress.test.ts
+++ b/tests/unit/quiz-progress/quizProgress.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-const { dbMocks } = vi.hoisted(() => ({
+const { dbMocks, badgeMock } = vi.hoisted(() => ({
   dbMocks: {
     findUnique: vi.fn(),
     findMany: vi.fn(),
@@ -8,6 +8,11 @@ const { dbMocks } = vi.hoisted(() => ({
     create: vi.fn(),
     count: vi.fn(),
   },
+  badgeMock: vi.fn(),
+}));
+
+vi.mock('@/server/services/badge', () => ({
+  assignBadgeAcademy: badgeMock,
 }));
 
 vi.mock('@/prisma/prisma', () => ({
@@ -89,10 +94,14 @@ const payload = (over: Record<string, unknown> = {}) => ({
 
 beforeEach(() => {
   Object.values(dbMocks).forEach((m) => m.mockReset());
-  // Default: no existing row — updateMany matches nothing, create succeeds
+  badgeMock.mockReset();
+  // Default: no existing row — updateMany matches nothing, create succeeds,
+  // and the course is not yet complete (count 0)
   dbMocks.updateMany.mockResolvedValue({ count: 0 });
   dbMocks.create.mockImplementation(async ({ data }: any) => data);
   dbMocks.findUnique.mockResolvedValue(null);
+  dbMocks.count.mockResolvedValue(0);
+  badgeMock.mockResolvedValue({ success: true });
 });
 
 describe('upsertQuizResponse — server-side correctness recompute', () => {
@@ -188,6 +197,48 @@ describe('upsertQuizResponse — server-side correctness recompute', () => {
         isCorrect: false,
       })),
     ).rejects.toThrow(QuizProgressValidationError);
+  });
+});
+
+describe('upsertQuizResponse — server-driven course completion (auto-award)', () => {
+  it('awards the academy badge when a correct write completes a course', async () => {
+    dbMocks.count.mockResolvedValue(2); // both q1 and q2 now correct
+
+    const result = await upsertQuizResponse('user-1', 'q1', payload());
+
+    expect(result.completedCourses).toEqual(['course-a']);
+    expect(badgeMock).toHaveBeenCalledWith({ userId: 'user-1', courseId: 'course-a' });
+  });
+
+  it('does not award when the course is still incomplete', async () => {
+    dbMocks.count.mockResolvedValue(1); // q2 still missing
+
+    const result = await upsertQuizResponse('user-1', 'q1', payload());
+
+    expect(result.completedCourses).toEqual([]);
+    expect(badgeMock).not.toHaveBeenCalled();
+  });
+
+  it('does not even check completion for an incorrect write', async () => {
+    const result = await upsertQuizResponse('user-1', 'q1', payload({
+      selectedAnswers: [0],
+      isCorrect: false,
+      attemptCount: 1,
+    }));
+
+    expect(result.completedCourses).toBeUndefined();
+    expect(dbMocks.count).not.toHaveBeenCalled();
+    expect(badgeMock).not.toHaveBeenCalled();
+  });
+
+  it('stores the response even when the badge award fails', async () => {
+    dbMocks.count.mockResolvedValue(2);
+    badgeMock.mockRejectedValue(new Error('badge service down'));
+
+    const result = await upsertQuizResponse('user-1', 'q1', payload());
+
+    expect(result.isCorrect).toBe(true);
+    expect(result.completedCourses).toEqual(['course-a']);
   });
 });
 

--- a/tests/unit/quiz-progress/quizSyncClient.test.ts
+++ b/tests/unit/quiz-progress/quizSyncClient.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// In-memory stand-in for the idb object stores. Persists across
+// vi.resetModules() (the mock factory closes over it), reset in beforeEach.
+const stores = new Map<string, Map<string, unknown>>();
+
+function store(name: string) {
+  if (!stores.has(name)) stores.set(name, new Map());
+  return stores.get(name)!;
+}
+
+vi.mock('idb', () => ({
+  openDB: vi.fn(async () => ({
+    getAllKeys: async (name: string) => [...store(name).keys()],
+    getAll: async (name: string) => [...store(name).values()],
+    get: async (name: string, key: string) => store(name).get(key),
+    put: async (name: string, value: unknown, key: string) => {
+      store(name).set(key, value);
+    },
+    delete: async (name: string, key: string) => {
+      store(name).delete(key);
+    },
+  })),
+}));
+
+// Simulated auth backend: flipping `authed` is the "user logged in through
+// the modal without a page load" moment — same JS module state survives.
+const auth = { authed: false, serverRows: [] as Array<Record<string, unknown>> };
+
+const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+  const method = init?.method ?? 'GET';
+  if (!auth.authed) return new Response(null, { status: 401 });
+  if (method === 'GET') return Response.json({ responses: auth.serverRows });
+  return Response.json({ ok: true });
+});
+
+const row = (over: Record<string, unknown> = {}) => ({
+  selectedAnswers: [1],
+  isAnswerChecked: true,
+  isCorrect: true,
+  attemptCount: 1,
+  lastAttemptAt: 1754500000000,
+  ...over,
+});
+
+async function freshModule() {
+  vi.resetModules();
+  return import('@/utils/quizzes/indexedDB');
+}
+
+beforeEach(() => {
+  stores.clear();
+  fetchMock.mockClear();
+  auth.authed = false;
+  auth.serverRows = [];
+  vi.stubGlobal('window', {});
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+const putCalls = () =>
+  fetchMock.mock.calls.filter(([, init]) => init?.method === 'PUT');
+const postCalls = () =>
+  fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST');
+const getCalls = () =>
+  fetchMock.mock.calls.filter(([, init]) => (init?.method ?? 'GET') === 'GET');
+
+describe('resyncQuizProgress — login without a page load (#4357 armin repro)', () => {
+  it('pulls the account rows that the signed-out first sync could not see', async () => {
+    const mod = await freshModule();
+
+    // Signed out: first read caches the 401 (this is browser B pre-login)
+    expect(await mod.getQuizResponse('q1')).toBeUndefined();
+
+    // User logs in through the modal — no reload, module state unchanged
+    auth.authed = true;
+    auth.serverRows = [{ quizId: 'q1', ...row() }];
+
+    // Without resync the stale one-shot sync keeps answers invisible
+    expect(await mod.getQuizResponse('q1')).toBeUndefined();
+
+    await mod.resyncQuizProgress();
+    expect(await mod.getQuizResponse('q1')).toMatchObject({ isCorrect: true });
+  });
+
+  it('resumes pushing saves that the cached signed-out state was skipping', async () => {
+    const mod = await freshModule();
+
+    await mod.getQuizResponse('q1'); // caches serverHasAccount = false
+    await mod.saveQuizResponse('q1', row());
+    expect(putCalls()).toHaveLength(0); // signed-out: push correctly skipped
+
+    auth.authed = true;
+    await mod.resyncQuizProgress();
+
+    await mod.saveQuizResponse('q2', row());
+    expect(putCalls()).toHaveLength(1); // post-login saves reach the API again
+  });
+
+  it('backfills rows that were answered between the 401 and the login', async () => {
+    const mod = await freshModule();
+
+    await mod.getQuizResponse('q1');
+    await mod.saveQuizResponse('q1', row()); // saved locally, push skipped
+
+    auth.authed = true;
+    await mod.resyncQuizProgress();
+
+    const bodies = postCalls().map(([, init]) => JSON.parse(init!.body as string));
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0].map((r: { quizId: string }) => r.quizId)).toContain('q1');
+  });
+
+  it('deduplicates concurrent resync calls into a single sync pass', async () => {
+    const mod = await freshModule();
+    auth.authed = true;
+
+    await Promise.all([mod.resyncQuizProgress(), mod.resyncQuizProgress()]);
+    expect(getCalls()).toHaveLength(1);
+  });
+
+  it('stays quiet when the user is still signed out after a resync', async () => {
+    const mod = await freshModule();
+
+    await mod.resyncQuizProgress(); // e.g. a session event fired while logged out
+    await mod.saveQuizResponse('q1', row());
+    expect(putCalls()).toHaveLength(0); // the resync's 401 re-arms the skip
+    expect(postCalls()).toHaveLength(0); // and no backfill was attempted
+  });
+});

--- a/tests/unit/quiz-progress/quizSyncClient.test.ts
+++ b/tests/unit/quiz-progress/quizSyncClient.test.ts
@@ -20,17 +20,27 @@ vi.mock('idb', () => ({
     delete: async (name: string, key: string) => {
       store(name).delete(key);
     },
+    clear: async (name: string) => {
+      store(name).clear();
+    },
   })),
 }));
 
 // Simulated auth backend: flipping `authed` is the "user logged in through
 // the modal without a page load" moment — same JS module state survives.
-const auth = { authed: false, serverRows: [] as Array<Record<string, unknown>> };
+// `userId` mirrors the GET response's account identity used for the
+// cross-account guard.
+const auth = {
+  authed: false,
+  userId: 'user-a',
+  serverRows: [] as Array<Record<string, unknown>>,
+};
 
 const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
   const method = init?.method ?? 'GET';
   if (!auth.authed) return new Response(null, { status: 401 });
-  if (method === 'GET') return Response.json({ responses: auth.serverRows });
+  if (method === 'GET')
+    return Response.json({ responses: auth.serverRows, userId: auth.userId });
   return Response.json({ ok: true });
 });
 
@@ -52,6 +62,7 @@ beforeEach(() => {
   stores.clear();
   fetchMock.mockClear();
   auth.authed = false;
+  auth.userId = 'user-a';
   auth.serverRows = [];
   vi.stubGlobal('window', {});
   vi.stubGlobal('fetch', fetchMock);
@@ -125,5 +136,72 @@ describe('resyncQuizProgress — login without a page load (#4357 armin repro)',
     await mod.saveQuizResponse('q1', row());
     expect(putCalls()).toHaveLength(0); // the resync's 401 re-arms the skip
     expect(postCalls()).toHaveLength(0); // and no backfill was attempted
+  });
+});
+
+describe('cross-account boundary on a shared browser (#4469 alejandro repro)', () => {
+  it('does not backfill the previous account\'s rows into the next account', async () => {
+    const mod = await freshModule();
+
+    // User A signs in and answers q1 on this browser
+    auth.authed = true;
+    auth.userId = 'user-a';
+    await mod.resyncQuizProgress();
+    await mod.saveQuizResponse('q1', row());
+
+    // A signs out, then B signs in — no page load, module state survives
+    auth.authed = false;
+    await mod.resyncQuizProgress();
+    auth.authed = true;
+    auth.userId = 'user-b';
+    auth.serverRows = [{ quizId: 'q9', ...row() }];
+    fetchMock.mockClear();
+    await mod.resyncQuizProgress();
+
+    // B's session must never receive A's q1 (this was the badge-contamination path)
+    const bodies = postCalls().map(([, init]) => JSON.parse(init!.body as string));
+    expect(bodies.flat().map((r: { quizId: string }) => r.quizId)).not.toContain('q1');
+
+    // A's row is no longer readable under B; B's own server rows are
+    expect(await mod.getQuizResponse('q1')).toBeUndefined();
+    expect(await mod.getQuizResponse('q9')).toMatchObject({ isCorrect: true });
+  });
+
+  it('keeps local rows when the same account signs back in (expired session heals)', async () => {
+    const mod = await freshModule();
+
+    auth.authed = true;
+    auth.userId = 'user-a';
+    await mod.resyncQuizProgress();
+    await mod.saveQuizResponse('q1', row());
+
+    // Session expires; the row saved during the gap must still backfill for A
+    auth.authed = false;
+    await mod.resyncQuizProgress();
+    await mod.saveQuizResponse('q2', row());
+
+    auth.authed = true;
+    fetchMock.mockClear();
+    await mod.resyncQuizProgress();
+
+    const bodies = postCalls().map(([, init]) => JSON.parse(init!.body as string));
+    expect(bodies.flat().map((r: { quizId: string }) => r.quizId)).toContain('q2');
+    expect(await mod.getQuizResponse('q1')).toMatchObject({ isCorrect: true });
+  });
+
+  it('still adopts anonymous progress on the first sign-in ever on the device', async () => {
+    const mod = await freshModule();
+
+    // Never-signed-in browser: anonymous progress accumulates
+    await mod.getQuizResponse('q1');
+    await mod.saveQuizResponse('q1', row());
+
+    auth.authed = true;
+    auth.userId = 'user-b';
+    await mod.resyncQuizProgress();
+
+    // First account on the device adopts the anonymous rows (the #4357 backfill)
+    const bodies = postCalls().map(([, init]) => JSON.parse(init!.body as string));
+    expect(bodies.flat().map((r: { quizId: string }) => r.quizId)).toContain('q1');
   });
 });

--- a/utils/quizzes/indexedDB.ts
+++ b/utils/quizzes/indexedDB.ts
@@ -138,6 +138,28 @@ function ensureSynced(): Promise<void> {
   return syncPromise
 }
 
+let resyncInFlight: Promise<void> | null = null
+
+/**
+ * Re-run the account sync after the auth session changes without a page load
+ * (the login modal closes in place — no navigation, so the module state above
+ * survives). Discards the cached one-shot sync AND the cached signed-out
+ * verdict, so the pull sees the account's rows and later saves push again.
+ * Concurrent callers (every mounted quiz fires on the same login event)
+ * share one pass.
+ */
+export function resyncQuizProgress(): Promise<void> {
+  if (typeof window === "undefined") return Promise.resolve()
+  if (!resyncInFlight) {
+    syncPromise = null
+    serverHasAccount = null
+    resyncInFlight = ensureSynced().finally(() => {
+      resyncInFlight = null
+    })
+  }
+  return resyncInFlight
+}
+
 async function pushResponse(quizId: string, response: QuizResponseValue): Promise<void> {
   if (serverHasAccount === false) return // signed out — local-only, no 401 noise
   // Awaited (not fire-and-forget) so that when quiz.tsx awaits

--- a/utils/quizzes/indexedDB.ts
+++ b/utils/quizzes/indexedDB.ts
@@ -45,15 +45,121 @@ function getDBPromise() {
   return dbPromise
 }
 
-export async function saveQuizResponse(quizId: string, response: QuizDB["quizResponses"]["value"]) {
-  if (typeof window !== "undefined") {
-    const db = await getDBPromise()
-    await db.put(quizStoreName, response, quizId)
+type QuizResponseValue = QuizDB["quizResponses"]["value"]
+
+// ---------------------------------------------------------------------------
+// Server sync (issue #4357)
+//
+// IndexedDB stays the local cache and the synchronous source of truth for the
+// UI, but every response is mirrored to the account via /api/quiz-progress so
+// progress survives browser switches and IndexedDB eviction. Signed-out users
+// keep the old local-only behavior: the API answers 401 and we stay quiet.
+// ---------------------------------------------------------------------------
+
+let syncPromise: Promise<void> | null = null
+
+function betterOf(a: QuizResponseValue, b: QuizResponseValue): QuizResponseValue {
+  if (a.isCorrect !== b.isCorrect) return a.isCorrect ? a : b
+  if ((a.attemptCount ?? 0) !== (b.attemptCount ?? 0))
+    return (a.attemptCount ?? 0) > (b.attemptCount ?? 0) ? a : b
+  return (a.lastAttemptAt ?? 0) >= (b.lastAttemptAt ?? 0) ? a : b
+}
+
+async function getAllLocalResponses(): Promise<Map<string, QuizResponseValue>> {
+  const db = await getDBPromise()
+  const keys = (await db.getAllKeys(quizStoreName)) as string[]
+  const values = await db.getAll(quizStoreName)
+  return new Map(keys.map((k, i) => [k, values[i]]))
+}
+
+/**
+ * One-shot per page load: pull the account's responses, merge them into
+ * IndexedDB (correct wins, then attempts, then recency), then push every
+ * local row the server doesn't have or has a worse version of. That push IS
+ * the backfill — pre-existing browser progress lands in the DB on the first
+ * signed-in visit without any server-side job.
+ */
+function ensureSynced(): Promise<void> {
+  if (typeof window === "undefined") return Promise.resolve()
+  if (!syncPromise) {
+    syncPromise = (async () => {
+      let serverRows: Array<QuizResponseValue & { quizId: string }>
+      try {
+        const res = await fetch("/api/quiz-progress", {
+          signal: AbortSignal.timeout(4000),
+        })
+        if (!res.ok) return // 401 signed out, or transient — stay local
+        serverRows = (await res.json()).responses ?? []
+      } catch {
+        return // offline/timeout — stay local, retried on next page load
+      }
+
+      try {
+        const local = await getAllLocalResponses()
+        const server = new Map(serverRows.map((r) => [r.quizId, r]))
+
+        // Server → local: adopt server rows that beat what we have
+        const db = await getDBPromise()
+        for (const [quizId, remote] of server) {
+          const mine = local.get(quizId)
+          if (!mine || betterOf(remote, mine) === remote) {
+            const { quizId: _, ...value } = remote
+            await db.put(quizStoreName, value, quizId)
+          }
+        }
+
+        // Local → server: backfill rows the server lacks or trails on
+        const toPush = [...local.entries()]
+          .filter(([quizId, mine]) => {
+            const remote = server.get(quizId)
+            return !remote || betterOf(mine, remote) === mine
+          })
+          .map(([quizId, value]) => ({ quizId, ...value }))
+
+        if (toPush.length > 0) {
+          await fetch("/api/quiz-progress", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(toPush),
+          })
+        }
+      } catch (error) {
+        console.error("[quiz-sync] initial sync failed:", error)
+      }
+    })()
+  }
+  return syncPromise
+}
+
+async function pushResponse(quizId: string, response: QuizResponseValue): Promise<void> {
+  // Awaited (not fire-and-forget) so that when quiz.tsx awaits
+  // saveQuizResponse before firing onQuizCompleted, the server already has
+  // the row — the badge award's course-completion check depends on it. A
+  // failed push never blocks local save; it self-heals on the next page
+  // load, when ensureSynced pushes local rows the server is missing.
+  try {
+    await fetch(`/api/quiz-progress/${encodeURIComponent(quizId)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(response),
+      signal: AbortSignal.timeout(4000),
+    })
+  } catch (error) {
+    console.error("[quiz-sync] PUT failed for", quizId, error)
   }
 }
 
-export async function getQuizResponse(quizId: string): Promise<QuizDB["quizResponses"]["value"] | undefined> {
+export async function saveQuizResponse(quizId: string, response: QuizResponseValue) {
   if (typeof window !== "undefined") {
+    const db = await getDBPromise()
+    await db.put(quizStoreName, response, quizId)
+    await pushResponse(quizId, response)
+  }
+}
+
+export async function getQuizResponse(quizId: string): Promise<QuizResponseValue | undefined> {
+  if (typeof window !== "undefined") {
+    await ensureSynced()
     const db = await getDBPromise()
     return db.get(quizStoreName, quizId)
   }

--- a/utils/quizzes/indexedDB.ts
+++ b/utils/quizzes/indexedDB.ts
@@ -57,6 +57,8 @@ type QuizResponseValue = QuizDB["quizResponses"]["value"]
 // ---------------------------------------------------------------------------
 
 let syncPromise: Promise<void> | null = null
+// null = unknown, false = signed out (skip pushes instead of spamming 401s)
+let serverHasAccount: boolean | null = null
 
 function betterOf(a: QuizResponseValue, b: QuizResponseValue): QuizResponseValue {
   if (a.isCorrect !== b.isCorrect) return a.isCorrect ? a : b
@@ -88,7 +90,12 @@ function ensureSynced(): Promise<void> {
         const res = await fetch("/api/quiz-progress", {
           signal: AbortSignal.timeout(4000),
         })
-        if (!res.ok) return // 401 signed out, or transient — stay local
+        if (res.status === 401 || res.status === 403) {
+          serverHasAccount = false // signed out — stay local, skip later pushes
+          return
+        }
+        if (!res.ok) return // transient — stay local, retried next page load
+        serverHasAccount = true
         serverRows = (await res.json()).responses ?? []
       } catch {
         return // offline/timeout — stay local, retried on next page load
@@ -132,6 +139,7 @@ function ensureSynced(): Promise<void> {
 }
 
 async function pushResponse(quizId: string, response: QuizResponseValue): Promise<void> {
+  if (serverHasAccount === false) return // signed out — local-only, no 401 noise
   // Awaited (not fire-and-forget) so that when quiz.tsx awaits
   // saveQuizResponse before firing onQuizCompleted, the server already has
   // the row — the badge award's course-completion check depends on it. A

--- a/utils/quizzes/indexedDB.ts
+++ b/utils/quizzes/indexedDB.ts
@@ -19,17 +19,26 @@ interface QuizDB {
       totalCards: number
     }
   }
+  syncMeta: {
+    key: string
+    value: string
+  }
 }
 
 const dbName = "QuizDatabase"
 const quizStoreName = "quizResponses"
 const flashcardStoreName = "flashcardProgress"
+const syncMetaStoreName = "syncMeta"
+// syncMeta key holding the user id of the account the local rows belong to
+// (or were adopted by). Rows written while signed out have no owner until the
+// first signed-in sync claims them.
+const lastSyncedUserKey = "lastSyncedUserId"
 
 let dbPromise: Promise<IDBPDatabase<QuizDB>> | null = null
 
 function getDBPromise() {
   if (!dbPromise) {
-    dbPromise = openDB<QuizDB>(dbName, 2, {
+    dbPromise = openDB<QuizDB>(dbName, 3, {
       upgrade(db, oldVersion) {
         if (oldVersion < 1) {
           db.createObjectStore(quizStoreName)
@@ -37,6 +46,11 @@ function getDBPromise() {
         if (oldVersion < 2) {
           if (!db.objectStoreNames.contains(flashcardStoreName)) {
             db.createObjectStore(flashcardStoreName)
+          }
+        }
+        if (oldVersion < 3) {
+          if (!db.objectStoreNames.contains(syncMetaStoreName)) {
+            db.createObjectStore(syncMetaStoreName)
           }
         }
       },
@@ -86,6 +100,7 @@ function ensureSynced(): Promise<void> {
   if (!syncPromise) {
     syncPromise = (async () => {
       let serverRows: Array<QuizResponseValue & { quizId: string }>
+      let serverUserId: string | undefined
       try {
         const res = await fetch("/api/quiz-progress", {
           signal: AbortSignal.timeout(4000),
@@ -96,17 +111,31 @@ function ensureSynced(): Promise<void> {
         }
         if (!res.ok) return // transient — stay local, retried next page load
         serverHasAccount = true
-        serverRows = (await res.json()).responses ?? []
+        const payload = await res.json()
+        serverRows = payload.responses ?? []
+        serverUserId = payload.userId
       } catch {
         return // offline/timeout — stay local, retried on next page load
       }
 
       try {
+        const db = await getDBPromise()
+
+        // Account boundary: local rows belong to the account recorded at the
+        // last signed-in sync (anonymous rows are claimed by it below). If a
+        // different account is signed in now, those rows must not leak into
+        // it — neither through the backfill POST nor through reads that feed
+        // course-completion awards. Their owner's copy is already on the
+        // server, so dropping them here loses nothing.
+        const lastUser = await db.get(syncMetaStoreName, lastSyncedUserKey)
+        if (serverUserId && lastUser && lastUser !== serverUserId) {
+          await db.clear(quizStoreName)
+        }
+
         const local = await getAllLocalResponses()
         const server = new Map(serverRows.map((r) => [r.quizId, r]))
 
         // Server → local: adopt server rows that beat what we have
-        const db = await getDBPromise()
         for (const [quizId, remote] of server) {
           const mine = local.get(quizId)
           if (!mine || betterOf(remote, mine) === remote) {
@@ -129,6 +158,12 @@ function ensureSynced(): Promise<void> {
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(toPush),
           })
+        }
+
+        // Record who the local rows belong to from here on. This also claims
+        // anonymous pre-login rows for the account that just adopted them.
+        if (serverUserId) {
+          await db.put(syncMetaStoreName, serverUserId, lastSyncedUserKey)
         }
       } catch (error) {
         console.error("[quiz-sync] initial sync failed:", error)


### PR DESCRIPTION
Quiz progress currently lives only in localStorage/IndexedDB, so it dies with the browser profile — and the Academy certificate flow can lock users out of badges they earned on another device (#4357).

This PR moves quiz progress to the database and keeps the client in sync:

- **`QuizResponse` model + `quizProgress` service** — per-user progress rows, correctness recomputed server-side (the client never gets to claim a right answer).
- **API** — `GET` all progress, `PUT` one response, bulk `POST` for first-visit backfill from the browser's existing local state.
- **Client sync layer** — pulls account rows on load, pushes saves, backfills local history once; signed-out users keep working locally and stop pushing to the API.
- **Badges** — course completion is verified against the DB before an academy badge is awarded.
- **Hardening** — Zod shape validation, rate-limited writes, atomic correct-row freeze, bounded selection arrays.
- **Login resync** (the two issues found in testing, one root cause): the login modal closes in place without a page load, so the sync layer's page-load cache survived login — answers stayed invisible and saves were skipped until refresh. `resyncQuizProgress()` drops both caches and re-runs the sync on the login-complete event and on any unauthenticated→authenticated session transition; the IndexedDB readers re-read once the pull lands. Verified against the reported flows on a live DB; 5 unit tests cover the resync layer (516 green total).

Closes #4357
