### PR TITLE
fix(console): rename Gnosis Safe multisig label to Safe multisig

### DIFF
--- a/components/toolbox/console/create-l1/CreateL1Questionnaire.tsx
+++ b/components/toolbox/console/create-l1/CreateL1Questionnaire.tsx
@@ -714,7 +714,7 @@ export default function CreateL1Questionnaire() {
                   selected={multisig}
                   onSelect={() => setMultisig(true)}
                   icon={<Users className="h-5 w-5" />}
-                  title="Gnosis Safe multisig"
+                  title="Safe multisig"
                   description={
                     vmLocation === 'c-chain'
                       ? 'Transfer ownership to a Safe on C-Chain. Production-ready security.'


### PR DESCRIPTION
﻿fixes #4211

the multisig option card in the l1 creation questionnaire still said "Gnosis Safe multisig" — safe dropped the gnosis brand in 2022 and the card's own description lines already say just "Safe". one-line label change, no logic touched.
