### PR TITLE
fix(login): surface basic-profile save failures and resolve pending user id

### DIFF
--- a/components/login/BasicProfileSetup.tsx
+++ b/components/login/BasicProfileSetup.tsx
@@ -37,6 +37,7 @@ import {
   TELEGRAM_ACCOUNT_PATTERN,
   X_ACCOUNT_PATTERN,
 } from '@/lib/profile/socialAccountValidation';
+import { saveBasicProfile } from '@/lib/profile/basicProfileSave';
 
 // Form schema. Social fields are optional; only name + country + at least
 // one role are required to complete the basic setup. When a social field is
@@ -103,6 +104,7 @@ interface BasicProfileSetupProps {
 
 export function BasicProfileSetup({ userId, onCompleteProfile }: BasicProfileSetupProps) {
   const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [githubConnected, setGithubConnected] = useState(false);
   const [xConnected, setXConnected] = useState(false);
   const pathname = usePathname();
@@ -199,6 +201,7 @@ export function BasicProfileSetup({ userId, onCompleteProfile }: BasicProfileSet
 
   const handleSave = async (data: BasicProfileFormValues) => {
     setIsSaving(true);
+    setSaveError(null);
     try {
       // Format data to match the API expected format
       const {
@@ -236,8 +239,26 @@ export function BasicProfileSetup({ userId, onCompleteProfile }: BasicProfileSet
         }
       };
 
-      // Save to API using extended profile endpoint
-      await axios.put(`/api/profile/extended/${userId}`, profileData);
+      // Save via the extracted flow: it resolves a still-pending user id
+      // through a session refresh before the PUT (a pending_* id always
+      // 403s), and only reports success when the server-confirmed profile
+      // passes the same completeness check that decides whether the modal
+      // reopens. Every failure becomes a visible message instead of a
+      // silently swallowed error (#4388).
+      const outcome = await saveBasicProfile(
+        {
+          userId,
+          refreshSession: update,
+          putProfile: async (id, payload) =>
+            (await axios.put(`/api/profile/extended/${id}`, payload)).data,
+        },
+        profileData,
+      );
+
+      if (!outcome.ok) {
+        setSaveError(outcome.message);
+        return;
+      }
 
       // Update session
       await update();
@@ -245,6 +266,7 @@ export function BasicProfileSetup({ userId, onCompleteProfile }: BasicProfileSet
       onCompleteProfile?.();
     } catch (error) {
       console.error('Error saving basic profile:', error);
+      setSaveError("Couldn't save your profile. Please try again.");
     } finally {
       setIsSaving(false);
     }
@@ -711,6 +733,11 @@ export function BasicProfileSetup({ userId, onCompleteProfile }: BasicProfileSet
             </div>
 
             {/* Submit */}
+            {saveError && (
+              <p role="alert" className="pt-3 text-sm text-red-600 dark:text-red-400">
+                {saveError}
+              </p>
+            )}
             <div className="pt-4 sm:pt-5">
               <LoadingButton
                 type="submit"

--- a/components/login/LoginModalWrapper.tsx
+++ b/components/login/LoginModalWrapper.tsx
@@ -296,8 +296,16 @@ export function LoginModalWrapper() {
                   <Dialog.Description>Complete basic profile information for your Builder Hub account.</Dialog.Description>
                 </VisuallyHidden>
                 <div className="px-5 py-5 overflow-y-auto" style={{ maxHeight: '90vh' }}>
+                  {/* Prefer the session's materialized id over a stored
+                      pending_* one: the profile PUT only accepts the
+                      session's own id, so saving against a stale pending id
+                      is a guaranteed 403 (#4388). */}
                   <BasicProfileSetup
-                    userId={(termsUserId || session?.user?.id)!}
+                    userId={
+                      (session?.user?.id && !session.user.id.startsWith('pending_')
+                        ? session.user.id
+                        : termsUserId || session?.user?.id)!
+                    }
                     onCompleteProfile={handleCompleteProfile}
                   />
                 </div>

--- a/lib/profile/basicProfileSave.ts
+++ b/lib/profile/basicProfileSave.ts
@@ -1,0 +1,98 @@
+import { hasCompleteBasicProfile, type BasicProfileShape } from './socialAccountValidation';
+
+/**
+ * Save flow for the "Help us know you better" basic profile modal.
+ *
+ * Extracted from the component so the failure paths are unit-testable: the
+ * modal used to swallow every save error (console.error only), which meant a
+ * failed PUT — most commonly a 403 from saving against a provisional
+ * `pending_*` user id before the session materializes — looked identical to
+ * success. Nothing reached the database, and the modal came back on every new
+ * device or session (#4388).
+ */
+
+export interface SaveBasicProfileDeps {
+  /** The user id the modal was opened with (may still be a `pending_*` id). */
+  userId: string;
+  /** Refreshes the auth session and resolves with the latest session object. */
+  refreshSession: () => Promise<{ user?: { id?: string | null } } | null | undefined>;
+  /** PUTs the profile payload and resolves with the server's updated profile. */
+  putProfile: (userId: string, payload: unknown) => Promise<BasicProfileShape | null | undefined>;
+}
+
+export type SaveBasicProfileOutcome =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: 'session-not-ready' | 'request-failed' | 'incomplete-after-save';
+      message: string;
+    };
+
+const isPendingId = (id: string | null | undefined): boolean =>
+  typeof id === 'string' && id.startsWith('pending_');
+
+/**
+ * Resolves the real user id to save against. A `pending_*` id is doomed to a
+ * 403 (the extended-profile route only accepts the session's own id), so we
+ * refresh the session first and only proceed with a materialized id.
+ */
+export async function resolveProfileUserId(
+  userId: string,
+  refreshSession: SaveBasicProfileDeps['refreshSession'],
+): Promise<string | null> {
+  if (!isPendingId(userId)) return userId;
+  try {
+    const session = await refreshSession();
+    const refreshedId = session?.user?.id;
+    if (refreshedId && !isPendingId(refreshedId)) return refreshedId;
+  } catch {
+    // fall through — treated as "session not ready"
+  }
+  return null;
+}
+
+export async function saveBasicProfile(
+  deps: SaveBasicProfileDeps,
+  payload: unknown,
+): Promise<SaveBasicProfileOutcome> {
+  const targetId = await resolveProfileUserId(deps.userId, deps.refreshSession);
+  if (!targetId) {
+    return {
+      ok: false,
+      reason: 'session-not-ready',
+      message: "Your session isn't ready yet. Please try saving again in a moment.",
+    };
+  }
+
+  let updated: BasicProfileShape | null | undefined;
+  try {
+    updated = await deps.putProfile(targetId, payload);
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'request-failed',
+      message: extractServerErrorMessage(error) ?? "Couldn't save your profile. Please try again.",
+    };
+  }
+
+  // Close only when the server-confirmed profile passes the same completeness
+  // check that decides whether to reopen the modal — otherwise it would
+  // silently come back on the next mount.
+  if (!hasCompleteBasicProfile(updated)) {
+    return {
+      ok: false,
+      reason: 'incomplete-after-save',
+      message: 'Your profile was saved but looks incomplete. Please review the required fields and save again.',
+    };
+  }
+
+  return { ok: true };
+}
+
+/** Pulls the API's `{ error: string }` body out of an axios-style error. */
+function extractServerErrorMessage(error: unknown): string | null {
+  if (typeof error !== 'object' || error === null) return null;
+  const response = (error as { response?: { data?: { error?: unknown } } }).response;
+  const message = response?.data?.error;
+  return typeof message === 'string' && message.length > 0 ? message : null;
+}

--- a/lib/profile/socialAccountValidation.ts
+++ b/lib/profile/socialAccountValidation.ts
@@ -6,7 +6,7 @@ export const LINKEDIN_ACCOUNT_PATTERN = /^https?:\/\/(?:www\.)?linkedin\.com\/(?
 export const GITHUB_ACCOUNT_PATTERN = /^(?:[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}|https?:\/\/(?:www\.)?github\.com\/[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}\/?)$/i;
 export const TELEGRAM_ACCOUNT_PATTERN = /^@?[A-Za-z][A-Za-z0-9_]{4,31}$/;
 
-type BasicProfileShape = {
+export type BasicProfileShape = {
   name?: unknown;
   country?: unknown;
   user_type?: {

--- a/tests/unit/profile/basicProfileSave.test.ts
+++ b/tests/unit/profile/basicProfileSave.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { resolveProfileUserId, saveBasicProfile } from '@/lib/profile/basicProfileSave';
+
+const COMPLETE_PROFILE = {
+  name: 'Test User',
+  country: 'Turkey',
+  user_type: { is_developer: true },
+};
+
+const completePayload = { name: 'Test User', country: 'Turkey', user_type: { is_developer: true } };
+
+describe('resolveProfileUserId', () => {
+  it('returns a materialized id untouched without refreshing the session', async () => {
+    const refreshSession = vi.fn();
+    expect(await resolveProfileUserId('user-1', refreshSession)).toBe('user-1');
+    expect(refreshSession).not.toHaveBeenCalled();
+  });
+
+  it('swaps a pending id for the refreshed session id', async () => {
+    const refreshSession = vi.fn().mockResolvedValue({ user: { id: 'user-real' } });
+    expect(await resolveProfileUserId('pending_abc', refreshSession)).toBe('user-real');
+  });
+
+  it('returns null when the session stays pending', async () => {
+    const refreshSession = vi.fn().mockResolvedValue({ user: { id: 'pending_abc' } });
+    expect(await resolveProfileUserId('pending_abc', refreshSession)).toBeNull();
+  });
+
+  it('returns null when the session refresh throws', async () => {
+    const refreshSession = vi.fn().mockRejectedValue(new Error('network'));
+    expect(await resolveProfileUserId('pending_abc', refreshSession)).toBeNull();
+  });
+});
+
+describe('saveBasicProfile', () => {
+  it('saves against the resolved id and confirms completeness (the #4388 repro, fixed)', async () => {
+    // Repro from the issue: modal opened with a pending_* id. The old code
+    // PUT against it, got a 403, and swallowed it — the user saw nothing and
+    // the profile never persisted. The fix resolves the real id first.
+    const putProfile = vi.fn().mockResolvedValue(COMPLETE_PROFILE);
+    const outcome = await saveBasicProfile(
+      {
+        userId: 'pending_abc',
+        refreshSession: vi.fn().mockResolvedValue({ user: { id: 'user-real' } }),
+        putProfile,
+      },
+      completePayload,
+    );
+    expect(outcome).toEqual({ ok: true });
+    expect(putProfile).toHaveBeenCalledWith('user-real', completePayload);
+  });
+
+  it('reports session-not-ready instead of PUTting a doomed pending id', async () => {
+    const putProfile = vi.fn();
+    const outcome = await saveBasicProfile(
+      {
+        userId: 'pending_abc',
+        refreshSession: vi.fn().mockResolvedValue({ user: { id: 'pending_abc' } }),
+        putProfile,
+      },
+      completePayload,
+    );
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.reason).toBe('session-not-ready');
+    expect(putProfile).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the server error body when the PUT fails', async () => {
+    const axios403 = Object.assign(new Error('Request failed with status code 403'), {
+      response: { data: { error: 'Forbidden: You can only update your own profile.' } },
+    });
+    const outcome = await saveBasicProfile(
+      {
+        userId: 'user-real',
+        refreshSession: vi.fn(),
+        putProfile: vi.fn().mockRejectedValue(axios403),
+      },
+      completePayload,
+    );
+    expect(outcome).toEqual({
+      ok: false,
+      reason: 'request-failed',
+      message: 'Forbidden: You can only update your own profile.',
+    });
+  });
+
+  it('falls back to a generic message when the failure has no server body', async () => {
+    const outcome = await saveBasicProfile(
+      {
+        userId: 'user-real',
+        refreshSession: vi.fn(),
+        putProfile: vi.fn().mockRejectedValue(new Error('Network Error')),
+      },
+      completePayload,
+    );
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.reason).toBe('request-failed');
+      expect(outcome.message).toBe("Couldn't save your profile. Please try again.");
+    }
+  });
+
+  it('refuses to report success when the stored profile would reopen the modal', async () => {
+    const outcome = await saveBasicProfile(
+      {
+        userId: 'user-real',
+        refreshSession: vi.fn(),
+        // Server answered 200 but the stored row lacks a role flag — the
+        // reopen check would bring the modal back on the next mount.
+        putProfile: vi.fn().mockResolvedValue({ name: 'Test User', country: 'Turkey', user_type: {} }),
+      },
+      completePayload,
+    );
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.reason).toBe('incomplete-after-save');
+  });
+});


### PR DESCRIPTION
﻿fixes #4388

the "help us know you better" modal decides whether to reopen from the server (`hasCompleteBasicProfile` over `/api/profile/extended`), but the save path could fail without telling anyone: `handleSave` swallowed every error (console.error only), and in the new-user flow the modal could be handed a stale `pending_*` user id — the profile PUT only accepts the session's own id, so that save was a guaranteed 403. net effect: the user filled the form, saw the spinner stop, nothing was stored, and the modal came back on every new device or session — exactly the report.

changes:
- extracted the save flow to `lib/profile/basicProfileSave.ts`: resolves a pending id through a session refresh before the PUT, surfaces the server's error body on failure, and only reports success when the server-confirmed profile passes the same completeness check the reopen logic uses
- `BasicProfileSetup` now shows a visible error (`role="alert"`) instead of swallowing failures
- `LoginModalWrapper` prefers the session's materialized id over a stored pending one
- 9 unit tests covering the pending-id repro and each failure path

verified locally against a real db: fresh email signup → terms → modal → save → `PUT /api/profile/extended/<real id> 200`, row persisted (name/country/user_type), and the modal no longer reappears on subsequent mounts.
