### PR TITLE
feat(evaluate): auto-hide link-less submissions + fix picking-phase gate

### DIFF
--- a/app/(home)/events/[id]/evaluate/page.tsx
+++ b/app/(home)/events/[id]/evaluate/page.tsx
@@ -7,6 +7,10 @@ import {
   hasAnyAttribute,
 } from "@/lib/auth/permissions";
 import { stripEvaluationsForViewer } from "@/lib/hackathons/evaluation-phase";
+import {
+  countReviewProgress,
+  projectHasNoLinks,
+} from "@/lib/hackathons/project-links";
 import { HackathonEvaluateDashboard } from "@/components/evaluate/HackathonEvaluateDashboard";
 
 export default async function HackathonEvaluatePage({
@@ -91,10 +95,17 @@ export default async function HackathonEvaluatePage({
   const viewerId = session!.user!.id;
   const isDevrel = hasAnyAttribute(session?.user?.custom_attributes, ["devrel"]);
 
-  // Rejected projects must never reach the client for non-devrel users — filter server-side.
+  // Link-less projects have nothing to judge: auto-hidden, like a manual reject.
+  const flaggedProjects = projects.map((p) => ({
+    ...p,
+    auto_hidden: projectHasNoLinks(p),
+  }));
+
+  // Hidden projects (rejected or auto-hidden) must never reach the client for
+  // non-devrel users — filter server-side.
   const visibleProjects = isDevrel
-    ? projects
-    : projects.filter((p) => !p.is_rejected);
+    ? flaggedProjects
+    : flaggedProjects.filter((p) => !p.is_rejected && !p.auto_hidden);
 
   const projectsForViewer = stripEvaluationsForViewer(
     visibleProjects,
@@ -102,8 +113,8 @@ export default async function HackathonEvaluatePage({
     viewerId,
   );
 
-  // Reviewed count is based on visible projects only
-  const reviewedCount = visibleProjects.filter((p) => p.evaluations.length > 0).length;
+  // Reviewed count only tracks projects judges can actually review
+  const { reviewed: reviewedCount } = countReviewProgress(visibleProjects);
 
   return (
     <main className="container relative px-4 py-8 lg:py-12">

--- a/app/api/events/[id]/evaluation-phase/route.ts
+++ b/app/api/events/[id]/evaluation-phase/route.ts
@@ -6,6 +6,10 @@ import {
   canEvaluateHackathon,
   canManageEvaluationPhase,
 } from "@/lib/auth/permissions";
+import {
+  countReviewProgress,
+  projectHasNoLinks,
+} from "@/lib/hackathons/project-links";
 import type { RouteParams } from "@/lib/protectedRoute";
 
 type Params = RouteParams<{ id: string }>;
@@ -17,16 +21,24 @@ async function loadPhaseWithCounts(hackathonId: string) {
   });
   if (!hackathon) return null;
 
-  const total = await prisma.project.count({
+  // Hidden projects (rejected or link-less) never reach judges, so only
+  // eligible projects count toward the review gate.
+  const projects = await prisma.project.findMany({
     where: { hackaton_id: hackathonId },
+    select: {
+      is_rejected: true,
+      github_repository: true,
+      demo_link: true,
+      demo_video_link: true,
+      website: true,
+      socials: true,
+      deployed_addresses: true,
+      evaluations: { select: { id: true }, take: 1 },
+    },
   });
-
-  const reviewedRows = await prisma.evaluation.findMany({
-    where: { project: { hackaton_id: hackathonId } },
-    select: { project_id: true },
-    distinct: ["project_id"],
-  });
-  const reviewed = reviewedRows.filter((r) => r.project_id !== null).length;
+  const { reviewed, total } = countReviewProgress(
+    projects.map((p) => ({ ...p, auto_hidden: projectHasNoLinks(p) })),
+  );
 
   return {
     phase: hackathon.evaluation_phase,
@@ -78,7 +90,10 @@ export async function POST(_request: NextRequest, context: Params) {
   if (current.total === 0 || current.reviewed < current.total) {
     return NextResponse.json(
       {
-        error: "Not all projects have been reviewed",
+        error:
+          current.total === 0
+            ? "No eligible projects to review — every submission is hidden or has no links"
+            : "Not all projects have been reviewed",
         reviewed: current.reviewed,
         total: current.total,
       },

--- a/app/api/events/[id]/projects/route.ts
+++ b/app/api/events/[id]/projects/route.ts
@@ -3,9 +3,11 @@ import { prisma } from "@/prisma/prisma";
 import { getAuthSession } from "@/lib/auth/authSession";
 import {
   canEvaluateHackathon,
+  hasAnyAttribute,
   verifyHackathonProjectsApiKey,
 } from "@/lib/auth/permissions";
 import { stripEvaluationsForViewer } from "@/lib/hackathons/evaluation-phase";
+import { projectHasNoLinks } from "@/lib/hackathons/project-links";
 import type { RouteParams } from "@/lib/protectedRoute";
 
 type Params = RouteParams<{ id: string }>;
@@ -62,12 +64,17 @@ export async function GET(request: NextRequest, context: Params) {
   if (internalAuthorized) {
     const session = await getAuthSession();
     const viewerId = session?.user?.id ?? null;
+    const isDevrel = hasAnyAttribute(session?.user?.custom_attributes, [
+      "devrel",
+    ]);
 
     const projects = await prisma.project.findMany({
       where: { hackaton_id: hackathonId },
       orderBy: { created_at: "asc" },
       select: {
         ...projectMetaSelect,
+        is_rejected: true,
+        deployed_addresses: true,
         members: {
           select: {
             id: true,
@@ -97,8 +104,14 @@ export async function GET(request: NextRequest, context: Params) {
       },
     });
 
+    // Hidden projects (rejected or link-less) must never reach non-devrel
+    // callers — same server-side filter as the evaluate page.
+    const visibleProjects = isDevrel
+      ? projects
+      : projects.filter((p) => !p.is_rejected && !projectHasNoLinks(p));
+
     const projectsForViewer = stripEvaluationsForViewer(
-      projects,
+      visibleProjects,
       hackathon.evaluation_phase,
       viewerId,
     );

--- a/components/evaluate/HackathonEvaluateDashboard.tsx
+++ b/components/evaluate/HackathonEvaluateDashboard.tsx
@@ -29,6 +29,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ArrowDown, ArrowUp, ArrowUpDown, CheckCircle2, Eye, EyeOff, Lock, Trophy, Unlock } from "lucide-react";
+import { countReviewProgress } from "@/lib/hackathons/project-links";
 import { SubmissionDetailPanel } from "./SubmissionDetailPanel";
 import type { EvaluationData, SubmissionRow, Verdict } from "./types";
 
@@ -78,6 +79,9 @@ type Project = {
   socials: unknown;
   is_winner: boolean | null;
   is_rejected: boolean;
+  // Derived server-side: the submission has no links at all, so it is hidden
+  // from judges automatically (no Restore — it heals itself if links appear).
+  auto_hidden: boolean;
   created_at: string;
   members: Member[];
   evaluations: Evaluation[];
@@ -261,9 +265,10 @@ export function HackathonEvaluateDashboard({
   const [phaseError, setPhaseError] = useState<string | null>(null);
 
   const isEvaluation = phase === HackathonEvaluationPhase.EVALUATION;
-  const totalProjects = projects.length;
-  const reviewedCount = useMemo(
-    () => projects.filter((p) => p.evaluations.length > 0).length,
+  // Hidden projects (rejected or auto-hidden) can never be reviewed by judges,
+  // so they must not count toward the phase gate.
+  const { reviewed: reviewedCount, total: totalProjects } = useMemo(
+    () => countReviewProgress(projects),
     [projects],
   );
   const reviewed = projects.length === 0 ? initialReviewed : reviewedCount;
@@ -311,10 +316,11 @@ export function HackathonEvaluateDashboard({
         return (av - bv) * dir;
       });
     })();
-    // Rejected projects always sink to the bottom
+    // Hidden projects (rejected or auto-hidden) always sink to the bottom
+    const isHidden = (p: Project) => p.is_rejected || p.auto_hidden;
     return [...base].sort((a, b) => {
-      if (a.is_rejected === b.is_rejected) return 0;
-      return a.is_rejected ? 1 : -1;
+      if (isHidden(a) === isHidden(b)) return 0;
+      return isHidden(a) ? 1 : -1;
     });
   }, [filtered, sort, viewerId]);
 
@@ -577,18 +583,19 @@ export function HackathonEvaluateDashboard({
               const mine = p.evaluations.find((e) => e.evaluator_id === viewerId);
               const evaluatedByMe = Boolean(mine);
               const isRejected = p.is_rejected;
+              const isHiddenRow = isRejected || p.auto_hidden;
               return (
                 <TableRow
                   key={p.id}
                   className={
                     "cursor-pointer relative " +
-                    (isRejected
+                    (isHiddenRow
                       ? "opacity-40 hover:opacity-60 transition-opacity"
                       : evaluatedByMe
                         ? "bg-emerald-50/40 dark:bg-emerald-500/5"
                         : "")
                   }
-                  onClick={() => !isRejected && setOpenProjectId(p.id)}
+                  onClick={() => !isHiddenRow && setOpenProjectId(p.id)}
                 >
                   <TableCell className="overflow-hidden">
                     <div className="flex items-center gap-3 min-w-0">
@@ -601,7 +608,7 @@ export function HackathonEvaluateDashboard({
                         <div className="flex items-center gap-2 min-w-0">
                           <div className={
                             "truncate text-sm font-medium " +
-                            (isRejected
+                            (isHiddenRow
                               ? "line-through text-zinc-400 dark:text-zinc-600"
                               : "text-zinc-900 dark:text-zinc-100")
                           }>
@@ -613,7 +620,13 @@ export function HackathonEvaluateDashboard({
                               Hidden
                             </span>
                           )}
-                          {!isRejected && evaluatedByMe && (
+                          {!isRejected && p.auto_hidden && (
+                            <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-zinc-500/15 px-1.5 py-0.5 text-[10px] font-medium text-zinc-500 dark:text-zinc-500">
+                              <EyeOff className="size-3" />
+                              No links
+                            </span>
+                          )}
+                          {!isHiddenRow && evaluatedByMe && (
                             <span
                               title="You have evaluated this project"
                               className="inline-flex shrink-0 items-center gap-1 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-400"
@@ -655,11 +668,15 @@ export function HackathonEvaluateDashboard({
                   </TableCell>
                   {canPickWinners && (
                     <TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
-                      <RejectControl
-                        isRejected={isRejected}
-                        isSaving={rejectSaving === p.id}
-                        onToggle={(next) => setIsRejected(p.id, next)}
-                      />
+                      {p.auto_hidden && !isRejected ? (
+                        <AutoHiddenLabel />
+                      ) : (
+                        <RejectControl
+                          isRejected={isRejected}
+                          isSaving={rejectSaving === p.id}
+                          onToggle={(next) => setIsRejected(p.id, next)}
+                        />
+                      )}
                     </TableCell>
                   )}
                 </TableRow>
@@ -710,6 +727,24 @@ export function HackathonEvaluateDashboard({
         </AlertDialogContent>
       </AlertDialog>
     </>
+  );
+}
+
+function AutoHiddenLabel() {
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex h-8 cursor-default items-center gap-1.5 px-3 text-xs font-medium text-zinc-400 dark:text-zinc-600">
+            <EyeOff className="size-3.5" />
+            Auto-hidden
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          Hidden from judges automatically because the submission has no links.
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 

--- a/lib/hackathons/project-links.ts
+++ b/lib/hackathons/project-links.ts
@@ -1,0 +1,65 @@
+// A project with no links at all (nothing in the evaluate panel's "Links"
+// section and no deployed addresses) gives judges nothing to verify, so the
+// evaluate flow auto-hides it and excludes it from the phase-gate counters.
+// Covers the same fields the SubmissionDetailPanel renders; any trimmed,
+// non-empty string value counts as a link (URL validity is not checked).
+
+export type ProjectLinkFields = {
+  github_repository: string | null;
+  demo_link: string | null;
+  demo_video_link: string | null;
+  website: unknown;
+  socials: unknown;
+  deployed_addresses: unknown;
+};
+
+function hasText(value: string | null | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function stringMapHasLink(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value as Record<string, unknown>).some(
+    (url) => typeof url === "string" && url.trim().length > 0,
+  );
+}
+
+function hasDeployedAddress(value: unknown): boolean {
+  if (!Array.isArray(value)) return false;
+  return value.some((item) => {
+    if (!item || typeof item !== "object") return false;
+    const address = (item as Record<string, unknown>).address;
+    return typeof address === "string" && address.trim().length > 0;
+  });
+}
+
+export function projectHasNoLinks(project: ProjectLinkFields): boolean {
+  return (
+    !hasText(project.github_repository) &&
+    !hasText(project.demo_link) &&
+    !hasText(project.demo_video_link) &&
+    !stringMapHasLink(project.website) &&
+    !stringMapHasLink(project.socials) &&
+    !hasDeployedAddress(project.deployed_addresses)
+  );
+}
+
+export type ReviewProgress = { reviewed: number; total: number };
+
+// Hidden projects (manually rejected or auto-hidden) can never be reviewed by
+// judges, so the "move to picking phase" gate must not count them: they drop
+// out of both reviewed and total. Single source of truth for the page, the
+// dashboard, and the evaluation-phase route.
+export function countReviewProgress(
+  projects: ReadonlyArray<{
+    is_rejected: boolean;
+    auto_hidden: boolean;
+    evaluations: ReadonlyArray<unknown>;
+  }>,
+): ReviewProgress {
+  const eligible = projects.filter((p) => !p.is_rejected && !p.auto_hidden);
+  return {
+    reviewed: eligible.filter((p) => p.evaluations.length > 0).length,
+    total: eligible.length,
+  };
+}

--- a/tests/unit/hackathons/project-links.test.ts
+++ b/tests/unit/hackathons/project-links.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import {
+  countReviewProgress,
+  projectHasNoLinks,
+} from '@/lib/hackathons/project-links';
+
+/**
+ * A hackathon project with no links at all (no GitHub, demo, video, website,
+ * socials, or deployed addresses) has nothing a judge can verify, so the
+ * evaluate flow auto-hides it. The definition here must mirror what the
+ * SubmissionDetailPanel "Links" section renders: trimmed, string-valued URLs.
+ */
+
+const emptyShell = {
+  github_repository: null,
+  demo_link: null,
+  demo_video_link: null,
+  website: null,
+  socials: null,
+  deployed_addresses: [],
+};
+
+describe('projectHasNoLinks — link-less shells', () => {
+  it('flags a project with every link field null/empty', () => {
+    expect(projectHasNoLinks(emptyShell)).toBe(true);
+  });
+
+  it('flags empty strings and whitespace-only strings as no link', () => {
+    expect(
+      projectHasNoLinks({
+        ...emptyShell,
+        github_repository: '',
+        demo_link: '   ',
+        demo_video_link: '\t',
+      }),
+    ).toBe(true);
+  });
+
+  it('flags empty website/socials objects as no link', () => {
+    expect(
+      projectHasNoLinks({ ...emptyShell, website: {}, socials: {} }),
+    ).toBe(true);
+  });
+
+  it('flags website/socials whose every value is empty or non-string', () => {
+    expect(
+      projectHasNoLinks({
+        ...emptyShell,
+        website: { main: '', docs: '  ' },
+        socials: { twitter: null, discord: 42 },
+      }),
+    ).toBe(true);
+  });
+
+  it('treats malformed website/socials shapes (array, string) as no link', () => {
+    expect(
+      projectHasNoLinks({
+        ...emptyShell,
+        website: ['https://example.com'],
+        socials: 'https://x.com/team',
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores deployed address entries without a usable address', () => {
+    expect(
+      projectHasNoLinks({
+        ...emptyShell,
+        deployed_addresses: [{ tag: 'token' }, { address: '   ' }, null, 'raw'],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('projectHasNoLinks — projects with at least one link', () => {
+  it.each([
+    ['github_repository', { github_repository: 'https://github.com/org/repo' }],
+    ['demo_link', { demo_link: 'https://demo.example.com' }],
+    ['demo_video_link', { demo_video_link: 'https://youtu.be/abc' }],
+  ] as const)('keeps a project with only %s', (_field, overrides) => {
+    expect(projectHasNoLinks({ ...emptyShell, ...overrides })).toBe(false);
+  });
+
+  it('keeps a project whose website map has one non-empty URL', () => {
+    expect(
+      projectHasNoLinks({
+        ...emptyShell,
+        website: { main: '', landing: 'https://example.com' },
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps a project whose socials map has one non-empty URL', () => {
+    expect(
+      projectHasNoLinks({
+        ...emptyShell,
+        socials: { twitter: 'https://x.com/team' },
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps a project with only a deployed address (on-chain evidence)', () => {
+    expect(
+      projectHasNoLinks({
+        ...emptyShell,
+        deployed_addresses: [{ address: '0x1234abcd', tag: 'token' }],
+      }),
+    ).toBe(false);
+  });
+});
+
+/**
+ * The "Move to picking phase" gate must only count projects judges can
+ * actually review: hidden projects (manually rejected or auto-hidden) drop
+ * out of both the reviewed and total counters, otherwise the gate can never
+ * be satisfied.
+ */
+
+function proj(overrides: {
+  is_rejected?: boolean;
+  auto_hidden?: boolean;
+  evaluations?: unknown[];
+}) {
+  return {
+    is_rejected: false,
+    auto_hidden: false,
+    evaluations: [],
+    ...overrides,
+  };
+}
+
+describe('countReviewProgress — eligibility-aware gate counters', () => {
+  it('counts only eligible projects in reviewed and total', () => {
+    const { reviewed, total } = countReviewProgress([
+      proj({ evaluations: [{}] }),
+      proj({}),
+      proj({ is_rejected: true, evaluations: [{}] }),
+      proj({ auto_hidden: true }),
+    ]);
+    expect(total).toBe(2);
+    expect(reviewed).toBe(1);
+  });
+
+  it('excludes a reviewed-then-hidden project from both counters', () => {
+    const { reviewed, total } = countReviewProgress([
+      proj({ is_rejected: true, evaluations: [{}, {}] }),
+      proj({ auto_hidden: true, evaluations: [{}] }),
+    ]);
+    expect(total).toBe(0);
+    expect(reviewed).toBe(0);
+  });
+
+  it('returns zeros for an empty project list', () => {
+    expect(countReviewProgress([])).toEqual({ reviewed: 0, total: 0 });
+  });
+
+  it('is satisfied exactly when every eligible project has a review', () => {
+    const { reviewed, total } = countReviewProgress([
+      proj({ evaluations: [{}] }),
+      proj({ evaluations: [{}] }),
+      proj({ is_rejected: true }),
+      proj({ auto_hidden: true }),
+    ]);
+    expect(reviewed).toBe(total);
+    expect(total).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Hackathon submissions with **no links at all** (no GitHub, demo, video, website, socials, and no deployed addresses) are now auto-hidden from judges on `/events/[id]/evaluate`, derived server-side at load time. No schema change, no backfill: the flag heals itself if links appear later.
- Devrel still sees auto-hidden rows greyed out with a "No links" badge and a static "Auto-hidden" label (tooltip explains why) instead of the Hide/Restore toggle. Manual Hide/Restore is unchanged, and a manually hidden project always keeps its Restore button.
- Fixes the "Move to picking phase" gate: hidden projects (manually rejected or auto-hidden) can never be reviewed by judges, yet they counted toward `reviewed/total` both client-side and in `POST /api/events/[id]/evaluation-phase`, making the gate permanently unsatisfiable once anything was hidden. Both sites now count only eligible projects through a shared `countReviewProgress` helper, and a zero-eligible event returns a distinct error instead of the misleading "not all projects reviewed".
- Closes a visibility bypass in `GET /api/events/[id]/projects` (session scope): non-devrel judges previously received every project, hidden ones included. The route now applies the same server-side filter as the evaluate page. The API-key (external) scope is unchanged.
- New `lib/hackathons/project-links.ts` (`projectHasNoLinks`, `countReviewProgress`) with 16 unit tests, including malformed Json shapes for `website`/`socials`/`deployed_addresses`.

## Test plan

- [ ] `npx vitest run tests/unit/hackathons/project-links.test.ts` passes (16 tests)
- [ ] `yarn tsc --noEmit` passes
- [ ] As a judge on an event with link-less submissions: they never appear, and the submitted/reviewed counts exclude them
- [ ] As devrel: link-less rows are greyed with a "No links" badge and an "Auto-hidden" label; Hide/Restore still works on linked projects
- [ ] "Move to picking phase" unlocks once every eligible project has at least one review, and the POST succeeds
- [ ] `GET /api/events/[id]/projects` with a non-devrel judge session omits hidden and link-less projects

## Notes / follow-ups (pre-existing, out of scope)

- Project writes are not deadline- or phase-gated, so participants can edit link fields mid-evaluation, which now also moves eligibility live. Cheapest fix: block project writes once evaluation starts, or snapshot eligibility at the deadline.
- `Project.hackaton_id` has no index; per-hackathon fetches are sequential scans.
- `GET /api/events/[id]/projects` returns member emails to judge sessions.
