### PR TITLE
fix(integrations): restore mobile menu on integrations pages

### DIFF
--- a/app/integrations/layout.tsx
+++ b/app/integrations/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { Footer } from '@/components/navigation/footer';
 import { baseOptions } from '@/app/layout.config';
 import { LayoutWrapper } from '@/app/layout-wrapper.client';
+import { NavbarDropdownInjector } from '@/components/navigation/navbar-dropdown-injector';
 
 export default function Layout({
   children,
@@ -9,6 +10,7 @@ export default function Layout({
   children: ReactNode;
 }): React.ReactElement {
   return <LayoutWrapper baseOptions={baseOptions}>
+    <NavbarDropdownInjector />
     {children}
     <Footer />
     </LayoutWrapper>;


### PR DESCRIPTION
## Summary

The mobile menu was completely missing on `/integrations` and `/integrations/[...slug]`. The site hides fumadocs' built-in hamburger on mobile (`app/global.css`, `max-width: 1023px` block) and replaces it with a custom `NavbarDropdown` that each section layout must mount via `NavbarDropdownInjector`. Every `HomeLayout`-based section does this (home, docs, blog, academy, console, chat) except the integrations layout, so integrations pages ended up with no menu at all on mobile.

This mounts `NavbarDropdownInjector` in `app/integrations/layout.tsx`, matching the pattern used by the other section layouts.

## Test plan

- [x] `yarn tsc --noEmit` passes
- [x] Headless check at 390px viewport: burger injected and visible on `/integrations` and `/integrations/aave`, menu opens with all sections
- [ ] Spot-check on the preview deploy from a real phone
