### PR TITLE
feat(og): social preview card for security audits

### DIFF
--- a/app/(home)/audits/layout.tsx
+++ b/app/(home)/audits/layout.tsx
@@ -7,6 +7,20 @@ export const metadata: Metadata = createMetadata({
     'Request audit quotes from every vetted security firm on the Ava Labs whitelist. Free, private, subsidized up to 75%.',
   openGraph: {
     url: '/audits',
+    images: {
+      url: '/api/og/audits',
+      width: 1200,
+      height: 630,
+      alt: 'Avalanche Security Audits',
+    },
+  },
+  twitter: {
+    images: {
+      url: '/api/og/audits',
+      width: 1200,
+      height: 630,
+      alt: 'Avalanche Security Audits',
+    },
   },
 });
 

--- a/app/api/og/audits/route.tsx
+++ b/app/api/og/audits/route.tsx
@@ -1,0 +1,18 @@
+import { ImageResponse } from 'next/og';
+import { loadFonts, createOGResponse } from '@/utils/og-image';
+
+export const runtime = 'edge';
+
+// Referenced by app/(home)/audits/layout.tsx. Copy mirrors that layout's
+// title + description so the card and the page's meta tags read the same.
+export async function GET(): Promise<ImageResponse> {
+  const fonts = await loadFonts();
+
+  return createOGResponse({
+    title: 'Security Audits',
+    description:
+      'Request audit quotes from every vetted security firm on the Ava Labs whitelist. Free, private, subsidized up to 75%.',
+    path: 'audits',
+    fonts,
+  });
+}

--- a/tests/unit/audits/ogCard.test.ts
+++ b/tests/unit/audits/ogCard.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { SectionCard, sectionFromPath, taglineFromPath } from '@/utils/og/section-card';
+import { metadata } from '@/app/(home)/audits/layout';
+
+/**
+ * The /audits social card. Until this branch the section fell through to the
+ * site-wide default card (utils/metadata.ts), so a shared link read
+ * "Avalanche Builder Hub" with no hint of the audit program.
+ */
+
+const AUDITS_OG_IMAGE = '/api/og/audits';
+
+type ImageLike = string | URL | { url: string | URL };
+
+const firstImageUrl = (images: unknown): string | undefined => {
+  const first = (Array.isArray(images) ? images[0] : images) as ImageLike | undefined;
+  if (!first) return undefined;
+  if (typeof first === 'string') return first;
+  if (first instanceof URL) return first.toString();
+  return String(first.url);
+};
+
+describe('audits section card', () => {
+  it('maps the audits path to its own footer tagline', () => {
+    expect(sectionFromPath('audits')).toBe('AUDITS');
+    expect(taglineFromPath('audits')).toBe('AVA LABS AUDIT PROGRAM · FREE FOR BUILDERS');
+  });
+
+  it('renders title, description, canonical path and tagline', () => {
+    const html = renderToStaticMarkup(
+      createElement(SectionCard, {
+        title: 'Security Audits',
+        description:
+          'Request audit quotes from every vetted security firm on the Ava Labs whitelist. Free, private, subsidized up to 75%.',
+        path: 'audits',
+      }),
+    );
+    expect(html).toContain('SECURITY AUDITS');
+    expect(html).toContain('EVERY VETTED SECURITY FIRM ON THE AVA LABS WHITELIST');
+    expect(html).toContain('SUBSIDIZED UP TO 75%.');
+    expect(html).toContain('BUILD.AVAX.NETWORK/AUDITS');
+    expect(html).toContain('AVA LABS AUDIT PROGRAM · FREE FOR BUILDERS');
+    expect(html).not.toContain('ONE NETWORK · TWO WAYS TO BUILD');
+    // "Security Audits" already carries the section, so no red AUDITS label.
+    expect(html).not.toMatch(/>AUDITS</);
+  });
+});
+
+describe('audits layout metadata', () => {
+  it('points og:image and twitter:image at the audits card', () => {
+    expect(firstImageUrl(metadata.openGraph?.images)).toBe(AUDITS_OG_IMAGE);
+    expect(firstImageUrl(metadata.twitter?.images)).toBe(AUDITS_OG_IMAGE);
+  });
+});

--- a/utils/og/section-card.tsx
+++ b/utils/og/section-card.tsx
@@ -31,6 +31,7 @@ const SECTION_TAGLINES: Record<string, string> = {
   solutions: 'PERFORMANCE · INTEROP · PRIVACY · COMPLIANCE',
   university: 'STUDENTS · EDUCATORS · RESEARCH',
   showcase: 'PROJECTS FROM THE COMMUNITY',
+  audits: 'AVA LABS AUDIT PROGRAM · FREE FOR BUILDERS',
   tools: 'DEVELOPER TOOLS',
 };
 


### PR DESCRIPTION
## Summary

The audit marketplace shipped without its own social preview, so shared `/audits` links unfurl with the generic Builder Hub card. This adds the audits section card in the FDE-85 card family.

- New `app/api/og/audits` route rendering the shared section card with the audits title and description
- `audits` entry in the section footer taglines (landing eyebrow copy verbatim)
- `/audits` layout now declares og:image and twitter:image at 1200x630
- Unit test covering the tagline, the rendered markup, and the layout metadata

## Test plan

- [x] `npx vitest run tests/unit/audits/ogCard.test.ts` passes
- [x] `yarn tsc --noEmit` passes
- [ ] Preview deployment: `/api/og/audits` returns a 1200x630 PNG with "SECURITY AUDITS" and the audits footer
- [ ] Preview deployment: `/audits` page source carries `og:image` and `twitter:image` pointing at `/api/og/audits`
- [ ] After merge: re-share build.avax.network/audits in Slack and confirm the new card unfurls

<img width="512" height="283" alt="image" src="https://github.com/user-attachments/assets/beb748d8-31ac-4a09-8610-b6887e7ee12d" />

