### PR TITLE
fix(profile): disconnect wallets individually instead of all at once

### DIFF
--- a/components/profile/shell/WalletPanel.tsx
+++ b/components/profile/shell/WalletPanel.tsx
@@ -8,7 +8,7 @@ import type { ProfileWallet } from "./types";
 interface Props {
   wallets: ProfileWallet[];
   onAddWallet: (address: string) => void;
-  /** Called once per existing wallet when the user disconnects. */
+  /** Disconnect a single wallet, identified by its address. */
   onRemove: (address: string) => void;
 }
 
@@ -20,10 +20,6 @@ function shorten(addr: string): string {
 export function WalletPanel({ wallets, onAddWallet, onRemove }: Props) {
   const isConnected = wallets.length > 0;
   const lastAddress = wallets[wallets.length - 1]?.address;
-
-  const handleDisconnectAll = () => {
-    for (const w of [...wallets]) onRemove(w.address);
-  };
 
   if (!isConnected) {
     return (
@@ -69,8 +65,8 @@ export function WalletPanel({ wallets, onAddWallet, onRemove }: Props) {
             <button
               type="button"
               className="pr-btn pr-btn--sm pr-btn--success"
-              onClick={handleDisconnectAll}
-              aria-label="Disconnect wallet"
+              onClick={() => onRemove(w.address)}
+              aria-label={`Disconnect wallet ${w.address}`}
             >
               <Check size={12} /> Connected
             </button>


### PR DESCRIPTION
## Summary

Focused fix for part of #4196 (Fix Wallet in Profile).

In the profile's wallet panel, each connected wallet rendered a "Connected"
button whose click handler removed **every** wallet, not just that one — so
disconnecting a single wallet disconnected all of them. This wires each button
to the existing per-address `onRemove`, so a wallet is disconnected
individually, and labels the button with its address for accessibility.

**Scope**
- `components/profile/shell/WalletPanel.tsx` — remove the disconnect-all handler;
  each card now disconnects only its own wallet.

The other items in #4196 (extension-side revoke/approval, reconciling a changed
connected wallet, and mainnet/testnet/custom-name tagging) are separate and not
included here.

## How to verify

Connect two wallets in the profile, then click "Connected" on one of them: only
that wallet is removed (toast: "Wallet removed") and the other stays connected.
Previously both were removed.

Part of #4196.
