### PR TITLE
fix(proxy): scope CORS to an origin allowlist instead of wildcard

### DIFF
--- a/lib/security/cors.ts
+++ b/lib/security/cors.ts
@@ -1,0 +1,94 @@
+/**
+ * Origin allowlisting for the site's Next.js proxy (middleware).
+ *
+ * Replaces a blanket `Access-Control-Allow-Origin: *` that the proxy used to
+ * stage on its response. We reflect the request `Origin` only when it is
+ * trusted, and never grant credentials — so a reflected origin can read only
+ * public, unauthenticated responses. The MCP endpoint keeps its own,
+ * Claude-specific allowlist in `lib/mcp/cors.ts`; this helper governs the proxy.
+ *
+ * See issue #3973.
+ */
+
+// ---------------------------------------------------------------------------
+// Allowed origins
+// ---------------------------------------------------------------------------
+
+/**
+ * Exact-match origins. `CORS_ALLOWED_ORIGINS` (comma-separated) fully overrides
+ * this list for self-hosted deployments — set it to include every origin you
+ * need, as it replaces rather than extends the default.
+ */
+export const STATIC_ALLOWED_ORIGINS: ReadonlySet<string> = new Set(
+  process.env.CORS_ALLOWED_ORIGINS?.split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean) ?? ['https://build.avax.network']
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1';
+}
+
+/**
+ * True when `origin` is trusted to make cross-origin browser requests.
+ *
+ * Beyond the static (production) allowlist, we additionally trust:
+ *  - localhost / 127.0.0.1 outside production, for local development; and
+ *  - sibling `*.vercel.app` deployments, but only when this deployment is
+ *    itself a Vercel preview (`VERCEL_ENV === 'preview'`) — never in
+ *    production. Preview builds carry no production data and, since we never
+ *    grant credentials, a reflected preview origin can read only public data.
+ */
+export function isAllowedOrigin(origin: string): boolean {
+  if (STATIC_ALLOWED_ORIGINS.has(origin)) return true;
+
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    return false;
+  }
+
+  const { protocol, hostname } = url;
+  if (protocol !== 'http:' && protocol !== 'https:') return false;
+
+  if (process.env.NODE_ENV !== 'production' && isLoopbackHost(hostname)) {
+    return true;
+  }
+
+  if (
+    process.env.VERCEL_ENV === 'preview' &&
+    protocol === 'https:' &&
+    hostname.endsWith('.vercel.app')
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * CORS headers for a request's `Origin`.
+ *
+ * Grants cross-origin access (by reflecting the origin) only when it is
+ * allowlisted, paired with `Vary: Origin` so shared caches key the response
+ * per-origin and never serve one origin's grant to another. For a missing
+ * `Origin` (same-origin / non-browser client) or a disallowed one, returns an
+ * empty object: no `Access-Control-Allow-Origin` is emitted, the browser blocks
+ * the cross-origin read (the secure default), and the response stays
+ * byte-identical to the pre-existing behavior. Mirrors `lib/mcp/cors.ts`.
+ */
+export function getCorsHeaders(origin: string | null): Record<string, string> {
+  if (!origin || !isAllowedOrigin(origin)) return {};
+
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    Vary: 'Origin',
+  };
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -4,22 +4,36 @@ import { NextMiddlewareResult } from "next/dist/server/web/types";
 import { NextRequest, NextResponse } from "next/server";
 import { hasTeam1AcademyAccess } from "@/lib/auth/roles";
 import { PROTECTED_PATHS } from "@/lib/auth/protected-paths";
+import { getCorsHeaders } from "@/lib/security/cors";
 
 export async function proxy(req: NextRequest) {
   const pathname = req.nextUrl.pathname;
-  const response = NextResponse.next();
-  response.headers.set("Access-Control-Allow-Origin", "*");
-  response.headers.set(
-    "Access-Control-Allow-Methods",
-    "GET, POST, PUT, DELETE, OPTIONS"
-  );
-  response.headers.set(
-    "Access-Control-Allow-Headers",
-    "Content-Type, Authorization"
-  );
+
+  // CORS: reflect only allowlisted origins instead of the blanket
+  // `Access-Control-Allow-Origin: *` this proxy used to stage on its response
+  // (see issue #3973). Credentials are never granted, so a reflected origin can
+  // read only public, unauthenticated responses. For a disallowed or absent
+  // Origin, `getCorsHeaders` returns nothing and the response is byte-identical
+  // to the prior same-origin behavior.
+  const corsHeaders = getCorsHeaders(req.headers.get("origin"));
+  const grantsCors = Object.keys(corsHeaders).length > 0;
+  const applyCors = (res: NextResponse): NextResponse => {
+    for (const [key, value] of Object.entries(corsHeaders)) {
+      if (key === "Vary") {
+        const existing = res.headers.get("Vary");
+        res.headers.set("Vary", existing ? `${existing}, ${value}` : value);
+      } else {
+        res.headers.set(key, value);
+      }
+    }
+    return res;
+  };
 
   if (req.method === "OPTIONS") {
-    return new Response(null, { status: 204 });
+    const headers = grantsCors
+      ? { ...corsHeaders, "Access-Control-Max-Age": "86400" }
+      : corsHeaders;
+    return new Response(null, { status: 204, headers });
   }
 
   // Team1 raw markdown API: the only branch we can't express through the
@@ -61,14 +75,14 @@ export async function proxy(req: NextRequest) {
     const apiUrl = new URL(`/api/raw${pathname}`, req.url);
     const rewriteResponse = NextResponse.rewrite(apiUrl);
     rewriteResponse.headers.set('Vary', 'Accept');
-    return rewriteResponse;
+    return applyCors(rewriteResponse);
   }
 
   // For content paths without markdown request, add Vary header and pass through
   if (isContentPath && !isProtectedAcademyPath) {
     const contentResponse = NextResponse.next();
     contentResponse.headers.set('Vary', 'Accept');
-    return contentResponse;
+    return applyCors(contentResponse);
   }
 
   const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
@@ -135,8 +149,9 @@ export async function proxy(req: NextRequest) {
     }
   }
 
-  // For non-protected paths or unauthenticated users on non-protected paths, allow access
-  return NextResponse.next();
+  // For non-protected paths or unauthenticated users on non-protected paths,
+  // allow access, carrying the scoped CORS headers on the pass-through.
+  return applyCors(NextResponse.next());
 }
 
 export const config = {

--- a/tests/unit/security/cors.test.ts
+++ b/tests/unit/security/cors.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getCorsHeaders, isAllowedOrigin } from '@/lib/security/cors';
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_VERCEL_ENV = process.env.VERCEL_ENV;
+
+function setEnv(nodeEnv: string | undefined, vercelEnv: string | undefined) {
+  if (nodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = nodeEnv;
+  if (vercelEnv === undefined) delete process.env.VERCEL_ENV;
+  else process.env.VERCEL_ENV = vercelEnv;
+}
+
+beforeEach(() => setEnv('test', undefined));
+afterEach(() => setEnv(ORIGINAL_NODE_ENV, ORIGINAL_VERCEL_ENV));
+
+describe('isAllowedOrigin', () => {
+  it('always allows the production origin', () => {
+    setEnv('production', 'production');
+    expect(isAllowedOrigin('https://build.avax.network')).toBe(true);
+  });
+
+  it('allows localhost only outside production', () => {
+    setEnv('development', undefined);
+    expect(isAllowedOrigin('http://localhost:3000')).toBe(true);
+    expect(isAllowedOrigin('http://127.0.0.1:3000')).toBe(true);
+
+    setEnv('production', 'production');
+    expect(isAllowedOrigin('http://localhost:3000')).toBe(false);
+  });
+
+  it('allows *.vercel.app only on https preview deployments, never in production', () => {
+    setEnv('production', 'preview');
+    expect(isAllowedOrigin('https://builders-hub-git-feature.vercel.app')).toBe(true);
+    // http previews are not trusted
+    expect(isAllowedOrigin('http://builders-hub-git-feature.vercel.app')).toBe(false);
+
+    // In production the site must not reflect arbitrary Vercel tenants.
+    setEnv('production', 'production');
+    expect(isAllowedOrigin('https://anything.vercel.app')).toBe(false);
+  });
+
+  it('rejects unknown and look-alike origins', () => {
+    setEnv('production', 'preview');
+    expect(isAllowedOrigin('https://evil.com')).toBe(false);
+    // Suffix must be a real subdomain boundary, not a substring.
+    expect(isAllowedOrigin('https://notvercel.app')).toBe(false);
+    // Production host as a prefix of an attacker domain must not match.
+    expect(isAllowedOrigin('https://build.avax.network.evil.com')).toBe(false);
+    // Userinfo trick: authority host is the attacker domain.
+    expect(isAllowedOrigin('https://build.avax.network@evil.com')).toBe(false);
+  });
+
+  it('rejects non-http(s) schemes and malformed origins', () => {
+    expect(isAllowedOrigin('file:///etc/passwd')).toBe(false);
+    expect(isAllowedOrigin('chrome-extension://abc')).toBe(false);
+    expect(isAllowedOrigin('null')).toBe(false);
+    expect(isAllowedOrigin('')).toBe(false);
+    expect(isAllowedOrigin('not-a-url')).toBe(false);
+  });
+});
+
+describe('getCorsHeaders', () => {
+  it('reflects an allowlisted origin and grants methods', () => {
+    setEnv('production', 'production');
+    const headers = getCorsHeaders('https://build.avax.network');
+    expect(headers['Access-Control-Allow-Origin']).toBe('https://build.avax.network');
+    expect(headers['Access-Control-Allow-Methods']).toContain('POST');
+    expect(headers['Vary']).toBe('Origin');
+  });
+
+  it('never emits a wildcard origin', () => {
+    setEnv('production', 'preview');
+    for (const origin of [
+      'https://build.avax.network',
+      'https://foo.vercel.app',
+      'https://evil.com',
+      null,
+    ]) {
+      expect(getCorsHeaders(origin)['Access-Control-Allow-Origin']).not.toBe('*');
+    }
+  });
+
+  it('grants nothing to a disallowed origin (empty headers, no CORS)', () => {
+    setEnv('production', 'production');
+    expect(getCorsHeaders('https://evil.com')).toEqual({});
+  });
+
+  it('grants nothing for requests without an Origin (same-origin / non-browser)', () => {
+    expect(getCorsHeaders(null)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Addresses the CORS wildcard flagged in #3973. The proxy staged a blanket
`Access-Control-Allow-Origin: *` on its base response; this replaces it with a
small origin allowlist and dynamic reflection.

**What changed**
- New `lib/security/cors.ts` — `getCorsHeaders(origin)` reflects the request
  `Origin` only when it is allowlisted (the production site; `localhost` outside
  production; `*.vercel.app` only on preview deployments), always paired with
  `Vary: Origin`. It never emits `*` and never grants credentials.
- `proxy.ts` — removes the wildcard, applies the scoped headers to the content
  and pass-through responses, and returns proper preflight headers on `OPTIONS`
  (previously a bare `204`) with a 24h `Access-Control-Max-Age`.
- Unit tests for the allowlist boundaries and header logic.

**Scope notes (for transparency)**
- The old `*` was staged on a response object the middleware never actually
  returned, so it was not being served. This is defense-in-depth hardening plus a
  correct, dynamic CORS implementation and a fixed preflight — not a patch for an
  actively exploitable wildcard.
- The middleware matcher does not cover general `/api/*` (faucet, upload, etc.);
  those routes currently emit no `Access-Control-Allow-Origin` at all, so they
  are not cross-origin readable today. I deliberately did not add a blanket
  `next.config.mjs` `/api/*` restriction (as attempted in the now-closed #3975),
  since that would also break legitimately public API/content consumers. Happy to
  layer that on per-endpoint if preferred.
- Credentials are intentionally not granted, so reflected origins can read only
  public, unauthenticated responses.

Refs #3973
