### PR TITLE
fix(console): pin EVM tx nonce to chain pending count

### DIFF
--- a/components/toolbox/hooks/contracts/parseContractError.ts
+++ b/components/toolbox/hooks/contracts/parseContractError.ts
@@ -194,7 +194,7 @@ export function parseContractError(err: unknown): string {
 
   // Nonce errors
   if (raw.includes('nonce')) {
-    return 'Transaction nonce error. Please try again.';
+    return 'Transaction nonce error: the wallet signed with an already-used nonce. Retry the transaction; a fresh nonce is fetched from the chain automatically. Do not edit the nonce manually.';
   }
 
   // Check for known selectors and error names

--- a/components/toolbox/hooks/contracts/useContractActions.ts
+++ b/components/toolbox/hooks/contracts/useContractActions.ts
@@ -139,6 +139,23 @@ export function useContractActions(contractAddress: string | null, abi: Abi | re
       }
     }
 
+    // Pin the nonce to the chain's pending count. The wallet's internal
+    // nonce cache can lag right after a prior transaction mines (e.g. the
+    // ICTT approve immediately after a send), which makes it sign with an
+    // already-used nonce and fail with "nonce too low" / NONCE_EXPIRED.
+    // The chain RPC is the source of truth; best-effort, fall back to the
+    // wallet's own nonce if the read fails.
+    if (publicClient) {
+      try {
+        txConfig.nonce = await publicClient.getTransactionCount({
+          address: walletEVMAddress as `0x${string}`,
+          blockTag: 'pending',
+        });
+      } catch {
+        // RPC blip: let the wallet fill the nonce as before.
+      }
+    }
+
     const writePromise = walletClient.writeContract(txConfig);
 
     notify(


### PR DESCRIPTION
## What changed
- `useContractActions.write` now fetches the pending nonce from the selected chain's RPC and passes it explicitly, instead of letting the wallet fill it. The wallet's internal nonce cache can lag right after a prior transaction mines (for example the ICTT approve immediately after a send), which produces "nonce too low" / NONCE_EXPIRED failures. Falls back to wallet-filled nonce if the RPC read fails. Same pattern as `useAdvanceProposerVM`.
- `parseContractError` nonce message is now actionable: retry, a fresh nonce is fetched automatically, do not edit the nonce manually.

## Why
A Core Support user hit this on /console/ictt/live (Fuji): first transfer succeeded, second transfer's approve failed with "nonce too low: next nonce 26, tx nonce 25".

## Verification
- `tsc --noEmit` passes; lint-staged (prettier, eslint, tsc) passed on commit.
- All ICTT writes (approve, send, register, collateral) route through `useContractActions.write`, so one change covers the flow.