### PR TITLE
fix(audits): gate admin pages with their own role check

### DIFF
--- a/app/(home)/audits/admin/auditors/page.tsx
+++ b/app/(home)/audits/admin/auditors/page.tsx
@@ -1,7 +1,11 @@
 import { getAdminAuditors } from "@/server/services/audits/visibility";
 import { AuditorsManager } from "@/components/audits/admin/AuditorsManager";
+import { denyIfNotAuditAdmin } from "@/app/(home)/audits/admin/require-admin";
 
 export default async function AuditAdminAuditorsPage() {
+  const denied = await denyIfNotAuditAdmin();
+  if (denied) return denied;
+
   const auditors = await getAdminAuditors();
   return <AuditorsManager auditors={auditors} />;
 }

--- a/app/(home)/audits/admin/page.tsx
+++ b/app/(home)/audits/admin/page.tsx
@@ -2,8 +2,12 @@ import Link from "next/link";
 import { getAdminOverview, getAdminRequests } from "@/server/services/audits/visibility";
 import { OverviewTiles } from "@/components/audits/admin/OverviewTiles";
 import { RequestsTable } from "@/components/audits/admin/RequestsTable";
+import { denyIfNotAuditAdmin } from "@/app/(home)/audits/admin/require-admin";
 
 export default async function AuditAdminOverviewPage() {
+  const denied = await denyIfNotAuditAdmin();
+  if (denied) return denied;
+
   const [overview, requests] = await Promise.all([
     getAdminOverview(),
     getAdminRequests({ take: 8, skip: 0 }),

--- a/app/(home)/audits/admin/requests/[id]/page.tsx
+++ b/app/(home)/audits/admin/requests/[id]/page.tsx
@@ -9,12 +9,16 @@ import { QuoteComparison } from "@/components/audits/admin/QuoteComparison";
 import { SubsidyWorksheet } from "@/components/audits/admin/SubsidyWorksheet";
 import { ReviewDecision } from "@/components/audits/admin/ReviewDecision";
 import { ActivityTrail } from "@/components/audits/admin/ActivityTrail";
+import { denyIfNotAuditAdmin } from "@/app/(home)/audits/admin/require-admin";
 
 export default async function AuditAdminDrilldownPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
+  const denied = await denyIfNotAuditAdmin();
+  if (denied) return denied;
+
   const { id } = await params;
   const detail = await getAdminRequestDetail(id);
   if (!detail) notFound();

--- a/app/(home)/audits/admin/requests/page.tsx
+++ b/app/(home)/audits/admin/requests/page.tsx
@@ -3,12 +3,16 @@ import { adminRequestFiltersSchema } from "@/types/audits";
 import { getAdminRequests } from "@/server/services/audits/visibility";
 import { RequestsFilters } from "@/components/audits/admin/RequestsFilters";
 import { RequestsTable } from "@/components/audits/admin/RequestsTable";
+import { denyIfNotAuditAdmin } from "@/app/(home)/audits/admin/require-admin";
 
 interface AdminRequestsPageProps {
   searchParams: Promise<{ status?: string; subsidy?: string; deadline_before?: string }>;
 }
 
 export default async function AuditAdminRequestsPage({ searchParams }: AdminRequestsPageProps) {
+  const denied = await denyIfNotAuditAdmin();
+  if (denied) return denied;
+
   const params = await searchParams;
   const parsed = adminRequestFiltersSchema.safeParse({
     status: params.status,

--- a/app/(home)/audits/admin/require-admin.tsx
+++ b/app/(home)/audits/admin/require-admin.tsx
@@ -1,0 +1,26 @@
+import { getAuthSession } from "@/lib/auth/authSession";
+import { canAdministerAuditProgram } from "@/lib/auth/permissions";
+import { AccessDenied } from "@/components/ui/access-denied";
+
+/**
+ * Page-level admin gate. The layout (layout.tsx:9-18) is the normal check,
+ * but Next 16 can render a page segment WITHOUT its ancestor layout when the
+ * client sends a crafted next-router-state-tree RSC header
+ * (walk-tree-with-flight-router-state.js:53-56, 114-150), so every admin page
+ * re-asserts the role before it reads anything.
+ *
+ * Returns AccessDenied to render-and-return when the caller is not an audit
+ * admin, else null. Returning a node (rather than redirect/notFound) keeps the
+ * fix out of the layout's children-discarding and boundary semantics: in a
+ * normal non-admin render the layout already returns AccessDenied and drops
+ * children, so this only ever renders alone on a bypass attempt.
+ */
+export async function denyIfNotAuditAdmin(): Promise<React.ReactNode | null> {
+  const session = await getAuthSession();
+  if (!session?.user || !canAdministerAuditProgram(session)) {
+    return (
+      <AccessDenied message="You need the audit program admin role to view this area." />
+    );
+  }
+  return null;
+}

--- a/tests/unit/audits/adminPageGuard.test.ts
+++ b/tests/unit/audits/adminPageGuard.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+/**
+ * S-1 hotfix guard. The four /audits/admin pages must each re-assert the
+ * admin role before any read: Next 16 can render a page segment without its
+ * ancestor layout when a client sends a crafted next-router-state-tree
+ * header, so the layout check is not sufficient on its own. Any admin page
+ * that forgets the guard, or a guard that no longer runs the real role check,
+ * fails here before it can ship.
+ */
+const ADMIN_ROOT = "app/(home)/audits/admin";
+const GUARD_RE = /denyIfNotAuditAdmin/;
+
+function walk(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) return walk(path);
+    return path.endsWith("page.tsx") ? [path] : [];
+  });
+}
+
+describe("audit admin page gate", () => {
+  const pages = walk(join(process.cwd(), ADMIN_ROOT));
+
+  it("scans every admin page (overview, auditors, requests, drilldown)", () => {
+    expect(pages.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("every admin page re-asserts the admin role before reading", () => {
+    const offenders = pages
+      .filter((file) => !GUARD_RE.test(readFileSync(file, "utf8")))
+      .map((file) => relative(process.cwd(), file));
+    expect(offenders).toEqual([]);
+  });
+
+  it("the guard itself runs the real session and permission check", () => {
+    const guard = readFileSync(
+      join(process.cwd(), ADMIN_ROOT, "require-admin.tsx"),
+      "utf8",
+    );
+    expect(guard).toContain("getAuthSession");
+    expect(guard).toContain("canAdministerAuditProgram");
+  });
+});


### PR DESCRIPTION
## Summary

The four `/audits/admin` pages relied on `app/(home)/audits/admin/layout.tsx` as their only role check. Next 16 can render a page segment without its ancestor layout when a client sends a crafted `next-router-state-tree` RSC header, so the layout gate alone is bypassable. Each admin page now re-asserts the audit-admin role via a shared `denyIfNotAuditAdmin()` guard before any read, and a static assertion pins that every admin `page.tsx` references it.

This ships ahead of the audit marketplace v1.1 work, which stacks on it.

## Test plan

- [ ] `yarn tsc --noEmit` clean
- [ ] `npx vitest run tests/unit/audits` green (adds `adminPageGuard.test.ts`)
- [ ] Preview deployment: an RSC request with a crafted `next-router-state-tree` header to each admin page, as a signed-out and as a non-admin session, returns AccessDenied and no whitelist/quote/requester data
- [ ] Signed-in admin: all four admin pages render unchanged
- [ ] Signed-out: `/audits/admin` still opens the login modal
