### PR TITLE
fix(integrations): repair 3 dead partner links

### DIFF
--- a/content/integrations/angle.mdx
+++ b/content/integrations/angle.mdx
@@ -6,7 +6,7 @@ description: "Angle Protocol provides decentralized stablecoins including EURA, 
 logo: /images/angle.png
 developer: Angle Protocol
 website: https://www.angle.money/
-documentation: https://docs.angle.money/
+documentation: https://angle.money/docs
 ---
 
 ## Overview

--- a/content/integrations/dkit.mdx
+++ b/content/integrations/dkit.mdx
@@ -5,7 +5,7 @@ available: ["C-Chain"]
 description: "dKit is a production-ready cross-chain DEX aggregation API/SDK that enables native swaps across 15+ blockchains including Avalanche by routing liquidity through THORChain, Chainflip, Maya, Jupiter, Garden and 1inch."
 logo: /images/dkit.png
 developer: dKit Team
-website: https://eldorito.club/
+website: https://app.eldorito.club/
 documentation: https://docs.eldorito.club/dkit-by-eldorito
 ---
 
@@ -29,7 +29,7 @@ dKiT is a unified cross-chain DEX aggregation layer that lets dApps execute **na
    Browse the [dKit Documentation](https://docs.eldorito.club/dkit-by-eldorito) to understand concepts, endpoints, and workflows.
 
 2. **Get an API Key**  
-   Request API keys on [El Dorito](https://eldorito.club/) → **Get API Key**.
+   Request API keys on [El Dorito](https://app.eldorito.club/) → **Get API Key**.
 
 3. **Install & Configure**  
    - Use the SDK (e.g., `@doritokit/sdk`) or call the REST API directly.  
@@ -50,7 +50,7 @@ dKiT is a unified cross-chain DEX aggregation layer that lets dApps execute **na
 - **API Reference / Swagger**: [dKit SDK Setup](https://docs.eldorito.club/dkit-by-eldorito/set-up-the-sdk)  
 - **Quick Start**: End-to-end example for quoting, executing, and tracking swaps  
 - **Revenue Generation**: [dKit Docs](https://docs.eldorito.club/dkit-by-eldorito)
-- **Status Page**: [El Dorito](https://eldorito.club/)
+- **Status Page**: [El Dorito](https://app.eldorito.club/)
 
 ## Supported Protocols & Aggregators
 

--- a/content/integrations/keyring.mdx
+++ b/content/integrations/keyring.mdx
@@ -6,7 +6,7 @@ description: Keyring provides privacy-preserving identity verification using zer
 logo: /images/keyring.png
 developer: Keyring Network
 website: https://www.keyring.network/
-documentation: https://docs.keyring.network/docs
+documentation: https://docs.keyring.network/
 ---
 
 ## Overview
@@ -47,7 +47,7 @@ Keyring works well with Avalanche's txAllowlist precompile:
 
 ## Documentation
 
-Keyring's developer docs are available at [docs.keyring.network/docs](https://docs.keyring.network/docs).
+Keyring's developer docs are available at [docs.keyring.network](https://docs.keyring.network/).
 
 ## Use Cases
 


### PR DESCRIPTION
## Summary

While auditing `content/integrations` (233 files, ~450 `website`/`documentation` URLs), I checked every URL against the live site. 30 initially looked broken (curl 403/404/429/timeout), but most of that was Cloudflare bot-protection on otherwise-live sites (snowtrace.io, routescan.io, revolut.com, etc.) rather than real breakage — I cross-checked each candidate with a second method (DNS resolution, a different fetch path, and/or Wayback Machine history) before touching anything. This PR is the 3 that survived that filter with a confident, verified replacement.

## Fixes

1. **`angle.mdx`** — `documentation` pointed to `docs.angle.money`, which has had no DNS record since ~2021 (confirmed via `getent hosts`, and the URL has no Wayback snapshot after 2021). Angle Protocol's current docs — now an end-of-life/redemption notice per AIP-112 — live at `angle.money/docs` (verified 200, real content).
2. **`keyring.mdx`** — `documentation` pointed to `docs.keyring.network/docs` (404). The bare `/docs` path 404s but the GitBook docs root does not; fixed to `docs.keyring.network/` (200). Also fixed the matching in-body link under "## Documentation".
3. **`dkit.mdx`** — `website` pointed to `eldorito.club`, whose root domain now 404s everywhere I checked it from (confirmed independently via two different fetch methods, not a one-off bot-block). The live product frontend is `app.eldorito.club` (200). Fixed the frontmatter field and two matching in-body links ("Get an API Key" and "Status Page") pointing at the same dead root. The `documentation` field (`docs.eldorito.club/...`) was already fine and untouched.

## Explicitly excluded (verified, not just skipped)

- **`proof-of-play.mdx`** (`proofofplay.com`, confirmed 404) — Proof of Play shut down as a studio (confirmed via news coverage: The Defiant, GameSpot). No confident live replacement exists that wouldn't misrepresent the listing as still-active; left for maintainers to decide whether to mark it deprecated instead.
- **`token-relations.mdx`** (`token-relations.com`, confirmed 404) — the only reachable lookalike, `tokenrelations.com` (no hyphen), turned out to be an unrelated parked/for-sale domain (`window._trfd.push({ap:"parking"})`), not the real company. No safe replacement found.
- Everything else that returned non-200 in the first pass (Gelato, Messari, OKX, Coinbase, Messiah, Xangle, etc.) stayed either genuinely ambiguous after a second check (bot-blocked but likely alive) or didn't have a replacement I could verify with the same confidence as the three above.

## Test plan
- [x] Extracted every `website`/`documentation` URL from `content/integrations/*.mdx` (455 URLs)
- [x] Checked each against its live target; re-verified every non-200 with a second method (DNS lookup, different UA/fetch path, or Wayback Machine) to rule out bot-blocking/rate-limiting false positives before treating it as broken
- [x] For each of the 3 fixes, confirmed the replacement URL independently (live 200 + real matching content, not just a redirect target)
- [x] `git diff` reviewed — only href strings changed, no prose/content changes

---
Emirhan Solmaz — Team1 Türkiye Collaborator