### PR TITLE
fix(explorer): unify date format on the staking page charts

### DIFF
--- a/components/explorer-v2/staking/StakingMetricPage.tsx
+++ b/components/explorer-v2/staking/StakingMetricPage.tsx
@@ -544,7 +544,7 @@ function RewardsSheet({ base, network }: { base: string; network: string }) {
               <ResponsiveContainer width="100%" height="100%">
                 <ComposedChart data={paidSeries} margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
                   <SheetGrid />
-                  <XAxis dataKey="date" tickLine={false} axisLine={false} minTickGap={48} tick={AXIS_TICK} />
+                  <XAxis dataKey="date" tickLine={false} axisLine={false} minTickGap={48} tick={AXIS_TICK} tickFormatter={dateTick} />
                   <YAxis domain={[0, "dataMax"]} width={54} tickLine={false} axisLine={false} tick={AXIS_TICK} tickFormatter={(v: number) => fmtCompact(v)} />
                   <RechartsTooltip
                     cursor={{ fill: "rgba(161,161,170,0.08)" }}
@@ -743,7 +743,7 @@ function ExpirySheet({ base, network }: { base: string; network: string }) {
               <ResponsiveContainer width="100%" height="100%">
                 <ComposedChart data={series} margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
                   <SheetGrid />
-                  <XAxis dataKey="date" tickLine={false} axisLine={false} minTickGap={48} tick={AXIS_TICK} />
+                  <XAxis dataKey="date" tickLine={false} axisLine={false} minTickGap={48} tick={AXIS_TICK} tickFormatter={dateTick} />
                   <YAxis yAxisId="day" domain={[0, "dataMax"]} width={54} tickLine={false} axisLine={false} tick={AXIS_TICK} tickFormatter={(v: number) => fmtCompact(v)} />
                   <YAxis yAxisId="cum" orientation="right" domain={[0, "dataMax"]} width={54} tickLine={false} axisLine={false} tick={AXIS_TICK} tickFormatter={(v: number) => fmtCompact(v)} />
                   <RechartsTooltip

--- a/lib/explorer-clickhouse.ts
+++ b/lib/explorer-clickhouse.ts
@@ -330,6 +330,7 @@ const PCHAIN_NETWORK_IDS: Record<string, number> = {
 };
 
 export interface PchainRewardPoint {
+  /** UTC day, YYYY-MM-DD; display formatting is the client's job */
   date: string;
   /** AVAX minted to stakers that day */
   avax: number;
@@ -338,6 +339,7 @@ export interface PchainRewardPoint {
 }
 
 export interface PchainUnlockPoint {
+  /** UTC day, YYYY-MM-DD; display formatting is the client's job */
   date: string;
   /** AVAX whose staking period ends that day (validators + delegators) */
   avax: number;
@@ -447,7 +449,7 @@ export async function getPchainStakingSeries(
 
     const rewardsByDay = new Map(rewardRows.map((r) => [r.day, r]));
     const rewards = buildPastDates(days).map((iso) => ({
-      date: formatDayLabel(iso),
+      date: iso,
       avax: Number(rewardsByDay.get(iso)?.avax) || 0,
       payouts: Number(rewardsByDay.get(iso)?.payouts) || 0,
     }));
@@ -460,7 +462,7 @@ export async function getPchainStakingSeries(
       unlocksByDay.set(r.day, day);
     }
     const unlocks = buildFutureDates(days).map((iso) => ({
-      date: formatDayLabel(iso),
+      date: iso,
       avax: Math.round(unlocksByDay.get(iso)?.avax ?? 0),
       stakers: unlocksByDay.get(iso)?.stakers ?? 0,
     }));


### PR DESCRIPTION
## What changed
The staking money-flow feed (`/api/pchain-activity`) baked "Aug 20" style labels into its JSON server side. Every other explorer feed serves ISO `YYYY-MM-DD` and formats at display time, so the two money-flow charts on `/explorer/mainnet/p-chain/staking` (Rewards Paid, Stake Expiring) showed a different date format than the rest of the page.

- `getPchainStakingSeries` now serves ISO dates; the interface docs state the contract.
- The two money-flow sheet axes (Paid Out Per Day, Unlock Schedule) get the same `MM-DD` tick formatter their sibling charts already use.
- Tooltips on the staking overview, both metric sheets, and the P-Chain home money cards now all show `YYYY-MM-DD`, matching the rest of explorer-v2.

## Verification
`tsc --noEmit` passes. All feed consumers checked: `PrimaryStaking`, `StakingMetricPage` (rewards + expiry sheets), `PchainHome`.

## Notes
CDN-cached responses keep the old labels for up to ~30 min after deploy; tooltips fall back to showing them as-is.
The daily-txs, L1-ops, and activity-mix feeds still serve pre-formatted labels on other pages; left as is to keep this to one concern.