### PR TITLE
fix(explorer): show precise time left on validator node page

### DIFF
--- a/components/explorer-v2/format.ts
+++ b/components/explorer-v2/format.ts
@@ -51,6 +51,39 @@ export function formatTime(unixSecs: number | undefined): string {
   return new Date(unixSecs * 1000).toISOString().replace("T", " ").slice(0, 19) + " UTC";
 }
 
+export interface TimeLeft {
+  /** whole days remaining, floored */
+  days: number;
+  /** the tile figure: "73" while days remain, "18h 24m" under a day, "45m" under an hour */
+  value: string;
+  /** compact inline form with its unit: "73d" / "18h 24m" / "45m" */
+  short: string;
+  /** full breakdown plus the exact end moment, for a hover title */
+  precise: string;
+}
+
+/** Remaining term time from the end timestamp. A whole-day integer (the
+ *  indexer's daysLeft) reads "0" for the entire final day of a term; this
+ *  keeps days as the headline while they last, then hands over to hours
+ *  and minutes. `nowMs` is injectable for tests. */
+export function timeLeft(endTimestamp: number, nowMs = Date.now()): TimeLeft {
+  const secs = Math.max(0, Math.floor(endTimestamp - nowMs / 1000));
+  const days = Math.floor(secs / 86_400);
+  const hours = Math.floor((secs % 86_400) / 3_600);
+  const mins = Math.floor((secs % 3_600) / 60);
+  const subDay = hours >= 1 ? `${hours}h ${mins}m` : `${mins}m`;
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (days > 0 || hours > 0) parts.push(`${hours}h`);
+  parts.push(`${mins}m`);
+  return {
+    days,
+    value: days >= 1 ? formatNumber(days) : subDay,
+    short: days >= 1 ? `${formatNumber(days)}d` : subDay,
+    precise: `${parts.join(" ")} left · ends ${formatTime(endTimestamp)}`,
+  };
+}
+
 /** Middle-truncate a hash/address: "2VLRYb…xNxj" */
 export function truncate(v: string | undefined, len = 10): string {
   if (!v) return "";

--- a/components/explorer-v2/pchain/PchainNode.tsx
+++ b/components/explorer-v2/pchain/PchainNode.tsx
@@ -25,7 +25,7 @@ import {
   TxTypePill,
   idInk,
 } from "@/components/explorer-v2/ui";
-import { formatAvax, formatNumber, formatTime, timeAgo, truncate } from "@/components/explorer-v2/format";
+import { formatAvax, formatNumber, formatTime, timeAgo, timeLeft, truncate } from "@/components/explorer-v2/format";
 import { usePchainData } from "./hooks";
 import { NotFound } from "./PchainTx";
 import {
@@ -176,7 +176,7 @@ export function PchainNode({
     const span = v.endTimestamp - v.startTimestamp;
     const progressPct =
       span > 0 ? Math.min(100, Math.max(0, ((now - v.startTimestamp) / span) * 100)) : null;
-    return { maxTotal, capacity, sharePct, feeTake, totalTake, progressPct };
+    return { maxTotal, capacity, sharePct, feeTake, totalTake, progressPct, left: timeLeft(v.endTimestamp) };
   }, [n, networkStake]);
   // pre-Banff validators carry one rewardOwner; later ones split the pair
   const validationPayout = identity?.validationRewardOwner ?? identity?.rewardOwner;
@@ -385,9 +385,13 @@ export function PchainNode({
                   tone={p2p ? (p2p.miss_rate_14d === 0 ? "good" : p2p.miss_rate_14d < 5 ? "warn" : "bad") : undefined}
                 />
                 <Tile label="Proposed · 14d" value={formatNumber(p2p?.proposed_14d ?? n.proposedBlocks14d)} />
+                {/* the indexer's integer daysLeft reads "0" all through the final
+                    day, so derive from the end timestamp: days while they last,
+                    hours/minutes after, exact countdown + end moment on hover */}
                 <Tile
-                  label="Days left"
-                  value={formatNumber(n.validator.daysLeft)}
+                  label={stake && stake.left.days < 1 ? "Time left" : "Days left"}
+                  value={stake ? stake.left.value : formatNumber(n.validator.daysLeft)}
+                  title={stake?.left.precise}
                   sub={stake?.progressPct != null ? `${stake.progressPct.toFixed(0)}% of term elapsed` : undefined}
                 />
               </div>
@@ -514,8 +518,8 @@ export function PchainNode({
                     <div className="flex items-baseline justify-between gap-3 font-mono text-[10px] tabular-nums text-zinc-400 dark:text-zinc-500">
                       <span>{formatTime(n.validator.startTimestamp)}</span>
                       {stake?.progressPct != null && (
-                        <span className="font-bold text-zinc-900 dark:text-zinc-100">
-                          {stake.progressPct.toFixed(1)}% · {formatNumber(n.validator.daysLeft)}d left
+                        <span className="font-bold text-zinc-900 dark:text-zinc-100" title={stake.left.precise}>
+                          {stake.progressPct.toFixed(1)}% · {stake.left.short} left
                         </span>
                       )}
                       <span>{formatTime(n.validator.endTimestamp)}</span>
@@ -1079,6 +1083,7 @@ function Tile({
   strong = false,
   tone,
   sub,
+  title,
 }: {
   label: string;
   value: string;
@@ -1087,6 +1092,8 @@ function Tile({
   tone?: "good" | "warn" | "bad";
   /** muted qualifier under the figure — a share, a cap, a count */
   sub?: string;
+  /** hover detail, shown as the native browser tooltip */
+  title?: string;
 }) {
   const toneCls =
     tone === "good"
@@ -1097,7 +1104,7 @@ function Tile({
           ? "text-[#E6212F]"
           : "text-zinc-900 dark:text-zinc-50";
   return (
-    <div className="flex flex-col gap-1.5 px-5 py-5 md:px-6">
+    <div title={title} className="flex flex-col gap-1.5 px-5 py-5 md:px-6">
       <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500 dark:text-zinc-400">
         {label}
       </span>

--- a/tests/unit/explorer-v2/time-left.test.ts
+++ b/tests/unit/explorer-v2/time-left.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { formatTime, timeLeft } from "../../../components/explorer-v2/format";
+
+const NOW_MS = Date.UTC(2026, 7, 31, 12, 0, 0); // 2026-08-31 12:00:00 UTC
+const NOW_SECS = NOW_MS / 1000;
+
+describe("timeLeft", () => {
+  it("keeps whole days as the figure while a day or more remains", () => {
+    const end = NOW_SECS + 73 * 86_400 + 5 * 3_600 + 12 * 60 + 30;
+    const t = timeLeft(end, NOW_MS);
+    expect(t.days).toBe(73);
+    expect(t.value).toBe("73");
+    expect(t.short).toBe("73d");
+    expect(t.precise).toBe(`73d 5h 12m left · ends ${formatTime(end)}`);
+  });
+
+  it("spells out zero hours and minutes on an exact day boundary", () => {
+    const end = NOW_SECS + 3 * 86_400;
+    const t = timeLeft(end, NOW_MS);
+    expect(t.value).toBe("3");
+    expect(t.precise).toBe(`3d 0h 0m left · ends ${formatTime(end)}`);
+  });
+
+  it("switches the figure to hours and minutes under a day", () => {
+    const end = NOW_SECS + 18 * 3_600 + 24 * 60 + 59;
+    const t = timeLeft(end, NOW_MS);
+    expect(t.days).toBe(0);
+    expect(t.value).toBe("18h 24m");
+    expect(t.short).toBe("18h 24m");
+    expect(t.precise).toBe(`18h 24m left · ends ${formatTime(end)}`);
+  });
+
+  it("shows minutes alone under an hour", () => {
+    const end = NOW_SECS + 45 * 60 + 10;
+    const t = timeLeft(end, NOW_MS);
+    expect(t.value).toBe("45m");
+    expect(t.precise).toBe(`45m left · ends ${formatTime(end)}`);
+  });
+
+  it("clamps to zero once the end has passed", () => {
+    const end = NOW_SECS - 3_600;
+    const t = timeLeft(end, NOW_MS);
+    expect(t.days).toBe(0);
+    expect(t.value).toBe("0m");
+    expect(t.precise).toBe(`0m left · ends ${formatTime(end)}`);
+  });
+
+  it("formats large day counts through formatNumber", () => {
+    const end = NOW_SECS + 1_001 * 86_400;
+    expect(timeLeft(end, NOW_MS).value).toBe("1,001");
+  });
+});


### PR DESCRIPTION
## Summary

The validator node page showed the remaining term only as a whole-day integer from the indexer (`validator.daysLeft`), which reads "0" for the entire final day and gives no sub-day precision anywhere.

- New `timeLeft(endTimestamp)` helper in `components/explorer-v2/format.ts`: whole days while a day or more remains, then "18h 24m" under a day, then "45m" under an hour, plus a `precise` string with the full countdown and exact end moment.
- The summary tile now derives from `endTimestamp` instead of the indexer integer. Under a day the label flips from "Days left" to "Time left" and the figure switches to hours/minutes.
- Hovering the tile or the term-bar label shows the exact countdown and end time (e.g. "73d 7h 59m left · ends 2026-11-12 20:28:10 UTC") via the native browser tooltip; `Tile` gained an optional `title` prop.
- The term progress bar uses the same compact form ("73d left", "18h 24m left").

No data or API changes: `endTimestamp` was already in the node payload, so this is client-side only. Rendering for validators with a day or more left is unchanged (same integer figure as before).

## Test plan

- [x] `npx vitest run tests/unit/explorer-v2/time-left.test.ts` — 6 new cases covering day/hour/minute switchover, exact day boundary, past-end clamping, thousands formatting (all passing)
- [x] `yarn tsc --noEmit` clean
- [x] Helper output verified against a live mainnet validator (NodeID-FcJF4qeHfTDzBV7YEy9zKkx7TvapfEEBS): tile "73" with hover "73d 7h 59m left · ends 2026-11-12 20:28:10 UTC"; a term ending in hours renders "3h 22m"
- [ ] Visual pass on the preview deployment: hover tooltip on the tile and the term bar, sub-day rendering
