### PR TITLE
fix(console): allow SSH before enabling ufw on primary network node setup

### DIFF
--- a/components/toolbox/console/primary-network/AvalancheGoDockerPrimaryNetwork.tsx
+++ b/components/toolbox/console/primary-network/AvalancheGoDockerPrimaryNetwork.tsx
@@ -1308,12 +1308,14 @@ function AvalancheGoDockerPrimaryNetworkInner() {
             lang="bash"
             code={
               isRPC
-                ? `# Open P2P and RPC ports
+                ? `# Open SSH, P2P, and RPC ports
+sudo ufw allow OpenSSH
 sudo ufw allow 9651/tcp comment 'AvalancheGo P2P'
 sudo ufw allow 9650/tcp comment 'AvalancheGo RPC'
 sudo ufw --force enable
 sudo ufw status`
-                : `# Open P2P port only (validators don't expose RPC)
+                : `# Open SSH and P2P ports (validators don't expose RPC)
+sudo ufw allow OpenSSH
 sudo ufw allow 9651/tcp comment 'AvalancheGo P2P'
 sudo ufw --force enable
 sudo ufw status`


### PR DESCRIPTION
## What changed

The primary network node setup firewall step ran `ufw --force enable` without allowing SSH first. Users following the steps on a cloud host locked themselves out. This adds `sudo ufw allow OpenSSH` before the port rules in both the RPC and validator variants.

The L1 node setup page already had this line. The two pages now match.

## Verification

- String-literal change inside a template block only, no logic touched.
- Checked the rendered command sequence in both `isRPC` branches.