### PR TITLE
docs(rpcs): expand base fee history and Helicon fee changes

### DIFF
--- a/content/docs/rpcs/other/guides/txn-fees.mdx
+++ b/content/docs/rpcs/other/guides/txn-fees.mdx
@@ -50,7 +50,27 @@ Based off of this information, you can specify the `gasFeeCap` and `gasTipCap` t
 
 #### Base Fee[​](#base-fee)
 
-The base fee can go as low as 1 wei and has no upper bound. With the upcoming Helicon Upgrade (ACP-283), the minimum gas price will become a dynamic parameter adjustable by validators. You can use the [`eth_baseFee`](/docs/rpcs/c-chain#eth_basefee) and [eth\_maxPriorityFeePerGas](/docs/rpcs/c-chain#eth_maxpriorityfeepergas) API methods, or [Snowtrace's C-Chain Gas Tracker](https://snowtrace.io/gastracker), to estimate the gas price to use in your transactions.
+Since the Fortuna upgrade activated [ACP-176](/docs/acps/176-dynamic-evm-gas-limit-and-price-discovery-updates) on April 8, 2025, the minimum base fee on the C-Chain is 1 wei, and there is no upper bound. Under normal load the base fee sits well below 1 nAVAX. You can use the [`eth_baseFee`](/docs/rpcs/c-chain#eth_basefee) and [eth\_maxPriorityFeePerGas](/docs/rpcs/c-chain#eth_maxpriorityfeepergas) API methods, or [Snowtrace's C-Chain Gas Tracker](https://snowtrace.io/gastracker), to estimate the gas price to use in your transactions.
+
+The minimum base fee has changed across network upgrades:
+
+| Minimum base fee | In effect | Introduced by |
+| --- | --- | --- |
+| 25 nAVAX | September 22, 2021 to December 16, 2024 | Apricot Phase 4 |
+| 1 nAVAX | December 16, 2024 to April 8, 2025 | Etna upgrade ([ACP-125](/docs/acps/125-basefee-reduction)) |
+| 1 wei | since April 8, 2025 | Fortuna upgrade ([ACP-176](/docs/acps/176-dynamic-evm-gas-limit-and-price-discovery-updates)) |
+
+With the Helicon upgrade (active on Fuji since July 28, 2026 at 15:00 UTC, not yet scheduled on Mainnet), [ACP-283](/docs/acps/283-dynamic-minimum-gas-price) makes the minimum gas price a dynamic parameter driven by stake-weighted validator preference. It starts at 1 wei at activation and moves only if validators prefer a different floor.
+
+<Callout type="info" title="Helicon also changes how transactions pay fees (ACP-194)">
+[Continuous Execution](/docs/acps/194-continuous-execution) decouples consensus from execution, which changes fee handling on networks where Helicon is active:
+
+- The `baseFeePerGas` field in block headers becomes a worst-case bound on the gas price at the start of the block's execution, not the realized price.
+- To be included, a transaction's sender must be able to cover the worst-case cost at inclusion time: the gas limit times the worst-case gas price, plus any transferred value.
+- Gas charged becomes `max(gasUsed, gasLimit / 2)`, so setting a gas limit more than twice the actual usage costs real money.
+
+See the [Helicon Upgrade page](/docs/primary-network/helicon-upgrade) for the full list of changes.
+</Callout>
 
 ### Atomic Transaction Fees[​](#atomic-transaction-fees)
 


### PR DESCRIPTION
## Summary

Follow-up to `de3c2c511`, which corrected the C-Chain base fee floor from "1 nAVAX" to "1 wei" after a user report (the stale claim dated from the Etna era and had been wrong since Fortuna activated ACP-176 in April 2025). This PR expands the Base Fee section of the transaction fees guide so the correction is self-explanatory and Helicon-ready:

- Attribute the 1 wei floor to ACP-176 (Fortuna, April 8, 2025) and note that the base fee sits well below 1 nAVAX under normal load (93 to 99.9 percent of blocks in every month of 2026).
- Add a minimum base fee history table: 25 nAVAX (Apricot Phase 4) to 1 nAVAX (Etna, ACP-125) to 1 wei (Fortuna, ACP-176).
- Replace "upcoming Helicon Upgrade" with the exact activation status (active on Fuji since July 28, 2026 at 15:00 UTC, not yet scheduled on Mainnet) and clarify that the ACP-283 dynamic floor starts at 1 wei and moves by stake-weighted validator preference.
- Add a callout for the ACP-194 (Continuous Execution) fee-facing changes: header `baseFeePerGas` becomes a worst-case bound, senders must cover worst-case cost at inclusion, and gas charged becomes `max(gasUsed, gasLimit / 2)`.

## Test plan

- [x] Floor values and dates cross-checked against `info.upgrades`, coreth constants (`ApricotPhase4MinBaseFee`, `EtnaMinBaseFee`), and the ACP-125/176/283/194 specs
- [x] Distribution claims verified on-chain (block-weighted monthly stats, chain 43114; live `eth_baseFee` currently ~0.06 nAVAX on Mainnet, 10 wei on Fuji)
- [x] All five internal links resolve (`/docs/acps/125`, `/docs/acps/176`, `/docs/acps/283`, `/docs/acps/194-continuous-execution`, `/docs/primary-network/helicon-upgrade`)
- [x] Table and `Callout` follow existing patterns in `content/docs/rpcs/`; no MDX-unsafe syntax
- [ ] Preview deploy renders the section correctly