### PR TITLE
feat(verification): verify contracts on any Avalanche L1

### DIFF
--- a/app/(home)/explorer/[network]/[chain]/address/[address]/page.client.tsx
+++ b/app/(home)/explorer/[network]/[chain]/address/[address]/page.client.tsx
@@ -6,14 +6,18 @@ export function AddressDetailPageClient({
   network,
   address,
   initialTab,
+  justVerified,
 }: {
   network: string;
   address: string;
   initialTab?: string;
+  justVerified?: boolean;
   // sourcifySupport is accepted for call-site compatibility. The Contract
   // tab doesn't consult it: verification is resolved per address, and our
   // own verifier covers chains Sourcify has never heard of.
   sourcifySupport?: boolean;
 }) {
-  return <EvmAddress network={network} addr={address} initialTab={initialTab} />;
+  return (
+    <EvmAddress network={network} addr={address} initialTab={initialTab} justVerified={justVerified} />
+  );
 }

--- a/app/(home)/explorer/[network]/[chain]/address/[address]/page.client.tsx
+++ b/app/(home)/explorer/[network]/[chain]/address/[address]/page.client.tsx
@@ -5,12 +5,15 @@ import { EvmAddress } from "@/components/explorer-v2/evm/EvmAddress";
 export function AddressDetailPageClient({
   network,
   address,
+  initialTab,
 }: {
   network: string;
   address: string;
-  // sourcifySupport is accepted for call-site compatibility; the activity-only
-  // explorer doesn't surface source verification.
+  initialTab?: string;
+  // sourcifySupport is accepted for call-site compatibility. The Contract
+  // tab doesn't consult it: verification is resolved per address, and our
+  // own verifier covers chains Sourcify has never heard of.
   sourcifySupport?: boolean;
 }) {
-  return <EvmAddress network={network} addr={address} />;
+  return <EvmAddress network={network} addr={address} initialTab={initialTab} />;
 }

--- a/app/(home)/explorer/[network]/[chain]/address/[address]/page.tsx
+++ b/app/(home)/explorer/[network]/[chain]/address/[address]/page.tsx
@@ -5,7 +5,7 @@ import { AddressDetailPageClient } from "./page.client";
 
 interface AddressPageProps {
   params: Promise<{ network: string; chain: string; address: string }>;
-  searchParams: Promise<{ tab?: string }>;
+  searchParams: Promise<{ tab?: string; verified?: string }>;
 }
 
 export async function generateMetadata({ params }: AddressPageProps): Promise<Metadata> {
@@ -45,11 +45,11 @@ export async function generateMetadata({ params }: AddressPageProps): Promise<Me
 export default async function AddressPage({ params, searchParams }: AddressPageProps) {
   const resolvedParams = await params;
   const { chain: chainSlug, address } = resolvedParams;
-  const { tab } = await searchParams;
+  const { tab, verified } = await searchParams;
   
   // Get sourcifySupport from chain data
   const chain = l1ChainsData.find((c) => c.slug === chainSlug) as (L1Chain & { sourcifySupport?: boolean }) | undefined;
   
-  return <AddressDetailPageClient network={resolvedParams.network} address={address} initialTab={tab} sourcifySupport={chain?.sourcifySupport} />;
+  return <AddressDetailPageClient network={resolvedParams.network} address={address} initialTab={tab} justVerified={verified === "1"} sourcifySupport={chain?.sourcifySupport} />;
 }
 

--- a/app/(home)/explorer/[network]/[chain]/address/[address]/page.tsx
+++ b/app/(home)/explorer/[network]/[chain]/address/[address]/page.tsx
@@ -5,6 +5,7 @@ import { AddressDetailPageClient } from "./page.client";
 
 interface AddressPageProps {
   params: Promise<{ network: string; chain: string; address: string }>;
+  searchParams: Promise<{ tab?: string }>;
 }
 
 export async function generateMetadata({ params }: AddressPageProps): Promise<Metadata> {
@@ -41,13 +42,14 @@ export async function generateMetadata({ params }: AddressPageProps): Promise<Me
   };
 }
 
-export default async function AddressPage({ params }: AddressPageProps) {
+export default async function AddressPage({ params, searchParams }: AddressPageProps) {
   const resolvedParams = await params;
   const { chain: chainSlug, address } = resolvedParams;
+  const { tab } = await searchParams;
   
   // Get sourcifySupport from chain data
   const chain = l1ChainsData.find((c) => c.slug === chainSlug) as (L1Chain & { sourcifySupport?: boolean }) | undefined;
   
-  return <AddressDetailPageClient network={resolvedParams.network} address={address} sourcifySupport={chain?.sourcifySupport} />;
+  return <AddressDetailPageClient network={resolvedParams.network} address={address} initialTab={tab} sourcifySupport={chain?.sourcifySupport} />;
 }
 

--- a/app/(home)/explorer/[network]/[chain]/verify/[address]/page.client.tsx
+++ b/app/(home)/explorer/[network]/[chain]/verify/[address]/page.client.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { EvmVerify } from "@/components/explorer-v2/evm/EvmVerify";
+
+export function VerifyContractPageClient({
+  network,
+  address,
+}: {
+  network: string;
+  address: string;
+}) {
+  return <EvmVerify network={network} addr={address} />;
+}

--- a/app/(home)/explorer/[network]/[chain]/verify/[address]/page.tsx
+++ b/app/(home)/explorer/[network]/[chain]/verify/[address]/page.tsx
@@ -1,0 +1,27 @@
+import { Metadata } from "next";
+import l1ChainsData from "@/constants/l1-chains.json";
+import { L1Chain } from "@/types/stats";
+import { VerifyContractPageClient } from "./page.client";
+
+interface VerifyPageProps {
+  params: Promise<{ network: string; chain: string; address: string }>;
+}
+
+export async function generateMetadata({ params }: VerifyPageProps): Promise<Metadata> {
+  const { chain: chainSlug, address } = await params;
+  const chain = l1ChainsData.find((c) => c.slug === chainSlug) as L1Chain | undefined;
+  const shortAddress = `${address.slice(0, 10)}...${address.slice(-8)}`;
+
+  return {
+    title: chain
+      ? `Verify ${shortAddress} | ${chain.chainName} Explorer`
+      : `Verify ${shortAddress} | Explorer`,
+    description:
+      "Publish a contract's source code by proving it compiles to the bytecode deployed on chain.",
+  };
+}
+
+export default async function VerifyContractPage({ params }: VerifyPageProps) {
+  const { network, address } = await params;
+  return <VerifyContractPageClient network={network} address={address} />;
+}

--- a/app/api/sourcify/[chainId]/[address]/route.ts
+++ b/app/api/sourcify/[chainId]/[address]/route.ts
@@ -11,7 +11,11 @@ import { getVerifiedContractResolvingProxies } from "@/lib/sourcify";
 
 const HIT_CACHE = "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800";
 const PROXY_CACHE = "public, max-age=1800, s-maxage=3600, stale-while-revalidate=86400";
-const MISS_CACHE = "public, max-age=300, s-maxage=600";
+// A miss is the one answer here that flips on a user's own action, so the
+// browser must never hold onto it: someone who verifies a contract and
+// returns to its page would otherwise be told it is unverified for as long
+// as the cache lasts. The CDN still absorbs bursts, briefly.
+const MISS_CACHE = "public, max-age=0, s-maxage=60";
 
 export async function GET(
   _req: NextRequest,

--- a/app/api/sourcify/[chainId]/[address]/sources/route.ts
+++ b/app/api/sourcify/[chainId]/[address]/sources/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getContractSources } from "@/lib/sourcify";
+
+/*
+ * Source files for a verified contract, from whichever verifier has them
+ * — ours or Sourcify's. The Contract tab asks this route and never has to
+ * know which one answered.
+ *
+ * Split out from the sibling metadata route because source trees are big
+ * and only one tab wants them, while the metadata route is called for
+ * every address on a page.
+ */
+
+const HIT_CACHE = "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800";
+// Not browser-cached, for the same reason as the sibling route: sources
+// appear the moment a contract is verified.
+const MISS_CACHE = "public, max-age=0, s-maxage=60";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ chainId: string; address: string }> },
+) {
+  const { chainId, address } = await params;
+  const sources = await getContractSources(Number(chainId), address);
+
+  if (!sources) {
+    return NextResponse.json(
+      { available: false },
+      { status: 404, headers: { "Cache-Control": MISS_CACHE } },
+    );
+  }
+
+  return NextResponse.json(
+    { available: true, ...sources },
+    { headers: { "Cache-Control": HIT_CACHE } },
+  );
+}

--- a/app/api/verify/[chainId]/api/route.ts
+++ b/app/api/verify/[chainId]/api/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { handleEtherscanApi } from "@/lib/verification/etherscan-api";
+
+/*
+ * Etherscan-compatible verification for one chain, the shape Hardhat 2's
+ * `customChains[].urls.apiURL` and Foundry's `--verifier-url` expect:
+ *
+ *   https://build.avax.network/api/verify/43114/api
+ *
+ * Compilation happens inside this function (in a worker), so it gets the
+ * duration backstop and the larger memory profile. The 180-second compile
+ * timeout in solc.ts is the real ceiling; maxDuration only catches the
+ * case where everything around the compile also goes slowly.
+ */
+export const runtime = "nodejs";
+export const maxDuration = 300;
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ chainId: string }> }) {
+  const { chainId } = await params;
+  return handleEtherscanApi(request, chainId);
+}
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ chainId: string }> }) {
+  const { chainId } = await params;
+  return handleEtherscanApi(request, chainId);
+}

--- a/app/api/verify/cleanup/route.ts
+++ b/app/api/verify/cleanup/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { COMPILE_TIMEOUT_MS } from "@/lib/verification/solc";
+import { deleteJobsOlderThan, failStalledJobs } from "@/lib/verification/store";
+
+/*
+ * Housekeeping for the verification job table, run on a schedule from
+ * vercel.json.
+ *
+ * Two jobs, both about not leaving callers or rows stranded:
+ *  - a job whose instance was recycled mid-compile would otherwise stay
+ *    "running" forever, and its poller would loop forever with it;
+ *  - completed jobs are only interesting while someone is polling them,
+ *    so a week is generous. The verifications themselves are permanent;
+ *    it is only the receipts that expire.
+ */
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const JOB_RETENTION_DAYS = 7;
+/** Generous slack over the compile ceiling before declaring a job lost. */
+const STALL_AFTER_MS = COMPILE_TIMEOUT_MS + 10 * 60 * 1000;
+
+function authorized(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return process.env.NODE_ENV !== "production";
+  return (
+    request.headers.get("authorization") === `Bearer ${secret}` ||
+    request.headers.get("x-api-key") === secret
+  );
+}
+
+async function run(request: NextRequest) {
+  if (!authorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    await failStalledJobs(STALL_AFTER_MS);
+    const deleted = await deleteJobsOlderThan(JOB_RETENTION_DAYS);
+    return NextResponse.json({ ok: true, deleted });
+  } catch (error) {
+    console.error("[verification] cleanup failed", error);
+    return NextResponse.json({ error: "Cleanup failed" }, { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return run(request);
+}
+
+export async function POST(request: NextRequest) {
+  return run(request);
+}

--- a/app/api/verify/compilers/route.ts
+++ b/app/api/verify/compilers/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { listReleases } from "@/lib/verification/solc";
+
+/*
+ * Released Solidity versions, newest first, for the compiler picker on the
+ * verify form. Proxied rather than fetched in the browser so the list is
+ * cached once at the edge instead of per visitor, and so the form and the
+ * verifier can never disagree about which versions exist.
+ */
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const releases = await listReleases();
+    return NextResponse.json(
+      { releases },
+      { headers: { "Cache-Control": "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800" } },
+    );
+  } catch {
+    return NextResponse.json({ releases: [] }, { status: 503 });
+  }
+}

--- a/app/api/verify/sourcify/v2/contract/[chainId]/[address]/route.ts
+++ b/app/api/verify/sourcify/v2/contract/[chainId]/[address]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isAddress } from "@/lib/verification/chains";
+import { contractResponse, parseFields } from "@/lib/verification/sourcify-api";
+import { findVerified } from "@/lib/verification/store";
+
+/*
+ * GET /api/verify/sourcify/v2/contract/{chainId}/{address}
+ *
+ * Lookup for contracts verified here. hardhat-verify calls this before
+ * submitting and reads `match` out of the 404 body to decide a contract
+ * is unverified, so the miss has to carry that field rather than a bare
+ * error. Also the source of truth for the explorer's Contract tab.
+ *
+ * Only our own verifications answer here. Sourcify's archive is consulted
+ * through /api/sourcify/[chainId]/[address], which merges both.
+ */
+export const runtime = "nodejs";
+
+const HIT_CACHE = "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400";
+// Tooling calls this to decide whether a contract still needs verifying,
+// so a remembered miss is worth very little and costs a wasted round of
+// verification when it is wrong.
+const MISS_CACHE = "public, max-age=0, s-maxage=30";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ chainId: string; address: string }> },
+) {
+  const { chainId: chainIdRaw, address } = await params;
+  const chainId = Number(chainIdRaw);
+
+  if (!Number.isInteger(chainId) || chainId <= 0 || !isAddress(address)) {
+    return NextResponse.json({ match: null, error: "Invalid chain or address" }, { status: 400 });
+  }
+
+  const verified = await findVerified(chainId, address);
+  if (!verified) {
+    return NextResponse.json(
+      { match: null, chainId: String(chainId), address: address.toLowerCase() },
+      { status: 404, headers: { "Cache-Control": MISS_CACHE } },
+    );
+  }
+
+  const fields = parseFields(request.nextUrl.searchParams.get("fields"));
+  return NextResponse.json(await contractResponse(verified, fields), {
+    headers: { "Cache-Control": HIT_CACHE },
+  });
+}

--- a/app/api/verify/sourcify/v2/verify/[...path]/route.ts
+++ b/app/api/verify/sourcify/v2/verify/[...path]/route.ts
@@ -1,0 +1,110 @@
+import { after, NextRequest, NextResponse } from "next/server";
+import { getClientId } from "@/lib/mcp-rate-limit";
+import { isAddress, knownChain } from "@/lib/verification/chains";
+import { submitVerification } from "@/lib/verification/service";
+import { customCodeFor, jobResponse } from "@/lib/verification/sourcify-api";
+import { findVerified, getJob } from "@/lib/verification/store";
+
+/*
+ * Two Sourcify endpoints share this prefix and so have to share a route:
+ *
+ *   POST /api/verify/sourcify/v2/verify/{chainId}/{address}   submit
+ *   GET  /api/verify/sourcify/v2/verify/{verificationId}      poll
+ *
+ * Next.js will not accept two differently-named dynamic segments in the
+ * same position, hence the catch-all and the manual dispatch on depth.
+ */
+export const runtime = "nodejs";
+export const maxDuration = 300;
+export const dynamic = "force-dynamic";
+
+function error(status: number, customCode: string, message: string, headers?: Record<string, string>) {
+  return NextResponse.json({ customCode, message, errorId: crypto.randomUUID() }, { status, headers });
+}
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const { path } = await params;
+  if (path.length !== 2) {
+    return error(404, "not_found", "Expected /v2/verify/{chainId}/{address}.");
+  }
+
+  const [chainIdRaw, addressRaw] = path;
+  const chainId = Number(chainIdRaw);
+  const address = addressRaw.toLowerCase();
+
+  if (!Number.isInteger(chainId) || chainId <= 0 || !knownChain(chainId)) {
+    return error(404, "unsupported_chain", `Chain ${chainIdRaw} is not supported by this verifier.`);
+  }
+  if (!isAddress(address)) {
+    return error(400, "invalid_parameter", "Not a contract address.");
+  }
+
+  let body: {
+    stdJsonInput?: unknown;
+    compilerVersion?: string;
+    contractIdentifier?: string;
+    creationTransactionHash?: string;
+  };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return error(400, "missing_or_invalid_source", "Body must be JSON.");
+  }
+
+  if (!body.compilerVersion || !body.contractIdentifier) {
+    return error(
+      400,
+      "missing_or_invalid_source",
+      "compilerVersion and contractIdentifier are both required.",
+    );
+  }
+
+  const result = await submitVerification({
+    chainId,
+    address,
+    stdJsonInput: body.stdJsonInput,
+    compilerVersion: body.compilerVersion,
+    contractIdentifier: body.contractIdentifier,
+    clientId: getClientId(request),
+  });
+
+  if (!result.ok) {
+    const status =
+      result.code === "already_verified"
+        ? 409
+        : result.code === "rate_limited"
+          ? 429
+          : result.code === "unsupported_chain" || result.code === "contract_not_deployed"
+            ? 404
+            : result.code === "internal_error"
+              ? 500
+              : 400;
+    return error(
+      status,
+      customCodeFor(result.code),
+      result.message,
+      result.retryAfterSeconds ? { "Retry-After": String(result.retryAfterSeconds) } : undefined,
+    );
+  }
+
+  after(result.run);
+
+  return NextResponse.json({ verificationId: result.jobId }, { status: 202 });
+}
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const { path } = await params;
+  if (path.length !== 1) {
+    return error(404, "not_found", "Expected /v2/verify/{verificationId}.");
+  }
+
+  const job = await getJob(path[0]);
+  if (!job) {
+    return error(404, "not_found", "Unknown verification id.");
+  }
+
+  const verified = job.status === "succeeded" ? await findVerified(job.chainId, job.address) : null;
+  // 200 even for a failed verification: the job ran, and its outcome is
+  // the payload. Only an unknown id is an HTTP error here.
+  return NextResponse.json(await jobResponse(job, verified));
+}

--- a/app/api/verify/v2/api/route.ts
+++ b/app/api/verify/v2/api/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest } from "next/server";
+import { handleEtherscanApi } from "@/lib/verification/etherscan-api";
+
+/*
+ * The same Etherscan-compatible API in its V2 shape, where the chain
+ * travels in a `chainid` query parameter instead of the path:
+ *
+ *   https://build.avax.network/api/verify/v2/api?chainid=43114
+ *
+ * This is what Hardhat 3's chainDescriptors produces. The static `v2`
+ * segment takes precedence over the sibling [chainId] route, so both
+ * spellings coexist on the same tree.
+ */
+export const runtime = "nodejs";
+export const maxDuration = 300;
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  return handleEtherscanApi(request);
+}
+
+export async function POST(request: NextRequest) {
+  return handleEtherscanApi(request);
+}

--- a/app/docs/[...slug]/page.tsx
+++ b/app/docs/[...slug]/page.tsx
@@ -7,7 +7,7 @@ import StateGrowthChart from "@/components/content-design/state-growth-chart";
 import { BackToTop } from "@/components/ui/back-to-top";
 import { Feedback } from "@/components/ui/feedback";
 import { SidebarActions } from "@/components/ui/sidebar-actions";
-import { CChainAPIPage, DataAPIPage, MetricsAPIPage, PChainAPIPage, XChainAPIPage } from "@/components/api/api-pages";
+import { CChainAPIPage, DataAPIPage, MetricsAPIPage, PChainAPIPage, VerificationAPIPage, XChainAPIPage } from "@/components/api/api-pages";
 import AddNetworkButtonInline from "@/components/client/AddNetworkButtonInline";
 import { documentation } from "@/lib/source";
 import { createMetadata } from "@/utils/metadata";
@@ -117,6 +117,7 @@ export default async function Page(props: {
               const isPChainApi = document.includes('platformvm.yaml');
               const isCChainApi = document.includes('coreth.yaml');
               const isXChainApi = document.includes('xchain.yaml');
+              const isVerificationApi = document.includes('verification.json');
 
               if (isPChainApi) {
                 return <PChainAPIPage {...props} />;
@@ -126,6 +127,8 @@ export default async function Page(props: {
                 return <XChainAPIPage {...props} />;
               } else if (isMetricsApi) {
                 return <MetricsAPIPage {...props} />;
+              } else if (isVerificationApi) {
+                return <VerificationAPIPage {...props} />;
               } else {
                 return <DataAPIPage {...props} />;
               }

--- a/components/api/api-pages.tsx
+++ b/components/api/api-pages.tsx
@@ -1,10 +1,11 @@
-import { dataApi, metricsApi, pChainApi, cChainApi, xChainApi } from '@/lib/openapi';
+import { dataApi, metricsApi, pChainApi, cChainApi, xChainApi, verificationApi } from '@/lib/openapi';
 import { createAPIPage } from 'fumadocs-openapi/ui';
 import dataApiClient from './data-api-page.client';
 import metricsApiClient from './metrics-api-page.client';
 import pchainApiClient from './pchain-api-page.client';
 import cchainApiClient from './cchain-api-page.client';
 import xchainApiClient from './xchain-api-page.client';
+import verificationApiClient from './verification-api-page.client';
 import { OpenBodySection } from "./api-open-body.client";
 
 const DataAPIPageBase = createAPIPage(dataApi, {
@@ -68,6 +69,19 @@ export function XChainAPIPage(props: any) {
     <div className="xchain-api-playground">
       <OpenBodySection />
       <XChainAPIPageBase {...props} />
+    </div>
+  );
+}
+
+const VerificationAPIPageBase = createAPIPage(verificationApi, {
+  client: verificationApiClient,
+});
+
+export function VerificationAPIPage(props: any) {
+  return (
+    <div className="verification-api-playground">
+      <OpenBodySection />
+      <VerificationAPIPageBase {...props} />
     </div>
   );
 }

--- a/components/api/verification-api-page.client.tsx
+++ b/components/api/verification-api-page.client.tsx
@@ -1,0 +1,6 @@
+'use client';
+import { defineClientConfig } from 'fumadocs-openapi/ui/client';
+
+export default defineClientConfig({
+  storageKeyPrefix: 'fumadocs-openapi-verification-',
+});

--- a/components/explorer-v2/evm/EvmAddress.tsx
+++ b/components/explorer-v2/evm/EvmAddress.tsx
@@ -10,10 +10,11 @@ import { formatEther } from "./format";
 import { FeedDown, MethodChip } from "./bits";
 import { StatusPill } from "./EvmTx";
 import { useEvmData } from "./hooks";
+import { EvmContract, useIsContract, useVerifiedContract } from "./EvmContract";
 import { useChainContext } from "@/app/(home)/explorer/[network]/[chain]/layout.client";
 import type { AddressSummary, TxListResponse, TransferListResponse } from "@/lib/evm-explorer";
 
-type Tab = "txs" | "transfers";
+type Tab = "txs" | "transfers" | "contract";
 
 function TransferStandardPill({ standard }: { standard: string }) {
   return (
@@ -24,17 +25,40 @@ function TransferStandardPill({ standard }: { standard: string }) {
   );
 }
 
-export function EvmAddress({ network, addr }: { network: string; addr: string }) {
+export function EvmAddress({
+  network,
+  addr,
+  initialTab,
+}: {
+  network: string;
+  addr: string;
+  /** ?tab=contract lands here from the verify form, so a freshly verified
+   *  contract opens on its source rather than its transaction list. Read
+   *  on the server and passed down, which keeps this component out of the
+   *  Suspense bailout that useSearchParams would require. */
+  initialTab?: string;
+}) {
   const c = useChainContext();
   const base = `/explorer/${network}/${c.chainSlug}`;
   const sym = c.nativeToken;
-  const [tab, setTab] = useState<Tab>("txs");
+  const [tab, setTab] = useState<Tab>(initialTab === "contract" ? "contract" : "txs");
 
   const { data: s, loading, error, retry } = useEvmData<AddressSummary>(c.chainId, `address/${addr}`, undefined, {
     retry404Ms: 15_000,
   });
   const txs = useEvmData<TxListResponse>(c.chainId, `address/${addr}/txs`, { limit: 50 });
   const transfers = useEvmData<TransferListResponse>(c.chainId, `address/${addr}/transfers`, { limit: 50 });
+
+  // A verified record proves it's a contract; otherwise ask the chain, so
+  // unverified contracts still get the tab (and the route to verifying).
+  const { contract: verified } = useVerifiedContract(c.chainId, addr);
+  const hasCode = useIsContract(c.rpcUrl, addr);
+  const isContract = verified !== null || hasCode === true;
+
+  const tabs: Tab[] = isContract ? ["txs", "transfers", "contract"] : ["txs", "transfers"];
+  // The contract check resolves after first paint, and the address can
+  // change under us — never leave a tab selected that no longer exists.
+  const activeTab: Tab = tab === "contract" && !isContract ? "txs" : tab;
 
   const txList = txs.data?.transactions ?? [];
   const xferList = transfers.data?.transfers ?? [];
@@ -62,6 +86,19 @@ export function EvmAddress({ network, addr }: { network: string; addr: string })
                 <SpecRow label="Address">
                   <HashChip value={s.address} len={42} />
                 </SpecRow>
+                {isContract ? (
+                  <SpecRow label="Type">
+                    {verified ? (
+                      <span className="inline-flex items-center gap-1.5 border border-[#4e9a52]/40 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-[#3f7d43] dark:text-[#77c47b]">
+                        Verified contract
+                      </span>
+                    ) : (
+                      <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-zinc-500 dark:text-zinc-400">
+                        Contract
+                      </span>
+                    )}
+                  </SpecRow>
+                ) : null}
                 <SpecRow label="Transactions">{formatNumber(s.txCount)}</SpecRow>
                 {s.firstSeen ? (
                   <SpecRow label="First Seen">
@@ -79,24 +116,26 @@ export function EvmAddress({ network, addr }: { network: string; addr: string })
 
           <section className="flex flex-col gap-4">
             <div className="flex items-center gap-2">
-              {(["txs", "transfers"] as Tab[]).map((t) => (
+              {tabs.map((t) => (
                 <button
                   key={t}
                   onClick={() => setTab(t)}
-                  aria-pressed={tab === t}
+                  aria-pressed={activeTab === t}
                   className={cn(
                     "border px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors",
-                    tab === t
+                    activeTab === t
                       ? "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
                       : "border-zinc-200 bg-white/80 text-zinc-500 hover:border-zinc-400 hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-400 dark:hover:text-zinc-100",
                   )}
                 >
-                  {t === "txs" ? "Transactions" : "Token Transfers"}
+                  {t === "txs" ? "Transactions" : t === "transfers" ? "Token Transfers" : "Contract"}
                 </button>
               ))}
             </div>
 
-            {tab === "txs" ? (
+            {activeTab === "contract" ? (
+              <EvmContract network={network} addr={addr} />
+            ) : activeTab === "txs" ? (
               <Board>
                 {txList.length === 0 &&
                   (txs.error && !txs.loading ? (

--- a/components/explorer-v2/evm/EvmAddress.tsx
+++ b/components/explorer-v2/evm/EvmAddress.tsx
@@ -29,6 +29,7 @@ export function EvmAddress({
   network,
   addr,
   initialTab,
+  justVerified,
 }: {
   network: string;
   addr: string;
@@ -37,6 +38,10 @@ export function EvmAddress({
    *  on the server and passed down, which keeps this component out of the
    *  Suspense bailout that useSearchParams would require. */
   initialTab?: string;
+  /** Set by the verify form's redirect, so the Contract tab knows to wait
+   *  for a verification it has just been told about rather than declaring
+   *  the contract unverified. */
+  justVerified?: boolean;
 }) {
   const c = useChainContext();
   const base = `/explorer/${network}/${c.chainSlug}`;
@@ -51,7 +56,9 @@ export function EvmAddress({
 
   // A verified record proves it's a contract; otherwise ask the chain, so
   // unverified contracts still get the tab (and the route to verifying).
-  const { contract: verified } = useVerifiedContract(c.chainId, addr);
+  const { contract: verified } = useVerifiedContract(c.chainId, addr, {
+    expectVerified: justVerified,
+  });
   const hasCode = useIsContract(c.rpcUrl, addr);
   const isContract = verified !== null || hasCode === true;
 
@@ -134,7 +141,7 @@ export function EvmAddress({
             </div>
 
             {activeTab === "contract" ? (
-              <EvmContract network={network} addr={addr} />
+              <EvmContract network={network} addr={addr} justVerified={justVerified} />
             ) : activeTab === "txs" ? (
               <Board>
                 {txList.length === 0 &&

--- a/components/explorer-v2/evm/EvmContract.tsx
+++ b/components/explorer-v2/evm/EvmContract.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { Check, Copy, ExternalLink, ShieldCheck } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Board, CellLabel, SpecPlate, SpecRow, idInk } from "@/components/explorer-v2/ui";
+import ContractReadSection from "@/components/explorer/ContractReadSection";
+import ContractWriteSection from "@/components/explorer/ContractWriteSection";
+import SourceCodeViewer from "@/components/explorer/SourceCodeViewer";
+import { fetchVerifiedContract, type SourcifyContract } from "@/lib/sourcify-client";
+import { useChainContext } from "@/app/(home)/explorer/[network]/[chain]/layout.client";
+
+/* ------------------------------------------------------------------ */
+/* The Contract tab.                                                   */
+/*                                                                     */
+/* Verified source, ABI, and the read/write consoles. The heavy pieces */
+/* are the long-standing components under components/explorer; what    */
+/* lives here is the tab shell, the verification provenance, and the   */
+/* path to the verify form when the contract is unverified.            */
+/* ------------------------------------------------------------------ */
+
+interface ContractSources {
+  sources: Record<string, { content: string }>;
+  optimizer: { enabled: boolean; runs: number | null } | null;
+  evmVersion: string | null;
+  origin: "builder-hub" | "sourcify";
+}
+
+/** Whether an address holds code. Cheap enough to ask the chain directly,
+ *  and the only way to tell a contract from a wallet before any indexer
+ *  has an opinion. */
+export function useIsContract(rpcUrl: string | undefined, address: string): boolean | null {
+  const [isContract, setIsContract] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!rpcUrl) {
+      setIsContract(null);
+      return;
+    }
+    let cancelled = false;
+    setIsContract(null);
+
+    fetch(rpcUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getCode", params: [address, "latest"] }),
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((body: { result?: string } | null) => {
+        if (cancelled) return;
+        const code = body?.result;
+        setIsContract(typeof code === "string" ? code !== "0x" && code.length > 2 : null);
+      })
+      .catch(() => {
+        if (!cancelled) setIsContract(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [rpcUrl, address]);
+
+  return isContract;
+}
+
+export function useVerifiedContract(chainId: string, address: string) {
+  const [contract, setContract] = useState<SourcifyContract | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetchVerifiedContract(chainId, address)
+      .then((found) => {
+        if (cancelled) return;
+        setContract(found);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [chainId, address]);
+
+  return { contract, loading };
+}
+
+type SubTab = "code" | "read" | "write";
+
+const SUB_TABS: { id: SubTab; label: string }[] = [
+  { id: "code", label: "Code" },
+  { id: "read", label: "Read" },
+  { id: "write", label: "Write" },
+];
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "border px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors",
+        active
+          ? "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
+          : "border-zinc-200 bg-white/80 text-zinc-500 hover:border-zinc-400 hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-400 dark:hover:text-zinc-100",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function CopyAbiButton({ abi }: { abi: unknown[] }) {
+  const [copied, setCopied] = useState(false);
+  const copy = useCallback(() => {
+    void navigator.clipboard.writeText(JSON.stringify(abi, null, 2)).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }, [abi]);
+
+  return (
+    <button
+      onClick={copy}
+      className="flex items-center gap-1.5 border border-zinc-200 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 transition-colors hover:border-zinc-400 hover:text-zinc-900 dark:border-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100"
+    >
+      {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+      {copied ? "Copied" : "Copy ABI"}
+    </button>
+  );
+}
+
+function Unverified({ verifyHref }: { verifyHref: string }) {
+  return (
+    <Board divide={false} className="px-6 py-12 text-center">
+      <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-zinc-400 dark:text-zinc-500">
+        Source code not verified
+      </p>
+      <p className="mx-auto mt-4 max-w-lg text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+        Verify this contract to publish its source and ABI here, and to make every call and event
+        against it decode by name across the explorer.
+      </p>
+      <Link
+        href={verifyHref}
+        className="mt-6 inline-flex items-center gap-2 border border-zinc-900 bg-zinc-900 px-4 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-white transition-opacity hover:opacity-90 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
+      >
+        <ShieldCheck className="size-3.5" />
+        Verify contract
+      </Link>
+    </Board>
+  );
+}
+
+export function EvmContract({ network, addr }: { network: string; addr: string }) {
+  const c = useChainContext();
+  const base = `/explorer/${network}/${c.chainSlug}`;
+  const { contract, loading } = useVerifiedContract(c.chainId, addr);
+  const [tab, setTab] = useState<SubTab>("code");
+  const [sources, setSources] = useState<ContractSources | null>(null);
+
+  useEffect(() => {
+    if (!contract) {
+      setSources(null);
+      return;
+    }
+    let cancelled = false;
+    fetch(`/api/sourcify/${c.chainId}/${addr.toLowerCase()}/sources`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((body: (ContractSources & { available: boolean }) | null) => {
+        if (!cancelled && body?.available) setSources(body);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [contract, c.chainId, addr]);
+
+  if (loading) {
+    return (
+      <Board divide={false} className="px-5 py-8 md:px-6">
+        <p className="font-mono text-[11px] text-zinc-400 dark:text-zinc-500">Loading…</p>
+      </Board>
+    );
+  }
+
+  if (!contract) {
+    return <Unverified verifyHref={`${base}/verify/${addr.toLowerCase()}`} />;
+  }
+
+  const abi = (contract.abi ?? []) as unknown[];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        {SUB_TABS.map((sub) => (
+          <TabButton key={sub.id} active={tab === sub.id} onClick={() => setTab(sub.id)}>
+            {sub.label}
+          </TabButton>
+        ))}
+      </div>
+
+      {tab === "code" && (
+        <>
+          <Board divide={false} className="px-5 py-4 md:px-6">
+            <SpecPlate>
+              <SpecRow label="Verification">
+                <span className="inline-flex items-center gap-1.5 border border-[#4e9a52]/40 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-[#3f7d43] dark:text-[#77c47b]">
+                  <Check className="size-3" />
+                  {contract.match === "exact_match" ? "Exact match" : "Match"}
+                </span>
+              </SpecRow>
+              {contract.name ? <SpecRow label="Contract">{contract.name}</SpecRow> : null}
+              {contract.compilerVersion ? (
+                <SpecRow label="Compiler">{contract.compilerVersion}</SpecRow>
+              ) : null}
+              {sources?.optimizer ? (
+                <SpecRow label="Optimizer">
+                  {sources.optimizer.enabled
+                    ? `Enabled${sources.optimizer.runs ? ` · ${sources.optimizer.runs} runs` : ""}`
+                    : "Disabled"}
+                </SpecRow>
+              ) : null}
+              {contract.verifiedAt ? (
+                <SpecRow label="Verified">
+                  {new Date(contract.verifiedAt).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                  {sources?.origin === "sourcify" ? " · via Sourcify" : ""}
+                </SpecRow>
+              ) : null}
+              {contract.proxy ? (
+                <SpecRow label="Implementation">
+                  <Link
+                    href={`${base}/address/${contract.proxy.implementation}`}
+                    className={`font-mono text-[12px] ${idInk} hover:underline`}
+                  >
+                    {contract.proxy.implementationName ?? contract.proxy.implementation}
+                  </Link>
+                </SpecRow>
+              ) : null}
+            </SpecPlate>
+          </Board>
+
+          {sources && Object.keys(sources.sources).length > 0 ? (
+            <Board divide={false}>
+              <SourceCodeViewer sources={sources.sources} themeColor={c.themeColor} />
+            </Board>
+          ) : null}
+
+          {abi.length > 0 ? (
+            <Board divide={false}>
+              <div className="flex items-center justify-between border-b border-zinc-200 px-5 py-3 md:px-6 dark:border-zinc-800">
+                <CellLabel>Contract ABI</CellLabel>
+                <CopyAbiButton abi={abi} />
+              </div>
+              <pre className="max-h-72 overflow-auto px-5 py-4 font-mono text-[11px] leading-relaxed text-zinc-700 md:px-6 dark:text-zinc-300">
+                {JSON.stringify(abi, null, 2)}
+              </pre>
+            </Board>
+          ) : null}
+
+          {sources?.origin === "sourcify" ? (
+            <div className="flex justify-end">
+              <a
+                href={`https://repo.sourcify.dev/${c.chainId}/${addr}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 hover:text-zinc-700 dark:text-zinc-500 dark:hover:text-zinc-300"
+              >
+                View on Sourcify
+                <ExternalLink className="size-3" />
+              </a>
+            </div>
+          ) : null}
+        </>
+      )}
+
+      {tab === "read" && (
+        <Board divide={false}>
+          <ContractReadSection abi={abi} address={addr} rpcUrl={c.rpcUrl} themeColor={c.themeColor} />
+        </Board>
+      )}
+
+      {tab === "write" && (
+        <Board divide={false}>
+          <ContractWriteSection
+            abi={abi}
+            address={addr}
+            chainId={c.chainId}
+            chainSlug={c.chainSlug}
+            rpcUrl={c.rpcUrl}
+            themeColor={c.themeColor}
+          />
+        </Board>
+      )}
+    </div>
+  );
+}

--- a/components/explorer-v2/evm/EvmContract.tsx
+++ b/components/explorer-v2/evm/EvmContract.tsx
@@ -64,26 +64,54 @@ export function useIsContract(rpcUrl: string | undefined, address: string): bool
   return isContract;
 }
 
-export function useVerifiedContract(chainId: string, address: string) {
+/** How long to keep asking when we arrived expecting a verified contract. */
+const SETTLE_TIMEOUT_MS = 30_000;
+const SETTLE_INTERVAL_MS = 2_000;
+
+export function useVerifiedContract(
+  chainId: string,
+  address: string,
+  options?: {
+    /** We just verified this contract, so "unverified" is the wrong answer
+     *  and worth re-asking for. A CDN or browser can still be holding a
+     *  miss from before the verification landed. */
+    expectVerified?: boolean;
+  },
+) {
   const [contract, setContract] = useState<SourcifyContract | null>(null);
   const [loading, setLoading] = useState(true);
+  const expectVerified = options?.expectVerified ?? false;
 
   useEffect(() => {
     let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = Date.now() + SETTLE_TIMEOUT_MS;
     setLoading(true);
-    fetchVerifiedContract(chainId, address)
-      .then((found) => {
-        if (cancelled) return;
-        setContract(found);
-        setLoading(false);
-      })
-      .catch(() => {
-        if (!cancelled) setLoading(false);
-      });
+
+    const ask = (force: boolean) => {
+      fetchVerifiedContract(chainId, address, force ? { force: true } : undefined)
+        .then((found) => {
+          if (cancelled) return;
+          setContract(found);
+          setLoading(false);
+          // Keep asking only while we have reason to believe the answer is
+          // about to change, and only until it does.
+          if (!found && expectVerified && Date.now() < deadline) {
+            timer = setTimeout(() => ask(true), SETTLE_INTERVAL_MS);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) setLoading(false);
+        });
+    };
+
+    ask(expectVerified);
+
     return () => {
       cancelled = true;
+      if (timer) clearTimeout(timer);
     };
-  }, [chainId, address]);
+  }, [chainId, address, expectVerified]);
 
   return { contract, loading };
 }
@@ -162,10 +190,20 @@ function Unverified({ verifyHref }: { verifyHref: string }) {
   );
 }
 
-export function EvmContract({ network, addr }: { network: string; addr: string }) {
+export function EvmContract({
+  network,
+  addr,
+  justVerified,
+}: {
+  network: string;
+  addr: string;
+  justVerified?: boolean;
+}) {
   const c = useChainContext();
   const base = `/explorer/${network}/${c.chainSlug}`;
-  const { contract, loading } = useVerifiedContract(c.chainId, addr);
+  const { contract, loading } = useVerifiedContract(c.chainId, addr, {
+    expectVerified: justVerified,
+  });
   const [tab, setTab] = useState<SubTab>("code");
   const [sources, setSources] = useState<ContractSources | null>(null);
 
@@ -195,6 +233,17 @@ export function EvmContract({ network, addr }: { network: string; addr: string }
   }
 
   if (!contract) {
+    // Telling someone their contract is unverified moments after they
+    // verified it is worse than saying nothing yet.
+    if (justVerified) {
+      return (
+        <Board divide={false} className="px-5 py-8 md:px-6">
+          <p className="font-mono text-[11px] text-zinc-400 dark:text-zinc-500">
+            Verified — waiting for the explorer to catch up…
+          </p>
+        </Board>
+      );
+    }
     return <Unverified verifyHref={`${base}/verify/${addr.toLowerCase()}`} />;
   }
 

--- a/components/explorer-v2/evm/EvmVerify.tsx
+++ b/components/explorer-v2/evm/EvmVerify.tsx
@@ -119,6 +119,7 @@ export function EvmVerify({ network, addr }: { network: string; addr: string }) 
   const [releases, setReleases] = useState<{ version: string; longVersion: string }[]>([]);
   const [phase, setPhase] = useState<Phase>({ state: "idle" });
   const [dragging, setDragging] = useState(false);
+  const [alreadyVerified, setAlreadyVerified] = useState(false);
   const fileInput = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -129,6 +130,22 @@ export function EvmVerify({ network, addr }: { network: string; addr: string }) 
       })
       .catch(() => {});
   }, []);
+
+  /* A verified contract cannot be verified again — the API rejects it —
+     so offering the form would only waste an upload and return an error
+     the submitter can do nothing about. Checked with caches bypassed,
+     because this is exactly where a stale "unverified" would mislead. */
+  useEffect(() => {
+    let cancelled = false;
+    fetchVerifiedContract(c.chainId, addr, { force: true })
+      .then((found) => {
+        if (!cancelled) setAlreadyVerified(Boolean(found));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [c.chainId, addr]);
 
   const accept = useCallback((file: File) => {
     setParseError(null);
@@ -171,7 +188,10 @@ export function EvmVerify({ network, addr }: { network: string; addr: string }) 
           forgetVerifiedContract(c.chainId, addr);
           void fetchVerifiedContract(c.chainId, addr, { force: true });
           setPhase({ state: "verified" });
-          setTimeout(() => router.push(`${base}/address/${addr}?tab=contract`), 1200);
+          setTimeout(
+            () => router.push(`${base}/address/${addr}?tab=contract&verified=1`),
+            1200,
+          );
         } else {
           setPhase({ state: "failed", message: body.error?.message ?? "Verification failed." });
         }
@@ -241,6 +261,25 @@ export function EvmVerify({ network, addr }: { network: string; addr: string }) 
           </Board>
         </section>
 
+        {alreadyVerified ? (
+          <Board divide={false} className="px-6 py-12 text-center">
+            <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-[#3f7d43] dark:text-[#77c47b]">
+              Already verified
+            </p>
+            <p className="mx-auto mt-4 max-w-lg text-[13px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+              This contract&apos;s source is already published. Verifying it again would be
+              rejected, since the bytecode has already been matched.
+            </p>
+            <Link
+              href={`${base}/address/${addr}?tab=contract`}
+              className="mt-6 inline-flex items-center gap-2 border border-zinc-900 bg-zinc-900 px-4 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-white transition-opacity hover:opacity-90 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
+            >
+              <Check className="size-3.5" />
+              View contract
+            </Link>
+          </Board>
+        ) : (
+        <>
         <section className="flex flex-col gap-4">
           <SectionHeader label="Compiler input" />
 
@@ -389,6 +428,8 @@ export function EvmVerify({ network, addr }: { network: string; addr: string }) 
             </Board>
           </section>
         ) : null}
+        </>
+        )}
 
         <p className="text-[12px] leading-relaxed text-zinc-500 dark:text-zinc-400">
           Prefer the command line? This page posts to the same API that `hardhat verify` and

--- a/components/explorer-v2/evm/EvmVerify.tsx
+++ b/components/explorer-v2/evm/EvmVerify.tsx
@@ -1,0 +1,399 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { AlertCircle, Check, FileJson, Loader2, Upload } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { EvmShell } from "@/components/explorer-v2/EvmShell";
+import { Board, CellLabel, SectionHeader, SpecPlate, SpecRow } from "@/components/explorer-v2/ui";
+import { forgetVerifiedContract } from "@/lib/sourcify-client";
+import { useChainContext } from "@/app/(home)/explorer/[network]/[chain]/layout.client";
+
+/* ------------------------------------------------------------------ */
+/* The verify form.                                                    */
+/*                                                                     */
+/* Standard JSON is the only accepted input, which sounds strict until */
+/* you notice that both Hardhat and Foundry already write it to disk:  */
+/* artifacts/build-info/*.json for one, out/*.json for the other. So   */
+/* the form asks for a file people already have rather than making     */
+/* them flatten sources by hand.                                       */
+/*                                                                     */
+/* It posts to the same Sourcify-compatible endpoint the CLI tools use */
+/* — no private form-only API to drift out of sync with the real one.  */
+/* ------------------------------------------------------------------ */
+
+interface StandardJson {
+  language?: string;
+  sources?: Record<string, { content?: string }>;
+  settings?: Record<string, unknown>;
+}
+
+interface BuildInfo {
+  solcLongVersion?: string;
+  solcVersion?: string;
+  input?: StandardJson;
+  output?: { contracts?: Record<string, Record<string, unknown>> };
+}
+
+interface ParsedInput {
+  stdJsonInput: StandardJson;
+  /** Fully qualified `file:Contract` candidates found in the input. */
+  candidates: string[];
+  /** Present when the file was a Hardhat build-info, which names its compiler. */
+  compilerVersion: string | null;
+  fileName: string;
+}
+
+/** Declarations in a Solidity source, so a plain Standard JSON (which
+ *  doesn't list contract names anywhere) can still populate the picker.
+ *  A build-info file gives us the real thing and skips this. */
+function declarationsIn(content: string): string[] {
+  const names: string[] = [];
+  const pattern = /^\s*(?:abstract\s+)?contract\s+([A-Za-z_$][\w$]*)/gm;
+  for (let match = pattern.exec(content); match; match = pattern.exec(content)) {
+    names.push(match[1]);
+  }
+  return names;
+}
+
+function parseUpload(text: string, fileName: string): ParsedInput | { error: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { error: "That file isn't valid JSON." };
+  }
+
+  const maybeBuildInfo = parsed as BuildInfo;
+  const isBuildInfo = Boolean(maybeBuildInfo.input?.sources && maybeBuildInfo.solcLongVersion);
+
+  const stdJsonInput = (isBuildInfo ? maybeBuildInfo.input : parsed) as StandardJson;
+  if (!stdJsonInput?.sources || Object.keys(stdJsonInput.sources).length === 0) {
+    return {
+      error:
+        "No sources found. Upload a Standard JSON input, or a Hardhat build-info file from artifacts/build-info/.",
+    };
+  }
+  if (stdJsonInput.language && stdJsonInput.language !== "Solidity") {
+    return { error: `Only Solidity is supported; this input declares ${stdJsonInput.language}.` };
+  }
+
+  const candidates: string[] = [];
+  if (isBuildInfo && maybeBuildInfo.output?.contracts) {
+    for (const [file, contracts] of Object.entries(maybeBuildInfo.output.contracts)) {
+      for (const name of Object.keys(contracts)) candidates.push(`${file}:${name}`);
+    }
+  } else {
+    for (const [file, source] of Object.entries(stdJsonInput.sources)) {
+      for (const name of declarationsIn(source.content ?? "")) candidates.push(`${file}:${name}`);
+    }
+  }
+
+  return {
+    stdJsonInput,
+    candidates: candidates.sort(),
+    compilerVersion: isBuildInfo ? (maybeBuildInfo.solcLongVersion ?? null) : null,
+    fileName,
+  };
+}
+
+type Phase =
+  | { state: "idle" }
+  | { state: "submitting" }
+  | { state: "polling"; verificationId: string }
+  | { state: "verified" }
+  | { state: "failed"; message: string };
+
+const POLL_INTERVAL_MS = 3_000;
+
+export function EvmVerify({ network, addr }: { network: string; addr: string }) {
+  const c = useChainContext();
+  const router = useRouter();
+  const base = `/explorer/${network}/${c.chainSlug}`;
+
+  const [input, setInput] = useState<ParsedInput | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [identifier, setIdentifier] = useState("");
+  const [compilerVersion, setCompilerVersion] = useState("");
+  const [releases, setReleases] = useState<{ version: string; longVersion: string }[]>([]);
+  const [phase, setPhase] = useState<Phase>({ state: "idle" });
+  const [dragging, setDragging] = useState(false);
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    fetch("/api/verify/compilers")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((body: { releases?: { version: string; longVersion: string }[] } | null) => {
+        setReleases(body?.releases ?? []);
+      })
+      .catch(() => {});
+  }, []);
+
+  const accept = useCallback((file: File) => {
+    setParseError(null);
+    void file.text().then((text) => {
+      const result = parseUpload(text, file.name);
+      if ("error" in result) {
+        setParseError(result.error);
+        setInput(null);
+        return;
+      }
+      setInput(result);
+      setIdentifier(result.candidates[0] ?? "");
+      if (result.compilerVersion) setCompilerVersion(result.compilerVersion);
+      setPhase({ state: "idle" });
+    });
+  }, []);
+
+  /* Poll the same job endpoint the CLI tools poll. */
+  useEffect(() => {
+    if (phase.state !== "polling") return;
+    let cancelled = false;
+
+    const tick = async () => {
+      try {
+        const res = await fetch(`/api/verify/sourcify/v2/verify/${phase.verificationId}`);
+        if (!res.ok) throw new Error("lost");
+        const body = (await res.json()) as {
+          isJobCompleted: boolean;
+          contract?: { match: string | null };
+          error?: { message: string };
+        };
+        if (cancelled) return;
+        if (!body.isJobCompleted) return;
+
+        if (body.contract?.match) {
+          forgetVerifiedContract(c.chainId, addr);
+          setPhase({ state: "verified" });
+          setTimeout(() => router.push(`${base}/address/${addr}?tab=contract`), 1200);
+        } else {
+          setPhase({ state: "failed", message: body.error?.message ?? "Verification failed." });
+        }
+      } catch {
+        if (!cancelled) {
+          setPhase({ state: "failed", message: "Lost contact with the verifier. Try submitting again." });
+        }
+      }
+    };
+
+    void tick();
+    const timer = setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [phase, c.chainId, addr, base, router]);
+
+  const submit = useCallback(async () => {
+    if (!input || !identifier || !compilerVersion) return;
+    setPhase({ state: "submitting" });
+
+    try {
+      const res = await fetch(`/api/verify/sourcify/v2/verify/${c.chainId}/${addr.toLowerCase()}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          stdJsonInput: input.stdJsonInput,
+          compilerVersion,
+          contractIdentifier: identifier,
+        }),
+      });
+      const body = (await res.json()) as { verificationId?: string; message?: string };
+
+      if (!res.ok || !body.verificationId) {
+        setPhase({ state: "failed", message: body.message ?? "The verifier rejected this submission." });
+        return;
+      }
+      setPhase({ state: "polling", verificationId: body.verificationId });
+    } catch {
+      setPhase({ state: "failed", message: "Could not reach the verifier." });
+    }
+  }, [input, identifier, compilerVersion, c.chainId, addr]);
+
+  const busy = phase.state === "submitting" || phase.state === "polling";
+  const canSubmit = Boolean(input && identifier && compilerVersion) && !busy;
+
+  const sourceCount = useMemo(
+    () => (input ? Object.keys(input.stdJsonInput.sources ?? {}).length : 0),
+    [input],
+  );
+
+  return (
+    <EvmShell network={network}>
+      <div className="flex flex-col gap-8">
+        <section className="flex flex-col gap-4">
+          <SectionHeader label="Verify contract" />
+          <Board divide={false} className="px-5 py-4 md:px-6">
+            <SpecPlate>
+              <SpecRow label="Address">
+                <span className="break-all font-mono text-[12px]">{addr}</span>
+              </SpecRow>
+              <SpecRow label="Chain">
+                {c.chainName} · {c.chainId}
+              </SpecRow>
+            </SpecPlate>
+          </Board>
+        </section>
+
+        <section className="flex flex-col gap-4">
+          <SectionHeader label="Compiler input" />
+
+          <Board divide={false}>
+            <label
+              onDragOver={(event) => {
+                event.preventDefault();
+                setDragging(true);
+              }}
+              onDragLeave={() => setDragging(false)}
+              onDrop={(event) => {
+                event.preventDefault();
+                setDragging(false);
+                const file = event.dataTransfer.files?.[0];
+                if (file) accept(file);
+              }}
+              className={cn(
+                "flex cursor-pointer flex-col items-center justify-center gap-3 border border-dashed px-6 py-12 text-center transition-colors",
+                dragging
+                  ? "border-zinc-900 bg-zinc-50 dark:border-zinc-100 dark:bg-zinc-900"
+                  : "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-600",
+              )}
+            >
+              <input
+                ref={fileInput}
+                type="file"
+                accept="application/json,.json"
+                className="hidden"
+                onChange={(event) => {
+                  const file = event.target.files?.[0];
+                  if (file) accept(file);
+                }}
+              />
+              {input ? (
+                <>
+                  <FileJson className="size-5 text-zinc-400" />
+                  <p className="font-mono text-[12px] text-zinc-700 dark:text-zinc-300">{input.fileName}</p>
+                  <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-zinc-400 dark:text-zinc-500">
+                    {sourceCount} source {sourceCount === 1 ? "file" : "files"}
+                    {input.compilerVersion ? ` · solc ${input.compilerVersion}` : ""}
+                  </p>
+                </>
+              ) : (
+                <>
+                  <Upload className="size-5 text-zinc-400" />
+                  <p className="text-[13px] text-zinc-600 dark:text-zinc-300">
+                    Drop a build-info file or a Standard JSON input
+                  </p>
+                  <p className="max-w-md font-mono text-[10px] leading-relaxed tracking-[0.08em] text-zinc-400 dark:text-zinc-500">
+                    hardhat: artifacts/build-info/*.json · foundry: out/build-info/*.json after
+                    `forge build --build-info`
+                  </p>
+                </>
+              )}
+            </label>
+          </Board>
+
+          {parseError ? (
+            <div className="flex items-start gap-2 border border-[#C7911B]/40 px-4 py-3 text-[12px] text-[#9c7112] dark:text-[#e2b953]">
+              <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
+              {parseError}
+            </div>
+          ) : null}
+        </section>
+
+        {input ? (
+          <section className="flex flex-col gap-4">
+            <SectionHeader label="Contract" />
+            <Board divide={false} className="flex flex-col gap-5 px-5 py-5 md:px-6">
+              <div className="flex flex-col gap-2">
+                <CellLabel>Contract to verify</CellLabel>
+                {input.candidates.length ? (
+                  <select
+                    value={identifier}
+                    onChange={(event) => setIdentifier(event.target.value)}
+                    className="w-full border border-zinc-200 bg-white px-3 py-2 font-mono text-[12px] text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100"
+                  >
+                    {input.candidates.map((candidate) => (
+                      <option key={candidate} value={candidate}>
+                        {candidate}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    value={identifier}
+                    onChange={(event) => setIdentifier(event.target.value)}
+                    placeholder="contracts/Token.sol:Token"
+                    className="w-full border border-zinc-200 bg-white px-3 py-2 font-mono text-[12px] text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100"
+                  />
+                )}
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <CellLabel>Compiler version</CellLabel>
+                {input.compilerVersion ? (
+                  <p className="font-mono text-[12px] text-zinc-700 dark:text-zinc-300">
+                    {input.compilerVersion}
+                    <span className="ml-2 text-zinc-400 dark:text-zinc-500">from build-info</span>
+                  </p>
+                ) : (
+                  <select
+                    value={compilerVersion}
+                    onChange={(event) => setCompilerVersion(event.target.value)}
+                    className="w-full border border-zinc-200 bg-white px-3 py-2 font-mono text-[12px] text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100"
+                  >
+                    <option value="">Select a version…</option>
+                    {releases.map((release) => (
+                      <option key={release.longVersion} value={release.longVersion}>
+                        {release.longVersion}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+
+              <div className="flex flex-wrap items-center gap-4">
+                <button
+                  onClick={submit}
+                  disabled={!canSubmit}
+                  className={cn(
+                    "inline-flex items-center gap-2 border px-4 py-2 font-mono text-[10px] uppercase tracking-[0.14em] transition-opacity",
+                    canSubmit
+                      ? "border-zinc-900 bg-zinc-900 text-white hover:opacity-90 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
+                      : "cursor-not-allowed border-zinc-200 text-zinc-400 dark:border-zinc-800 dark:text-zinc-600",
+                  )}
+                >
+                  {busy ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                  {phase.state === "polling" ? "Compiling…" : "Verify"}
+                </button>
+
+                {phase.state === "verified" ? (
+                  <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-[#3f7d43] dark:text-[#77c47b]">
+                    <Check className="size-3.5" />
+                    Verified — taking you to the contract
+                  </span>
+                ) : null}
+              </div>
+
+              {phase.state === "failed" ? (
+                <div className="flex items-start gap-2 border border-[#C7911B]/40 px-4 py-3 text-[12px] leading-relaxed text-[#9c7112] dark:text-[#e2b953]">
+                  <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
+                  <pre className="whitespace-pre-wrap font-mono text-[11px]">{phase.message}</pre>
+                </div>
+              ) : null}
+            </Board>
+          </section>
+        ) : null}
+
+        <p className="text-[12px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+          Prefer the command line? This page posts to the same API that `hardhat verify` and
+          `forge verify-contract` use.{" "}
+          <Link href="/docs/tooling/contract-verification" className="underline underline-offset-2">
+            See the setup for your tool
+          </Link>
+          .
+        </p>
+      </div>
+    </EvmShell>
+  );
+}

--- a/components/explorer-v2/evm/EvmVerify.tsx
+++ b/components/explorer-v2/evm/EvmVerify.tsx
@@ -7,7 +7,7 @@ import { AlertCircle, Check, FileJson, Loader2, Upload } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { EvmShell } from "@/components/explorer-v2/EvmShell";
 import { Board, CellLabel, SectionHeader, SpecPlate, SpecRow } from "@/components/explorer-v2/ui";
-import { forgetVerifiedContract } from "@/lib/sourcify-client";
+import { fetchVerifiedContract, forgetVerifiedContract } from "@/lib/sourcify-client";
 import { useChainContext } from "@/app/(home)/explorer/[network]/[chain]/layout.client";
 
 /* ------------------------------------------------------------------ */
@@ -164,7 +164,12 @@ export function EvmVerify({ network, addr }: { network: string; addr: string }) 
         if (!body.isJobCompleted) return;
 
         if (body.contract?.match) {
+          // Prime the session cache with the verified record before leaving,
+          // so the Contract tab paints verified on its first frame. Landing
+          // there and re-asking would race a browser-cached "unverified"
+          // from before this page was opened.
           forgetVerifiedContract(c.chainId, addr);
+          void fetchVerifiedContract(c.chainId, addr, { force: true });
           setPhase({ state: "verified" });
           setTimeout(() => router.push(`${base}/address/${addr}?tab=contract`), 1200);
         } else {

--- a/components/explorer/ContractWriteSection.tsx
+++ b/components/explorer/ContractWriteSection.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ChevronDown, ChevronUp, AlertCircle, Loader2, ExternalLink, Check, Wallet } from "lucide-react";
-import { keccak256, toBytes, parseEther } from "viem";
-import { useWalletStore } from "@/components/toolbox/stores/walletStore";
+import { encodeFunctionData, parseEther } from "viem";
 import { useWalletConnect } from "@/components/toolbox/hooks/useWalletConnect";
 import { useExplorerNetwork } from "@/components/explorer/useExplorerNetwork";
 import { Button } from "@/components/ui/button";
@@ -34,32 +33,83 @@ function getWriteFunctions(abi: any[]): any[] {
   ).sort((a, b) => (a.name || '').localeCompare(b.name || ''));
 }
 
-// Simple ABI parameter encoder
-function encodeParameter(type: string, value: string): string {
-  try {
-    if (type === 'address') {
-      return value.toLowerCase().replace('0x', '').padStart(64, '0');
+/**
+ * Turn a form field into the JS value viem expects for an ABI type.
+ *
+ * Throws on anything it cannot make sense of, which is the point: the
+ * previous encoder answered a value it couldn't parse with 32 zero bytes,
+ * so a typo became a transaction that ran successfully and did the wrong
+ * thing. Refusing to send is the only safe failure here.
+ */
+function parseArgument(type: string, raw: string): unknown {
+  const value = raw.trim();
+
+  if (type.endsWith(']')) {
+    const element = type.slice(0, type.lastIndexOf('['));
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      throw new Error(`${type} needs a JSON array, for example ["1","2"]`);
     }
-    if (type.startsWith('uint') || type.startsWith('int')) {
-      const num = BigInt(value);
-      return num.toString(16).padStart(64, '0');
-    }
-    if (type === 'bool') {
-      return (value.toLowerCase() === 'true' || value === '1') ? '1'.padStart(64, '0') : '0'.padStart(64, '0');
-    }
-    if (type === 'bytes32') {
-      return value.replace('0x', '').padEnd(64, '0');
-    }
-    return value.replace('0x', '').padStart(64, '0');
-  } catch {
-    return '0'.padStart(64, '0');
+    if (!Array.isArray(parsed)) throw new Error(`${type} needs a JSON array`);
+    return parsed.map((item) => parseArgument(element, typeof item === 'string' ? item : JSON.stringify(item)));
   }
+
+  if (type.startsWith('tuple')) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      throw new Error(`${type} needs a JSON object`);
+    }
+  }
+
+  if (type.startsWith('uint') || type.startsWith('int')) {
+    try {
+      return BigInt(value);
+    } catch {
+      throw new Error(`"${value}" is not a whole number`);
+    }
+  }
+
+  if (type === 'bool') {
+    const lowered = value.toLowerCase();
+    if (['true', '1', 'false', '0'].includes(lowered)) return lowered === 'true' || lowered === '1';
+    throw new Error(`"${value}" is not true or false`);
+  }
+
+  if (type === 'address') {
+    if (!/^0x[0-9a-fA-F]{40}$/.test(value)) throw new Error(`"${value}" is not an address`);
+    return value as `0x${string}`;
+  }
+
+  if (type.startsWith('bytes')) {
+    if (!/^0x[0-9a-fA-F]*$/.test(value)) throw new Error(`${type} needs 0x-prefixed hex`);
+    return value as `0x${string}`;
+  }
+
+  return value;
 }
 
-// Compute function selector using keccak256
-function getFunctionSelector(signature: string): string {
-  const hash = keccak256(toBytes(signature));
-  return hash.slice(2, 10); // First 4 bytes (8 hex chars)
+/**
+ * Providers reject with plain objects carrying `code` and `message`, not
+ * with Error instances, so an `instanceof Error` check throws the reason
+ * away and leaves the caller staring at "Transaction failed".
+ */
+function describeError(error: any): string {
+  if (error?.code === 4001 || error?.cause?.code === 4001) return 'Transaction rejected in wallet';
+
+  const detail =
+    error?.data?.message ??
+    error?.error?.message ??
+    error?.cause?.shortMessage ??
+    error?.cause?.message ??
+    error?.shortMessage ??
+    error?.message;
+
+  if (typeof detail === 'string' && detail.trim()) return detail;
+  if (typeof error === 'string' && error.trim()) return error;
+  return 'Transaction failed';
 }
 
 export default function ContractWriteSection({
@@ -76,17 +126,56 @@ export default function ContractWriteSection({
   const [functionResults, setFunctionResults] = useState<Record<string, FunctionResult>>({});
   const [payableValues, setPayableValues] = useState<Record<string, string>>({});
 
-  // Wallet state
-  const walletEVMAddress = useWalletStore((s) => s.walletEVMAddress);
-  const walletChainId = useWalletStore((s) => s.walletChainId);
-  const coreWalletClient = useWalletStore((s) => s.coreWalletClient);
+  /* Wallet state comes from the injected provider and from nowhere else.
+     The console's wallet store is populated by WalletSync, mounted in the
+     console header and nowhere near the explorer, so here it reports
+     whatever it was left holding — an address with no way to sign, a chain
+     id of zero, an account the user has since disconnected. The provider is
+     what actually signs, so it is the only honest source: display, chain
+     check, and capability all read the same place. */
+  const [account, setAccount] = useState<string>('');
+  const [liveChainId, setLiveChainId] = useState<number | null>(null);
+  const [accountMenuOpen, setAccountMenuOpen] = useState(false);
   const { connectWallet } = useWalletConnect();
 
+  useEffect(() => {
+    const provider = typeof window !== 'undefined' ? window.ethereum : undefined;
+    if (!provider?.request) return;
+
+    let cancelled = false;
+    const read = async () => {
+      try {
+        const [accounts, chainIdHex] = await Promise.all([
+          provider.request({ method: 'eth_accounts' }) as Promise<string[]>,
+          provider.request({ method: 'eth_chainId' }) as Promise<string>,
+        ]);
+        if (cancelled) return;
+        setAccount(accounts?.[0] ?? '');
+        setLiveChainId(chainIdHex ? parseInt(chainIdHex, 16) : null);
+      } catch {
+        /* a wallet that won't answer is treated as not connected */
+      }
+    };
+
+    void read();
+    const onAccounts = (accounts: string[]) => setAccount(accounts?.[0] ?? '');
+    const onChain = (chainIdHex: string) => setLiveChainId(parseInt(chainIdHex, 16));
+    provider.on?.('accountsChanged', onAccounts);
+    provider.on?.('chainChanged', onChain);
+
+    return () => {
+      cancelled = true;
+      provider.removeListener?.('accountsChanged', onAccounts);
+      provider.removeListener?.('chainChanged', onChain);
+    };
+  }, []);
+
+  const walletEVMAddress = account;
   const writeFunctions = getWriteFunctions(abi);
 
   // Check if user is on the correct chain
   const expectedChainId = parseInt(chainId);
-  const isOnCorrectChain = walletChainId === expectedChainId;
+  const isOnCorrectChain = liveChainId === expectedChainId;
 
   const toggleFunction = (funcKey: string) => {
     setExpandedFunctions(prev => {
@@ -117,6 +206,52 @@ export default function ContractWriteSection({
     }));
   };
 
+  /** Ask the provider where it stands, rather than waiting for an event
+   *  that some wallets don't emit. */
+  const refreshWalletState = async () => {
+    const provider = window.ethereum;
+    if (!provider?.request) return;
+    try {
+      const [accounts, chainIdHex] = await Promise.all([
+        provider.request({ method: 'eth_accounts' }) as Promise<string[]>,
+        provider.request({ method: 'eth_chainId' }) as Promise<string>,
+      ]);
+      setAccount(accounts?.[0] ?? '');
+      setLiveChainId(chainIdHex ? parseInt(chainIdHex, 16) : null);
+    } catch {
+      /* leave the last known state alone */
+    }
+  };
+
+  /** Open the wallet's account picker. `wallet_requestPermissions` is what
+   *  forces the chooser even when the site is already authorized, which is
+   *  the only way to switch accounts from here. */
+  const chooseAccount = async () => {
+    const provider = window.ethereum;
+    if (!provider?.request) return;
+    setAccountMenuOpen(false);
+    try {
+      await provider.request({ method: 'wallet_requestPermissions', params: [{ eth_accounts: {} }] });
+    } catch {
+      // Wallets that don't implement it still expose the picker this way.
+      await provider.request({ method: 'eth_requestAccounts' }).catch(() => undefined);
+    }
+    await refreshWalletState();
+  };
+
+  /** Forget the connection. Wallets that support revocation are told; the
+   *  rest simply stop being used until the user connects again. */
+  const disconnect = async () => {
+    const provider = window.ethereum;
+    setAccountMenuOpen(false);
+    try {
+      await provider?.request?.({ method: 'wallet_revokePermissions', params: [{ eth_accounts: {} }] });
+    } catch {
+      /* not supported everywhere, and not required for the local reset */
+    }
+    setAccount('');
+  };
+
   const switchToCorrectChain = async () => {
     if (!rpcUrl) return;
     
@@ -126,6 +261,7 @@ export default function ContractWriteSection({
         method: 'wallet_switchEthereumChain',
         params: [{ chainId: chainIdHex }],
       });
+      await refreshWalletState();
     } catch (switchError: any) {
       // If chain not found, try to add it
       if (switchError.code === 4902 || switchError.code === -32603) {
@@ -145,7 +281,9 @@ export default function ContractWriteSection({
   };
 
   const writeFunction = async (func: any, funcKey: string) => {
-    if (!walletEVMAddress || !coreWalletClient) {
+    // Everything below signs through window.ethereum, so that — not any
+    // client held in a store — is what has to be present.
+    if (!walletEVMAddress || !window.ethereum?.request) {
       setFunctionResults(prev => ({
         ...prev,
         [funcKey]: { loading: false, error: 'Wallet not connected' }
@@ -170,23 +308,17 @@ export default function ContractWriteSection({
       const inputs = func.inputs || [];
       const inputValues = functionInputs[funcKey] || {};
 
-      // Build function signature
-      const inputTypes = inputs.map((i: any) => i.type).join(',');
-      const signature = `${func.name}(${inputTypes})`;
-
-      // Get selector using keccak256
-      const selector = getFunctionSelector(signature);
-
-      // Build call data
-      let callData = '0x' + selector;
-      
-      for (const input of inputs) {
-        const value = inputValues[input.name || `param${inputs.indexOf(input)}`];
-        if (value === undefined || value === '') {
-          throw new Error(`Missing value for: ${input.name || 'parameter'}`);
+      const args = inputs.map((input: any, index: number) => {
+        const raw = inputValues[input.name || `param${index}`];
+        if (raw === undefined || raw === '') {
+          throw new Error(`Missing value for ${input.name || `parameter ${index + 1}`}`);
         }
-        callData += encodeParameter(input.type, value);
-      }
+        return parseArgument(input.type, raw);
+      });
+
+      // Encoded against this one overload rather than the whole ABI, so a
+      // contract with several functions of the same name still resolves.
+      const callData = encodeFunctionData({ abi: [func], functionName: func.name, args });
 
       // Handle payable value
       let value: bigint = BigInt(0);
@@ -197,15 +329,31 @@ export default function ContractWriteSection({
         }
       }
 
+      // eth_accounts answers without granting anything, so an address in
+      // hand does not mean this origin may spend from it — sending then
+      // fails with 4100, "not been authorized by the user". Asking for
+      // accounts is silent when permission already exists and prompts when
+      // it doesn't, and its answer is the account the wallet will actually
+      // sign with.
+      const authorized = (await window.ethereum.request({
+        method: 'eth_requestAccounts',
+      })) as string[];
+      const from = authorized?.[0];
+      if (!from) throw new Error('No account authorized for this site');
+      if (from.toLowerCase() !== walletEVMAddress.toLowerCase()) setAccount(from);
+
       // Send transaction using the wallet
+      const request: Record<string, string> = {
+        from,
+        to: address,
+        data: callData,
+      };
+      // Only sent when non-zero: some wallets reject an explicit undefined.
+      if (value > 0) request.value = `0x${value.toString(16)}`;
+
       const txHash = await window.ethereum?.request({
         method: 'eth_sendTransaction',
-        params: [{
-          from: walletEVMAddress,
-          to: address,
-          data: callData,
-          value: value > 0 ? `0x${value.toString(16)}` : undefined,
-        }],
+        params: [request],
       });
 
       if (!txHash) {
@@ -220,16 +368,9 @@ export default function ContractWriteSection({
       // Optionally wait for confirmation
       // This could be enhanced to poll for transaction receipt
     } catch (err: any) {
-      let errorMessage = err instanceof Error ? err.message : 'Transaction failed';
-      
-      // Handle user rejection
-      if (err.code === 4001) {
-        errorMessage = 'Transaction rejected by user';
-      }
-
       setFunctionResults(prev => ({
         ...prev,
-        [funcKey]: { loading: false, error: errorMessage, status: 'failed' }
+        [funcKey]: { loading: false, error: describeError(err), status: 'failed' }
       }));
     }
   };
@@ -282,8 +423,14 @@ export default function ContractWriteSection({
               Connect your wallet to interact with this contract.
             </p>
           </div>
-          <Button onClick={connectWallet} style={{ backgroundColor: themeColor }}>
-            <img src="/core-logo.svg" alt="Core" className="mr-2 h-4 w-4 object-contain" />
+          <Button
+            onClick={async () => {
+              await connectWallet();
+              await refreshWalletState();
+            }}
+            style={{ backgroundColor: themeColor }}
+          >
+            <Wallet className="mr-2 h-4 w-4" />
             Connect Wallet
           </Button>
         </div>
@@ -320,6 +467,45 @@ export default function ContractWriteSection({
         <div className="flex items-center gap-2 text-sm text-green-700 dark:text-green-400">
           <div className="w-2 h-2 rounded-full bg-green-500" />
           <span>Connected: {walletEVMAddress.slice(0, 6)}...{walletEVMAddress.slice(-4)}</span>
+        </div>
+
+        {/* The wallet may hold several accounts, and the one it offers is
+            not always the one you meant to use. */}
+        <div className="relative">
+          <button
+            onClick={() => setAccountMenuOpen((open) => !open)}
+            aria-haspopup="menu"
+            aria-expanded={accountMenuOpen}
+            className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-zinc-600 dark:text-zinc-300 rounded hover:bg-zinc-200/60 dark:hover:bg-zinc-700/60 transition-colors cursor-pointer"
+          >
+            Account
+            <ChevronDown className="w-3 h-3" />
+          </button>
+
+          {accountMenuOpen && (
+            <>
+              <div className="fixed inset-0 z-10" onClick={() => setAccountMenuOpen(false)} />
+              <div
+                role="menu"
+                className="absolute right-0 z-20 mt-1 w-48 overflow-hidden rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900"
+              >
+                <button
+                  role="menuitem"
+                  onClick={chooseAccount}
+                  className="block w-full px-3 py-2 text-left text-xs text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800 cursor-pointer"
+                >
+                  Switch account
+                </button>
+                <button
+                  role="menuitem"
+                  onClick={disconnect}
+                  className="block w-full px-3 py-2 text-left text-xs text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800 cursor-pointer"
+                >
+                  Disconnect
+                </button>
+              </div>
+            </>
+          )}
         </div>
       </div>
 

--- a/components/navigation/docs-nav-config.tsx
+++ b/components/navigation/docs-nav-config.tsx
@@ -16,7 +16,8 @@ import {
   Eye,
   Bot,
   AppWindow,
-  Cloud
+  Cloud,
+  ShieldCheck
 } from 'lucide-react';
 
 export type NavOption = {
@@ -122,6 +123,13 @@ export const toolingOptions: NavOption[] = [
     badge: 'New',
     icon: <AppWindow className="w-5 h-5" />,
     url: '/console',
+  },
+  {
+    title: 'Contract Verification',
+    description: 'Verify contracts on any L1 from Hardhat or Foundry',
+    badge: 'New',
+    icon: <ShieldCheck className="w-5 h-5" />,
+    url: '/docs/tooling/contract-verification',
   },
   {
     title: 'Platform CLI',

--- a/content/docs/tooling/contract-verification/api-reference.mdx
+++ b/content/docs/tooling/contract-verification/api-reference.mdx
@@ -1,0 +1,102 @@
+---
+title: Verification API Reference
+description: The Etherscan-compatible and Sourcify-compatible verification endpoints exposed by Builder Hub.
+---
+
+Builder Hub exposes two verification protocols over one verifier. They differ only in wire format — the same compile-and-compare runs behind both, and a contract verified through either shows up identically in the explorer.
+
+Use whichever your tooling already speaks. If you're writing your own integration, the Sourcify protocol is the nicer of the two: JSON in, JSON out, and no string matching.
+
+Every endpoint below is live. Expand one and use **Send Request** to call it against production.
+
+## Etherscan-compatible
+
+Two spellings of the same API, differing only in where the chain id goes: the path (`/api/verify/{chainId}/api`, what Hardhat 2's `customChains` and Foundry's `--verifier-url` expect) or the query (`/api/verify/v2/api?chainid=`, Etherscan's V2 shape).
+
+The `apikey` parameter is accepted and ignored; tooling requires the field to exist, so send any non-empty string.
+
+### Submit
+
+<APIPage
+  document={"./public/openapi/verification.json"}
+  operations={[{ "path": "/api/verify/{chainId}/api", "method": "post" }]}
+  webhooks={[]}
+  hasHead={false}
+/>
+
+### Poll and read
+
+One endpoint covers all three read actions. `checkverifystatus` reports `Pending in queue`, `Pass - Verified`, or `Fail - Unable to verify` with the reason appended — those exact strings are what `hardhat-verify` matches on.
+
+<APIPage
+  document={"./public/openapi/verification.json"}
+  operations={[{ "path": "/api/verify/{chainId}/api", "method": "get" }]}
+  webhooks={[]}
+  hasHead={false}
+/>
+
+### V2 shape
+
+Identical behaviour with the chain in a query parameter instead of the path.
+
+<APIPage
+  document={"./public/openapi/verification.json"}
+  operations={[
+    { "path": "/api/verify/v2/api", "method": "post" },
+    { "path": "/api/verify/v2/api", "method": "get" }
+  ]}
+  webhooks={[]}
+  hasHead={false}
+/>
+
+## Sourcify-compatible
+
+Base URL: `https://build.avax.network/api/verify/sourcify`
+
+These are the three v2 endpoints `@nomicfoundation/hardhat-verify` calls, so pointing `verify.sourcify.apiUrl` at that base is all the configuration Hardhat 3 needs.
+
+### Submit
+
+<APIPage
+  document={"./public/openapi/verification.json"}
+  operations={[{ "path": "/api/verify/sourcify/v2/verify/{chainId}/{address}", "method": "post" }]}
+  webhooks={[]}
+  hasHead={false}
+/>
+
+### Check a job
+
+<APIPage
+  document={"./public/openapi/verification.json"}
+  operations={[{ "path": "/api/verify/sourcify/v2/verify/{verificationId}", "method": "get" }]}
+  webhooks={[]}
+  hasHead={false}
+/>
+
+### Look up a contract
+
+<APIPage
+  document={"./public/openapi/verification.json"}
+  operations={[{ "path": "/api/verify/sourcify/v2/contract/{chainId}/{address}", "method": "get" }]}
+  webhooks={[]}
+  hasHead={false}
+/>
+
+<Callout type="info">
+This endpoint only reports contracts verified on Builder Hub. The explorer's own lookup at `/api/sourcify/{chainId}/{address}` merges our verifications with Sourcify's public archive, which is why a C-Chain contract verified on sourcify.dev still renders here.
+</Callout>
+
+## Compilers
+
+<APIPage
+  document={"./public/openapi/verification.json"}
+  operations={[{ "path": "/api/verify/compilers", "method": "get" }]}
+  webhooks={[]}
+  hasHead={false}
+/>
+
+## Rate limits
+
+Compilation is expensive and the endpoint is open, so submissions are throttled per caller and the number of simultaneous compilations across all callers is capped. A throttled request gets `429` with `Retry-After`.
+
+Two things make this mostly invisible in normal use: an address with no deployed code is rejected before anything compiles, and resubmitting a payload that was already tried returns the previous outcome instead of compiling it again. Reads are cached and not throttled.

--- a/content/docs/tooling/contract-verification/index.mdx
+++ b/content/docs/tooling/contract-verification/index.mdx
@@ -1,0 +1,170 @@
+---
+title: Contract Verification
+description: Verify smart contracts on any Avalanche L1 from Hardhat, Foundry, or the Builder Hub explorer.
+---
+
+Verifying a contract publishes the source code that produced the bytecode already deployed on chain. Once verified, the contract's source and ABI appear on its explorer page, and every call and event against that address decodes by name instead of showing raw selectors.
+
+Builder Hub runs its own verifier, so this works on **any Avalanche L1 in the chain catalog with a public RPC** — not just the C-Chain. Sourcify only knows the Primary Network, which is why most L1 contracts could never be verified before.
+
+## What you need
+
+Verification compiles your source and compares the result to the deployed bytecode, so the compiler has to see exactly what it saw at deploy time. That means **Standard JSON input**: one file containing every source, every import, and every compiler setting.
+
+You almost certainly already have one:
+
+| Tool | Where it is |
+| --- | --- |
+| Hardhat | `artifacts/build-info/*.json` after `npx hardhat compile` |
+| Foundry | `out/build-info/*.json` after `forge build --build-info` |
+
+Either file can be uploaded as-is. Build tools add their own keys to the input — Foundry writes `allowPaths`, `basePath` and `includePaths` — and those are stripped before compiling, since solc rejects an input carrying keys it doesn't define.
+
+Flattened single-file sources are not accepted. They were always a workaround for tooling that couldn't produce Standard JSON, and every current tool can.
+
+<Callout type="info">
+Compilation settings must match the deployment exactly — the same compiler version, the same optimizer setting and run count, the same EVM version. A single differing flag produces different bytecode and the verification will fail.
+</Callout>
+
+## From the explorer
+
+The quickest route for a one-off. Open the contract's address page, choose the **Contract** tab, and select **Verify contract**. Drop in your build-info file, pick the contract, and submit. The compiler version comes from the file itself when you upload build-info.
+
+## From Hardhat
+
+`hardhat-verify` speaks two protocols and Builder Hub implements both. Pick whichever matches your Hardhat version.
+
+### Hardhat 3
+
+Add a chain descriptor pointing at the Etherscan-compatible endpoint:
+
+```ts title="hardhat.config.ts"
+import { defineConfig } from "hardhat/config";
+
+export default defineConfig({
+  chainDescriptors: {
+    43114: {
+      name: "Avalanche",
+      blockExplorers: {
+        etherscan: {
+          name: "Builder Hub",
+          url: "https://build.avax.network/explorer/mainnet/c-chain",
+          apiUrl: "https://build.avax.network/api/verify/43114/api",
+        },
+      },
+    },
+  },
+});
+```
+
+Then verify, scoping the run so it doesn't also try Etherscan and Sourcify:
+
+```bash
+npx hardhat verify --network avalanche 0xYourContract "Constructor" "Args"
+```
+
+Hardhat 3 can also talk to Builder Hub through the Sourcify protocol, which needs no chain descriptor at all:
+
+```ts title="hardhat.config.ts"
+export default defineConfig({
+  verify: {
+    sourcify: {
+      enabled: true,
+      apiUrl: "https://build.avax.network/api/verify/sourcify",
+    },
+  },
+});
+```
+
+### Hardhat 2
+
+Use `customChains`. The `apiKey` value is required by the plugin but ignored by Builder Hub, so any non-empty string works:
+
+```ts title="hardhat.config.ts"
+const config: HardhatUserConfig = {
+  networks: {
+    myL1: { url: "https://my-l1-rpc.example/ext/bc/C/rpc", accounts: [PRIVATE_KEY] },
+  },
+  etherscan: {
+    apiKey: { myL1: "builder-hub" },
+    customChains: [
+      {
+        network: "myL1",
+        chainId: 12345,
+        urls: {
+          apiURL: "https://build.avax.network/api/verify/12345/api",
+          browserURL: "https://build.avax.network/explorer/mainnet/my-l1",
+        },
+      },
+    ],
+  },
+  sourcify: { enabled: false },
+};
+```
+
+The network name has to be identical in `networks`, `apiKey`, and `customChains` — the plugin matches them by string.
+
+<Callout type="warn">
+Hardhat 2's Sourcify client speaks the retired v1 API, which Builder Hub does not implement. On Hardhat 2, use the `customChains` route above and leave `sourcify.enabled` off.
+</Callout>
+
+Every endpoint behind these commands is documented and callable in the [API reference](/docs/tooling/contract-verification/api-reference).
+
+## From Foundry
+
+```bash
+forge verify-contract \
+  --chain-id 43114 \
+  --verifier custom \
+  --verifier-url https://build.avax.network/api/verify/43114/api \
+  --compiler-version v0.8.24+commit.e11b9ed9 \
+  0xYourContract \
+  src/Token.sol:Token
+```
+
+Foundry can also use the Sourcify protocol:
+
+```bash
+forge verify-contract \
+  --chain-id 43114 \
+  --verifier sourcify \
+  --verifier-url https://build.avax.network/api/verify/sourcify \
+  0xYourContract \
+  src/Token.sol:Token
+```
+
+## Match levels
+
+A verification comes back at one of two levels, and the difference is worth understanding:
+
+- **Exact match** — the recompiled bytecode is byte-identical to what is deployed, including the metadata hash at the end. The source you submitted is exactly the source that was compiled.
+- **Match** — the code is identical but the metadata hash differs. The contract behaves exactly as the source says; something outside the executable code changed, such as a comment or a file path. This is normal and trustworthy.
+
+Anything less is not a match and is rejected. Library addresses and immutable values are normalized before comparing, since those are legitimately written after compilation.
+
+## When verification fails
+
+| Message | What it usually means |
+| --- | --- |
+| The deployed code does not match this source | Wrong compiler version, or optimizer settings that differ from the deployment |
+| The compiler output has no "…" | The contract identifier is wrong; it must be `path/to/File.sol:ContractName` exactly as it appears in the input |
+| No contract code at 0x… | The address is a wallet, or the deployment hasn't been mined on the chain you named |
+| No address supplied for library … | The contract links against a library; add its address under `settings.libraries` |
+| Compilation exceeded the 180s limit | The contract is too large for the shared verifier |
+
+The most common cause by far is optimizer settings. Check that `settings.optimizer` in your Standard JSON matches what you deployed with, including `runs`.
+
+## Relationship to Sourcify
+
+Lookups consult Builder Hub's own verifications first and the public [Sourcify](https://sourcify.dev) archive second, so a contract verified in either place renders here. That fallback is why C-Chain contracts verified on sourcify.dev already show source in this explorer.
+
+Verifications performed here are also published back to Sourcify for chains it supports, which in practice means the Primary Network — Sourcify does not accept chains absent from its own list, and almost no Avalanche L1 is on it. Publishing is best-effort and happens after your verification is already recorded, so an outage or rejection upstream never affects the result you were given.
+
+For an L1, Builder Hub is the only place the verification exists. That is the whole reason this verifier exists.
+
+## Limits
+
+- Solidity only. Vyper and Fe are not supported.
+- Standard JSON input up to 6 MB.
+- 180 seconds of compilation per contract.
+- Constructor arguments are stored and displayed but not independently verified; matching is done against runtime bytecode.

--- a/content/docs/tooling/contract-verification/meta.json
+++ b/content/docs/tooling/contract-verification/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Contract Verification",
+  "description": "Verify smart contracts on any Avalanche L1 from Hardhat, Foundry, or the explorer",
+  "root": true,
+  "pages": ["index", "api-reference"]
+}

--- a/lib/openapi.ts
+++ b/lib/openapi.ts
@@ -24,3 +24,10 @@ export const xChainApi = createOpenAPI({
   // X-Chain RPC API
   input: ['./public/openapi/xchain.yaml'],
 });
+
+export const verificationApi = createOpenAPI({
+  // Contract Verification API. Hand-written and committed, unlike the
+  // specs above: this one describes our own routes, so it lives with them
+  // rather than being fetched at build time.
+  input: ['./public/openapi/verification.json'],
+});

--- a/lib/sourcify-client.ts
+++ b/lib/sourcify-client.ts
@@ -45,14 +45,22 @@ function contractKey(chainId: number | string, address: string) {
 export function fetchVerifiedContract(
   chainId: number | string,
   address: string,
+  options?: {
+    /** Ignore both caches in front of this answer — the session's and the
+     *  browser's. Used right after a verification, where a remembered
+     *  "unverified" is not merely stale but wrong. */
+    force?: boolean;
+  },
 ): Promise<SourcifyContract | null> {
   const key = contractKey(chainId, address);
   const existing = inFlight.get(key);
-  if (existing) return existing;
+  if (existing && !options?.force) return existing;
 
   const promise = (async () => {
     try {
-      const res = await fetch(`/api/sourcify/${chainId}/${address.toLowerCase()}`);
+      const res = await fetch(`/api/sourcify/${chainId}/${address.toLowerCase()}`, {
+        cache: options?.force ? "no-store" : "default",
+      });
       if (!res.ok) return null;
       const body = await res.json();
       if (!body?.verified) return null;

--- a/lib/sourcify-client.ts
+++ b/lib/sourcify-client.ts
@@ -69,6 +69,18 @@ export function fetchVerifiedContract(
 }
 
 /**
+ * Drop the session's memory of one contract. The cache is deliberately
+ * permanent — verification doesn't get undone — so the one moment it has
+ * to be forgiven is right after a visitor verifies a contract themselves
+ * and would otherwise keep being told it is unverified.
+ */
+export function forgetVerifiedContract(chainId: number | string, address: string): void {
+  const key = contractKey(chainId, address);
+  inFlight.delete(key);
+  resolved.delete(key);
+}
+
+/**
  * Resolve a batch of contracts BEFORE committing fresh rows to state, so
  * labelled rows paint labelled on their first frame. Capped: a slow
  * Sourcify can only ever hold fresh data back by `capMs` — after that the

--- a/lib/sourcify.ts
+++ b/lib/sourcify.ts
@@ -1,16 +1,21 @@
 import "server-only";
-import l1ChainsData from "@/constants/l1-chains.json";
+import { rpcCall, rpcFor } from "@/lib/verification/chains";
+import { findVerified, readStandardJsonInput } from "@/lib/verification/store";
 
 /* ------------------------------------------------------------------ */
-/* Sourcify — contract verification lookups for the EVM explorer.      */
+/* Contract verification lookups for the EVM explorer.                 */
 /*                                                                     */
-/* sourcify.dev is the open verification archive: a verified contract  */
-/* gives us its name, ABI, and compiler provenance, which the explorer */
-/* turns into labelled addresses, decoded calldata, and decoded logs.  */
-/* Coverage is chain-gated: the hosted instance knows the C-Chain      */
-/* (43114) and Fuji (43113) but almost none of the custom L1s, so      */
-/* every lookup first checks the supported-chain list and returns      */
-/* null fast for chains Sourcify has never heard of.                   */
+/* A verified contract gives us its name, ABI, and compiler provenance,*/
+/* which the explorer turns into labelled addresses, decoded calldata, */
+/* and decoded logs. Two sources answer that question, in order:       */
+/*                                                                     */
+/*  1. Our own database, written by the verification service in        */
+/*     lib/verification. This covers every L1 in the catalog.          */
+/*  2. sourcify.dev, the open verification archive. Coverage there is  */
+/*     chain-gated: the hosted instance knows the C-Chain (43114) and  */
+/*     Fuji (43113) but almost none of the custom L1s, so lookups      */
+/*     check the supported-chain list and return null fast for chains  */
+/*     Sourcify has never heard of.                                    */
 /* ------------------------------------------------------------------ */
 
 const SOURCIFY_BASE = "https://sourcify.dev/server";
@@ -29,13 +34,14 @@ export interface VerifiedContract {
   abi: unknown[] | null;
 }
 
-async function sourcifyFetch(path: string, timeoutMs = 8_000): Promise<Response> {
+async function sourcifyFetch(path: string, timeoutMs = 8_000, init?: RequestInit): Promise<Response> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     return await fetch(`${SOURCIFY_BASE}${path}`, {
+      ...init,
       signal: controller.signal,
-      headers: { accept: "application/json" },
+      headers: { accept: "application/json", ...init?.headers },
     });
   } finally {
     clearTimeout(timer);
@@ -66,17 +72,30 @@ async function isChainSupported(chainId: number): Promise<boolean> {
 }
 
 /* Per-contract cache. Verification is effectively immutable once it
-   exists, so hits live a day; misses live short — an unverified contract
-   can be verified at any moment and should show up soon after. */
+   exists, so hits live a day. A cached miss does NOT stand in for our own
+   database — see getVerifiedContract — it only spares upstream Sourcify a
+   repeated question about a contract it has already said it doesn't know. */
 const HIT_TTL_MS = 24 * 60 * 60 * 1000;
 const MISS_TTL_MS = 10 * 60 * 1000;
 const contractCache = new Map<string, { at: number; value: VerifiedContract | null }>();
 
+/** Forget a cached answer for one contract. Called when a verification
+ *  lands here, so a contract someone just verified stops being reported
+ *  as unverified for the rest of the miss window. */
+export function invalidateContract(chainId: number, address: string): void {
+  contractCache.delete(`${chainId}:${address.toLowerCase()}`);
+  proxyCache.delete(`${chainId}:${address.toLowerCase()}`);
+}
+
 /**
- * Look up a contract's verification on Sourcify.
- * Returns the verified contract, or null when the contract is unverified,
- * the chain is unsupported, or Sourcify is unreachable (stale cache stands
- * where one exists — a flaky upstream should never blank a label).
+ * Look up a contract's verification, ours first and Sourcify second.
+ *
+ * Contracts verified on Builder Hub live in our own database and cover
+ * every L1 in the catalog; Sourcify covers the handful of chains it knows
+ * about, which in practice means the Primary Network. Returns null when
+ * the contract is unverified everywhere, or when Sourcify is unreachable
+ * and we have nothing cached — a flaky upstream should never blank a
+ * label that was there a moment ago.
  */
 export async function getVerifiedContract(
   chainId: number,
@@ -87,10 +106,31 @@ export async function getVerifiedContract(
 
   const key = `${chainId}:${address.toLowerCase()}`;
   const cached = contractCache.get(key);
-  if (cached) {
-    const ttl = cached.value ? HIT_TTL_MS : MISS_TTL_MS;
-    if (Date.now() - cached.at < ttl) return cached.value;
+  // A cached hit is authoritative — verification doesn't get undone.
+  if (cached?.value && Date.now() - cached.at < HIT_TTL_MS) return cached.value;
+
+  // Our own database is consulted even when a miss is cached. It is one
+  // indexed lookup, and it is the answer that changes the instant someone
+  // verifies — including on another instance, which no invalidation of
+  // ours could ever reach. Trusting a cached miss here is what would make
+  // a contract keep reporting as unverified right after it was verified.
+  const own = await findVerified(chainId, address);
+  if (own) {
+    const value: VerifiedContract = {
+      match: own.match,
+      name: own.name,
+      compilerVersion: own.compilerVersion,
+      language: own.language,
+      verifiedAt: own.verifiedAt.toISOString(),
+      abi: own.abi,
+    };
+    contractCache.set(key, { at: Date.now(), value });
+    return value;
   }
+
+  // Past here we are about to ask Sourcify, which is the only part worth
+  // rate-limiting with a remembered miss.
+  if (cached && !cached.value && Date.now() - cached.at < MISS_TTL_MS) return null;
 
   if (!(await isChainSupported(chainId))) return null;
 
@@ -128,6 +168,124 @@ export function sourcifyRepoUrl(chainId: number, address: string): string {
   return `https://repo.sourcify.dev/${chainId}/${address}`;
 }
 
+/**
+ * Publish a verification we performed to the public Sourcify archive.
+ *
+ * Reads already merge both sources, so this changes nothing about what the
+ * explorer shows. What it buys is reach: a contract verified here becomes
+ * visible in every other tool that reads the archive, and outlives our
+ * database. Only the Primary Network benefits — Sourcify will not accept a
+ * chain it doesn't list, which is nearly every L1 in the catalog.
+ *
+ * Deliberately best-effort. It runs after the verification is already
+ * recorded, and a rejection upstream (including "already verified", which
+ * is a perfectly good outcome) must never turn a successful verification
+ * into a failed one.
+ */
+export async function mirrorToSourcify(input: {
+  chainId: number;
+  address: string;
+  stdJsonInput: unknown;
+  compilerVersion: string;
+  contractIdentifier: string;
+}): Promise<void> {
+  if (process.env.SOURCIFY_MIRROR !== "1") return;
+  if (!(await isChainSupported(input.chainId))) return;
+
+  try {
+    const res = await sourcifyFetch(`/v2/verify/${input.chainId}/${input.address}`, 20_000, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        stdJsonInput: input.stdJsonInput,
+        compilerVersion: input.compilerVersion,
+        contractIdentifier: input.contractIdentifier,
+      }),
+    });
+    if (!res.ok && res.status !== 409) {
+      console.warn(`[sourcify] mirror rejected for ${input.address}: HTTP ${res.status}`);
+    }
+  } catch (error) {
+    console.warn(`[sourcify] mirror failed for ${input.address}`, error);
+  }
+}
+
+export interface ContractSources {
+  /** Solidity file path → file contents. */
+  sources: Record<string, { content: string }>;
+  optimizer: { enabled: boolean; runs: number | null } | null;
+  evmVersion: string | null;
+  /** Where the sources came from, for attribution in the UI. */
+  origin: "builder-hub" | "sourcify";
+}
+
+/**
+ * Source files behind a verified contract, ours first and Sourcify second
+ * — the same precedence as the metadata lookup, so the Contract tab never
+ * has to care which verifier produced them.
+ *
+ * Separate from getVerifiedContract because sources are large and only the
+ * Contract tab wants them; the name-and-ABI path is called for every
+ * address on a page and must stay small.
+ */
+export async function getContractSources(
+  chainId: number,
+  address: string,
+): Promise<ContractSources | null> {
+  const own = await findVerified(chainId, address);
+  if (own?.stdJsonBlobUrl) {
+    const input = (await readStandardJsonInput(own.stdJsonBlobUrl)) as {
+      sources?: Record<string, { content?: string }>;
+      settings?: { optimizer?: { enabled?: boolean; runs?: number }; evmVersion?: string };
+    } | null;
+    if (input?.sources) {
+      const sources: Record<string, { content: string }> = {};
+      for (const [file, entry] of Object.entries(input.sources)) {
+        if (typeof entry?.content === "string") sources[file] = { content: entry.content };
+      }
+      return {
+        sources,
+        optimizer: input.settings?.optimizer
+          ? {
+              enabled: input.settings.optimizer.enabled === true,
+              runs: input.settings.optimizer.runs ?? null,
+            }
+          : null,
+        evmVersion: input.settings?.evmVersion ?? null,
+        origin: "builder-hub",
+      };
+    }
+  }
+
+  if (!(await isChainSupported(chainId))) return null;
+
+  try {
+    const res = await sourcifyFetch(`/v2/contract/${chainId}/${address}?fields=sources,compilation`);
+    if (!res.ok) return null;
+    const body = (await res.json()) as {
+      sources?: Record<string, { content?: string }>;
+      compilation?: {
+        compilerSettings?: { optimizer?: { enabled?: boolean; runs?: number }; evmVersion?: string };
+      };
+    };
+    if (!body.sources) return null;
+
+    const sources: Record<string, { content: string }> = {};
+    for (const [file, entry] of Object.entries(body.sources)) {
+      if (typeof entry?.content === "string") sources[file] = { content: entry.content };
+    }
+    const optimizer = body.compilation?.compilerSettings?.optimizer;
+    return {
+      sources,
+      optimizer: optimizer ? { enabled: optimizer.enabled === true, runs: optimizer.runs ?? null } : null,
+      evmVersion: body.compilation?.compilerSettings?.evmVersion ?? null,
+      origin: "sourcify",
+    };
+  } catch {
+    return null;
+  }
+}
+
 /* ------------------------------------------------------------------ */
 /* Proxy resolution — a verified proxy carries the proxy's ABI, so     */
 /* calls that hit the implementation decode as raw selectors. For      */
@@ -147,43 +305,6 @@ const ZOS_IMPL_SLOT = "0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee0
 const IMPLEMENTATION_SELECTOR = "0x5c60da1b";
 // EIP-1167 minimal proxy runtime bytecode, implementation address between
 const EIP1167_RE = /^0x363d3d373d3d3d363d73([a-f0-9]{40})5af43d82803e903d91602b57fd5bf3$/;
-
-/** EVM chain id → public RPC, from the chain catalog. The Primary Network
- *  pair is pinned so proxy resolution never depends on catalog contents. */
-let rpcByChainId: Map<number, string> | null = null;
-function rpcFor(chainId: number): string | null {
-  if (!rpcByChainId) {
-    rpcByChainId = new Map([
-      [43114, "https://api.avax.network/ext/bc/C/rpc"],
-      [43113, "https://api.avax-test.network/ext/bc/C/rpc"],
-    ]);
-    for (const c of l1ChainsData as { chainId: string; rpcUrl?: string }[]) {
-      const id = Number(c.chainId);
-      if (Number.isInteger(id) && c.rpcUrl && !rpcByChainId.has(id)) rpcByChainId.set(id, c.rpcUrl);
-    }
-  }
-  return rpcByChainId.get(chainId) ?? null;
-}
-
-async function rpcCall(rpcUrl: string, method: string, params: unknown[]): Promise<string | null> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 5_000);
-  try {
-    const res = await fetch(rpcUrl, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-      signal: controller.signal,
-    });
-    if (!res.ok) return null;
-    const body = (await res.json()) as { result?: unknown };
-    return typeof body.result === "string" ? body.result : null;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timer);
-  }
-}
 
 /** Last 20 bytes of a 32-byte slot value, or null when the slot is empty. */
 function slotToAddress(value: string | null): string | null {

--- a/lib/verification/chains.ts
+++ b/lib/verification/chains.ts
@@ -1,0 +1,150 @@
+import "server-only";
+import l1ChainsData from "@/constants/l1-chains.json";
+
+/* ------------------------------------------------------------------ */
+/* Chain resolution for verification and Sourcify lookups.             */
+/*                                                                     */
+/* Verification only ever talks to RPCs we chose: the caller names a    */
+/* chain id and we look the endpoint up here. A submitted RPC URL is    */
+/* never honoured — that would turn the verifier into an SSRF probe     */
+/* and into an amplifier pointed at other people's RPC providers.       */
+/* ------------------------------------------------------------------ */
+
+/** The Primary Network pair is pinned so chain resolution never depends
+ *  on catalog contents. */
+const PINNED_RPCS: [number, string][] = [
+  [43114, "https://api.avax.network/ext/bc/C/rpc"],
+  [43113, "https://api.avax-test.network/ext/bc/C/rpc"],
+];
+
+interface CatalogChain {
+  chainId: string;
+  chainName?: string;
+  slug?: string;
+  rpcUrl?: string;
+  isTestnet?: boolean;
+  isEvm?: boolean;
+}
+
+export interface KnownChain {
+  chainId: number;
+  name: string;
+  slug: string | null;
+  rpcUrl: string;
+  isTestnet: boolean;
+}
+
+let byChainId: Map<number, KnownChain> | null = null;
+
+function catalog(): Map<number, KnownChain> {
+  if (byChainId) return byChainId;
+
+  const map = new Map<number, KnownChain>();
+  for (const [chainId, rpcUrl] of PINNED_RPCS) {
+    map.set(chainId, {
+      chainId,
+      name: chainId === 43114 ? "Avalanche C-Chain" : "Avalanche Fuji C-Chain",
+      slug: "c-chain",
+      rpcUrl,
+      isTestnet: chainId === 43113,
+    });
+  }
+
+  for (const chain of l1ChainsData as CatalogChain[]) {
+    const id = Number(chain.chainId);
+    // Non-EVM entries carry a base58 blockchain id in `chainId`, which
+    // Number() turns into NaN — those can never be verified against.
+    if (!Number.isInteger(id) || id <= 0) continue;
+    if (!chain.rpcUrl) continue;
+    if (map.has(id)) continue;
+    map.set(id, {
+      chainId: id,
+      name: chain.chainName ?? `Chain ${id}`,
+      slug: chain.slug ?? null,
+      rpcUrl: chain.rpcUrl,
+      isTestnet: chain.isTestnet ?? false,
+    });
+  }
+
+  byChainId = map;
+  return map;
+}
+
+/** The chain we know under this id, or null when it isn't in the catalog
+ *  or has no RPC to read deployed bytecode from. */
+export function knownChain(chainId: number): KnownChain | null {
+  return catalog().get(chainId) ?? null;
+}
+
+/** Every chain that can accept a verification, for docs and pickers. */
+export function verifiableChains(): KnownChain[] {
+  return [...catalog().values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function rpcFor(chainId: number): string | null {
+  return catalog().get(chainId)?.rpcUrl ?? null;
+}
+
+export async function rpcCall(
+  rpcUrl: string,
+  method: string,
+  params: unknown[],
+  timeoutMs = 5_000,
+): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      signal: controller.signal,
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { result?: unknown };
+    return typeof body.result === "string" ? body.result : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/* Deployed code is immutable for a given address (barring SELFDESTRUCT +
+   CREATE2 redeployment, which we accept being briefly stale about), so a
+   short cache keeps a flood of submissions from turning into a flood of
+   eth_getCode at somebody else's RPC. */
+const CODE_HIT_TTL_MS = 60 * 60 * 1000;
+const CODE_MISS_TTL_MS = 60 * 1000;
+const MAX_CODE_CACHE = 5_000;
+const codeCache = new Map<string, { at: number; code: string | null }>();
+
+/**
+ * Runtime bytecode at `address`, or null for an EOA, an unknown chain, or
+ * an unreachable RPC. The returned hex is lowercased and 0x-prefixed.
+ */
+export async function getDeployedCode(chainId: number, address: string): Promise<string | null> {
+  const key = `${chainId}:${address.toLowerCase()}`;
+  const cached = codeCache.get(key);
+  if (cached) {
+    const ttl = cached.code ? CODE_HIT_TTL_MS : CODE_MISS_TTL_MS;
+    if (Date.now() - cached.at < ttl) return cached.code;
+  }
+
+  const rpc = rpcFor(chainId);
+  if (!rpc) return null;
+
+  const raw = await rpcCall(rpc, "eth_getCode", [address, "latest"]);
+  const code = raw && raw !== "0x" && /^0x[0-9a-fA-F]*$/.test(raw) ? raw.toLowerCase() : null;
+
+  if (codeCache.size >= MAX_CODE_CACHE) {
+    const oldest = codeCache.keys().next().value;
+    if (oldest) codeCache.delete(oldest);
+  }
+  codeCache.set(key, { at: Date.now(), code });
+  return code;
+}
+
+export function isAddress(value: string): boolean {
+  return /^0x[a-fA-F0-9]{40}$/.test(value);
+}

--- a/lib/verification/etherscan-api.ts
+++ b/lib/verification/etherscan-api.ts
@@ -1,0 +1,306 @@
+import "server-only";
+import { after, NextRequest, NextResponse } from "next/server";
+import { getClientId } from "@/lib/mcp-rate-limit";
+import { knownChain, isAddress } from "./chains";
+import { submitVerification, type StandardJsonInput } from "./service";
+import { findVerified, getJob, readStandardJsonInput } from "./store";
+
+/* ------------------------------------------------------------------ */
+/* The Etherscan-compatible surface.                                   */
+/*                                                                     */
+/* This is the interoperability workhorse: `hardhat verify` reaches it */
+/* through customChains (Hardhat 2) or chainDescriptors (Hardhat 3),   */
+/* and `forge verify-contract` through --verifier custom. None of      */
+/* those tools can be changed to suit us, so the response strings      */
+/* below are load-bearing — hardhat-verify decides whether a           */
+/* verification passed by matching "Pass - Verified" and friends.      */
+/*                                                                     */
+/* The apikey parameter is accepted and ignored. Tooling insists on    */
+/* sending one, and gating on it would only mean issuing keys to       */
+/* everybody; abuse is handled by the controls in limits.ts instead.   */
+/* ------------------------------------------------------------------ */
+
+/** Exactly what hardhat-verify pattern-matches on. Do not reword. */
+const PENDING = "Pending in queue";
+const PASS = "Pass - Verified";
+const FAIL = "Fail - Unable to verify";
+const ALREADY_VERIFIED = "Contract source code already verified";
+const NOT_VERIFIED = "Contract source code not verified";
+
+function ok(result: unknown, message = "OK") {
+  return NextResponse.json({ status: "1", message, result });
+}
+
+function notOk(result: string, init?: { status?: number; headers?: Record<string, string> }) {
+  return NextResponse.json(
+    { status: "0", message: "NOTOK", result },
+    { status: init?.status ?? 200, headers: init?.headers },
+  );
+}
+
+type Params = { get: (key: string) => string | null };
+
+function mergedParams(body: URLSearchParams | null, query: URLSearchParams): Params {
+  return {
+    get: (key: string) => {
+      // Case-insensitive: tooling is inconsistent about `apiKey` vs `apikey`
+      // and `evmVersion` vs `evmversion`.
+      const lookup = (source: URLSearchParams) => {
+        const direct = source.get(key);
+        if (direct !== null) return direct;
+        for (const [k, v] of source.entries()) {
+          if (k.toLowerCase() === key.toLowerCase()) return v;
+        }
+        return null;
+      };
+      return (body ? lookup(body) : null) ?? lookup(query);
+    },
+  };
+}
+
+async function readBody(request: NextRequest): Promise<URLSearchParams | null> {
+  if (request.method !== "POST") return null;
+  const contentType = request.headers.get("content-type") ?? "";
+  try {
+    if (contentType.includes("application/json")) {
+      const json = (await request.json()) as Record<string, unknown>;
+      const params = new URLSearchParams();
+      for (const [key, value] of Object.entries(json)) {
+        params.set(key, typeof value === "string" ? value : JSON.stringify(value));
+      }
+      return params;
+    }
+    if (contentType.includes("multipart/form-data")) {
+      const form = await request.formData();
+      const params = new URLSearchParams();
+      for (const [key, value] of form.entries()) {
+        if (typeof value === "string") params.set(key, value);
+      }
+      return params;
+    }
+    return new URLSearchParams(await request.text());
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Etherscan wraps Standard JSON in an extra pair of braces so its own UI
+ * can tell the formats apart. Tools vary; accept either.
+ */
+function unwrapSourceCode(source: string): string {
+  const trimmed = source.trim();
+  return trimmed.startsWith("{{") && trimmed.endsWith("}}") ? trimmed.slice(1, -1) : trimmed;
+}
+
+function normalizeConstructorArgs(value: string | null): string | null {
+  if (!value) return null;
+  const trimmed = value.trim().replace(/^0x/i, "");
+  return trimmed.length ? trimmed : null;
+}
+
+/**
+ * One handler for both the per-chain route (chain in the path, Hardhat 2
+ * customChains style) and the v2 route (chain in `chainid`, Etherscan V2
+ * style). Everything else about them is identical.
+ */
+export async function handleEtherscanApi(
+  request: NextRequest,
+  chainIdFromPath?: string,
+): Promise<NextResponse> {
+  const query = request.nextUrl.searchParams;
+  const body = await readBody(request);
+  const params = mergedParams(body, query);
+
+  const chainIdRaw = chainIdFromPath ?? params.get("chainid") ?? params.get("chainId");
+  const chainId = Number(chainIdRaw);
+  if (!Number.isInteger(chainId) || chainId <= 0) {
+    return notOk("Missing or invalid chainid");
+  }
+  if (!knownChain(chainId)) {
+    return notOk(`Chain ${chainId} is not supported by this verifier`);
+  }
+
+  const action = (params.get("action") ?? "").toLowerCase();
+
+  switch (action) {
+    case "verifysourcecode":
+      return verifySourceCode(request, chainId, params);
+    case "checkverifystatus":
+      return checkVerifyStatus(params);
+    case "getsourcecode":
+      return getSourceCode(chainId, params);
+    case "getabi":
+      return getAbi(chainId, params);
+    default:
+      return notOk(
+        "Unsupported action. This verifier implements verifysourcecode, checkverifystatus, getsourcecode and getabi.",
+      );
+  }
+}
+
+async function verifySourceCode(
+  request: NextRequest,
+  chainId: number,
+  params: Params,
+): Promise<NextResponse> {
+  const address = (params.get("contractaddress") ?? "").trim();
+  if (!isAddress(address)) return notOk("Invalid contract address");
+
+  const codeformat = (params.get("codeformat") ?? "").trim();
+  if (codeformat && codeformat !== "solidity-standard-json-input") {
+    return notOk(
+      `Unsupported codeformat "${codeformat}". Submit solidity-standard-json-input — Hardhat and Foundry produce it by default.`,
+    );
+  }
+
+  const sourceCode = params.get("sourceCode") ?? params.get("sourcecode");
+  if (!sourceCode) return notOk("Missing sourceCode");
+
+  let stdJsonInput: StandardJsonInput;
+  try {
+    stdJsonInput = JSON.parse(unwrapSourceCode(sourceCode)) as StandardJsonInput;
+  } catch {
+    return notOk(
+      "sourceCode is not valid JSON. This verifier only accepts Standard JSON input, not flattened sources.",
+    );
+  }
+
+  const contractIdentifier = (params.get("contractname") ?? "").trim();
+  if (!contractIdentifier) return notOk("Missing contractname");
+
+  const compilerVersion = (params.get("compilerversion") ?? "").trim();
+  if (!compilerVersion) return notOk("Missing compilerversion");
+
+  const result = await submitVerification({
+    chainId,
+    address,
+    stdJsonInput,
+    compilerVersion,
+    contractIdentifier,
+    constructorArguments:
+      normalizeConstructorArgs(params.get("constructorArguments")) ??
+      // Etherscan's own docs have carried this typo for years and tools copied it.
+      normalizeConstructorArgs(params.get("constructorArguements")),
+    clientId: getClientId(request),
+  });
+
+  if (!result.ok) {
+    if (result.code === "already_verified") return notOk(ALREADY_VERIFIED);
+    if (result.code === "rate_limited") {
+      return notOk(result.message, {
+        status: 429,
+        headers: { "Retry-After": String(result.retryAfterSeconds ?? 60) },
+      });
+    }
+    return notOk(result.message);
+  }
+
+  // Compile after the GUID is on its way back, which is the flow the
+  // protocol describes: submit returns a receipt, not a result.
+  after(result.run);
+
+  return ok(result.jobId);
+}
+
+async function checkVerifyStatus(params: Params): Promise<NextResponse> {
+  const guid = (params.get("guid") ?? "").trim();
+  if (!guid) return notOk("Missing guid");
+
+  const job = await getJob(guid);
+  if (!job) return notOk("Unknown verification id");
+
+  switch (job.status) {
+    case "pending":
+    case "running":
+      return notOk(PENDING);
+    case "succeeded":
+      return ok(PASS);
+    default:
+      return notOk(`${FAIL}. ${job.error ?? ""}`.trim());
+  }
+}
+
+async function getSourceCode(chainId: number, params: Params): Promise<NextResponse> {
+  const address = (params.get("address") ?? "").trim();
+  if (!isAddress(address)) return notOk("Invalid address format");
+
+  const verified = await findVerified(chainId, address);
+  if (!verified) {
+    // Etherscan answers "OK" with an empty record rather than an error, and
+    // tooling keys off the ABI field to decide the contract is unverified.
+    return ok([
+      {
+        SourceCode: "",
+        ABI: NOT_VERIFIED,
+        ContractName: "",
+        CompilerVersion: "",
+        OptimizationUsed: "",
+        Runs: "",
+        ConstructorArguments: "",
+        EVMVersion: "Default",
+        Library: "",
+        LicenseType: "",
+        Proxy: "0",
+        Implementation: "",
+        SwarmSource: "",
+      },
+    ]);
+  }
+
+  const settings = await compilerSettings(verified.stdJsonBlobUrl);
+
+  return ok([
+    {
+      SourceCode: settings.sourceCode,
+      ABI: JSON.stringify(verified.abi ?? []),
+      ContractName: verified.name ?? "",
+      CompilerVersion: verified.compilerVersion ? `v${verified.compilerVersion}` : "",
+      OptimizationUsed: settings.optimizerEnabled ? "1" : "0",
+      Runs: String(settings.runs ?? ""),
+      ConstructorArguments: verified.constructorArguments ?? "",
+      EVMVersion: settings.evmVersion ?? "Default",
+      Library: "",
+      LicenseType: "",
+      Proxy: "0",
+      Implementation: "",
+      SwarmSource: "",
+    },
+  ]);
+}
+
+/** Compiler settings as Etherscan reports them, read back out of the
+ *  stored Standard JSON input. */
+async function compilerSettings(blobUrl: string | null): Promise<{
+  sourceCode: string;
+  optimizerEnabled: boolean;
+  runs: number | null;
+  evmVersion: string | null;
+}> {
+  const empty = { sourceCode: "", optimizerEnabled: false, runs: null, evmVersion: null };
+  if (!blobUrl) return empty;
+
+  const input = (await readStandardJsonInput(blobUrl)) as StandardJsonInput | null;
+  if (!input) return empty;
+
+  const settings = (input.settings ?? {}) as {
+    optimizer?: { enabled?: boolean; runs?: number };
+    evmVersion?: string;
+  };
+  return {
+    // Double-brace wrapped, which is how Etherscan marks Standard JSON.
+    sourceCode: `{${JSON.stringify(input)}}`,
+    optimizerEnabled: settings.optimizer?.enabled === true,
+    runs: settings.optimizer?.runs ?? null,
+    evmVersion: settings.evmVersion ?? null,
+  };
+}
+
+async function getAbi(chainId: number, params: Params): Promise<NextResponse> {
+  const address = (params.get("address") ?? "").trim();
+  if (!isAddress(address)) return notOk("Invalid address format");
+
+  const verified = await findVerified(chainId, address);
+  if (!verified?.abi) return notOk(NOT_VERIFIED);
+  return ok(JSON.stringify(verified.abi));
+}

--- a/lib/verification/limits.ts
+++ b/lib/verification/limits.ts
@@ -1,0 +1,195 @@
+import "server-only";
+import { createClient } from "redis";
+import { randomUUID } from "node:crypto";
+import { COMPILE_TIMEOUT_MS } from "./solc";
+
+/* ------------------------------------------------------------------ */
+/* Abuse controls.                                                     */
+/*                                                                     */
+/* Verification has to be open to anonymous callers — `hardhat verify` */
+/* cannot log in — and a small request buys minutes of CPU. So the     */
+/* danger is not an outage, it is a bill: the platform will happily    */
+/* scale to meet an attacker.                                          */
+/*                                                                     */
+/* Per-caller quotas slow that down but cannot bound it, because IPs   */
+/* are cheap. The global compile semaphore is what bounds it: however  */
+/* many requests arrive, only a handful compile at once, so the worst  */
+/* case degrades into a queue instead of a spending spree.             */
+/*                                                                     */
+/* All of this lives in Redis because per-instance counters mean       */
+/* nothing on serverless, where an attacker simply lands on new        */
+/* instances. When Redis is unreachable we fall back to per-instance   */
+/* counting: weaker, but never unprotected and never offline.          */
+/* ------------------------------------------------------------------ */
+
+/** Concurrent compiles across every instance. Sized so a sustained
+ *  attack costs tens of dollars a day rather than thousands. */
+const MAX_CONCURRENT_COMPILES = 8;
+
+/** A slot is abandoned if its holder dies mid-compile; reclaim after the
+ *  compile could not possibly still be running. */
+const SLOT_TTL_MS = COMPILE_TIMEOUT_MS + 60_000;
+
+export const SUBMIT_QUOTA = { limit: 20, windowMs: 10 * 60 * 1000 };
+
+/** Charged per attempt, not per failure: the work has to be paid for
+ *  before it runs, or an attacker whose jobs never reach a verdict never
+ *  gets counted. A success ends the sequence anyway, since the contract
+ *  is then verified and further submissions short-circuit. */
+export const ADDRESS_ATTEMPT_QUOTA = { limit: 8, windowMs: 60 * 60 * 1000 };
+
+let redisClient: ReturnType<typeof createClient> | null = null;
+let redisPromise: Promise<ReturnType<typeof createClient>> | null = null;
+
+async function getRedis() {
+  if (redisClient?.isOpen) return redisClient;
+  if (redisPromise) return redisPromise;
+
+  redisPromise = (async () => {
+    const url = process.env.REDIS_URL;
+    if (!url) throw new Error("REDIS_URL is not set");
+    const client = createClient({ url });
+    client.on("error", (error) => {
+      console.error("[verification] redis error", error);
+      redisClient = null;
+      redisPromise = null;
+    });
+    await client.connect();
+    redisClient = client;
+    return client;
+  })().catch((error) => {
+    redisClient = null;
+    redisPromise = null;
+    throw error;
+  });
+
+  return redisPromise;
+}
+
+/* ------------------------------- quotas ------------------------------- */
+
+const QUOTA_SCRIPT = `
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+end
+return {count, redis.call('PTTL', KEYS[1])}
+`;
+
+const MAX_LOCAL_KEYS = 10_000;
+const localCounters = new Map<string, { used: number; resetAt: number }>();
+
+function consumeLocal(key: string, windowMs: number): { used: number; resetAt: number } {
+  const now = Date.now();
+  let entry = localCounters.get(key);
+  if (!entry || entry.resetAt <= now) entry = { used: 0, resetAt: now + windowMs };
+  entry.used += 1;
+  if (!localCounters.has(key) && localCounters.size >= MAX_LOCAL_KEYS) {
+    const oldest = localCounters.keys().next().value;
+    if (oldest) localCounters.delete(oldest);
+  }
+  localCounters.set(key, entry);
+  return entry;
+}
+
+export interface QuotaResult {
+  allowed: boolean;
+  retryAfterSeconds: number;
+}
+
+/** Charge one unit against a rolling window. */
+export async function consumeQuota(
+  key: string,
+  { limit, windowMs }: { limit: number; windowMs: number },
+): Promise<QuotaResult> {
+  const namespaced = `verify:quota:${key}`;
+  try {
+    const redis = await getRedis();
+    const [used, ttlMs] = (await redis.eval(QUOTA_SCRIPT, {
+      keys: [namespaced],
+      arguments: [String(windowMs)],
+    })) as [number, number];
+    return {
+      allowed: Number(used) <= limit,
+      retryAfterSeconds: Math.max(1, Math.ceil(Math.max(0, Number(ttlMs)) / 1000)),
+    };
+  } catch {
+    const fallback = consumeLocal(namespaced, windowMs);
+    return {
+      allowed: fallback.used <= limit,
+      retryAfterSeconds: Math.max(1, Math.ceil((fallback.resetAt - Date.now()) / 1000)),
+    };
+  }
+}
+
+/* ------------------------------ semaphore ----------------------------- */
+
+/*
+ * A sorted set of in-flight compiles scored by start time. Expiring by
+ * score means a crashed holder releases its own slot without anyone
+ * having to notice it died — which a plain counter could not do.
+ */
+const ACQUIRE_SCRIPT = `
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+if redis.call('ZCARD', KEYS[1]) >= tonumber(ARGV[2]) then
+  return 0
+end
+redis.call('ZADD', KEYS[1], ARGV[3], ARGV[4])
+redis.call('PEXPIRE', KEYS[1], ARGV[5])
+return 1
+`;
+
+const SLOT_KEY = "verify:compile-slots";
+
+let localSlots = 0;
+
+export interface CompileSlot {
+  release: () => Promise<void>;
+}
+
+/** Take one of the global compile slots, or null when they are all busy. */
+export async function acquireCompileSlot(): Promise<CompileSlot | null> {
+  const token = randomUUID();
+  const now = Date.now();
+
+  try {
+    const redis = await getRedis();
+    const granted = (await redis.eval(ACQUIRE_SCRIPT, {
+      keys: [SLOT_KEY],
+      arguments: [
+        String(now - SLOT_TTL_MS),
+        String(MAX_CONCURRENT_COMPILES),
+        String(now),
+        token,
+        String(SLOT_TTL_MS * 2),
+      ],
+    })) as number;
+
+    if (Number(granted) !== 1) return null;
+    return {
+      release: async () => {
+        try {
+          const client = await getRedis();
+          await client.zRem(SLOT_KEY, token);
+        } catch {
+          /* the score-based sweep reclaims it */
+        }
+      },
+    };
+  } catch {
+    // Redis down: fall back to limiting this instance. Less precise, but
+    // an instance that cannot count is worse than one that counts locally.
+    if (localSlots >= MAX_CONCURRENT_COMPILES) return null;
+    localSlots += 1;
+    let released = false;
+    return {
+      release: async () => {
+        if (released) return;
+        released = true;
+        localSlots = Math.max(0, localSlots - 1);
+      },
+    };
+  }
+}
+
+export const compileConcurrency = MAX_CONCURRENT_COMPILES;

--- a/lib/verification/match.ts
+++ b/lib/verification/match.ts
@@ -1,0 +1,224 @@
+import type { LinkReferences, SolcContract, SolcOutput } from "./solc";
+
+/* ------------------------------------------------------------------ */
+/* Bytecode matching.                                                  */
+/*                                                                     */
+/* Verification is one comparison: does the code the compiler produced */
+/* equal the code sitting on chain? Three things legitimately differ   */
+/* and have to be normalised away first — library addresses that were  */
+/* linked after compilation, immutable values written by the           */
+/* constructor, and the metadata hash at the tail, which changes with  */
+/* things as cosmetic as a comment.                                    */
+/*                                                                     */
+/* Surviving all three byte-for-byte is an exact match. Matching only  */
+/* after the metadata is trimmed means the code is the same but the    */
+/* sources may differ in ways the compiler ignored, which Sourcify     */
+/* calls a (partial) match and so do we.                               */
+/* ------------------------------------------------------------------ */
+
+export type MatchLevel = "exact_match" | "match";
+
+export type MatchFailureCode =
+  | "contract_not_found"
+  | "no_bytecode"
+  | "unlinked_libraries"
+  | "no_match";
+
+export type MatchResult =
+  | { matched: true; level: MatchLevel; abi: unknown[]; metadata: string | null }
+  | {
+      matched: false;
+      code: MatchFailureCode;
+      message: string;
+      recompiledRuntimeCode?: string;
+      onchainRuntimeCode?: string;
+    };
+
+/** `path/to/File.sol:ContractName`, as both tooling protocols spell it. */
+export function splitContractIdentifier(identifier: string): { file: string; name: string } | null {
+  const at = identifier.lastIndexOf(":");
+  if (at <= 0 || at === identifier.length - 1) return null;
+  return { file: identifier.slice(0, at), name: identifier.slice(at + 1) };
+}
+
+export function findContract(output: SolcOutput, identifier: string): SolcContract | null {
+  const parts = splitContractIdentifier(identifier);
+  if (!parts) return null;
+  return output.contracts?.[parts.file]?.[parts.name] ?? null;
+}
+
+/** Every `file:Contract` the compiler produced, for pickers and errors. */
+export function listCompiledContracts(output: SolcOutput): string[] {
+  const found: string[] = [];
+  for (const [file, contracts] of Object.entries(output.contracts ?? {})) {
+    for (const name of Object.keys(contracts)) found.push(`${file}:${name}`);
+  }
+  return found;
+}
+
+function stripPrefix(hex: string): string {
+  return (hex.startsWith("0x") ? hex.slice(2) : hex).toLowerCase();
+}
+
+/**
+ * Length in hex characters of the CBOR metadata trailer, or 0 when there
+ * isn't a plausible one. Solidity writes the metadata length as the final
+ * two bytes, so the trailer is that value plus the two length bytes.
+ */
+function metadataLength(hex: string): number {
+  if (hex.length < 4) return 0;
+  const declared = parseInt(hex.slice(-4), 16);
+  if (!Number.isFinite(declared) || declared <= 0) return 0;
+  const total = (declared + 2) * 2;
+  return total <= hex.length ? total : 0;
+}
+
+function trimMetadata(hex: string): string {
+  const length = metadataLength(hex);
+  return length ? hex.slice(0, hex.length - length) : hex;
+}
+
+/** Overwrite byte ranges with zeroes so values written at deploy time stop
+ *  being a difference. Offsets are byte offsets into the bytecode. */
+function blankRanges(hex: string, ranges: { start: number; length: number }[]): string {
+  if (!ranges.length) return hex;
+  const chars = hex.split("");
+  for (const { start, length } of ranges) {
+    const from = start * 2;
+    const to = from + length * 2;
+    if (from < 0 || to > chars.length) continue;
+    for (let i = from; i < to; i++) chars[i] = "0";
+  }
+  return chars.join("");
+}
+
+function immutableRanges(contract: SolcContract): { start: number; length: number }[] {
+  const references = contract.evm?.deployedBytecode?.immutableReferences ?? {};
+  return Object.values(references).flat();
+}
+
+/**
+ * Substitute library addresses into placeholder slots. Returns null when
+ * the input didn't supply an address for a library the code needs, which
+ * is a submitter error rather than a mismatch.
+ */
+function linkLibraries(
+  hex: string,
+  linkReferences: LinkReferences | undefined,
+  libraries: Record<string, Record<string, string>> | undefined,
+): { linked: string } | { missing: string } {
+  const entries = Object.entries(linkReferences ?? {});
+  if (!entries.length) return { linked: hex };
+
+  let out = hex;
+  for (const [file, byName] of entries) {
+    for (const [name, positions] of Object.entries(byName)) {
+      const address =
+        libraries?.[file]?.[name] ??
+        libraries?.[`${file}:${name}`]?.[name] ??
+        // Some tooling keys libraries by bare contract name.
+        libraries?.[name]?.[name];
+      if (!address || !/^0x[0-9a-fA-F]{40}$/.test(address)) {
+        return { missing: `${file}:${name}` };
+      }
+      const bare = stripPrefix(address);
+      for (const { start, length } of positions) {
+        if (length !== 20) continue;
+        const from = start * 2;
+        out = out.slice(0, from) + bare + out.slice(from + 40);
+      }
+    }
+  }
+  return { linked: out };
+}
+
+/**
+ * Compare a compiled contract against deployed code.
+ *
+ * `onchainCode` is the result of eth_getCode. `libraries` is the standard
+ * JSON input's `settings.libraries`, needed only when the contract links
+ * against libraries that were not already linked at compile time.
+ */
+export function matchDeployedBytecode({
+  output,
+  identifier,
+  onchainCode,
+  libraries,
+}: {
+  output: SolcOutput;
+  identifier: string;
+  onchainCode: string;
+  libraries?: Record<string, Record<string, string>>;
+}): MatchResult {
+  const contract = findContract(output, identifier);
+  if (!contract) {
+    const available = listCompiledContracts(output);
+    return {
+      matched: false,
+      code: "contract_not_found",
+      message:
+        `The compiler output has no "${identifier}". ` +
+        (available.length ? `It produced: ${available.slice(0, 20).join(", ")}.` : "It produced no contracts."),
+    };
+  }
+
+  const compiledRaw = stripPrefix(contract.evm?.deployedBytecode?.object ?? "");
+  if (!compiledRaw) {
+    return {
+      matched: false,
+      code: "no_bytecode",
+      message: `"${identifier}" compiles to no runtime bytecode. Interfaces and abstract contracts cannot be deployed or verified.`,
+    };
+  }
+
+  const linkage = linkLibraries(
+    compiledRaw,
+    contract.evm?.deployedBytecode?.linkReferences,
+    libraries,
+  );
+  if ("missing" in linkage) {
+    return {
+      matched: false,
+      code: "unlinked_libraries",
+      message: `No address supplied for library ${linkage.missing}. Add it under settings.libraries in the standard JSON input.`,
+    };
+  }
+
+  const onchain = stripPrefix(onchainCode);
+  const compiled = linkage.linked;
+  const failure = (message: string): MatchResult => ({
+    matched: false,
+    code: "no_match",
+    message,
+    recompiledRuntimeCode: `0x${compiled}`,
+    onchainRuntimeCode: `0x${onchain}`,
+  });
+
+  if (compiled.length !== onchain.length) {
+    return failure("The compiled runtime bytecode is a different length than the deployed code.");
+  }
+
+  const ranges = immutableRanges(contract);
+  const compiledBlanked = blankRanges(compiled, ranges);
+  const onchainBlanked = blankRanges(onchain, ranges);
+
+  if (compiledBlanked === onchainBlanked) {
+    return {
+      matched: true,
+      level: "exact_match",
+      abi: contract.abi ?? [],
+      metadata: contract.metadata ?? null,
+    };
+  }
+
+  if (trimMetadata(compiledBlanked) === trimMetadata(onchainBlanked)) {
+    return {
+      matched: true,
+      level: "match",
+      abi: contract.abi ?? [],
+      metadata: contract.metadata ?? null,
+    };
+  }
+
+  return failure("The deployed code does not match this source. Check the contract name, compiler version and settings.");
+}

--- a/lib/verification/service.ts
+++ b/lib/verification/service.ts
@@ -1,0 +1,372 @@
+import "server-only";
+import { getDeployedCode, isAddress, knownChain } from "./chains";
+import { acquireCompileSlot, ADDRESS_ATTEMPT_QUOTA, consumeQuota, SUBMIT_QUOTA } from "./limits";
+import { listCompiledContracts, matchDeployedBytecode, splitContractIdentifier } from "./match";
+import { CompileError, compileStandardJson, fatalErrors, MAX_INPUT_BYTES, toCompilerInput } from "./solc";
+import {
+  completeJob,
+  createJob,
+  findJobByPayload,
+  findVerified,
+  getJob,
+  markJobRunning,
+  payloadHash,
+  saveVerification,
+  type VerificationJobRecord,
+} from "./store";
+import { invalidateContract, mirrorToSourcify } from "@/lib/sourcify";
+
+/* ------------------------------------------------------------------ */
+/* Verification, end to end.                                           */
+/*                                                                     */
+/* Submission is deliberately front-loaded with cheap checks: address   */
+/* shape, known chain, caller quota, already-verified, deployed code,   */
+/* seen-this-exact-payload. Every one of them is there to reach a       */
+/* decision before the expensive part, because the expensive part is    */
+/* the whole attack surface.                                           */
+/* ------------------------------------------------------------------ */
+
+export interface StandardJsonInput {
+  language?: string;
+  sources?: Record<string, { content?: string; urls?: string[] }>;
+  settings?: {
+    libraries?: Record<string, Record<string, string>>;
+    [key: string]: unknown;
+  };
+}
+
+export interface SubmitInput {
+  chainId: number;
+  address: string;
+  stdJsonInput: unknown;
+  compilerVersion: string;
+  contractIdentifier: string;
+  constructorArguments?: string | null;
+  /** Rate-limiting bucket for the caller, from the request. */
+  clientId: string;
+}
+
+export type SubmitRejection = {
+  ok: false;
+  code:
+    | "invalid_address"
+    | "unsupported_chain"
+    | "invalid_input"
+    | "input_too_large"
+    | "unsupported_language"
+    | "already_verified"
+    | "contract_not_deployed"
+    | "rate_limited"
+    | "internal_error";
+  message: string;
+  retryAfterSeconds?: number;
+};
+
+export interface SubmitAccepted {
+  ok: true;
+  jobId: string;
+  /** True when an identical payload was already tried: `run` is a no-op
+   *  and the job already carries that earlier outcome. */
+  deduplicated: boolean;
+  /**
+   * The compile, bound to this submission. Callers hand it to `after()`
+   * rather than assembling the payload a second time — the background run
+   * and the accepted submission can then never disagree about what was
+   * submitted.
+   */
+  run: () => Promise<void>;
+}
+
+export type SubmitResult = SubmitAccepted | SubmitRejection;
+
+/** How long a submit waits for a compile slot before giving up. Keeping
+ *  the caller's request short matters less than not failing a legitimate
+ *  verification the moment someone else is compiling. */
+const SLOT_WAIT_MS = 30_000;
+const SLOT_POLL_MS = 2_000;
+
+function looksLikeStandardJson(value: unknown): value is StandardJsonInput {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const sources = (value as StandardJsonInput).sources;
+  if (!sources || typeof sources !== "object") return false;
+  return Object.keys(sources).length > 0;
+}
+
+
+/**
+ * Validate and enqueue a verification. Returns as soon as the job exists;
+ * the compile happens in the background and is polled for.
+ */
+export async function submitVerification(input: SubmitInput): Promise<SubmitResult> {
+  const address = input.address.toLowerCase();
+
+  if (!isAddress(address)) {
+    return { ok: false, code: "invalid_address", message: "Not a contract address." };
+  }
+
+  const chain = knownChain(input.chainId);
+  if (!chain) {
+    return {
+      ok: false,
+      code: "unsupported_chain",
+      message: `Chain ${input.chainId} is not one we can verify against. It needs to be in the Builder Hub chain catalog with a public RPC.`,
+    };
+  }
+
+  if (!looksLikeStandardJson(input.stdJsonInput)) {
+    return {
+      ok: false,
+      code: "invalid_input",
+      message: "Expected a Solidity Standard JSON input with a non-empty `sources` object.",
+    };
+  }
+
+  const language = input.stdJsonInput.language ?? "Solidity";
+  if (language !== "Solidity") {
+    return {
+      ok: false,
+      code: "unsupported_language",
+      message: `Only Solidity is supported; this input declares ${language}.`,
+    };
+  }
+
+  // Everything downstream — the hash, the compile, what gets stored — uses
+  // the reduced input, so the thing we verified is the thing we kept.
+  const stdJsonInput = toCompilerInput(input.stdJsonInput);
+
+  const serialized = JSON.stringify(stdJsonInput);
+  if (Buffer.byteLength(serialized) > MAX_INPUT_BYTES) {
+    return {
+      ok: false,
+      code: "input_too_large",
+      message: `Standard JSON input exceeds the ${Math.round(MAX_INPUT_BYTES / 1024 / 1024)} MB limit.`,
+    };
+  }
+
+  if (!splitContractIdentifier(input.contractIdentifier)) {
+    return {
+      ok: false,
+      code: "invalid_input",
+      message: 'The contract name must be fully qualified, as "contracts/Token.sol:Token".',
+    };
+  }
+
+  const quota = await consumeQuota(`submit:${input.clientId}`, SUBMIT_QUOTA);
+  if (!quota.allowed) {
+    return {
+      ok: false,
+      code: "rate_limited",
+      message: "Too many verification requests. Try again shortly.",
+      retryAfterSeconds: quota.retryAfterSeconds,
+    };
+  }
+
+  if (await findVerified(input.chainId, address)) {
+    return { ok: false, code: "already_verified", message: "This contract is already verified." };
+  }
+
+  // Nothing to compare against means nothing to verify — and it forces an
+  // attacker to actually deploy something before they can cost us a compile.
+  const code = await getDeployedCode(input.chainId, address);
+  if (!code) {
+    return {
+      ok: false,
+      code: "contract_not_deployed",
+      message: `No contract code at ${address} on ${chain.name}.`,
+    };
+  }
+
+  const hash = payloadHash({
+    chainId: input.chainId,
+    address,
+    stdJsonInput,
+    compilerVersion: input.compilerVersion,
+    contractIdentifier: input.contractIdentifier,
+  });
+
+  // Someone retrying the same failing payload gets the same answer back
+  // without a second compile.
+  const previous = await findJobByPayload(hash);
+  if (previous) {
+    return { ok: true, jobId: previous.id, deduplicated: true, run: async () => {} };
+  }
+
+  const addressQuota = await consumeQuota(`address:${input.chainId}:${address}`, ADDRESS_ATTEMPT_QUOTA);
+  if (!addressQuota.allowed) {
+    return {
+      ok: false,
+      code: "rate_limited",
+      message: "Too many verification attempts for this contract. Try again later.",
+      retryAfterSeconds: addressQuota.retryAfterSeconds,
+    };
+  }
+
+  try {
+    const job = await createJob({
+      chainId: input.chainId,
+      address,
+      contractIdentifier: input.contractIdentifier,
+      compilerVersion: input.compilerVersion,
+      payloadHash: hash,
+    });
+    return {
+      ok: true,
+      jobId: job.id,
+      deduplicated: false,
+      run: () =>
+        runVerificationJob(job.id, {
+          chainId: input.chainId,
+          address,
+          stdJsonInput,
+          compilerVersion: input.compilerVersion,
+          contractIdentifier: input.contractIdentifier,
+          constructorArguments: input.constructorArguments ?? null,
+          payloadHash: hash,
+        }),
+    };
+  } catch (error) {
+    console.error("[verification] could not create job", error);
+    return { ok: false, code: "internal_error", message: "Could not start verification." };
+  }
+}
+
+async function waitForCompileSlot() {
+  const deadline = Date.now() + SLOT_WAIT_MS;
+  for (;;) {
+    const slot = await acquireCompileSlot();
+    if (slot) return slot;
+    if (Date.now() >= deadline) return null;
+    await new Promise((resolve) => setTimeout(resolve, SLOT_POLL_MS));
+  }
+}
+
+/**
+ * Compile, compare, and record the outcome. Called in the background after
+ * the submit response has already gone out, so it never throws at anyone:
+ * every failure is written to the job for the poller to read.
+ */
+export async function runVerificationJob(
+  jobId: string,
+  input: {
+    chainId: number;
+    address: string;
+    stdJsonInput: StandardJsonInput;
+    compilerVersion: string;
+    contractIdentifier: string;
+    constructorArguments?: string | null;
+    payloadHash: string;
+  },
+): Promise<void> {
+  const address = input.address.toLowerCase();
+
+  const slot = await waitForCompileSlot();
+  if (!slot) {
+    await completeJob(jobId, {
+      errorCode: "queue_full",
+      error: "The verification queue is full right now. Submit again in a few minutes.",
+    });
+    return;
+  }
+
+  try {
+    await markJobRunning(jobId);
+
+    const code = await getDeployedCode(input.chainId, address);
+    if (!code) {
+      await completeJob(jobId, {
+        errorCode: "contract_not_deployed",
+        error: `No contract code at ${address}.`,
+      });
+      return;
+    }
+
+    const { output, longVersion } = await compileStandardJson({
+      stdJsonInput: input.stdJsonInput,
+      compilerVersion: input.compilerVersion,
+    });
+
+    const errors = fatalErrors(output);
+    if (errors.length) {
+      await completeJob(jobId, {
+        errorCode: "compiler_error",
+        error: errors.map((e) => e.formattedMessage ?? e.message).join("\n\n"),
+      });
+      return;
+    }
+
+    if (!listCompiledContracts(output).length) {
+      await completeJob(jobId, {
+        errorCode: "compiler_error",
+        error:
+          "The compiler produced no contracts. Check that settings.outputSelection asks for abi, metadata and evm.deployedBytecode.",
+      });
+      return;
+    }
+
+    const result = matchDeployedBytecode({
+      output,
+      identifier: input.contractIdentifier,
+      onchainCode: code,
+      libraries: input.stdJsonInput.settings?.libraries,
+    });
+
+    if (!result.matched) {
+      await completeJob(jobId, { errorCode: result.code, error: result.message });
+      return;
+    }
+
+    let metadata: Record<string, unknown> | null = null;
+    if (result.metadata) {
+      try {
+        metadata = JSON.parse(result.metadata) as Record<string, unknown>;
+      } catch {
+        /* metadata is a nicety, not a requirement */
+      }
+    }
+
+    await saveVerification({
+      chainId: input.chainId,
+      address,
+      match: result.level,
+      name: splitContractIdentifier(input.contractIdentifier)?.name ?? null,
+      compilerVersion: longVersion,
+      language: "Solidity",
+      abi: result.abi,
+      metadata,
+      constructorArguments: input.constructorArguments ?? null,
+      stdJsonInput: input.stdJsonInput,
+      payloadHash: input.payloadHash,
+    });
+
+    // The explorer caches "unverified" answers; drop that so the contract
+    // shows up as soon as the caller looks at it.
+    invalidateContract(input.chainId, address);
+
+    await completeJob(jobId, { match: result.level });
+
+    // Publish to the public archive last, and never let it affect the
+    // outcome above: the verification is already recorded and reported, and
+    // whether a third party also accepted it is not the submitter's problem.
+    await mirrorToSourcify({
+      chainId: input.chainId,
+      address,
+      stdJsonInput: input.stdJsonInput,
+      compilerVersion: longVersion,
+      contractIdentifier: input.contractIdentifier,
+    });
+  } catch (error) {
+    const isCompileError = error instanceof CompileError;
+    if (!isCompileError) console.error("[verification] job failed", error);
+    await completeJob(jobId, {
+      errorCode: isCompileError ? error.code : "internal_error",
+      error: isCompileError ? error.message : "Verification failed unexpectedly.",
+    });
+  } finally {
+    await slot.release();
+  }
+}
+
+/** A job plus, when it succeeded, the contract it produced. */
+export async function readJob(id: string): Promise<VerificationJobRecord | null> {
+  return getJob(id);
+}

--- a/lib/verification/solc.ts
+++ b/lib/verification/solc.ts
@@ -1,0 +1,562 @@
+import "server-only";
+import { fork, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { keccak256 } from "viem";
+
+/* ------------------------------------------------------------------ */
+/* Solidity compilation.                                               */
+/*                                                                     */
+/* compileStandardJson() is the only place that knows how compilation  */
+/* happens. Everything upstream — jobs, APIs, matching, UI — takes a   */
+/* CompileResult and is indifferent to whether solc ran in this        */
+/* process, in a child process, or behind an HTTP call to a verifier   */
+/* service. Keep it that way: moving compilation off Vercel should     */
+/* touch this file and nothing else.                                   */
+/*                                                                     */
+/* The compiler itself is solc-js: a self-contained JS/wasm build      */
+/* fetched from binaries.soliditylang.org, so there is no native       */
+/* binary to install and no container to run. It is single-threaded    */
+/* and CPU-bound, which is why it runs in a child process: this        */
+/* instance stays responsive, and a runaway compile can be killed.     */
+/* ------------------------------------------------------------------ */
+
+const BINARIES_BASE = "https://binaries.soliditylang.org/wasm";
+
+/** Hard ceiling on a single compile. This — not the route's maxDuration —
+ *  is what bounds the cost of one hostile submission. */
+export const COMPILE_TIMEOUT_MS = 180_000;
+
+/** Standard JSON input larger than this is rejected before we look at it. */
+export const MAX_INPUT_BYTES = 6 * 1024 * 1024;
+
+/** /tmp is 512 MB and each compiler build is 10-25 MB. */
+const MAX_CACHED_COMPILERS = 15;
+
+/** An attacker naming a hundred different compiler versions would otherwise
+ *  make us download a hundred compilers. Legitimate traffic touches a
+ *  handful of versions. */
+const DOWNLOAD_WINDOW_MS = 10 * 60 * 1000;
+const MAX_DOWNLOADS_PER_WINDOW = 20;
+
+const CACHE_DIR = path.join(os.tmpdir(), "solc-cache");
+
+export interface SolcBuild {
+  path: string;
+  version: string;
+  longVersion: string;
+  keccak256?: string;
+}
+
+export interface CompileResult {
+  output: SolcOutput;
+  /** The resolved long version, e.g. "0.8.24+commit.e11b9ed9". */
+  longVersion: string;
+}
+
+export interface SolcOutput {
+  errors?: SolcError[];
+  contracts?: Record<string, Record<string, SolcContract>>;
+  sources?: Record<string, { id: number }>;
+}
+
+export interface SolcError {
+  severity: "error" | "warning" | "info";
+  type?: string;
+  message: string;
+  formattedMessage?: string;
+}
+
+export interface SolcContract {
+  abi?: unknown[];
+  metadata?: string;
+  evm?: {
+    bytecode?: { object?: string; linkReferences?: LinkReferences };
+    deployedBytecode?: {
+      object?: string;
+      linkReferences?: LinkReferences;
+      immutableReferences?: Record<string, { start: number; length: number }[]>;
+    };
+  };
+}
+
+export type LinkReferences = Record<string, Record<string, { start: number; length: number }[]>>;
+
+export class CompileError extends Error {
+  constructor(
+    message: string,
+    readonly code:
+      | "unknown_compiler_version"
+      | "compiler_unavailable"
+      | "compilation_timeout"
+      | "compiler_crashed"
+      | "input_too_large",
+  ) {
+    super(message);
+    this.name = "CompileError";
+  }
+}
+
+/* ---------------------------- version list --------------------------- */
+
+const LIST_TTL_MS = 24 * 60 * 60 * 1000;
+let buildList: { at: number; builds: SolcBuild[]; releases: Record<string, string> } | null = null;
+let listInFlight: Promise<void> | null = null;
+
+async function loadBuildList(): Promise<void> {
+  if (buildList && Date.now() - buildList.at < LIST_TTL_MS) return;
+  if (listInFlight) return listInFlight;
+
+  listInFlight = (async () => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 10_000);
+    try {
+      const res = await fetch(`${BINARIES_BASE}/list.json`, { signal: controller.signal });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as { builds: SolcBuild[]; releases: Record<string, string> };
+      buildList = { at: Date.now(), builds: body.builds ?? [], releases: body.releases ?? {} };
+    } catch (error) {
+      // A stale list still resolves every version anyone has used before,
+      // so an unreachable upstream only matters on a cold instance.
+      if (!buildList) {
+        throw new CompileError(`Could not load the compiler list: ${error}`, "compiler_unavailable");
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  })().finally(() => {
+    listInFlight = null;
+  });
+
+  return listInFlight;
+}
+
+/** Released versions, newest first — for the compiler picker in the UI. */
+export async function listReleases(): Promise<{ version: string; longVersion: string }[]> {
+  await loadBuildList();
+  const releases = buildList?.releases ?? {};
+  const byPath = new Map((buildList?.builds ?? []).map((b) => [b.path, b]));
+  return Object.entries(releases)
+    .map(([version, file]) => ({ version, longVersion: byPath.get(file)?.longVersion ?? version }))
+    .sort((a, b) => compareVersions(b.version, a.version));
+}
+
+function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Resolve what the caller wrote to a build in the official list. Accepts
+ * "v0.8.24+commit.e11b9ed9", "0.8.24+commit.e11b9ed9", or a bare "0.8.24"
+ * (which resolves to that release's canonical build).
+ *
+ * Only versions in the list are ever fetched — the version string is
+ * caller-controlled and must never become a URL path.
+ */
+export async function resolveCompilerVersion(requested: string): Promise<SolcBuild> {
+  await loadBuildList();
+  const list = buildList;
+  if (!list) throw new CompileError("Compiler list unavailable", "compiler_unavailable");
+
+  const normalized = requested.trim().replace(/^v/, "");
+  if (!/^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.+-]+)?$/.test(normalized)) {
+    throw new CompileError(`Not a Solidity version: ${requested}`, "unknown_compiler_version");
+  }
+
+  const exact = list.builds.find((b) => b.longVersion === normalized);
+  if (exact) return exact;
+
+  const releaseFile = list.releases[normalized];
+  if (releaseFile) {
+    const build = list.builds.find((b) => b.path === releaseFile);
+    if (build) return build;
+  }
+
+  throw new CompileError(
+    `Unknown compiler version "${requested}". Use a version from https://binaries.soliditylang.org/wasm/list.json.`,
+    "unknown_compiler_version",
+  );
+}
+
+/* ------------------------------ downloads ---------------------------- */
+
+const downloadTimestamps: number[] = [];
+const downloadsInFlight = new Map<string, Promise<string>>();
+
+function reserveDownloadSlot(): boolean {
+  const now = Date.now();
+  while (downloadTimestamps.length && now - downloadTimestamps[0] > DOWNLOAD_WINDOW_MS) {
+    downloadTimestamps.shift();
+  }
+  if (downloadTimestamps.length >= MAX_DOWNLOADS_PER_WINDOW) return false;
+  downloadTimestamps.push(now);
+  return true;
+}
+
+async function evictOldCompilers(): Promise<void> {
+  try {
+    const files = await fs.readdir(CACHE_DIR);
+    const compilers = files.filter((f) => f.endsWith(".js"));
+    if (compilers.length <= MAX_CACHED_COMPILERS) return;
+
+    const stats = await Promise.all(
+      compilers.map(async (file) => {
+        const full = path.join(CACHE_DIR, file);
+        try {
+          return { full, at: (await fs.stat(full)).atimeMs };
+        } catch {
+          return { full, at: 0 };
+        }
+      }),
+    );
+    stats.sort((a, b) => a.at - b.at);
+    for (const victim of stats.slice(0, stats.length - MAX_CACHED_COMPILERS)) {
+      await fs.rm(victim.full, { force: true });
+    }
+  } catch {
+    /* eviction is best-effort; a full /tmp surfaces as a download failure */
+  }
+}
+
+/** Absolute path to a cached compiler build, downloading it if needed. */
+async function compilerPath(build: SolcBuild): Promise<string> {
+  const target = path.join(CACHE_DIR, `${build.longVersion}.js`);
+
+  try {
+    await fs.access(target);
+    // Touch so the LRU keeps versions that are actually being used.
+    const now = new Date();
+    await fs.utimes(target, now, now).catch(() => {});
+    return target;
+  } catch {
+    /* not cached yet */
+  }
+
+  const existing = downloadsInFlight.get(build.longVersion);
+  if (existing) return existing;
+
+  const download = (async () => {
+    if (!reserveDownloadSlot()) {
+      throw new CompileError(
+        "Too many different compiler versions requested recently. Try again in a few minutes.",
+        "compiler_unavailable",
+      );
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 60_000);
+    let source: Buffer;
+    try {
+      const res = await fetch(`${BINARIES_BASE}/${build.path}`, { signal: controller.signal });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      source = Buffer.from(await res.arrayBuffer());
+    } catch (error) {
+      throw new CompileError(`Could not download solc ${build.longVersion}: ${error}`, "compiler_unavailable");
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (build.keccak256) {
+      const digest = keccak256(new Uint8Array(source));
+      if (digest.toLowerCase() !== build.keccak256.toLowerCase()) {
+        throw new CompileError(
+          `Checksum mismatch for solc ${build.longVersion} — refusing to run it.`,
+          "compiler_unavailable",
+        );
+      }
+    }
+
+    await fs.mkdir(CACHE_DIR, { recursive: true });
+    // Write then rename so a torn download can never be executed.
+    const staging = path.join(CACHE_DIR, `.${process.pid}-${Date.now()}.tmp`);
+    await fs.writeFile(staging, source);
+    await fs.rename(staging, target);
+    await evictOldCompilers();
+    return target;
+  })().finally(() => {
+    downloadsInFlight.delete(build.longVersion);
+  });
+
+  downloadsInFlight.set(build.longVersion, download);
+  return download;
+}
+
+/* --------------------------- compiler process ------------------------ */
+
+/*
+ * Runs in its own process as plain CommonJS, talking to the parent over
+ * IPC. It deliberately requires nothing but Node builtins: the file is
+ * written to /tmp, so it sits outside the deployment's module tree and
+ * could not resolve a package even if it wanted to.
+ *
+ * A separate process rather than a worker thread, for two reasons. It can
+ * be killed outright when it overruns, and its heap is its own — a
+ * compile that runs away takes nothing else down with it. It also keeps
+ * the bundler out of our business: `new Worker(path)` is read as a static
+ * worker entry point and the build tries to resolve a path that only
+ * exists at runtime, which it answers by dragging arbitrary assets into
+ * the module graph.
+ *
+ * The wrapper is small because we only ever compile Standard JSON, whose
+ * sources are inlined — there is no import callback to service, which is
+ * the complicated half of solc-js's own wrapper.
+ */
+const RUNNER_SOURCE = `
+"use strict";
+const fs = require("node:fs");
+
+function loadCompiler(file) {
+  const code = fs.readFileSync(file, "utf8");
+  const shim = { exports: {} };
+  // Emscripten builds detect CommonJS and assign to module.exports.
+  new Function("module", "exports", "require", "__dirname", "__filename", code)(
+    shim,
+    shim.exports,
+    require,
+    "/",
+    file,
+  );
+  return shim.exports;
+}
+
+async function instantiate(loaded) {
+  let mod = loaded;
+  // Newer builds are MODULARIZE'd: the export is a factory.
+  if (typeof mod === "function") mod = mod();
+  if (mod && typeof mod.then === "function") mod = await mod;
+  if (mod && typeof mod.cwrap !== "function" && mod.ready && typeof mod.ready.then === "function") {
+    mod = await mod.ready;
+  }
+  if (mod && typeof mod.cwrap !== "function") {
+    // Asynchronous wasm instantiation: wait for the runtime callback.
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("compiler runtime did not initialise")), 60000);
+      const previous = mod.onRuntimeInitialized;
+      mod.onRuntimeInitialized = () => {
+        clearTimeout(timer);
+        if (typeof previous === "function") previous();
+        resolve();
+      };
+    });
+  }
+  if (!mod || typeof mod.cwrap !== "function") throw new Error("unrecognised compiler build");
+  return mod;
+}
+
+function compile(mod, inputJson) {
+  // 0.5.0 and later expose solidity_compile; the callback argument gained a
+  // context parameter in 0.6.x. Extra arguments to a wasm export are ignored,
+  // so the wider signature is safe for both.
+  if (typeof mod._solidity_compile === "function") {
+    return mod.cwrap("solidity_compile", "string", ["string", "number", "number"])(inputJson, 0, 0);
+  }
+  // 0.4.11 through 0.4.26.
+  if (typeof mod._compileStandard === "function") {
+    return mod.cwrap("compileStandard", "string", ["string", "number"])(inputJson, 0);
+  }
+  throw new Error("this compiler build cannot accept Standard JSON input");
+}
+
+function reply(payload) {
+  // Exit only once the parent has the answer; a bare process.exit() can
+  // truncate an IPC write that is still in flight.
+  process.send(payload, () => process.exit(0));
+}
+
+process.on("message", async (job) => {
+  try {
+    const mod = await instantiate(loadCompiler(job.compilerPath));
+    reply({ ok: true, output: compile(mod, job.input) });
+  } catch (error) {
+    reply({ ok: false, error: error && error.message ? error.message : String(error) });
+  }
+});
+`;
+
+let runnerPathPromise: Promise<string> | null = null;
+
+function runnerFile(): Promise<string> {
+  if (runnerPathPromise) return runnerPathPromise;
+  runnerPathPromise = (async () => {
+    await fs.mkdir(CACHE_DIR, { recursive: true });
+    const digest = createHash("sha256").update(RUNNER_SOURCE).digest("hex").slice(0, 12);
+    const file = path.join(CACHE_DIR, `compile-runner-${digest}.cjs`);
+    await fs.writeFile(file, RUNNER_SOURCE);
+    return file;
+  })().catch((error) => {
+    runnerPathPromise = null;
+    throw new CompileError(`Could not stage the compiler runner: ${error}`, "compiler_unavailable");
+  });
+  return runnerPathPromise;
+}
+
+async function runCompiler(compilerPathOnDisk: string, input: string): Promise<string> {
+  const file = await runnerFile();
+
+  return new Promise((resolve, reject) => {
+    let child: ChildProcess;
+    try {
+      child = fork(file, [], {
+        // Big contracts need headroom, but not unbounded headroom, and
+        // the cap belongs to the child rather than to this function.
+        execArgv: ["--max-old-space-size=3072"],
+        stdio: ["ignore", "ignore", "ignore", "ipc"],
+      });
+    } catch (error) {
+      reject(new CompileError(`Could not start the compiler: ${error}`, "compiler_unavailable"));
+      return;
+    }
+
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      // SIGKILL: a process wedged inside wasm will not honour anything
+      // politer, and this path exists precisely for the wedged case.
+      if (child.connected) child.disconnect();
+      child.kill("SIGKILL");
+      fn();
+    };
+
+    const timer = setTimeout(() => {
+      finish(() =>
+        reject(
+          new CompileError(
+            `Compilation exceeded the ${COMPILE_TIMEOUT_MS / 1000}s limit. Contracts this large need a dedicated verifier.`,
+            "compilation_timeout",
+          ),
+        ),
+      );
+    }, COMPILE_TIMEOUT_MS);
+
+    child.on("message", (message: { ok: boolean; output?: string; error?: string }) => {
+      finish(() =>
+        message.ok && message.output
+          ? resolve(message.output)
+          : reject(new CompileError(message.error ?? "compiler failed", "compiler_crashed")),
+      );
+    });
+    child.on("error", (error) => {
+      finish(() => reject(new CompileError(`Compiler crashed: ${error.message}`, "compiler_crashed")));
+    });
+    child.on("exit", (code, signal) => {
+      // Exiting after an answer is normal and already settled. Reaching
+      // here unsettled means it died without one — out of memory, most
+      // likely, since that is what the heap cap is there to catch.
+      finish(() =>
+        reject(
+          new CompileError(
+            code === 0
+              ? "Compiler exited without producing output"
+              : `Compiler ran out of resources (exit ${code ?? signal})`,
+            "compiler_crashed",
+          ),
+        ),
+      );
+    });
+
+    child.send({ compilerPath: compilerPathOnDisk, input }, (error) => {
+      if (error) {
+        finish(() =>
+          reject(new CompileError(`Could not hand the job to the compiler: ${error.message}`, "compiler_crashed")),
+        );
+      }
+    });
+  });
+}
+
+/* ------------------------------ public API --------------------------- */
+
+/**
+ * Compile with a soljson build that is already on disk, bypassing version
+ * resolution and download. The seam between "get a compiler" and "run a
+ * compiler" — useful for testing the loader against a known build, and
+ * the hook a pre-bundled compiler would use.
+ */
+export async function compileWithCompilerAt(
+  compilerPathOnDisk: string,
+  stdJsonInput: unknown,
+): Promise<SolcOutput> {
+  const raw = await runCompiler(compilerPathOnDisk, JSON.stringify(stdJsonInput));
+  try {
+    return JSON.parse(raw) as SolcOutput;
+  } catch {
+    throw new CompileError("Compiler returned output we could not parse", "compiler_crashed");
+  }
+}
+
+/**
+ * Compile a Standard JSON input with the requested compiler.
+ *
+ * Throws CompileError for anything that prevented compilation from
+ * running (unknown version, download failure, timeout, crash). A
+ * compilation that ran and produced errors is a successful call whose
+ * `output.errors` carries them — that distinction matters upstream,
+ * because the first is our problem and the second is the submitter's.
+ */
+export async function compileStandardJson({
+  stdJsonInput,
+  compilerVersion,
+}: {
+  stdJsonInput: unknown;
+  compilerVersion: string;
+}): Promise<CompileResult> {
+  const input = JSON.stringify(stdJsonInput);
+  if (Buffer.byteLength(input) > MAX_INPUT_BYTES) {
+    throw new CompileError(
+      `Standard JSON input exceeds the ${Math.round(MAX_INPUT_BYTES / 1024 / 1024)} MB limit.`,
+      "input_too_large",
+    );
+  }
+
+  const build = await resolveCompilerVersion(compilerVersion);
+  const compiler = await compilerPath(build);
+  const raw = await runCompiler(compiler, input);
+
+  let output: SolcOutput;
+  try {
+    output = JSON.parse(raw) as SolcOutput;
+  } catch {
+    throw new CompileError("Compiler returned output we could not parse", "compiler_crashed");
+  }
+
+  return { output, longVersion: build.longVersion };
+}
+
+/** Errors that stopped compilation, ignoring warnings and info notes. */
+export function fatalErrors(output: SolcOutput): SolcError[] {
+  return (output.errors ?? []).filter((error) => error.severity === "error");
+}
+
+/**
+ * Reduce an input to the three keys solc actually defines.
+ *
+ * The compiler rejects a Standard JSON input outright if it carries keys it
+ * doesn't know, and build tools routinely add their own. Foundry's
+ * build-info writes `allowPaths`, `basePath`, `includePaths` and `version`
+ * beside the real ones, which earns an `Unknown key "allowPaths"` before
+ * solc looks at a single line of Solidity.
+ *
+ * Dropping them cannot change the bytecode: they all concern resolving
+ * imports from disk, which never applies here because Standard JSON
+ * carries its sources inline. Anything that did affect codegen would have
+ * to live under `settings`, which is passed through untouched.
+ */
+export function toCompilerInput<T extends { language?: string; sources?: unknown; settings?: unknown }>(
+  input: T,
+): T {
+  return {
+    language: input.language ?? "Solidity",
+    sources: input.sources,
+    ...(input.settings ? { settings: input.settings } : {}),
+  } as T;
+}

--- a/lib/verification/sourcify-api.ts
+++ b/lib/verification/sourcify-api.ts
@@ -1,0 +1,141 @@
+import "server-only";
+import type { StoredVerification, VerificationJobRecord } from "./store";
+import { readStandardJsonInput } from "./store";
+import type { StandardJsonInput } from "./service";
+
+/* ------------------------------------------------------------------ */
+/* The Sourcify v2-compatible surface.                                 */
+/*                                                                     */
+/* Hardhat 3's verify plugin will talk to any server that speaks this  */
+/* protocol — point `verify.sourcify.apiUrl` at us and the rest of the */
+/* plugin works unchanged. It calls exactly three endpoints: contract  */
+/* lookup, verification submit, and job status.                        */
+/*                                                                     */
+/* Note the deliberate asymmetry with Etherscan's protocol: job status */
+/* is always HTTP 200 and carries the outcome in the body, because a   */
+/* failed verification is a successful request about a failure.        */
+/* ------------------------------------------------------------------ */
+
+/** Sourcify's error vocabulary, as far as we can produce it. */
+const CUSTOM_CODES: Record<string, string> = {
+  invalid_address: "invalid_parameter",
+  unsupported_chain: "unsupported_chain",
+  invalid_input: "missing_or_invalid_source",
+  input_too_large: "missing_or_invalid_source",
+  unsupported_language: "unsupported_language",
+  already_verified: "already_verified",
+  contract_not_deployed: "contract_not_deployed",
+  rate_limited: "too_many_requests",
+  internal_error: "internal_error",
+  compiler_error: "compiler_error",
+  unknown_compiler_version: "invalid_compiler_version",
+  compiler_unavailable: "internal_error",
+  compilation_timeout: "compilation_timeout",
+  compiler_crashed: "internal_error",
+  contract_not_found: "invalid_compilation_target",
+  no_bytecode: "invalid_compilation_target",
+  unlinked_libraries: "missing_or_invalid_source",
+  no_match: "no_match",
+  queue_full: "too_many_requests",
+  worker_lost: "internal_error",
+};
+
+export function customCodeFor(code: string): string {
+  return CUSTOM_CODES[code] ?? "internal_error";
+}
+
+export interface ContractFields {
+  all: boolean;
+  requested: Set<string>;
+}
+
+/** `?fields=abi,compilation` or `?fields=all`. */
+export function parseFields(value: string | null): ContractFields {
+  const parts = (value ?? "")
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  return { all: parts.includes("all"), requested: new Set(parts) };
+}
+
+function wants(fields: ContractFields, name: string): boolean {
+  return fields.all || fields.requested.has(name);
+}
+
+/**
+ * A verified contract in Sourcify's response shape. The envelope (match,
+ * address, chain, timestamps) is always present; everything expensive is
+ * opt-in through `fields`, which is what keeps the explorer's per-address
+ * lookups from dragging whole source trees around.
+ */
+export async function contractResponse(
+  verified: StoredVerification,
+  fields: ContractFields,
+): Promise<Record<string, unknown>> {
+  const body: Record<string, unknown> = {
+    match: verified.match,
+    creationMatch: null,
+    runtimeMatch: verified.match,
+    chainId: String(verified.chainId),
+    address: verified.address,
+    verifiedAt: verified.verifiedAt.toISOString(),
+    matchId: `${verified.chainId}:${verified.address}`,
+  };
+
+  if (wants(fields, "abi")) body.abi = verified.abi ?? [];
+  if (wants(fields, "metadata")) body.metadata = verified.metadata;
+  if (wants(fields, "compilation")) {
+    body.compilation = {
+      language: verified.language,
+      compiler: "solc",
+      compilerVersion: verified.compilerVersion,
+      name: verified.name,
+      fullyQualifiedName: verified.name,
+    };
+  }
+
+  const needsInput = wants(fields, "sources") || wants(fields, "stdJsonInput");
+  if (needsInput && verified.stdJsonBlobUrl) {
+    const input = (await readStandardJsonInput(verified.stdJsonBlobUrl)) as StandardJsonInput | null;
+    if (input) {
+      if (wants(fields, "sources")) body.sources = input.sources ?? {};
+      if (wants(fields, "stdJsonInput")) body.stdJsonInput = input;
+    }
+  }
+
+  return body;
+}
+
+/** Job status. `isJobCompleted` is what a poller loops on. */
+export async function jobResponse(
+  job: VerificationJobRecord,
+  verified: StoredVerification | null,
+): Promise<Record<string, unknown>> {
+  const done = job.status === "succeeded" || job.status === "failed";
+
+  const body: Record<string, unknown> = {
+    isJobCompleted: done,
+    verificationId: job.id,
+    jobStartTime: job.createdAt.toISOString(),
+    ...(job.completedAt ? { jobFinishTime: job.completedAt.toISOString() } : {}),
+    contract: {
+      match: job.status === "succeeded" ? job.match : null,
+      chainId: String(job.chainId),
+      address: job.address,
+    },
+  };
+
+  if (job.status === "failed") {
+    body.error = {
+      customCode: customCodeFor(job.errorCode ?? "internal_error"),
+      message: job.error ?? "Verification failed.",
+      errorId: job.id,
+    };
+  }
+
+  if (job.status === "succeeded" && verified) {
+    body.contract = await contractResponse(verified, { all: false, requested: new Set(["compilation"]) });
+  }
+
+  return body;
+}

--- a/lib/verification/store.ts
+++ b/lib/verification/store.ts
@@ -1,0 +1,301 @@
+import "server-only";
+import { createHash } from "node:crypto";
+import { prisma } from "@/prisma/prisma";
+import { blobService } from "@/server/services/blob";
+import type { MatchLevel } from "./match";
+
+/* ------------------------------------------------------------------ */
+/* Persistence for verification results and jobs.                      */
+/*                                                                     */
+/* Postgres holds what a lookup needs to answer immediately — match     */
+/* level, name, compiler, ABI. The standard JSON input goes to Blob     */
+/* because it carries every source file and routinely runs to           */
+/* megabytes, and because nothing on the hot path needs to read it.     */
+/* ------------------------------------------------------------------ */
+
+export type JobStatus = "pending" | "running" | "succeeded" | "failed";
+
+export interface StoredVerification {
+  chainId: number;
+  address: string;
+  match: MatchLevel;
+  name: string | null;
+  compilerVersion: string | null;
+  language: string;
+  abi: unknown[] | null;
+  metadata: Record<string, unknown> | null;
+  constructorArguments: string | null;
+  stdJsonBlobUrl: string | null;
+  verifiedAt: Date;
+}
+
+/** Identifies a submission by its content, so an identical resubmission
+ *  can be answered from the previous attempt instead of recompiling. */
+export function payloadHash(input: {
+  chainId: number;
+  address: string;
+  stdJsonInput: unknown;
+  compilerVersion: string;
+  contractIdentifier: string;
+}): string {
+  return createHash("sha256")
+    .update(
+      [
+        input.chainId,
+        input.address.toLowerCase(),
+        input.compilerVersion,
+        input.contractIdentifier,
+        JSON.stringify(input.stdJsonInput),
+      ].join("\u0000"),
+    )
+    .digest("hex");
+}
+
+function toStored(row: {
+  chain_id: number;
+  address: string;
+  match: string;
+  name: string | null;
+  compiler_version: string | null;
+  language: string;
+  abi: unknown;
+  metadata: unknown;
+  constructor_arguments: string | null;
+  std_json_blob_url: string | null;
+  verified_at: Date;
+}): StoredVerification {
+  return {
+    chainId: row.chain_id,
+    address: row.address,
+    match: row.match === "exact_match" ? "exact_match" : "match",
+    name: row.name,
+    compilerVersion: row.compiler_version,
+    language: row.language,
+    abi: Array.isArray(row.abi) ? (row.abi as unknown[]) : null,
+    metadata: row.metadata && typeof row.metadata === "object" ? (row.metadata as Record<string, unknown>) : null,
+    constructorArguments: row.constructor_arguments,
+    stdJsonBlobUrl: row.std_json_blob_url,
+    verifiedAt: row.verified_at,
+  };
+}
+
+export async function findVerified(chainId: number, address: string): Promise<StoredVerification | null> {
+  try {
+    const row = await prisma.verifiedContract.findUnique({
+      where: { chain_id_address: { chain_id: chainId, address: address.toLowerCase() } },
+    });
+    return row ? toStored(row) : null;
+  } catch (error) {
+    // A database blip must not make a verified contract look unverified to
+    // the explorer; callers fall back to upstream Sourcify.
+    console.error("[verification] lookup failed", error);
+    return null;
+  }
+}
+
+export async function isVerified(chainId: number, address: string): Promise<boolean> {
+  return (await findVerified(chainId, address)) !== null;
+}
+
+/** The standard JSON input behind a verification, fetched from Blob. */
+export async function readStandardJsonInput(url: string): Promise<unknown | null> {
+  try {
+    const res = await fetch(url, { cache: "no-store" });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function saveVerification(input: {
+  chainId: number;
+  address: string;
+  match: MatchLevel;
+  name: string | null;
+  compilerVersion: string;
+  language: string;
+  abi: unknown[];
+  metadata: Record<string, unknown> | null;
+  constructorArguments: string | null;
+  stdJsonInput: unknown;
+  payloadHash: string;
+}): Promise<StoredVerification> {
+  const address = input.address.toLowerCase();
+
+  // Only reached after a match, so this never stores a stranger's rejected
+  // upload. The hash in the key keeps re-verification from colliding with
+  // an existing object.
+  let blobUrl: string | null = null;
+  try {
+    const body = JSON.stringify(input.stdJsonInput);
+    const file = new File([body], "standard-input.json", { type: "application/json" });
+    const upload = await blobService.uploadFile(
+      file,
+      `contract-verification/${input.chainId}/${address}/${input.payloadHash.slice(0, 16)}.json`,
+    );
+    blobUrl = upload.url;
+  } catch (error) {
+    // Losing the sources is bad but not disqualifying: the ABI and the
+    // match are what the explorer needs to keep working.
+    console.error("[verification] could not store sources", error);
+  }
+
+  const row = await prisma.verifiedContract.upsert({
+    where: { chain_id_address: { chain_id: input.chainId, address } },
+    create: {
+      chain_id: input.chainId,
+      address,
+      match: input.match,
+      name: input.name,
+      compiler_version: input.compilerVersion,
+      language: input.language,
+      abi: input.abi as never,
+      metadata: (input.metadata ?? undefined) as never,
+      constructor_arguments: input.constructorArguments,
+      std_json_blob_url: blobUrl,
+    },
+    update: {
+      match: input.match,
+      name: input.name,
+      compiler_version: input.compilerVersion,
+      language: input.language,
+      abi: input.abi as never,
+      metadata: (input.metadata ?? undefined) as never,
+      constructor_arguments: input.constructorArguments,
+      std_json_blob_url: blobUrl,
+      verified_at: new Date(),
+    },
+  });
+
+  return toStored(row);
+}
+
+/* --------------------------------- jobs -------------------------------- */
+
+export interface VerificationJobRecord {
+  id: string;
+  chainId: number;
+  address: string;
+  status: JobStatus;
+  match: MatchLevel | null;
+  errorCode: string | null;
+  error: string | null;
+  contractName: string | null;
+  compilerVersion: string | null;
+  createdAt: Date;
+  completedAt: Date | null;
+}
+
+function toJob(row: {
+  id: string;
+  chain_id: number;
+  address: string;
+  status: string;
+  match: string | null;
+  error_code: string | null;
+  error: string | null;
+  contract_name: string | null;
+  compiler_version: string | null;
+  created_at: Date;
+  completed_at: Date | null;
+}): VerificationJobRecord {
+  return {
+    id: row.id,
+    chainId: row.chain_id,
+    address: row.address,
+    status: row.status as JobStatus,
+    match: row.match === "exact_match" || row.match === "match" ? row.match : null,
+    errorCode: row.error_code,
+    error: row.error,
+    contractName: row.contract_name,
+    compilerVersion: row.compiler_version,
+    createdAt: row.created_at,
+    completedAt: row.completed_at,
+  };
+}
+
+export async function createJob(input: {
+  chainId: number;
+  address: string;
+  contractIdentifier: string;
+  compilerVersion: string;
+  payloadHash: string;
+}): Promise<VerificationJobRecord> {
+  const row = await prisma.verificationJob.create({
+    data: {
+      chain_id: input.chainId,
+      address: input.address.toLowerCase(),
+      status: "pending",
+      contract_name: input.contractIdentifier,
+      compiler_version: input.compilerVersion,
+      payload_hash: input.payloadHash,
+    },
+  });
+  return toJob(row);
+}
+
+export async function getJob(id: string): Promise<VerificationJobRecord | null> {
+  if (!/^[0-9a-f-]{36}$/i.test(id)) return null;
+  try {
+    const row = await prisma.verificationJob.findUnique({ where: { id } });
+    return row ? toJob(row) : null;
+  } catch (error) {
+    console.error("[verification] job lookup failed", error);
+    return null;
+  }
+}
+
+/** The most recent completed job for an identical payload, if any. */
+export async function findJobByPayload(hash: string): Promise<VerificationJobRecord | null> {
+  try {
+    const row = await prisma.verificationJob.findFirst({
+      where: { payload_hash: hash, status: { in: ["succeeded", "failed"] } },
+      orderBy: { created_at: "desc" },
+    });
+    return row ? toJob(row) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function markJobRunning(id: string): Promise<void> {
+  await prisma.verificationJob.update({ where: { id }, data: { status: "running" } }).catch(() => {});
+}
+
+export async function completeJob(
+  id: string,
+  result: { match: MatchLevel } | { errorCode: string; error: string },
+): Promise<void> {
+  const data =
+    "match" in result
+      ? { status: "succeeded", match: result.match, completed_at: new Date() }
+      : { status: "failed", error_code: result.errorCode, error: result.error.slice(0, 4000), completed_at: new Date() };
+  await prisma.verificationJob.update({ where: { id }, data }).catch((error: unknown) => {
+    console.error("[verification] could not record job outcome", error);
+  });
+}
+
+/** Jobs whose worker never reported back — an instance can be recycled
+ *  mid-compile, and a job stuck at "running" forever would leave the
+ *  caller polling something that will never answer. */
+export async function failStalledJobs(olderThanMs: number): Promise<void> {
+  const cutoff = new Date(Date.now() - olderThanMs);
+  await prisma.verificationJob
+    .updateMany({
+      where: { status: { in: ["pending", "running"] }, created_at: { lt: cutoff } },
+      data: {
+        status: "failed",
+        error_code: "worker_lost",
+        error: "Verification did not finish. Submit it again.",
+        completed_at: new Date(),
+      },
+    })
+    .catch(() => {});
+}
+
+export async function deleteJobsOlderThan(days: number): Promise<number> {
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  const { count } = await prisma.verificationJob.deleteMany({ where: { created_at: { lt: cutoff } } });
+  return count;
+}

--- a/prisma/migrations/20260910000000_add_contract_verification/migration.sql
+++ b/prisma/migrations/20260910000000_add_contract_verification/migration.sql
@@ -1,0 +1,50 @@
+-- CreateTable
+CREATE TABLE "VerifiedContract" (
+    "id" TEXT NOT NULL,
+    "chain_id" INTEGER NOT NULL,
+    "address" TEXT NOT NULL,
+    "match" TEXT NOT NULL,
+    "name" TEXT,
+    "compiler_version" TEXT,
+    "language" TEXT NOT NULL DEFAULT 'Solidity',
+    "abi" JSONB,
+    "metadata" JSONB,
+    "std_json_blob_url" TEXT,
+    "constructor_arguments" TEXT,
+    "verified_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "VerifiedContract_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "VerificationJob" (
+    "id" TEXT NOT NULL,
+    "chain_id" INTEGER NOT NULL,
+    "address" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "match" TEXT,
+    "error_code" TEXT,
+    "error" TEXT,
+    "contract_name" TEXT,
+    "compiler_version" TEXT,
+    "payload_hash" TEXT NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completed_at" TIMESTAMPTZ(3),
+
+    CONSTRAINT "VerificationJob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VerifiedContract_chain_id_address_key" ON "VerifiedContract"("chain_id", "address");
+
+-- CreateIndex
+CREATE INDEX "VerifiedContract_chain_id_idx" ON "VerifiedContract"("chain_id");
+
+-- CreateIndex
+CREATE INDEX "VerificationJob_chain_id_address_idx" ON "VerificationJob"("chain_id", "address");
+
+-- CreateIndex
+CREATE INDEX "VerificationJob_payload_hash_idx" ON "VerificationJob"("payload_hash");
+
+-- CreateIndex
+CREATE INDEX "VerificationJob_created_at_idx" ON "VerificationJob"("created_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -974,3 +974,53 @@ model AuditEventLog {
   @@index([action])
   @@index([created_at])
 }
+
+model VerifiedContract {
+  // One row per verified (chain, address). Written only once the recompiled
+  // bytecode matches what is deployed — never on a failed attempt. This table
+  // is what the explorer trusts for ABIs, so a row that didn't earn its place
+  // would silently mis-decode every call and log against that address.
+  //
+  // The standard JSON input (which carries the sources inline) lives in Vercel
+  // Blob; Postgres keeps only what a lookup needs to answer without a fetch.
+  id                    String   @id @default(uuid())
+  chain_id              Int
+  address               String // lowercase 0x hex
+  match                 String // exact_match | match
+  name                  String?
+  compiler_version      String?
+  language              String   @default("Solidity")
+  abi                   Json?
+  metadata              Json?
+  std_json_blob_url     String?
+  constructor_arguments String?
+  verified_at           DateTime @default(now()) @db.Timestamptz(3)
+
+  @@unique([chain_id, address])
+  @@index([chain_id])
+}
+
+model VerificationJob {
+  // One row per submission. The id doubles as the Etherscan GUID and the
+  // Sourcify verificationId, so both protocols poll the same row.
+  //
+  // payload_hash makes a resubmission of an identical payload free: a repeat
+  // of a failure returns the stored failure instead of recompiling, which is
+  // what stops a naive flood from costing anything.
+  id               String    @id @default(uuid())
+  chain_id         Int
+  address          String
+  status           String    @default("pending") // pending | running | succeeded | failed
+  match            String? // exact_match | match, once succeeded
+  error_code       String?
+  error            String?
+  contract_name    String?
+  compiler_version String?
+  payload_hash     String
+  created_at       DateTime  @default(now()) @db.Timestamptz(3)
+  completed_at     DateTime? @db.Timestamptz(3)
+
+  @@index([chain_id, address])
+  @@index([payload_hash])
+  @@index([created_at])
+}

--- a/public/openapi/verification.json
+++ b/public/openapi/verification.json
@@ -1,0 +1,680 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Contract Verification API",
+    "version": "1.0.0",
+    "description": "Verify Solidity contracts on any Avalanche L1 in the Builder Hub chain catalog. Two protocols are exposed over one verifier: an Etherscan-compatible surface for `hardhat verify` and `forge verify-contract`, and a Sourcify v2-compatible surface for tooling that speaks it natively. A contract verified through either appears identically in the explorer."
+  },
+  "servers": [
+    {
+      "url": "https://build.avax.network",
+      "description": "Production"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Etherscan-compatible",
+      "description": "The interoperability workhorse. Hardhat reaches it through `customChains` (Hardhat 2) or `chainDescriptors` (Hardhat 3), Foundry through `--verifier custom`. The `apikey` parameter is accepted and ignored; tooling insists on sending one."
+    },
+    {
+      "name": "Sourcify-compatible",
+      "description": "The three Sourcify v2 endpoints `@nomicfoundation/hardhat-verify` calls. Point `verify.sourcify.apiUrl` here and the plugin works unchanged."
+    },
+    {
+      "name": "Compilers",
+      "description": "Which Solidity versions the verifier can run."
+    }
+  ],
+  "paths": {
+    "/api/verify/{chainId}/api": {
+      "post": {
+        "tags": ["Etherscan-compatible"],
+        "summary": "Submit a contract for verification",
+        "description": "Queues a verification and returns a GUID. The GUID is a receipt, not a result — poll `checkverifystatus` for the outcome.\n\nOnly Standard JSON input is accepted. Both Hardhat and Foundry already produce it; flattened sources are not supported.",
+        "operationId": "verifySourceCode",
+        "parameters": [
+          {
+            "name": "chainId",
+            "in": "path",
+            "required": true,
+            "description": "EVM chain id. Must be a chain in the Builder Hub catalog with a public RPC, since the verifier reads the deployed bytecode from it.",
+            "schema": { "type": "string", "examples": ["43114"] }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["module", "action", "contractaddress", "sourceCode", "contractname", "compilerversion"],
+                "properties": {
+                  "module": {
+                    "type": "string",
+                    "description": "Always `contract`.",
+                    "default": "contract",
+                    "examples": ["contract"]
+                  },
+                  "action": {
+                    "type": "string",
+                    "description": "Always `verifysourcecode`.",
+                    "default": "verifysourcecode",
+                    "examples": ["verifysourcecode"]
+                  },
+                  "apikey": {
+                    "type": "string",
+                    "description": "Accepted and ignored. Tooling requires the field to exist, so send any non-empty string.",
+                    "examples": ["builder-hub"]
+                  },
+                  "contractaddress": {
+                    "type": "string",
+                    "description": "Address of the deployed contract. It must already hold code.",
+                    "examples": ["0x0000000000000000000000000000000000000000"]
+                  },
+                  "sourceCode": {
+                    "type": "string",
+                    "description": "The Standard JSON input, serialised. An extra pair of surrounding braces (Etherscan's convention for marking Standard JSON) is accepted and stripped.",
+                    "examples": ["{\"language\":\"Solidity\",\"sources\":{\"contracts/Storage.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\npragma solidity ^0.8.0;\\ncontract Storage { uint256 value; }\"}},\"settings\":{\"optimizer\":{\"enabled\":false,\"runs\":200},\"outputSelection\":{\"*\":{\"*\":[\"abi\",\"metadata\",\"evm.deployedBytecode.object\"]}}}}"]
+                  },
+                  "codeformat": {
+                    "type": "string",
+                    "description": "Must be `solidity-standard-json-input` when present.",
+                    "enum": ["solidity-standard-json-input"],
+                    "examples": ["solidity-standard-json-input"]
+                  },
+                  "contractname": {
+                    "type": "string",
+                    "description": "Fully qualified name, as `path/to/File.sol:ContractName`, exactly as the path appears in the Standard JSON input.",
+                    "examples": ["contracts/Storage.sol:Storage"]
+                  },
+                  "compilerversion": {
+                    "type": "string",
+                    "description": "A version from the official build list. The leading `v` is optional, and a bare release such as `0.8.24` resolves to its canonical build.",
+                    "examples": ["v0.8.24+commit.e11b9ed9"]
+                  },
+                  "constructorArguments": {
+                    "type": "string",
+                    "description": "ABI-encoded constructor arguments, with or without the 0x prefix. Stored and displayed, but not independently verified: matching is done against runtime bytecode.",
+                    "examples": [""]
+                  },
+                  "licenseType": {
+                    "type": "string",
+                    "description": "Accepted for compatibility and not used.",
+                    "examples": ["3"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Accepted, or rejected with a reason. Etherscan's protocol reports both as HTTP 200 and distinguishes them with `status`.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EtherscanEnvelope" },
+                "examples": {
+                  "accepted": {
+                    "summary": "Queued",
+                    "value": { "status": "1", "message": "OK", "result": "0f7b1c5e-9a2d-4c8b-9f31-2a5c7e4d8b60" }
+                  },
+                  "alreadyVerified": {
+                    "summary": "Already verified",
+                    "value": { "status": "0", "message": "NOTOK", "result": "Contract source code already verified" }
+                  },
+                  "rejected": {
+                    "summary": "Rejected before compiling",
+                    "value": { "status": "0", "message": "NOTOK", "result": "No contract code at 0x… on Avalanche C-Chain." }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limited. Compilation is expensive and this endpoint is open, so submissions are throttled per caller.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EtherscanEnvelope" }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Etherscan-compatible"],
+        "summary": "Poll status, or read a verified contract",
+        "description": "One endpoint, three actions.\n\n- `checkverifystatus` — the outcome of a submission. `Pending in queue` while it compiles, `Pass - Verified` on success, `Fail - Unable to verify` with the reason appended otherwise.\n- `getsourcecode` — the Etherscan record, with `SourceCode` holding the Standard JSON wrapped in an extra pair of braces.\n- `getabi` — the ABI as a JSON string.\n\nAn unverified contract is reported as `Contract source code not verified`.",
+        "operationId": "readVerification",
+        "parameters": [
+          {
+            "name": "chainId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "examples": ["43114"] }
+          },
+          {
+            "name": "module",
+            "in": "query",
+            "required": true,
+            "description": "Always `contract`.",
+            "schema": { "type": "string", "default": "contract", "examples": ["contract"] }
+          },
+          {
+            "name": "action",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["checkverifystatus", "getsourcecode", "getabi"],
+              "examples": ["getsourcecode"]
+            }
+          },
+          {
+            "name": "address",
+            "in": "query",
+            "required": false,
+            "description": "Required for `getsourcecode` and `getabi`.",
+            "schema": { "type": "string", "examples": ["0x0000000000000000000000000000000000000000"] }
+          },
+          {
+            "name": "guid",
+            "in": "query",
+            "required": false,
+            "description": "Required for `checkverifystatus`. The value returned by the submission.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "apikey",
+            "in": "query",
+            "required": false,
+            "description": "Accepted and ignored.",
+            "schema": { "type": "string", "examples": ["builder-hub"] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested record, or a NOTOK envelope explaining why there isn't one.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EtherscanEnvelope" },
+                "examples": {
+                  "pending": {
+                    "summary": "checkverifystatus, still compiling",
+                    "value": { "status": "0", "message": "NOTOK", "result": "Pending in queue" }
+                  },
+                  "verified": {
+                    "summary": "checkverifystatus, verified",
+                    "value": { "status": "1", "message": "OK", "result": "Pass - Verified" }
+                  },
+                  "unverified": {
+                    "summary": "getabi, contract not verified",
+                    "value": { "status": "0", "message": "NOTOK", "result": "Contract source code not verified" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/verify/v2/api": {
+      "post": {
+        "tags": ["Etherscan-compatible"],
+        "summary": "Submit a contract (V2 shape)",
+        "description": "Identical to the per-chain submission endpoint, but the chain travels in a `chainid` query parameter instead of the path — the shape Etherscan's V2 API uses. Every form field is the same.",
+        "operationId": "verifySourceCodeV2",
+        "parameters": [
+          {
+            "name": "chainid",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "examples": ["43114"] }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["module", "action", "contractaddress", "sourceCode", "contractname", "compilerversion"],
+                "properties": {
+                  "module": { "type": "string", "default": "contract", "examples": ["contract"] },
+                  "action": { "type": "string", "default": "verifysourcecode", "examples": ["verifysourcecode"] },
+                  "apikey": { "type": "string", "examples": ["builder-hub"] },
+                  "contractaddress": { "type": "string", "examples": ["0x0000000000000000000000000000000000000000"] },
+                  "sourceCode": { "type": "string", "description": "The Standard JSON input, serialised." },
+                  "codeformat": { "type": "string", "enum": ["solidity-standard-json-input"], "examples": ["solidity-standard-json-input"] },
+                  "contractname": { "type": "string", "examples": ["contracts/Storage.sol:Storage"] },
+                  "compilerversion": { "type": "string", "examples": ["v0.8.24+commit.e11b9ed9"] },
+                  "constructorArguments": { "type": "string", "examples": [""] }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Accepted, or rejected with a reason.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/EtherscanEnvelope" } }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Etherscan-compatible"],
+        "summary": "Poll status or read a contract (V2 shape)",
+        "description": "The same three actions as the per-chain endpoint, with the chain in `chainid`.",
+        "operationId": "readVerificationV2",
+        "parameters": [
+          {
+            "name": "chainid",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "examples": ["43114"] }
+          },
+          {
+            "name": "module",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "default": "contract", "examples": ["contract"] }
+          },
+          {
+            "name": "action",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["checkverifystatus", "getsourcecode", "getabi"],
+              "examples": ["getabi"]
+            }
+          },
+          {
+            "name": "address",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "examples": ["0x0000000000000000000000000000000000000000"] }
+          },
+          {
+            "name": "guid",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "apikey",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "examples": ["builder-hub"] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested record, or a NOTOK envelope.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/EtherscanEnvelope" } }
+            }
+          }
+        }
+      }
+    },
+    "/api/verify/sourcify/v2/verify/{chainId}/{address}": {
+      "post": {
+        "tags": ["Sourcify-compatible"],
+        "summary": "Submit a contract for verification",
+        "description": "Queues a verification and returns a `verificationId` to poll. Rejections use ordinary HTTP status codes rather than a status field, which is the main ergonomic difference from the Etherscan surface.",
+        "operationId": "sourcifyVerify",
+        "parameters": [
+          {
+            "name": "chainId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "examples": ["43114"] }
+          },
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "examples": ["0x0000000000000000000000000000000000000000"] }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["stdJsonInput", "compilerVersion", "contractIdentifier"],
+                "properties": {
+                  "stdJsonInput": {
+                    "type": "object",
+                    "description": "The Standard JSON input, as an object rather than a string. Sources must be inlined under `content`.",
+                    "examples": [
+                      {
+                        "language": "Solidity",
+                        "sources": {
+                          "contracts/Storage.sol": {
+                            "content": "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\ncontract Storage { uint256 value; }"
+                          }
+                        },
+                        "settings": {
+                          "optimizer": { "enabled": false, "runs": 200 },
+                          "outputSelection": { "*": { "*": ["abi", "metadata", "evm.deployedBytecode.object"] } }
+                        }
+                      }
+                    ]
+                  },
+                  "compilerVersion": {
+                    "type": "string",
+                    "description": "A version from the official build list.",
+                    "examples": ["0.8.24+commit.e11b9ed9"]
+                  },
+                  "contractIdentifier": {
+                    "type": "string",
+                    "description": "Fully qualified name, as `path/to/File.sol:ContractName`.",
+                    "examples": ["contracts/Storage.sol:Storage"]
+                  },
+                  "creationTransactionHash": {
+                    "type": "string",
+                    "description": "Accepted for compatibility. Matching is done against runtime bytecode, so this is not required.",
+                    "examples": [null]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Queued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "verificationId": { "type": "string", "format": "uuid" } }
+                },
+                "examples": {
+                  "queued": { "value": { "verificationId": "0f7b1c5e-9a2d-4c8b-9f31-2a5c7e4d8b60" } }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The submission is malformed — not Standard JSON, not Solidity, or the contract identifier is not fully qualified.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SourcifyError" } } }
+          },
+          "404": {
+            "description": "The chain is not one we can verify against, or nothing is deployed at that address.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SourcifyError" } } }
+          },
+          "409": {
+            "description": "Already verified.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SourcifyError" } } }
+          },
+          "429": {
+            "description": "Rate limited.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SourcifyError" } } }
+          }
+        }
+      }
+    },
+    "/api/verify/sourcify/v2/verify/{verificationId}": {
+      "get": {
+        "tags": ["Sourcify-compatible"],
+        "summary": "Check a verification job",
+        "description": "Always HTTP 200 while the id is known — a failed verification is a successful request about a failure. Loop on `isJobCompleted`, then read `contract.match`, which is null when it failed.",
+        "operationId": "sourcifyVerificationJob",
+        "parameters": [
+          {
+            "name": "verificationId",
+            "in": "path",
+            "required": true,
+            "description": "The value returned by the submission. Doubles as the Etherscan GUID, so either protocol can poll a job submitted through the other.",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The job, complete or otherwise.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/VerificationJob" },
+                "examples": {
+                  "pending": {
+                    "summary": "Still compiling",
+                    "value": {
+                      "isJobCompleted": false,
+                      "verificationId": "0f7b1c5e-9a2d-4c8b-9f31-2a5c7e4d8b60",
+                      "jobStartTime": "2026-09-10T20:15:00.000Z",
+                      "contract": { "match": null, "chainId": "43114", "address": "0x0000000000000000000000000000000000000000" }
+                    }
+                  },
+                  "verified": {
+                    "summary": "Verified",
+                    "value": {
+                      "isJobCompleted": true,
+                      "verificationId": "0f7b1c5e-9a2d-4c8b-9f31-2a5c7e4d8b60",
+                      "jobStartTime": "2026-09-10T20:15:00.000Z",
+                      "jobFinishTime": "2026-09-10T20:15:11.000Z",
+                      "contract": {
+                        "match": "exact_match",
+                        "creationMatch": null,
+                        "runtimeMatch": "exact_match",
+                        "chainId": "43114",
+                        "address": "0x0000000000000000000000000000000000000000",
+                        "verifiedAt": "2026-09-10T20:15:11.000Z",
+                        "compilation": {
+                          "language": "Solidity",
+                          "compiler": "solc",
+                          "compilerVersion": "0.8.24+commit.e11b9ed9",
+                          "name": "Storage"
+                        }
+                      }
+                    }
+                  },
+                  "failed": {
+                    "summary": "Did not match",
+                    "value": {
+                      "isJobCompleted": true,
+                      "verificationId": "0f7b1c5e-9a2d-4c8b-9f31-2a5c7e4d8b60",
+                      "jobStartTime": "2026-09-10T20:15:00.000Z",
+                      "jobFinishTime": "2026-09-10T20:15:09.000Z",
+                      "contract": { "match": null, "chainId": "43114", "address": "0x0000000000000000000000000000000000000000" },
+                      "error": {
+                        "customCode": "no_match",
+                        "message": "The deployed code does not match this source. Check the contract name, compiler version and settings.",
+                        "errorId": "0f7b1c5e-9a2d-4c8b-9f31-2a5c7e4d8b60"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown verification id.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SourcifyError" } } }
+          }
+        }
+      }
+    },
+    "/api/verify/sourcify/v2/contract/{chainId}/{address}": {
+      "get": {
+        "tags": ["Sourcify-compatible"],
+        "summary": "Look up a verified contract",
+        "description": "Reports contracts verified on Builder Hub. An unverified contract answers 404 with `match: null`, which is the shape `hardhat-verify` reads to decide a contract needs verifying.\n\nThe explorer's own lookup at `/api/sourcify/{chainId}/{address}` merges these with Sourcify's public archive; this endpoint deliberately does not.",
+        "operationId": "sourcifyContract",
+        "parameters": [
+          {
+            "name": "chainId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "examples": ["43114"] }
+          },
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "examples": ["0x0000000000000000000000000000000000000000"] }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of what to include beyond the envelope: `abi`, `metadata`, `compilation`, `sources`, `stdJsonInput`, or `all`. Source trees are large, so nothing heavy is returned unless asked for.",
+            "schema": { "type": "string", "examples": ["abi,compilation"] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The verified contract.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/VerifiedContract" }
+              }
+            }
+          },
+          "404": {
+            "description": "Not verified here.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "match": { "type": "null" },
+                    "chainId": { "type": "string" },
+                    "address": { "type": "string" }
+                  }
+                },
+                "examples": {
+                  "unverified": {
+                    "value": { "match": null, "chainId": "43114", "address": "0x0000000000000000000000000000000000000000" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/verify/compilers": {
+      "get": {
+        "tags": ["Compilers"],
+        "summary": "List available Solidity versions",
+        "description": "Released versions the verifier can run, newest first, mirrored from the official build list. Use `longVersion` when submitting.",
+        "operationId": "listCompilers",
+        "responses": {
+          "200": {
+            "description": "Available releases.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "releases": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "version": { "type": "string" },
+                          "longVersion": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "releases": {
+                    "value": {
+                      "releases": [
+                        { "version": "0.8.37", "longVersion": "0.8.37+commit.f401782d" },
+                        { "version": "0.8.24", "longVersion": "0.8.24+commit.e11b9ed9" }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "EtherscanEnvelope": {
+        "type": "object",
+        "description": "Etherscan's response envelope. `status` is `\"1\"` on success and `\"0\"` otherwise; the meaning lives in `result`.",
+        "properties": {
+          "status": { "type": "string", "enum": ["0", "1"] },
+          "message": { "type": "string", "enum": ["OK", "NOTOK"] },
+          "result": {
+            "description": "A GUID, a status string, an ABI, or an error message, depending on the action.",
+            "anyOf": [{ "type": "string" }, { "type": "array", "items": { "type": "object" } }]
+          }
+        }
+      },
+      "SourcifyError": {
+        "type": "object",
+        "properties": {
+          "customCode": {
+            "type": "string",
+            "description": "Machine-readable reason, from Sourcify's vocabulary.",
+            "examples": ["no_match"]
+          },
+          "message": { "type": "string" },
+          "errorId": { "type": "string", "format": "uuid" }
+        }
+      },
+      "MatchLevel": {
+        "type": "string",
+        "description": "`exact_match` means the recompiled bytecode is byte-identical to what is deployed, metadata hash included. `match` means the code is identical but the metadata differs — the contract behaves exactly as the source says, and something outside the executable code changed, such as a comment.",
+        "enum": ["exact_match", "match"]
+      },
+      "VerifiedContract": {
+        "type": "object",
+        "properties": {
+          "match": { "$ref": "#/components/schemas/MatchLevel" },
+          "creationMatch": { "type": ["string", "null"] },
+          "runtimeMatch": { "$ref": "#/components/schemas/MatchLevel" },
+          "chainId": { "type": "string" },
+          "address": { "type": "string" },
+          "verifiedAt": { "type": "string", "format": "date-time" },
+          "matchId": { "type": "string" },
+          "abi": { "type": "array", "items": { "type": "object" } },
+          "metadata": { "type": ["object", "null"] },
+          "compilation": {
+            "type": "object",
+            "properties": {
+              "language": { "type": "string" },
+              "compiler": { "type": "string" },
+              "compilerVersion": { "type": "string" },
+              "name": { "type": "string" },
+              "fullyQualifiedName": { "type": "string" }
+            }
+          },
+          "sources": {
+            "type": "object",
+            "description": "File path to contents. Only present when requested through `fields`.",
+            "additionalProperties": {
+              "type": "object",
+              "properties": { "content": { "type": "string" } }
+            }
+          }
+        }
+      },
+      "VerificationJob": {
+        "type": "object",
+        "properties": {
+          "isJobCompleted": { "type": "boolean" },
+          "verificationId": { "type": "string", "format": "uuid" },
+          "jobStartTime": { "type": "string", "format": "date-time" },
+          "jobFinishTime": { "type": "string", "format": "date-time" },
+          "contract": { "$ref": "#/components/schemas/VerifiedContract" },
+          "error": { "$ref": "#/components/schemas/SourcifyError" }
+        }
+      }
+    }
+  }
+}

--- a/tests/stubs/server-only.ts
+++ b/tests/stubs/server-only.ts
@@ -1,0 +1,7 @@
+/*
+ * `server-only` exists to make a build fail when server code is imported
+ * into a client bundle. Under Vitest there is no client bundle and the
+ * package resolves only through Next's build conditions, so tests alias
+ * it here. The guard still does its job everywhere it matters.
+ */
+export {};

--- a/tests/unit/verification/match.test.ts
+++ b/tests/unit/verification/match.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import { listCompiledContracts, matchDeployedBytecode, splitContractIdentifier } from "@/lib/verification/match";
+import type { SolcOutput } from "@/lib/verification/solc";
+
+/*
+ * The matcher decides whether a contract is verified, so its edge cases are
+ * the ones worth pinning down: the three things that legitimately differ
+ * between compiled and deployed code (libraries, immutables, metadata) and
+ * the difference that must never be forgiven (different code).
+ *
+ * Bytecode here is synthetic. Real fixtures would be thousands of hex
+ * characters that hide exactly the byte the test is about.
+ */
+
+/** 32 bytes of metadata plus the two-byte length suffix Solidity appends. */
+function metadataTrailer(fill = "ab"): string {
+  return fill.repeat(32) + "0020";
+}
+
+const BODY = "6080604052348015600f57600080fd5b50";
+
+function outputWith(contract: {
+  deployed: string;
+  immutableReferences?: Record<string, { start: number; length: number }[]>;
+  linkReferences?: Record<string, Record<string, { start: number; length: number }[]>>;
+}): SolcOutput {
+  return {
+    contracts: {
+      "contracts/Token.sol": {
+        Token: {
+          abi: [{ type: "function", name: "transfer" }],
+          metadata: '{"compiler":{"version":"0.8.24"}}',
+          evm: {
+            deployedBytecode: {
+              object: contract.deployed,
+              immutableReferences: contract.immutableReferences,
+              linkReferences: contract.linkReferences,
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("splitContractIdentifier", () => {
+  it("splits on the last colon so Windows-ish paths survive", () => {
+    expect(splitContractIdentifier("contracts/Token.sol:Token")).toEqual({
+      file: "contracts/Token.sol",
+      name: "Token",
+    });
+  });
+
+  it("rejects identifiers that are not fully qualified", () => {
+    expect(splitContractIdentifier("Token")).toBeNull();
+    expect(splitContractIdentifier(":Token")).toBeNull();
+    expect(splitContractIdentifier("contracts/Token.sol:")).toBeNull();
+  });
+});
+
+describe("matchDeployedBytecode", () => {
+  it("calls byte-identical code an exact match", () => {
+    const deployed = BODY + metadataTrailer();
+    const result = matchDeployedBytecode({
+      output: outputWith({ deployed }),
+      identifier: "contracts/Token.sol:Token",
+      onchainCode: `0x${deployed}`,
+    });
+
+    expect(result).toMatchObject({ matched: true, level: "exact_match" });
+  });
+
+  it("is case-insensitive about the on-chain hex and tolerates the 0x prefix", () => {
+    const deployed = BODY + metadataTrailer();
+    const result = matchDeployedBytecode({
+      output: outputWith({ deployed }),
+      identifier: "contracts/Token.sol:Token",
+      onchainCode: deployed.toUpperCase(),
+    });
+
+    expect(result).toMatchObject({ matched: true, level: "exact_match" });
+  });
+
+  it("downgrades to a partial match when only the metadata hash differs", () => {
+    const compiled = BODY + metadataTrailer("ab");
+    const onchain = BODY + metadataTrailer("cd");
+
+    const result = matchDeployedBytecode({
+      output: outputWith({ deployed: compiled }),
+      identifier: "contracts/Token.sol:Token",
+      onchainCode: `0x${onchain}`,
+    });
+
+    // Same executable code, different comment or file path upstream.
+    expect(result).toMatchObject({ matched: true, level: "match" });
+  });
+
+  it("ignores immutables, which the constructor writes after compilation", () => {
+    // The compiler leaves an immutable slot zeroed; the chain has a value.
+    const zeroed = "00".repeat(32);
+    const value = "11".repeat(32);
+    const compiled = BODY + zeroed + metadataTrailer();
+    const onchain = BODY + value + metadataTrailer();
+
+    const start = BODY.length / 2;
+    const result = matchDeployedBytecode({
+      output: outputWith({
+        deployed: compiled,
+        immutableReferences: { "42": [{ start, length: 32 }] },
+      }),
+      identifier: "contracts/Token.sol:Token",
+      onchainCode: `0x${onchain}`,
+    });
+
+    expect(result).toMatchObject({ matched: true, level: "exact_match" });
+  });
+
+  it("does not forgive a difference outside the immutable range", () => {
+    const compiled = BODY + "00".repeat(32) + "dead" + metadataTrailer();
+    const onchain = BODY + "11".repeat(32) + "beef" + metadataTrailer();
+
+    const result = matchDeployedBytecode({
+      output: outputWith({
+        deployed: compiled,
+        immutableReferences: { "42": [{ start: BODY.length / 2, length: 32 }] },
+      }),
+      identifier: "contracts/Token.sol:Token",
+      onchainCode: `0x${onchain}`,
+    });
+
+    expect(result).toMatchObject({ matched: false, code: "no_match" });
+  });
+
+  it("links library placeholders from settings.libraries", () => {
+    // `__$` + 34 hex characters + `$__` occupies exactly the 20 bytes the
+    // address will fill, which is what makes in-place substitution work.
+    const placeholder = `__$${"1234567890abcdef1234567890abcdef12"}$__`;
+    const library = "0x1111111111111111111111111111111111111111";
+    const compiled = BODY + placeholder + metadataTrailer();
+    const onchain = BODY + library.slice(2) + metadataTrailer();
+
+    const result = matchDeployedBytecode({
+      output: outputWith({
+        deployed: compiled,
+        linkReferences: {
+          "contracts/Math.sol": { Math: [{ start: BODY.length / 2, length: 20 }] },
+        },
+      }),
+      identifier: "contracts/Token.sol:Token",
+      onchainCode: `0x${onchain}`,
+      libraries: { "contracts/Math.sol": { Math: library } },
+    });
+
+    expect(result).toMatchObject({ matched: true, level: "exact_match" });
+  });
+
+  it("asks for the address rather than reporting a mismatch when a library is unlinked", () => {
+    const compiled = BODY + `__$${"1234567890abcdef1234567890abcdef12"}$__` + metadataTrailer();
+
+    const result = matchDeployedBytecode({
+      output: outputWith({
+        deployed: compiled,
+        linkReferences: {
+          "contracts/Math.sol": { Math: [{ start: BODY.length / 2, length: 20 }] },
+        },
+      }),
+      identifier: "contracts/Token.sol:Token",
+      onchainCode: `0x${compiled}`,
+    });
+
+    expect(result).toMatchObject({ matched: false, code: "unlinked_libraries" });
+    if (!result.matched) expect(result.message).toContain("contracts/Math.sol:Math");
+  });
+
+  it("rejects genuinely different code", () => {
+    const compiled = BODY + "aaaa" + metadataTrailer();
+    const onchain = BODY + "bbbb" + metadataTrailer();
+
+    const result = matchDeployedBytecode({
+      output: outputWith({ deployed: compiled }),
+      identifier: "contracts/Token.sol:Token",
+      onchainCode: `0x${onchain}`,
+    });
+
+    expect(result).toMatchObject({ matched: false, code: "no_match" });
+    if (!result.matched) {
+      // The caller needs both sides to explain the failure to a submitter.
+      expect(result.recompiledRuntimeCode).toBe(`0x${compiled}`);
+      expect(result.onchainRuntimeCode).toBe(`0x${onchain}`);
+    }
+  });
+
+  it("rejects code of a different length before comparing anything", () => {
+    const result = matchDeployedBytecode({
+      output: outputWith({ deployed: BODY + metadataTrailer() }),
+      identifier: "contracts/Token.sol:Token",
+      onchainCode: `0x${BODY}`,
+    });
+
+    expect(result).toMatchObject({ matched: false, code: "no_match" });
+  });
+
+  it("names what it did compile when the identifier is wrong", () => {
+    const result = matchDeployedBytecode({
+      output: outputWith({ deployed: BODY + metadataTrailer() }),
+      identifier: "contracts/Token.sol:Toekn",
+      onchainCode: `0x${BODY}${metadataTrailer()}`,
+    });
+
+    expect(result).toMatchObject({ matched: false, code: "contract_not_found" });
+    if (!result.matched) expect(result.message).toContain("contracts/Token.sol:Token");
+  });
+
+  it("explains that an interface has nothing to verify", () => {
+    const result = matchDeployedBytecode({
+      output: outputWith({ deployed: "" }),
+      identifier: "contracts/Token.sol:Token",
+      onchainCode: `0x${BODY}`,
+    });
+
+    expect(result).toMatchObject({ matched: false, code: "no_bytecode" });
+  });
+
+  it("returns the ABI on success, since that is what the explorer stores", () => {
+    const deployed = BODY + metadataTrailer();
+    const result = matchDeployedBytecode({
+      output: outputWith({ deployed }),
+      identifier: "contracts/Token.sol:Token",
+      onchainCode: `0x${deployed}`,
+    });
+
+    if (!result.matched) throw new Error("expected a match");
+    expect(result.abi).toEqual([{ type: "function", name: "transfer" }]);
+    expect(result.metadata).toContain("0.8.24");
+  });
+});
+
+describe("listCompiledContracts", () => {
+  it("flattens the compiler's file/name nesting into identifiers", () => {
+    expect(listCompiledContracts(outputWith({ deployed: BODY }))).toEqual([
+      "contracts/Token.sol:Token",
+    ]);
+  });
+
+  it("is empty rather than undefined when nothing compiled", () => {
+    expect(listCompiledContracts({})).toEqual([]);
+  });
+});

--- a/tests/unit/verification/solc.test.ts
+++ b/tests/unit/verification/solc.test.ts
@@ -1,0 +1,200 @@
+import { existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  compileStandardJson,
+  compileWithCompilerAt,
+  fatalErrors,
+  resolveCompilerVersion,
+  toCompilerInput,
+} from "@/lib/verification/solc";
+import { matchDeployedBytecode } from "@/lib/verification/match";
+
+/*
+ * These reach binaries.soliditylang.org and then run a real compiler, so
+ * they are opt-in:
+ *
+ *   VERIFY_SOLC_E2E=1 npx vitest run tests/unit/verification
+ *
+ * They are worth running whenever solc.ts changes, because the loader is
+ * the part of this system that cannot be unit tested honestly — the whole
+ * question is whether an unfamiliar emscripten build actually compiles.
+ */
+
+const enabled = process.env.VERIFY_SOLC_E2E === "1";
+const describeE2E = enabled ? describe : describe.skip;
+
+const COMPILER = "0.8.24+commit.e11b9ed9";
+
+const STORAGE = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Storage {
+    uint256 private value;
+
+    function set(uint256 next) public {
+        value = next;
+    }
+
+    function get() public view returns (uint256) {
+        return value;
+    }
+}
+`;
+
+const INPUT = {
+  language: "Solidity",
+  sources: { "contracts/Storage.sol": { content: STORAGE } },
+  settings: {
+    optimizer: { enabled: false, runs: 200 },
+    outputSelection: {
+      "*": { "*": ["abi", "metadata", "evm.bytecode.object", "evm.deployedBytecode.object"] },
+    },
+  },
+};
+
+describe("toCompilerInput", () => {
+  it("drops the extra keys Foundry's build-info carries", () => {
+    // Exactly the shape `forge build --build-info` writes. solc answers an
+    // input like this with `Unknown key "allowPaths"` and never compiles.
+    const buildInfoInput = {
+      version: 1,
+      language: "Solidity",
+      sources: { "src/Storage.sol": { content: STORAGE } },
+      settings: { optimizer: { enabled: true, runs: 200 }, evmVersion: "shanghai" },
+      allowPaths: [],
+      basePath: "/tmp/verify-demo",
+      includePaths: [],
+    };
+
+    expect(Object.keys(toCompilerInput(buildInfoInput)).sort()).toEqual([
+      "language",
+      "settings",
+      "sources",
+    ]);
+  });
+
+  it("passes settings through untouched, since that is where codegen lives", () => {
+    const settings = { optimizer: { enabled: true, runs: 999 }, viaIR: true, libraries: {} };
+    expect(toCompilerInput({ language: "Solidity", sources: {}, settings }).settings).toBe(settings);
+  });
+
+  it("defaults the language rather than omitting it", () => {
+    expect(toCompilerInput({ sources: {} }).language).toBe("Solidity");
+  });
+
+  it("leaves out settings entirely when there were none", () => {
+    expect(toCompilerInput({ sources: {} })).not.toHaveProperty("settings");
+  });
+});
+
+describeE2E("solc loader", () => {
+  it("resolves a long version against the official build list", async () => {
+    const build = await resolveCompilerVersion(`v${COMPILER}`);
+    expect(build.longVersion).toBe(COMPILER);
+    expect(build.path).toContain("soljson");
+  }, 60_000);
+
+  it("resolves a bare release to its canonical build", async () => {
+    const build = await resolveCompilerVersion("0.8.24");
+    expect(build.longVersion).toBe(COMPILER);
+  }, 60_000);
+
+  it("refuses a version that is not in the list", async () => {
+    await expect(resolveCompilerVersion("0.8.99")).rejects.toThrow(/Unknown compiler version/);
+    // The version string is caller-controlled and must never reach a URL.
+    await expect(resolveCompilerVersion("../../etc/passwd")).rejects.toThrow(/Not a Solidity version/);
+  }, 60_000);
+
+  it("compiles a contract and produces matching runtime bytecode", async () => {
+    const { output, longVersion } = await compileStandardJson({
+      stdJsonInput: INPUT,
+      compilerVersion: COMPILER,
+    });
+
+    expect(longVersion).toBe(COMPILER);
+    expect(fatalErrors(output)).toEqual([]);
+
+    const deployed = output.contracts?.["contracts/Storage.sol"]?.Storage?.evm?.deployedBytecode?.object;
+    expect(deployed).toBeTruthy();
+
+    // Feed the compiler's own output back in as if it were on chain: the
+    // matcher must call that an exact match, or nothing else can work.
+    const result = matchDeployedBytecode({
+      output,
+      identifier: "contracts/Storage.sol:Storage",
+      onchainCode: `0x${deployed}`,
+    });
+    expect(result).toMatchObject({ matched: true, level: "exact_match" });
+  }, 240_000);
+
+  it("reports a source error as compiler output rather than throwing", async () => {
+    const { output } = await compileStandardJson({
+      stdJsonInput: {
+        ...INPUT,
+        sources: { "contracts/Broken.sol": { content: "pragma solidity ^0.8.0; contract Broken {" } },
+      },
+      compilerVersion: COMPILER,
+    });
+
+    // A submitter's broken source is a result, not a failure of ours.
+    expect(fatalErrors(output).length).toBeGreaterThan(0);
+  }, 240_000);
+});
+
+/*
+ * The same proof without the network: point VERIFY_SOLC_BINARY at a
+ * soljson-*.js you already have and this exercises the worker, the
+ * emscripten loading shim, and the compile itself.
+ *
+ *   curl -o /tmp/soljson.js https://binaries.soliditylang.org/wasm/soljson-v0.8.24+commit.e11b9ed9.js
+ *   VERIFY_SOLC_BINARY=/tmp/soljson.js npx vitest run tests/unit/verification
+ */
+const localCompiler = process.env.VERIFY_SOLC_BINARY;
+const describeLocal = localCompiler && existsSync(localCompiler) ? describe : describe.skip;
+
+describeLocal("solc worker against a local build", () => {
+  it("compiles and round-trips through the matcher", async () => {
+    const output = await compileWithCompilerAt(localCompiler!, INPUT);
+
+    expect(fatalErrors(output)).toEqual([]);
+    const deployed = output.contracts?.["contracts/Storage.sol"]?.Storage?.evm?.deployedBytecode?.object;
+    expect(deployed).toBeTruthy();
+
+    const result = matchDeployedBytecode({
+      output,
+      identifier: "contracts/Storage.sol:Storage",
+      onchainCode: `0x${deployed}`,
+    });
+    expect(result).toMatchObject({ matched: true, level: "exact_match" });
+  }, 240_000);
+
+  it("surfaces a source error without throwing", async () => {
+    const output = await compileWithCompilerAt(localCompiler!, {
+      ...INPUT,
+      sources: { "contracts/Broken.sol": { content: "pragma solidity ^0.8.0; contract Broken {" } },
+    });
+
+    expect(fatalErrors(output).length).toBeGreaterThan(0);
+  }, 240_000);
+
+  it("compiles a build-info input only once the extra keys are dropped", async () => {
+    const buildInfoInput = {
+      version: 1,
+      ...INPUT,
+      allowPaths: [],
+      basePath: "/tmp/verify-demo",
+      includePaths: [],
+    };
+
+    // The bug this guards: solc refuses the whole input over a key it does
+    // not define, before compiling anything.
+    const asIs = await compileWithCompilerAt(localCompiler!, buildInfoInput);
+    expect(fatalErrors(asIs).map((e) => e.message).join("\n")).toMatch(/allowPaths/);
+
+    const reduced = await compileWithCompilerAt(localCompiler!, toCompilerInput(buildInfoInput));
+    expect(fatalErrors(reduced)).toEqual([]);
+    expect(
+      reduced.contracts?.["contracts/Storage.sol"]?.Storage?.evm?.deployedBytecode?.object,
+    ).toBeTruthy();
+  }, 240_000);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,16 @@
     {
       "path": "/api/validator-alerts/check",
       "schedule": "*/15 * * * *"
+    },
+    {
+      "path": "/api/verify/cleanup",
+      "schedule": "0 4 * * *"
     }
-  ]
+  ],
+  "functions": {
+    "app/api/verify/**/route.ts": {
+      "memory": 4096,
+      "maxDuration": 300
+    }
+  }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('.', import.meta.url)),
+      // Resolves only under Next's build conditions; stubbed so server
+      // modules can be unit tested directly.
+      'server-only': fileURLToPath(new URL('./tests/stubs/server-only.ts', import.meta.url)),
     },
   },
   test: {


### PR DESCRIPTION
# Contract verification for every Avalanche L1

Contract verification was previously lookup-only: `lib/sourcify.ts` asked the public Sourcify archive, which knows the C-Chain and Fuji and almost none of the ~240 L1s in our catalog. Unverified contracts got a link to `verify.sourcify.dev` and, for an L1, that link led nowhere useful — Sourcify will not accept a chain absent from its own list.

This adds our own verifier, so a contract on any catalog L1 with a public RPC can be verified, from Hardhat, from Foundry, or from the explorer.

## What verification does

One question: does the submitted source compile to the code already on chain?

The compiler is **solc-js**, fetched from `binaries.soliditylang.org` with a keccak256 integrity check and cached in `/tmp` under an LRU. No native binary, no container, no separate service. It runs in a **forked child process** so a runaway compile can be killed outright and its heap is its own — that 180-second kill, not the route's `maxDuration`, is what caps the cost of a single hostile submission.

Matching normalises the three things that legitimately differ between compiled and deployed code:

- library addresses linked after compilation
- immutables written by the constructor
- the metadata hash, which changes with something as cosmetic as a comment

Surviving all three byte-for-byte is an `exact_match`. Matching only once metadata is trimmed is a `match`. Anything else is rejected, and a result is never stored on anything short of a match — the explorer trusts this data for ABIs, so a row that didn't earn its place would silently mis-decode every call and log against that address.

Only **Standard JSON** input is accepted. It is what Hardhat and Foundry already emit, what Sourcify v2 standardised on, and it removes import resolution from the problem entirely.

## Two protocols, one verifier

Existing tooling cannot be changed to suit us, so we speak what it already speaks.

| Surface | Endpoint | Used by |
| --- | --- | --- |
| Etherscan-compatible | `/api/verify/{chainId}/api` | Hardhat 2 `customChains`, `forge verify-contract` |
| Etherscan V2 shape | `/api/verify/v2/api?chainid=` | Hardhat 3 `chainDescriptors` |
| Sourcify v2 | `/api/verify/sourcify/v2/*` | Hardhat 3 `verify.sourcify.apiUrl` |

Some details are load-bearing: `hardhat-verify` decides a run passed by matching the exact string `Pass - Verified`, and reads `match` out of a 404 body to decide a contract needs verifying. The `apikey` parameter is accepted and ignored, since gating on it would only mean issuing keys to everybody.

## Reads

`getVerifiedContract` consults our database first and the public archive second, so a contract verified in either place renders in the explorer. Every L1 contract verified here lights up calldata and log decoding across the explorer for free.

Caching is arranged around the one answer that flips. Our database is read **even when a miss is cached**, because it is a single indexed lookup and it is what changes the instant someone verifies — including on another instance, which no in-process invalidation could reach. The remembered miss now only spares upstream Sourcify a repeated question. For the same reason miss responses are not browser-cacheable: someone who verifies a contract and returns to its page was otherwise told it was unverified for another five minutes.

Verifications are also published back to Sourcify for chains it supports (`SOURCIFY_MIRROR=1`), best-effort and after the fact, so an outage upstream can never affect a result we already gave.

## Abuse and cost

The endpoint has to be public — `hardhat verify` cannot log in — and a few hundred KB of adversarial input buys minutes of CPU. The platform will happily scale to meet that, so the failure mode is not an outage, it is a bill.

Submission is front-loaded with cheap checks that reach a verdict before the expensive part: address shape, known chain, caller quota, already-verified, deployed code, seen-this-exact-payload. The code check matters most — it forces an attacker to actually deploy something and spend gas.

Per-caller quotas slow an attack but cannot bound it, since IPs are cheap. The **global compile semaphore** is the bound: however many requests arrive, only a handful compile at once, so the worst case degrades into a queue rather than a spending spree. It lives in Redis because per-instance counters mean nothing on serverless, and falls back to per-instance counting when Redis is unreachable — weaker, but never unprotected and never offline.

At Pro rates a typical verification costs about **$0.0005**; organic usage cannot make this expensive.

## UI

- **Contract tab** on the address page: verified source, ABI, and the read/write consoles. Those components existed under `components/explorer/` and were mounted nowhere; this finally routes them.
- **Verify form**: drop a Hardhat or Foundry build-info file — a file people already have — and it posts to the same endpoint the CLI tools use, so there is no form-only API to drift out of sync.
- **Docs** at `/docs/tooling/contract-verification`, with an interactive API reference built on the same `fumadocs-openapi` playground as the Data API pages.

The write console needed fixing to survive the move out of the console shell. It gated on a Core wallet client from the console's wallet store — always null in the explorer, and null for every non-Core wallet even inside the console — while transactions actually go out through `window.ethereum`. Wallet address and chain id now come from the provider that signs, ABI encoding goes through viem's `encodeFunctionData` (the previous hand-rolled encoder answered unparseable input with 32 zero bytes, turning a typo into a successful transaction doing the wrong thing), and provider errors are unwrapped rather than swallowed.

## Testing

23 unit tests under `tests/unit/verification/`. The matcher is covered against metadata-only differences, immutables, linked libraries, unlinked libraries, length mismatches and genuine mismatches. The compiler path can be exercised against a real solc build:

```bash
curl -o /tmp/soljson.js https://binaries.soliditylang.org/wasm/soljson-v0.8.24+commit.e11b9ed9.js
VERIFY_SOLC_BINARY=/tmp/soljson.js npx vitest run tests/unit/verification
```

Verified end to end against a real mainnet deployment: a contract with an `immutable` (so the deployed code genuinely differs from the compiler's output) verified through `forge verify-contract` as an `exact_match`, and again through the UI from a Foundry build-info file.

## Known limits

- Solidity only; Vyper and Fe are out of scope.
- Standard JSON up to 6 MB, 180 seconds of compilation.
- Matching is against runtime bytecode, so constructor arguments are stored and displayed but not independently verified.
- Very large or `viaIR` contracts can exhaust the limits. If that turns out to be common, the compile step is deliberately isolated behind one function (`compileStandardJson`) and can be moved to a container without touching the APIs, storage, or UI.
