### PR TITLE
docs(helicon): announce Mainnet activation for September 22, 2026

### DIFF
--- a/app/layout-wrapper.client.tsx
+++ b/app/layout-wrapper.client.tsx
@@ -51,7 +51,7 @@ export function LayoutWrapper({ children, baseOptions }: LayoutWrapperProps) {
   return (
     <>
       <ActiveNavHighlighter />
-      {/* <CustomCountdownBanner /> */}
+      <CustomCountdownBanner />
       <HomeLayout {...updatedOptions}>{children}</HomeLayout>
     </>
   );

--- a/components/ui/custom-countdown-banner.tsx
+++ b/components/ui/custom-countdown-banner.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useCountdown } from "@/components/hackathons/project-submission/hooks/Count-down";
 
 const BLOG_URL = "/blog/helicon-upgrade";
-const ACTIVATION = Date.UTC(2026, 6, 28, 15, 0, 0); // Fuji Testnet activation: July 28, 2026 11:00 AM ET (EDT, UTC-4)
+const ACTIVATION = Date.UTC(2026, 8, 22, 15, 0, 0); // Mainnet activation: September 22, 2026 11:00 AM ET (EDT, UTC-4)
 
 export function CustomCountdownBanner() {
   const timeLeft = useCountdown(ACTIVATION);
@@ -17,21 +17,21 @@ export function CustomCountdownBanner() {
 
   return (
     <Banner
-      id="helicon-upgrade-fuji-2026"
+      id="helicon-upgrade-mainnet-2026"
       variant="rainbow"
       className="z-50 max-md:!h-auto max-md:min-h-12 max-md:py-2"
       style={{ background: "linear-gradient(90deg, #0b1e30 0%, #1a3a5c 50%, #0b1e30 100%)", color: "#fff" }}
     >
       <div className="inline-flex items-center gap-2 flex-wrap justify-center text-center">
         <span className="md:hidden">
-          <strong>Helicon Upgrade</strong> hits the Fuji Testnet <strong>July 28</strong>.
+          <strong>Helicon Upgrade</strong> hits Mainnet <strong>September 22</strong>.
         </span>
         <span className="hidden md:inline">
-          <strong>Avalanche Helicon Upgrade</strong> activates on the Fuji Testnet on{" "}
-          <strong>July 28, 11:00 AM ET 2026</strong>: auto-renewed staking, shorter minimum durations, and Continuous Execution.
+          <strong>Avalanche Helicon Upgrade</strong> activates on Mainnet on{" "}
+          <strong>September 22, 11:00 AM ET 2026</strong>: auto-renewed staking, shorter minimum durations, and Continuous Execution.
         </span>
         <span className="rounded-full bg-white/15 px-2 py-0.5 text-xs font-semibold tracking-wide">
-          {mounted ? `Fuji in${timeLeft}` : "Fuji Testnet July 28"}
+          {mounted ? `Mainnet in${timeLeft}` : "Mainnet September 22"}
         </span>
         <Link
           href={BLOG_URL}

--- a/content/blog/helicon-upgrade.mdx
+++ b/content/blog/helicon-upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Helicon: Improved Staking Economics and Continuous Execution"
 description: The Avalanche Helicon upgrade activates six ACPs, bringing auto-renewed staking, a higher validator uptime requirement, shorter minimum staking durations, Continuous Execution for the C-Chain, a dynamic minimum gas price, and a recalibrated staking reward curve.
-date: 2026-07-28
+date: 2026-09-08
 authors: [AvaxDevelopers]
 topics: [Network Updates, Helicon Upgrade, Staking, P-Chain, C-Chain, ACP-236, ACP-267, ACP-273, ACP-194, ACP-283, ACP-285]
 comments: true
@@ -12,7 +12,7 @@ import { StakingRewardCurveChart } from "@/components/content-design/staking-rew
 
 ## Introducing the Helicon Upgrade
 
-Helicon has been activated on the Fuji Testnet. Building on [Octane](https://build.avax.network/blog/octane-optimizing-c-chain-gas-fees) and [Granite](https://build.avax.network/blog/granite-upgrade), this upgrade brings Continuous Execution to the C-Chain, along with changes to Avalanche's staking economics.
+Helicon is scheduled to activate on Mainnet on **September 22, 2026 at 11:00 AM ET (15:00 UTC)**, and has been live on the Fuji Testnet since July 28, 2026. Building on [Octane](https://build.avax.network/blog/octane-optimizing-c-chain-gas-fees) and [Granite](https://build.avax.network/blog/granite-upgrade), this upgrade brings Continuous Execution to the C-Chain, along with changes to Avalanche's staking economics.
 
 The upgrade is driven by six Avalanche Community Proposals:
 
@@ -24,7 +24,7 @@ The upgrade is driven by six Avalanche Community Proposals:
 - [ACP-285:](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/285-reduce-minimum-consumption-rate) Reduce Minimum Consumption Rate (progressive rollout post-Helicon activation)
 
 
-**Mainnet release:** Activation times and the required AvalancheGo version will be confirmed with the Mainnet pre-release.
+**Mainnet activation:** September 22, 2026 at 11:00 AM ET (15:00 UTC). Mainnet validators must be running [AvalancheGo v1.15.0](https://github.com/ava-labs/avalanchego/releases/tag/v1.15.0) before then.
 
 ---
 
@@ -72,7 +72,7 @@ While the 80% threshold has served the network adequately, higher validator upti
 
 **The reward model is unchanged:** validators must meet the uptime threshold during their staking period to receive rewards. There are no partial payouts if validators fall short of 90% uptime, and the cycle's reward is forfeited in full.
 
-The new threshold applies to validations that started on or after April 1, 2026 and that haven't ended before the AvalancheGo release implementing this ACP. Validators whose staking period began before April 1, 2026 will **continue to be evaluated against the existing 80% requirement,** with no retroactive penalty.
+The new threshold applies to validations whose staking period starts on or after the activation of the Helicon network upgrade. Validators whose staking period began before activation will **continue to be evaluated against the existing 80% requirement,** with no retroactive penalty.
 
 Uptime is measured by observed peer responsiveness throughout the staking period, consistent with the existing calculation method. There are no changes to how uptime is tracked — only the threshold at which rewards are issued.
 
@@ -157,7 +157,7 @@ The concrete changes for developers and node operators, ordered by ACP.
 - **ACP-283**: new `min-price-target` (wei) for the validator-voted minimum gas price; fetch fee parameters from the network instead of assuming a fixed floor.
 - **ACP-285**: mean consumption rate ramps from 10% to 7.5% over 90 days from activation.
 
-[Read the full release notes](https://github.com/ava-labs/avalanchego/releases/tag/v1.15.0-fuji)
+[Read the full release notes](https://github.com/ava-labs/avalanchego/releases/tag/v1.15.0)
 
 Questions? [Join the discussion on GitHub](https://github.com/avalanche-foundation/ACPs/discussions)
 

--- a/content/docs/primary-network/helicon-upgrade.mdx
+++ b/content/docs/primary-network/helicon-upgrade.mdx
@@ -12,11 +12,13 @@ Helicon is a Primary Network upgrade that activates six Avalanche Community Prop
 | Network | Activation | Status |
 |---------|------------|--------|
 | **Fuji** | July 28, 2026 at 15:00 UTC | Active |
-| **Mainnet** | Not yet scheduled | Pending |
+| **Mainnet** | September 22, 2026 at 15:00 UTC (11:00 AM ET) | Scheduled |
 | Local and custom networks | Active from genesis | Active by default |
 
-<Callout type="warn" title="Fuji nodes must run a Helicon-capable release">
-Helicon activation on Fuji shipped in [AvalancheGo v1.15.0-fuji](https://github.com/ava-labs/avalanchego/releases/tag/v1.15.0-fuji). That release is Fuji-only and refuses to start against a Mainnet configuration. It also does not support C-Chain state sync once Helicon is active; a release that does is expected before Mainnet activation is scheduled.
+<Callout type="warn" title="Nodes must run a Helicon-capable release">
+Mainnet activation ships in [AvalancheGo v1.15.0](https://github.com/ava-labs/avalanchego/releases/tag/v1.15.0). Mainnet nodes must be running it before September 22, 2026 at 15:00 UTC.
+
+Fuji activation shipped earlier in [AvalancheGo v1.15.0-fuji](https://github.com/ava-labs/avalanchego/releases/tag/v1.15.0-fuji). That release is Fuji-only, refuses to start against a Mainnet configuration, and does not support C-Chain state sync once Helicon is active.
 </Callout>
 
 ## What Changes
@@ -65,10 +67,10 @@ Delegators are not affected and keep the existing minimum. The maximum staking d
 
 ## What You Need to Do
 
-**Validators on Fuji.** Upgrade to a Helicon-capable release. Then check that your node clears 90% uptime rather than 80%, since any validation you start now is judged against the higher threshold. Call [`info.uptime`](/docs/rpcs/other/info-rpc#infouptime) on your own node and cross-check against the [validator health dashboard](https://stats.avax.network/dashboard/validator-health-check/), because a single node's view of its own uptime can be misleading.
+**Validators on Fuji.** Upgrade to [AvalancheGo v1.15.0-fuji](https://github.com/ava-labs/avalanchego/releases/tag/v1.15.0-fuji) or later. Then check that your node clears 90% uptime rather than 80%, since any validation you start now is judged against the higher threshold. Call [`info.uptime`](/docs/rpcs/other/info-rpc#infouptime) on your own node and cross-check against the [validator health dashboard](https://stats.avax.network/dashboard/validator-health-check/), because a single node's view of its own uptime can be misleading.
 
-**Validators on Mainnet.** Nothing is required yet. Mainnet activation is not scheduled, so plan for the uptime threshold to rise when it is.
+**Validators on Mainnet.** Upgrade to [AvalancheGo v1.15.0](https://github.com/ava-labs/avalanchego/releases/tag/v1.15.0) before September 22, 2026 at 15:00 UTC. A node still on an older release when Helicon activates will not follow the upgraded chain. Plan for the uptime threshold as well: any validation you start on or after activation is judged against 90% rather than 80%, and validations already running keep the 80% requirement.
 
-**C-Chain developers.** ACP-194 changes when state is available relative to block acceptance, and several C-Chain RPC namespaces are deprecated alongside it. Read [Streaming Asynchronous Execution](/docs/primary-network/streaming-async-execution) and the [v1.15.0-fuji release notes](https://github.com/ava-labs/avalanchego/releases/tag/v1.15.0-fuji) before assuming existing behavior holds.
+**C-Chain developers.** ACP-194 changes when state is available relative to block acceptance, and several C-Chain RPC namespaces are deprecated alongside it. Read [Streaming Asynchronous Execution](/docs/primary-network/streaming-async-execution) and the [v1.15.0 release notes](https://github.com/ava-labs/avalanchego/releases/tag/v1.15.0) before assuming existing behavior holds.
 
-**Exchanges and custodians.** The staking minimums and the uptime threshold both move. If you quote a two-week minimum staking period to users, that number becomes 48 hours on Mainnet at activation.
+**Exchanges and custodians.** The staking minimums and the uptime threshold both move. If you quote a two-week minimum staking period to users, that number becomes 48 hours on Mainnet on September 22, 2026.

--- a/content/docs/primary-network/validate/rewards-formula.mdx
+++ b/content/docs/primary-network/validate/rewards-formula.mdx
@@ -108,7 +108,7 @@ For reference we list below the Primary Network parameters on Mainnet:
 - `UptimeRequirement = 0.8`, that is `80%`.
 
 <Callout type="info" title="Three of these parameters change with the Helicon upgrade">
-The Helicon upgrade is active on Fuji as of July 28, 2026 at 15:00 UTC and is not yet scheduled on Mainnet. The values above are the Mainnet values in effect today. Three of them change once Helicon activates on a network:
+The Helicon upgrade is active on Fuji as of July 28, 2026 at 15:00 UTC and is scheduled on Mainnet for September 22, 2026 at 15:00 UTC. The values above are the Mainnet values in effect until then. Three of them change once Helicon activates on a network:
 
 - **`MinConsumptionRate` drops from `0.10` to `0.075`** ([ACP-285](/docs/acps/285-reduce-minimum-consumption-rate)). The change is not applied at once: it ramps linearly over the 90 days following activation, and the rate used for a staking period is the one in effect at that period's **start time**. A stake that starts 45 days after activation therefore uses roughly `0.0875`.
 - **The effective uptime requirement rises from `80%` to `90%`** ([ACP-267](/docs/acps/267-uptime-requirement-increase)). This one is not a genesis parameter: `UptimeRequirement` above stays `0.8`, and the `90%` threshold is applied when deciding reward eligibility for any Primary Network validation whose **start time** is at or after Helicon activation. Validations that started earlier are still judged against `80%`, and Avalanche L1 validators keep the requirement set by their own subnet transformation.

--- a/content/docs/primary-network/validate/staking-for-finance-professionals.mdx
+++ b/content/docs/primary-network/validate/staking-for-finance-professionals.mdx
@@ -229,8 +229,8 @@ For detailed technical implementation support, refer to the [How to Stake](/docs
 
 ## Auto-Renewed Staking (ACP-236)
 
-<Callout type="info" title="Live on Fuji, not yet on Mainnet">
-[ACP-236: Auto-Renewed Staking](/docs/acps/236-auto-renewed-staking) activated on Fuji with the Helicon upgrade on July 28, 2026 at 15:00 UTC. Mainnet activation is not yet scheduled.
+<Callout type="info" title="Live on Fuji, scheduled on Mainnet">
+[ACP-236: Auto-Renewed Staking](/docs/acps/236-auto-renewed-staking) activated on Fuji with the Helicon upgrade on July 28, 2026 at 15:00 UTC. Mainnet activation is scheduled for September 22, 2026 at 15:00 UTC (11:00 AM ET).
 </Callout>
 
 ### What Is Auto-Renewed Staking?
@@ -290,7 +290,7 @@ Only the address set as the validator authority when the validator was created c
 - **Reduced operational burden.** Staying staked no longer requires a transaction per period.
 - **Automatic compounding.** Rewards restake each cycle at the percentage you set.
 - **Reduced key exposure.** Fewer signing events over the life of a position.
-- **Cycle length bounds.** A cycle must be at least the network minimum (12 hours on Fuji, 48 hours on Mainnet once Helicon activates there) and at most the maximum staking duration of one year.
+- **Cycle length bounds.** A cycle must be at least the network minimum (12 hours on Fuji, 48 hours on Mainnet from September 22, 2026) and at most the maximum staking duration of one year.
 - **Uptime discipline matters more.** A single cycle that misses the uptime requirement ends the position rather than simply skipping a reward.
 
 ### Impact on Delegators

--- a/content/docs/rpcs/other/guides/txn-fees.mdx
+++ b/content/docs/rpcs/other/guides/txn-fees.mdx
@@ -60,7 +60,7 @@ The minimum base fee has changed across network upgrades:
 | 1 nAVAX | December 16, 2024 to April 8, 2025 | Etna upgrade ([ACP-125](/docs/acps/125-basefee-reduction)) |
 | 1 wei | since April 8, 2025 | Fortuna upgrade ([ACP-176](/docs/acps/176-dynamic-evm-gas-limit-and-price-discovery-updates)) |
 
-With the Helicon upgrade (active on Fuji since July 28, 2026 at 15:00 UTC, not yet scheduled on Mainnet), [ACP-283](/docs/acps/283-dynamic-minimum-gas-price) makes the minimum gas price a dynamic parameter driven by stake-weighted validator preference. It starts at 1 wei at activation and moves only if validators prefer a different floor.
+With the Helicon upgrade (active on Fuji since July 28, 2026 at 15:00 UTC, scheduled on Mainnet for September 22, 2026 at 15:00 UTC), [ACP-283](/docs/acps/283-dynamic-minimum-gas-price) makes the minimum gas price a dynamic parameter driven by stake-weighted validator preference. It starts at 1 wei at activation and moves only if validators prefer a different floor.
 
 <Callout type="info" title="Helicon also changes how transactions pay fees (ACP-194)">
 [Continuous Execution](/docs/acps/194-continuous-execution) decouples consensus from execution, which changes fee handling on networks where Helicon is active:

--- a/content/docs/tooling/avalanche-sdk/client/methods/wallet-methods/p-chain-wallet.mdx
+++ b/content/docs/tooling/avalanche-sdk/client/methods/wallet-methods/p-chain-wallet.mdx
@@ -322,7 +322,7 @@ const delegatorTx =
 Prepare a transaction to add an auto-renewed validator (ACP-236) to the Primary Network. The validator automatically starts a new validation cycle of length `period` at each cycle boundary and can compound a configurable share of its rewards. Renewal happens only if the validator met its uptime requirement for the cycle (90% for Primary Network validators); otherwise it is removed from the validator set at the cycle boundary, its staked funds unlock, and the reward for that cycle is forfeited.
 
 <Callout>
-  ACP-236 transactions require the Helicon upgrade — active on Fuji from July 28, 2026 at 15:00 UTC, and not yet scheduled on Mainnet.
+  ACP-236 transactions require the Helicon upgrade — active on Fuji from July 28, 2026 at 15:00 UTC, and scheduled on Mainnet for September 22, 2026 at 15:00 UTC.
 </Callout>
 
 **Function Signature:**


### PR DESCRIPTION
## What

Updates every Helicon reference on the site from the Fuji-only messaging to the scheduled Mainnet activation: **September 22, 2026 at 11:00 AM ET (15:00 UTC)**, shipping in AvalancheGo v1.15.0.

## Changes

**Banner**
- Countdown retargeted to the Mainnet activation instant
- Re-enabled in `layout-wrapper.client.tsx`, where it was commented out
- Banner id changed so anyone who dismissed the Fuji banner sees this one

**Blog** (`content/blog/helicon-upgrade.mdx`)
- Lead and Mainnet release section now state the date and the v1.15.0 requirement
- Post date moved to 2026-09-08 to match the official announcement
- Fixes ACP-267 effective date: said "April 1, 2026", but [the ACP](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/267-uptime-requirement-increase) specifies Helicon activation

**Docs** (5 pages)
- `primary-network/helicon-upgrade.mdx`: activation table, release callout, and the "What You Need to Do" section, which told Mainnet validators nothing was required
- `rewards-formula.mdx`, `staking-for-finance-professionals.mdx`, `txn-fees.mdx`, `p-chain-wallet.mdx`: "not yet scheduled on Mainnet" → the scheduled date