### PR TITLE
feat(audits): audit marketplace v1.1

### DIFF
--- a/app/(audit-portal)/audits/portal/firm/page.tsx
+++ b/app/(audit-portal)/audits/portal/firm/page.tsx
@@ -1,0 +1,22 @@
+import { redirect } from "next/navigation";
+import { getAuthSession } from "@/lib/auth/authSession";
+import { resolveAuditorByEmail } from "@/server/services/audits/auditors";
+import { getOwnFirm } from "@/server/services/audits/visibility";
+import { NotWhitelisted } from "@/components/audits/portal/NotWhitelisted";
+import { FirmDetails } from "@/components/audits/portal/FirmDetails";
+
+export default async function FirmDetailsPage() {
+  const session = await getAuthSession();
+  const email = session?.user?.email?.trim().toLowerCase();
+  if (!email) redirect("/audits/portal/sign-in");
+
+  const auditor = await resolveAuditorByEmail(email);
+  if (!auditor) return <NotWhitelisted email={email} />;
+
+  const firm = await getOwnFirm(auditor.id);
+  if (!firm) return <NotWhitelisted email={email} />;
+
+  return (
+    <FirmDetails firm={firm} isOwner={email === auditor.quote_email} readOnly={!auditor.active} />
+  );
+}

--- a/app/(audit-portal)/audits/portal/page.tsx
+++ b/app/(audit-portal)/audits/portal/page.tsx
@@ -16,5 +16,12 @@ export default async function AuditorInboxPage() {
   // Deactivated firms keep read-only access to their history (round-3 N-4).
   const items = await getAuditorInbox(auditor.id);
   // The signed-in address itself receives the notices (every approved address does).
-  return <PortalInbox items={items} notifyEmail={email} readOnly={!auditor.active} />;
+  return (
+    <PortalInbox
+      items={items}
+      notifyEmail={email}
+      readOnly={!auditor.active}
+      servicesEmpty={auditor.active && auditor.services.length === 0}
+    />
+  );
 }

--- a/app/(audit-portal)/audits/portal/sign-in/page.tsx
+++ b/app/(audit-portal)/audits/portal/sign-in/page.tsx
@@ -48,8 +48,8 @@ export default async function AuditorSignInPage({
               <span className="text-brand">One inbox.</span>
             </h1>
             <p className="mt-5 max-w-[46ch] text-base text-[#A2AFB2]">
-              Audit requests from Avalanche ecosystem projects fan out to every vetted firm at
-              once. Quote what you want to win.
+              Audit requests from Avalanche ecosystem projects fan out to vetted firms the moment
+              Ava Labs approves them. Quote what you want to win.
             </p>
             <p className="mt-8 font-mono text-[10px] uppercase tracking-[0.18em] text-[#7A8689]">
               Run by Ava Labs · free for builders and auditors

--- a/app/(home)/audits/[id]/page.tsx
+++ b/app/(home)/audits/[id]/page.tsx
@@ -33,6 +33,8 @@ export default async function AuditRequestPage({ params, searchParams }: AuditRe
           projectName={detail.project_name || "Your request"}
           submittedAt={detail.submitted_at}
           quoteDeadline={detail.quote_deadline}
+          chosenCount={detail.shortlist_firms.length}
+          whitelistCount={detail.whitelist_count}
         />
       ) : (
         <RequestDetailView detail={detail} userId={session.user.id} />

--- a/app/(home)/audits/admin/requests/[id]/page.tsx
+++ b/app/(home)/audits/admin/requests/[id]/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { prisma } from "@/prisma/prisma";
 import { getAdminRequestDetail } from "@/server/services/audits/visibility";
 import { StatusBadge } from "@/components/audits/shared/StatusBadge";
 import { MONO_LABEL, MONO_LABEL_SM } from "@/components/audits/shared/classes";
@@ -29,11 +28,10 @@ export default async function AuditAdminDrilldownPage({
   );
   const latestDecision = detail.subsidy_decisions[0] ?? null;
   // Pending requests have no delivery rows yet, so the panel counts the
-  // firms that WOULD be notified rather than the ones already notified.
+  // firms that WOULD be notified rather than the ones already notified. The
+  // projection's whitelist_count replaces the page's own auditor read (S-3).
   const activeAuditorCount =
-    detail.display_status === "pending_review"
-      ? await prisma.auditor.count({ where: { active: true } })
-      : 0;
+    detail.display_status === "pending_review" ? detail.whitelist_count : 0;
 
   return (
     <div className="mt-6">
@@ -97,7 +95,12 @@ export default async function AuditAdminDrilldownPage({
 
         <div>
           {detail.display_status === "pending_review" ? (
-            <ReviewDecision requestId={detail.id} fanoutTarget={activeAuditorCount} />
+            <ReviewDecision
+              requestId={detail.id}
+              fanoutTarget={activeAuditorCount}
+              shortlistFirms={detail.shortlist_firms}
+              whitelistCount={detail.whitelist_count}
+            />
           ) : accepted ? (
             <SubsidyWorksheet
               requestId={detail.id}

--- a/app/(home)/audits/firms/page.tsx
+++ b/app/(home)/audits/firms/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+import { createMetadata } from "@/utils/metadata";
+import { getPublicFirms } from "@/server/services/audits/visibility";
+import { FirmsList } from "@/components/audits/firms/FirmsList";
+
+export const dynamic = "force-dynamic";
+// revalidate = 60 is the lever if traffic ever matters (S-22).
+
+export const metadata: Metadata = createMetadata({
+  title: "Vetted firms",
+  description:
+    "The vetted security firms on the Ava Labs audit whitelist and the services each one offers. One request reaches all of them, or only the ones you choose.",
+  openGraph: {
+    url: "/audits/firms",
+    images: { url: "/api/og/audits", width: 1200, height: 630, alt: "Avalanche Security Audits" },
+  },
+  twitter: {
+    images: { url: "/api/og/audits", width: 1200, height: 630, alt: "Avalanche Security Audits" },
+  },
+});
+
+export default async function VettedFirmsPage() {
+  const firms = await getPublicFirms();
+  return (
+    <main className="container relative max-w-[1400px]">
+      <FirmsList firms={firms} />
+    </main>
+  );
+}

--- a/app/(home)/audits/layout.tsx
+++ b/app/(home)/audits/layout.tsx
@@ -4,7 +4,7 @@ import { createMetadata } from '@/utils/metadata';
 export const metadata: Metadata = createMetadata({
   title: 'Security Audits',
   description:
-    'Request audit quotes from every vetted security firm on the Ava Labs whitelist. Free, private, subsidized up to 75%.',
+    'Request audit quotes from the vetted security firms on the Ava Labs whitelist. Free, private, subsidized up to 75%.',
   openGraph: {
     url: '/audits',
     images: {

--- a/app/(home)/audits/new/page.tsx
+++ b/app/(home)/audits/new/page.tsx
@@ -1,5 +1,5 @@
 import { getAuthSession } from "@/lib/auth/authSession";
-import { getOwnerRequestDetail } from "@/server/services/audits/visibility";
+import { getOwnerRequestDetail, getPublicFirms } from "@/server/services/audits/visibility";
 import { AuthLoading } from "@/components/ui/auth-loading";
 import { AuditWizard } from "@/components/audits/wizard/WizardShell";
 import { draftToValues } from "@/components/audits/wizard/types";
@@ -28,12 +28,18 @@ export default async function NewAuditRequestPage({ searchParams }: NewAuditRequ
     }
   }
 
+  // Server-rendered into the wizard context once, so the picker shares one list
+  // for the wizard's lifetime with no refetch (spec 7.2.1). pending_ sessions
+  // receive it like any signed-in user.
+  const firms = await getPublicFirms();
+
   return (
     <main className="container relative max-w-[1400px] px-4 py-6 lg:py-10">
       <AuditWizard
         initialDraft={initialDraft}
         prefill={prefill}
         importProjectId={project ?? null}
+        firms={firms}
       />
     </main>
   );

--- a/app/(home)/audits/page.tsx
+++ b/app/(home)/audits/page.tsx
@@ -1,8 +1,7 @@
 import { getAuthSession } from "@/lib/auth/authSession";
 import { canAdministerAuditProgram } from "@/lib/auth/permissions";
-import { prisma } from "@/prisma/prisma";
 import { findAuditorByEmail } from "@/server/services/audits/auditors";
-import { getOwnerRequests } from "@/server/services/audits/visibility";
+import { countActiveFirms, getOwnerRequests } from "@/server/services/audits/visibility";
 import { AuditsLanding } from "@/components/audits/landing/AuditsLanding";
 import { FirstRun } from "@/components/audits/landing/FirstRun";
 import { MyRequestsList } from "@/components/audits/landing/MyRequestsList";
@@ -37,7 +36,7 @@ export default async function AuditsPage() {
 }
 
 async function SignedOut() {
-  const firmCount = await prisma.auditor.count({ where: { active: true } });
+  const firmCount = await countActiveFirms();
   return <AuditsLanding firmCount={firmCount} />;
 }
 
@@ -50,7 +49,15 @@ async function SignedIn({
   isAdmin: boolean;
   isAuditor: boolean;
 }) {
-  const requests = await getOwnerRequests(userId);
-  if (requests.length === 0) return <FirstRun isAdmin={isAdmin} isAuditor={isAuditor} />;
-  return <MyRequestsList requests={requests} isAdmin={isAdmin} isAuditor={isAuditor} />;
+  const [requests, firmCount] = await Promise.all([getOwnerRequests(userId), countActiveFirms()]);
+  if (requests.length === 0)
+    return <FirstRun isAdmin={isAdmin} isAuditor={isAuditor} firmCount={firmCount} />;
+  return (
+    <MyRequestsList
+      requests={requests}
+      isAdmin={isAdmin}
+      isAuditor={isAuditor}
+      firmCount={firmCount}
+    />
+  );
 }

--- a/app/api/audits/admin/auditors/[id]/members/[memberId]/route.ts
+++ b/app/api/audits/admin/auditors/[id]/members/[memberId]/route.ts
@@ -18,7 +18,11 @@ export async function DELETE(
   const { id, memberId } = await context.params;
 
   try {
-    const result = await removeAuditorMember(id, memberId, { id: admin.userId, name: admin.name });
+    const result = await removeAuditorMember(id, memberId, {
+      type: "admin",
+      id: admin.userId,
+      name: admin.name,
+    });
     if (!result.success) {
       return NextResponse.json(
         { success: false, message: "Email not found on this firm." },

--- a/app/api/audits/admin/auditors/[id]/members/route.ts
+++ b/app/api/audits/admin/auditors/[id]/members/route.ts
@@ -32,7 +32,11 @@ export async function POST(request: NextRequest, context: RouteParams<{ id: stri
   }
 
   try {
-    const result = await addAuditorMember(id, parsed.data, { id: admin.userId, name: admin.name });
+    const result = await addAuditorMember(id, parsed.data, {
+      type: "admin",
+      id: admin.userId,
+      name: admin.name,
+    });
     if (!result.success && result.code === "not_found") {
       return NextResponse.json({ success: false, message: "Firm not found." }, { status: 404 });
     }

--- a/app/api/audits/admin/auditors/[id]/route.ts
+++ b/app/api/audits/admin/auditors/[id]/route.ts
@@ -30,7 +30,11 @@ export async function PATCH(request: NextRequest, context: RouteParams<{ id: str
   }
 
   try {
-    const result = await updateAuditor(id, parsed.data, { id: admin.userId, name: admin.name });
+    const result = await updateAuditor(id, parsed.data, {
+      type: "admin",
+      id: admin.userId,
+      name: admin.name,
+    });
     if (!result.success) {
       return NextResponse.json({ success: false, message: "Firm not found." }, { status: 404 });
     }

--- a/app/api/audits/portal/me/members/[memberId]/route.ts
+++ b/app/api/audits/portal/me/members/[memberId]/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import type { RouteParams } from "@/lib/protectedRoute";
+import { withAuditor, isFirmOwner } from "@/app/api/audits/portal/utils";
+import { applyRateLimit, DAY_MS } from "@/app/api/audits/utils";
+import { removeAuditorMember } from "@/server/services/audits/members";
+
+/** Revoke a teammate's access, from the portal. Owner-gated (S-16). */
+export const DELETE = withAuditor<RouteParams<{ memberId: string }>>(
+  async (_request, context, auditor, actorEmail) => {
+    const limited = applyRateLimit("firm-member-remove", auditor.quote_email, {
+      windowMs: DAY_MS,
+      maxRequests: 50,
+    });
+    if (limited) return limited;
+    if (!isFirmOwner(auditor, actorEmail)) {
+      return NextResponse.json(
+        { success: false, message: "Only the firm's quote email can manage teammates." },
+        { status: 403 },
+      );
+    }
+    const { memberId } = await context.params;
+
+    try {
+      const result = await removeAuditorMember(auditor.id, memberId, {
+        type: "auditor",
+        id: auditor.id,
+        email: actorEmail,
+      });
+      if (!result.success) {
+        return NextResponse.json(
+          { success: false, message: "Email not found on this firm." },
+          { status: 404 },
+        );
+      }
+      return NextResponse.json({ success: true });
+    } catch (err) {
+      console.error("[Audits] portal teammate remove failed:", err);
+      return NextResponse.json(
+        { success: false, message: "We couldn't remove this email right now." },
+        { status: 500 },
+      );
+    }
+  },
+);

--- a/app/api/audits/portal/me/members/route.ts
+++ b/app/api/audits/portal/me/members/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { withAuditor, isFirmOwner } from "@/app/api/audits/portal/utils";
+import { applyRateLimit, DAY_MS } from "@/app/api/audits/utils";
+import { AUDITOR_MEMBER_LIMIT } from "@/lib/audits/constants";
+import { auditorMemberCreateSchema } from "@/types/audits";
+import { addAuditorMember } from "@/server/services/audits/members";
+
+/**
+ * Approve one more sign-in address for the firm, from the portal. Owner-gated:
+ * only the quote-email identity manages the team (S-16). The service sends the
+ * S-2 notice to the quote email and stores added_by null for a portal add.
+ */
+export const POST = withAuditor(async (request, _context, auditor, actorEmail) => {
+  if (request.headers.get("content-type")?.split(";")[0].trim() !== "application/json") {
+    return NextResponse.json({ success: false, message: "Send JSON." }, { status: 415 });
+  }
+  const limited = applyRateLimit("firm-member-add", auditor.quote_email, {
+    windowMs: DAY_MS,
+    maxRequests: 10,
+  });
+  if (limited) return limited;
+  if (!isFirmOwner(auditor, actorEmail)) {
+    return NextResponse.json(
+      { success: false, message: "Only the firm's quote email can manage teammates." },
+      { status: 403 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, message: "Invalid body" }, { status: 400 });
+  }
+
+  const parsed = auditorMemberCreateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, message: "Validation failed", errors: parsed.error.flatten().fieldErrors },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await addAuditorMember(auditor.id, parsed.data, {
+      type: "auditor",
+      id: auditor.id,
+      email: actorEmail,
+    });
+    if (!result.success && result.code === "not_found") {
+      return NextResponse.json({ success: false, message: "Firm not found." }, { status: 404 });
+    }
+    if (!result.success && result.code === "limit_reached") {
+      return NextResponse.json(
+        { success: false, message: `A firm can have up to ${AUDITOR_MEMBER_LIMIT} approved emails.` },
+        { status: 409 },
+      );
+    }
+    if (!result.success) {
+      return NextResponse.json(
+        { success: false, message: "This email can't be added to your firm." },
+        { status: 409 },
+      );
+    }
+    const { id: memberId, email, invited_at, first_login_at } = result.member;
+    return NextResponse.json(
+      {
+        success: true,
+        member: { id: memberId, email, invited_at, first_login_at },
+        inviteSent: result.inviteSent,
+      },
+      { status: 201 },
+    );
+  } catch (err) {
+    console.error("[Audits] portal teammate add failed:", err);
+    return NextResponse.json(
+      { success: false, message: "We couldn't add this email right now." },
+      { status: 500 },
+    );
+  }
+});

--- a/app/api/audits/portal/me/route.ts
+++ b/app/api/audits/portal/me/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
 import { withAuditor } from "@/app/api/audits/portal/utils";
+import { applyRateLimit, DAY_MS } from "@/app/api/audits/utils";
+import { auditorSelfUpdateSchema } from "@/types/audits";
+import { updateAuditor } from "@/server/services/audits/auditors";
 
 export const GET = withAuditor(
   async (_request, _context, auditor) => {
@@ -14,3 +17,51 @@ export const GET = withAuditor(
   },
   { allowInactive: true },
 );
+
+/**
+ * A firm edits its own services and website (any active identity). No
+ * allowInactive, so a deactivated firm's write fails 403. The response is
+ * built from the ACCEPTED fields, never result.auditor, which carries
+ * attio_ref (S-5).
+ */
+export const PATCH = withAuditor(async (request, _context, auditor, actorEmail) => {
+  if (request.headers.get("content-type")?.split(";")[0].trim() !== "application/json") {
+    return NextResponse.json({ success: false, message: "Send JSON." }, { status: 415 });
+  }
+  const limited = applyRateLimit("firm-update", auditor.quote_email, {
+    windowMs: DAY_MS,
+    maxRequests: 50,
+  });
+  if (limited) return limited;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, message: "Invalid body" }, { status: 400 });
+  }
+
+  const parsed = auditorSelfUpdateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, message: "Validation failed", errors: parsed.error.flatten().fieldErrors },
+      { status: 400 },
+    );
+  }
+
+  const result = await updateAuditor(auditor.id, parsed.data, {
+    type: "auditor",
+    id: auditor.id,
+    email: actorEmail,
+  });
+  if (!result.success) {
+    return NextResponse.json({ success: false, message: "Firm not found." }, { status: 404 });
+  }
+  return NextResponse.json({
+    success: true,
+    auditor: {
+      ...(parsed.data.services !== undefined ? { services: parsed.data.services } : {}),
+      ...(parsed.data.website !== undefined ? { website: parsed.data.website } : {}),
+    },
+  });
+});

--- a/app/api/audits/portal/utils.ts
+++ b/app/api/audits/portal/utils.ts
@@ -47,3 +47,12 @@ export function withAuditor<TContext = unknown>(
     return handler(request, context, auditor, email);
   };
 }
+
+/**
+ * The signed-in address is the firm's quote-email identity, the only identity
+ * allowed to manage teammates. Both sides are lowercase already: withAuditor
+ * lowercases the session email, the column is stored lowercase (S-16).
+ */
+export function isFirmOwner(auditor: Pick<Auditor, "quote_email">, actorEmail: string): boolean {
+  return actorEmail === auditor.quote_email;
+}

--- a/app/api/og/audits/route.tsx
+++ b/app/api/og/audits/route.tsx
@@ -11,7 +11,7 @@ export async function GET(): Promise<ImageResponse> {
   return createOGResponse({
     title: 'Security Audits',
     description:
-      'Request audit quotes from every vetted security firm on the Ava Labs whitelist. Free, private, subsidized up to 75%.',
+      'Request audit quotes from the vetted security firms on the Ava Labs whitelist. Free, private, subsidized up to 75%.',
     path: 'audits',
     fonts,
   });

--- a/components/audits/admin/ActivityTrail.tsx
+++ b/components/audits/admin/ActivityTrail.tsx
@@ -51,8 +51,20 @@ function eventLine(event: TrailEvent, fanoutFirms: string[]): string {
       ]
         .filter(Boolean)
         .join(" · ");
-    case "fanout_created":
-      return `Fanned out to ${typeof meta.auditor_count === "number" ? meta.auditor_count : "all"} whitelisted firms${fanoutFirmsSuffix(fanoutFirms)}`;
+    case "fanout_created": {
+      const suffix = fanoutFirmsSuffix(fanoutFirms);
+      const auditorCount = typeof meta.auditor_count === "number" ? meta.auditor_count : null;
+      const whitelist = typeof meta.whitelist_count === "number" ? meta.whitelist_count : null;
+      const shortlist = typeof meta.shortlist_count === "number" ? meta.shortlist_count : 0;
+      // Pre-v1.1 events carry no whitelist_count: keep today's "all" line.
+      if (whitelist === null) {
+        return `Fanned out to ${auditorCount ?? "all"} whitelisted firms${suffix}`;
+      }
+      if (shortlist > 0) {
+        return `Fanned out to ${auditorCount} of ${whitelist} whitelisted firms · project chose ${shortlist}${suffix}`;
+      }
+      return `Fanned out to ${auditorCount} whitelisted firms${suffix}`;
+    }
     case "quote_submitted":
       return ["Quote submitted", firm, actor ? `by ${actor}` : null, price]
         .filter(Boolean)
@@ -81,8 +93,16 @@ function eventLine(event: TrailEvent, fanoutFirms: string[]): string {
       return ["Subsidy declined", admin ? `by ${admin}` : null].filter(Boolean).join(" · ");
     case "request_withdrawn":
       return "Request withdrawn by the project";
-    case "request_reopened":
-      return "Request reopened for one more round";
+    case "request_reopened": {
+      const auditorCount = typeof meta.auditor_count === "number" ? meta.auditor_count : null;
+      const whitelist = typeof meta.whitelist_count === "number" ? meta.whitelist_count : null;
+      const shortlist = typeof meta.shortlist_count === "number" ? meta.shortlist_count : 0;
+      // Pre-v1.1 events carry no whitelist_count: keep today's line.
+      if (whitelist === null) return "Request reopened for one more round";
+      return shortlist > 0
+        ? `Request reopened for one more round · ${auditorCount} of ${whitelist} whitelisted firms notified again · project chose ${shortlist}`
+        : `Request reopened for one more round · ${auditorCount} whitelisted firms notified again`;
+    }
     default:
       return event.action.replaceAll("_", " ");
   }

--- a/components/audits/admin/AuditorDetailPanel.tsx
+++ b/components/audits/admin/AuditorDetailPanel.tsx
@@ -28,15 +28,9 @@ import { AUDIT_SERVICES, AUDITOR_MEMBER_LIMIT } from "@/lib/audits/constants";
 import type { AdminAuditorMember, AdminAuditorRow } from "@/server/services/audits/visibility";
 import { ChipGroup, asChips } from "@/components/audits/shared/ChipGroup";
 import { AUDITS_DIALOG, MONO_LABEL_META, MONO_LABEL_SM } from "@/components/audits/shared/classes";
-import { formatIsoDate } from "@/components/audits/shared/format";
-
-const initialsOf = (name: string) =>
-  name
-    .split(/\s+/)
-    .map((word) => word[0])
-    .join("")
-    .slice(0, 2)
-    .toUpperCase();
+import { formatIsoDate, monogramOf } from "@/components/audits/shared/format";
+import { isAllowedLogoSrc } from "@/lib/audits/logoSrc";
+import { LogoControl } from "@/components/audits/admin/LogoControl";
 
 export type PanelState = { mode: "add" } | { mode: "edit"; auditor: AdminAuditorRow } | null;
 
@@ -48,7 +42,8 @@ interface AuditorDetailPanelProps {
 /**
  * The auditor detail panel (design 2b): row click opens edit mode, the Add
  * auditor button opens the same panel in add mode. Services use the wizard's
- * category list and are informational only; they never gate fan-out.
+ * category list; they never gate fan-out on the server (only the wizard's
+ * quick-pick reads them, to help a project shortlist firms).
  */
 export function AuditorDetailPanel({ state, onClose }: AuditorDetailPanelProps) {
   const router = useRouter();
@@ -62,6 +57,8 @@ export function AuditorDetailPanel({ state, onClose }: AuditorDetailPanelProps) 
   const [members, setMembers] = useState<AdminAuditorMember[]>([]);
   const [memberEmail, setMemberEmail] = useState("");
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
+  const [website, setWebsite] = useState("");
+  const [logoUrl, setLogoUrl] = useState<string | null>(null);
 
   useEffect(() => {
     setFirmName(auditor?.firm_name ?? "");
@@ -70,6 +67,8 @@ export function AuditorDetailPanel({ state, onClose }: AuditorDetailPanelProps) 
     setMembers(auditor?.members ?? []);
     setMemberEmail("");
     setConfirmRemoveId(null);
+    setWebsite(auditor?.website ?? "");
+    setLogoUrl(auditor?.logo_url ?? null);
   }, [auditor, state?.mode]);
 
   const finish = (message: string) => {
@@ -116,7 +115,7 @@ export function AuditorDetailPanel({ state, onClose }: AuditorDetailPanelProps) 
       {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ firm_name: firmName, services }),
+        body: JSON.stringify({ firm_name: firmName, services, website, logo_url: logoUrl }),
       },
       "Saved.",
     );
@@ -209,12 +208,22 @@ export function AuditorDetailPanel({ state, onClose }: AuditorDetailPanelProps) 
             (board 2b; the IcmMessageSheet anatomy). */}
         <SheetHeader className="border-b border-zinc-200 px-4 py-3.5 dark:border-white/10">
           <div className="flex items-center gap-3 pr-8">
-            <span
-              aria-hidden
-              className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-lg bg-zinc-100 font-mono text-[11px] font-bold text-zinc-600 dark:bg-white/10 dark:text-zinc-300"
-            >
-              {auditor ? initialsOf(auditor.firm_name) : "+"}
-            </span>
+            {auditor && logoUrl && isAllowedLogoSrc(logoUrl) ? (
+              <span
+                aria-hidden
+                className="flex h-[30px] w-[30px] shrink-0 items-center justify-center overflow-hidden rounded-lg border border-zinc-200 bg-white dark:border-white/10"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={logoUrl} alt="" className="h-5 w-5 object-contain" />
+              </span>
+            ) : (
+              <span
+                aria-hidden
+                className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-lg bg-zinc-100 font-mono text-[11px] font-bold text-zinc-600 dark:bg-white/10 dark:text-zinc-300"
+              >
+                {auditor ? monogramOf(auditor.firm_name) : "+"}
+              </span>
+            )}
             <div className="min-w-0 flex-1">
               <SheetTitle className="text-[15px]">
                 {auditor ? auditor.firm_name : "Add auditor"}
@@ -298,7 +307,7 @@ export function AuditorDetailPanel({ state, onClose }: AuditorDetailPanelProps) 
               Services{" "}
               <span className="font-normal text-zinc-500 dark:text-zinc-400">
                 {auditor
-                  ? "· shown on the whitelist table and on quotes"
+                  ? "· shown on the whitelist table, on quotes and on the vetted firms page"
                   : "· optional now, editable anytime"}
               </span>
             </p>
@@ -311,10 +320,38 @@ export function AuditorDetailPanel({ state, onClose }: AuditorDetailPanelProps) 
               aria-label="Services"
             />
             <p className="text-xs text-zinc-500 dark:text-zinc-400">
-              Same category list the project wizard uses. Informational only: every active firm
-              still receives every fan-out.
+              Same category list the project wizard uses. Tags never limit fan-out by themselves;
+              projects may use them to pick which firms receive a request.
             </p>
           </div>
+
+          {auditor ? (
+            <div className="space-y-3">
+              <div>
+                <p className="text-sm font-medium">Public listing</p>
+                <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                  Shown on the vetted firms page
+                </p>
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium" htmlFor="auditor-website">
+                  Website
+                </label>
+                <Input
+                  id="auditor-website"
+                  value={website}
+                  onChange={(event) => setWebsite(event.target.value)}
+                  placeholder="firm.example"
+                  inputMode="url"
+                  className="h-11 font-mono text-[13px] md:h-10"
+                />
+              </div>
+              <LogoControl value={logoUrl} onChange={setLogoUrl} firmName={firmName} />
+              <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                PNG or JPG, square, under 2MB.
+              </p>
+            </div>
+          ) : null}
 
           {auditor ? (
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded-[10px] border border-zinc-200 bg-zinc-50 px-3.5 py-3 text-sm dark:border-white/10 dark:bg-white/[0.02]">
@@ -345,7 +382,9 @@ export function AuditorDetailPanel({ state, onClose }: AuditorDetailPanelProps) 
           ) : null}
 
           {/* Team emails (2026-09-02): approved teammate addresses that sign in
-              to this firm's portal and receive every notice. Admin-managed. */}
+              to this firm's portal and receive every notice. Admins manage them
+              here; the firm's quote email manages them from the portal's firm
+              details page. */}
           {auditor ? (
             <div className="space-y-2">
               <p className="text-sm font-medium">
@@ -427,7 +466,7 @@ export function AuditorDetailPanel({ state, onClose }: AuditorDetailPanelProps) 
                   [
                     ["01", "OTP invite goes to the quote email", "On add"],
                     ["02", "First sign-in stamps the firm as active", "First login"],
-                    ["03", "Every new request fans out to them", "From now on"],
+                    ["03", "New requests fan out to them", "From now on"],
                   ] as const
                 ).map(([num, line, when], index) => (
                   <div
@@ -503,7 +542,7 @@ export function AuditorDetailPanel({ state, onClose }: AuditorDetailPanelProps) 
               </Button>
               <p className="text-xs text-zinc-500 dark:text-zinc-400">
                 Sends the sign-in link to the quote email. The firm appears as Invited until first
-                login and joins every fan-out from the moment it is added.
+                login and can receive requests from the moment it is added.
               </p>
             </div>
           )}

--- a/components/audits/admin/LogoControl.tsx
+++ b/components/audits/admin/LogoControl.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { isAllowedLogoSrc } from "@/lib/audits/logoSrc";
+import { monogramOf } from "@/components/audits/shared/format";
+
+const MAX = 2 * 1024 * 1024;
+const OK_TYPES = ["image/png", "image/jpeg"];
+
+/**
+ * Admin logo upload for the whitelist sheet. Reuses /api/file's mechanics (not
+ * the profile LogoUploader's classes). Client pre-check is a friendliness
+ * layer; the server enforces the PNG/JPEG allowlist. The saved URL is guarded
+ * by isAllowedLogoSrc on write and again at render, failing closed to the
+ * monogram.
+ */
+export function LogoControl({
+  value,
+  onChange,
+  firmName,
+}: {
+  value: string | null;
+  onChange: (url: string | null) => void;
+  firmName: string;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const showLogo = value ? isAllowedLogoSrc(value) : false;
+
+  async function handleFile(file: File) {
+    if (!OK_TYPES.includes(file.type) || file.size > MAX) {
+      toast.error("Use a PNG or JPG under 2MB.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const res = await fetch("/api/file", { method: "POST", body: form });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok || !body.url) {
+        toast.error(body.error ?? "Upload failed.");
+        return;
+      }
+      onChange(body.url as string);
+      toast.success("Logo uploaded.");
+    } finally {
+      setBusy(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      {showLogo ? (
+        <span
+          aria-hidden
+          className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-zinc-200 bg-white dark:border-white/10"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={value as string} alt="" className="h-[26px] w-[26px] object-contain" />
+        </span>
+      ) : (
+        <span
+          aria-hidden
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-zinc-100 font-mono text-[13px] font-semibold text-zinc-600 dark:bg-white/10 dark:text-zinc-300"
+        >
+          {monogramOf(firmName)}
+        </span>
+      )}
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-10"
+          disabled={busy}
+          onClick={() => inputRef.current?.click()}
+        >
+          {busy ? <Loader2 aria-hidden className="mr-2 h-4 w-4 animate-spin" /> : null}
+          {value ? "Replace" : "Choose file"}
+        </Button>
+        {value ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-10"
+            disabled={busy}
+            onClick={() => {
+              onChange(null);
+              toast.success("Logo removed.");
+            }}
+          >
+            Remove
+          </Button>
+        ) : null}
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".png,.jpg,.jpeg"
+        className="sr-only"
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) void handleFile(f);
+        }}
+      />
+    </div>
+  );
+}

--- a/components/audits/admin/ReviewDecision.tsx
+++ b/components/audits/admin/ReviewDecision.tsx
@@ -16,12 +16,20 @@ import { CARD, MONO_LABEL_SM } from "@/components/audits/shared/classes";
 export function ReviewDecision({
   requestId,
   fanoutTarget,
+  shortlistFirms = [],
+  whitelistCount = 0,
 }: {
   requestId: string;
-  /** Active firms that will be notified the moment this is approved. */
+  /** Active firms notified when there is no shortlist (the send-to-all case). */
   fanoutTarget: number;
+  /** Every stored chosen firm that resolves, carrying active (spec 7.2.5). */
+  shortlistFirms?: { id: string; firm_name: string; active: boolean }[];
+  whitelistCount?: number;
 }) {
   const router = useRouter();
+  const chose = shortlistFirms.length;
+  const activeChosen = shortlistFirms.filter((firm) => firm.active).length;
+  const hasShortlist = chose > 0;
   const [busy, setBusy] = useState<"approve" | "reject" | null>(null);
   const [rejecting, setRejecting] = useState(false);
   const [reason, setReason] = useState("");
@@ -51,7 +59,9 @@ export function ReviewDecision({
         toast.success(
           count > 0
             ? `Approved · notified ${count} firm${count === 1 ? "" : "s"}.`
-            : "Approved. No active firms on the whitelist, so nobody was notified.",
+            : hasShortlist
+              ? "Approved. None of the firms this project chose is still active, so nobody was notified."
+              : "Approved. No active firms on the whitelist, so nobody was notified.",
         );
       } else {
         toast.success("Request rejected. Nothing was sent to any firm.");
@@ -73,10 +83,21 @@ export function ReviewDecision({
         until you approve.
       </h3>
       <p className="mt-2.5 text-sm leading-relaxed text-zinc-600 dark:text-[#A2AFB2]">
-        {fanoutTarget > 0
-          ? `Approving notifies ${fanoutTarget} active firm${fanoutTarget === 1 ? "" : "s"} and starts the quote window from now.`
-          : "There are no active firms on the whitelist, so approving opens the request without notifying anyone."}
+        {hasShortlist
+          ? activeChosen > 0
+            ? `Approving notifies ${activeChosen} of the ${chose} firms this project chose and starts the quote window from now · ${whitelistCount} active on the whitelist.`
+            : `None of the ${chose} firms this project chose is still active. Approving opens the request without notifying anyone.`
+          : fanoutTarget > 0
+            ? `Approving notifies ${fanoutTarget} active firm${fanoutTarget === 1 ? "" : "s"} and starts the quote window from now.`
+            : "There are no active firms on the whitelist, so approving opens the request without notifying anyone."}
       </p>
+      {hasShortlist ? (
+        <p className="mt-1.5 text-xs leading-relaxed text-zinc-500 dark:text-zinc-400">
+          {shortlistFirms
+            .map((firm) => `${firm.firm_name}${firm.active ? "" : " (deactivated)"}`)
+            .join(" · ")}
+        </p>
+      ) : null}
 
       {rejecting ? (
         <div className="mt-4">

--- a/components/audits/detail/CollectingBanner.tsx
+++ b/components/audits/detail/CollectingBanner.tsx
@@ -6,6 +6,7 @@ import { formatIsoDate } from "@/components/audits/shared/format";
 
 /** The collecting-state banner (design 3b): wash, red clock, honest counts. */
 export function CollectingBanner({ detail }: { detail: OwnerRequestDetail }) {
+  const narrowed = detail.shortlist_auditor_ids.length > 0;
   return (
     <div className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-white/10 dark:bg-white/[0.03]">
       <Clock aria-hidden className="h-4 w-4 shrink-0 text-brand dark:text-brand-soft" />
@@ -29,8 +30,10 @@ export function CollectingBanner({ detail }: { detail: OwnerRequestDetail }) {
           </>
         ) : (
           <span className="text-zinc-500 dark:text-zinc-400">
-            sent to <span className="font-medium">0 firms</span> · the whitelist was empty at
-            submission
+            sent to <span className="font-medium">0 firms</span> ·{" "}
+            {narrowed
+              ? "none of the firms you chose was still listed at approval"
+              : "the whitelist was empty at submission"}
           </span>
         )}
       </p>
@@ -38,7 +41,9 @@ export function CollectingBanner({ detail }: { detail: OwnerRequestDetail }) {
       <p className={MONO_LABEL_SM}>
         {detail.fanout_count > 0
           ? "Most quotes land in the final days"
-          : "Reopen after expiry re-notifies every active firm"}
+          : narrowed
+            ? "Reopen after expiry re-notifies the firms you chose"
+            : "Reopen after expiry re-notifies every active firm"}
       </p>
     </div>
   );

--- a/components/audits/detail/RequestDetailView.tsx
+++ b/components/audits/detail/RequestDetailView.tsx
@@ -296,7 +296,11 @@ export function RequestDetailView({
         {status === "expired" ? (
           <StateCard
             title="The quote window closed without quotes."
-            body="This request can be reopened for one more round; every active firm is notified again."
+            body={
+              detail.shortlist_auditor_ids.length > 0
+                ? "This request can be reopened for one more round; the firms you chose are notified again."
+                : "This request can be reopened for one more round; every active firm is notified again."
+            }
             action={<ReopenButton requestId={detail.id} />}
           />
         ) : null}

--- a/components/audits/detail/RequestSummary.tsx
+++ b/components/audits/detail/RequestSummary.tsx
@@ -30,15 +30,37 @@ export function RequestSummary({ detail }: { detail: OwnerRequestDetail }) {
       : []),
   ].filter(Boolean);
 
+  // narrowed = the project chose a subset (spec 7.2.5); the Firms row is
+  // pre-approval only, after which the delivery rows speak.
+  const narrowed = detail.shortlist_auditor_ids.length > 0;
+  const preApproval = detail.status === "pending_review" || detail.status === "rejected";
+
   return (
     <div className={`${CARD} space-y-4 p-5`}>
       {/* Before approval no firm has received anything, and claiming
           otherwise is the one line that makes the gate look broken. */}
       <p className={MONO_LABEL_SM}>
-        {detail.status === "pending_review" || detail.status === "rejected"
+        {preApproval
           ? "Your request · what firms will receive"
-          : "Your request · what every firm received"}
+          : narrowed
+            ? "Your request · what the firms you chose received"
+            : "Your request · what every firm received"}
       </p>
+      {preApproval && narrowed ? (
+        <SummaryRow label="Firms">
+          {detail.shortlist_firms.length > 0 ? (
+            <>
+              {detail.shortlist_firms.map((firm) => firm.firm_name).join(" · ")}
+              <span className="text-zinc-500 dark:text-zinc-400">
+                {" "}
+                · {detail.shortlist_firms.length} of {detail.whitelist_count} whitelisted firms
+              </span>
+            </>
+          ) : (
+            "None of the firms you chose is still listed."
+          )}
+        </SummaryRow>
+      ) : null}
       {detail.description ? <SummaryRow label="Project">{detail.description}</SummaryRow> : null}
       {detail.scope ? (
         <SummaryRow label="Scope">

--- a/components/audits/detail/SubmissionReceipt.tsx
+++ b/components/audits/detail/SubmissionReceipt.tsx
@@ -8,6 +8,10 @@ interface SubmissionReceiptProps {
   projectName: string;
   submittedAt: Date | null;
   quoteDeadline: Date | null;
+  /** Resolved count of the firms the project chose, and the active whitelist
+      size; narrowed only when a real subset was chosen (spec 7.2.5). */
+  chosenCount?: number;
+  whitelistCount?: number;
 }
 
 const shortDate = (date: Date) =>
@@ -23,7 +27,10 @@ export function SubmissionReceipt({
   projectName,
   submittedAt,
   quoteDeadline,
+  chosenCount = 0,
+  whitelistCount = 0,
 }: SubmissionReceiptProps) {
+  const narrowed = chosenCount > 0 && chosenCount < whitelistCount;
   // Nothing has been emailed at this point: the approval gate means the
   // program team sees the request before any firm does.
   const timeline = [
@@ -33,7 +40,9 @@ export function SubmissionReceipt({
     },
     {
       when: "NEXT",
-      what: "Once approved, every whitelisted firm is notified and quotes appear in My requests as they arrive.",
+      what: narrowed
+        ? `Once approved, the ${chosenCount} firms you chose are notified and quotes appear in My requests as they arrive.`
+        : "Once approved, every whitelisted firm is notified and quotes appear in My requests as they arrive.",
     },
     {
       when: quoteDeadline ? shortDate(new Date(quoteDeadline)) : "THEN",
@@ -55,8 +64,9 @@ export function SubmissionReceipt({
           </p>
           <h1 className="v2-display relative mt-2 text-[26px] text-white">Request submitted.</h1>
           <p className="relative mt-2 max-w-[56ch] text-[13px] leading-relaxed text-[#A2AFB2]">
-            {projectName} is queued for review. Every whitelisted firm is notified the moment the
-            program team approves it, and nothing is sent before that.
+            {narrowed
+              ? `${projectName} is queued for review. The ${chosenCount} firms you chose are notified the moment the program team approves it, and nothing is sent before that.`
+              : `${projectName} is queued for review. Every whitelisted firm is notified the moment the program team approves it, and nothing is sent before that.`}
           </p>
         </div>
 

--- a/components/audits/firms/FirmsList.tsx
+++ b/components/audits/firms/FirmsList.tsx
@@ -1,0 +1,113 @@
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
+import type { PublicFirm } from "@/server/services/audits/visibility";
+import { MONO_LABEL } from "@/components/audits/shared/classes";
+import { hostOf, monogramOf, truncate } from "@/components/audits/shared/format";
+import { isAllowedLogoSrc } from "@/lib/audits/logoSrc";
+
+const PILL =
+  "inline-flex items-center whitespace-nowrap rounded-full border border-zinc-200 px-2.5 py-0.5 text-xs font-medium text-zinc-600 dark:border-white/15 dark:text-zinc-300";
+
+function FirmRow({ firm }: { firm: PublicFirm }) {
+  const host = firm.website ? hostOf(firm.website) : "";
+  const showLogo = firm.logo_url ? isAllowedLogoSrc(firm.logo_url) : false;
+  return (
+    <div className="flex items-start gap-4 border-b border-zinc-200 px-5 py-4 transition-colors last:border-b-0 hover:bg-zinc-50 dark:border-white/10 dark:hover:bg-white/[0.03]">
+      {showLogo ? (
+        <span
+          aria-hidden
+          className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-zinc-200 bg-white dark:border-white/10"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={firm.logo_url as string} alt="" className="h-[26px] w-[26px] object-contain" />
+        </span>
+      ) : (
+        <span
+          aria-hidden
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-zinc-100 font-mono text-[13px] font-semibold tracking-[0.04em] text-zinc-600 dark:bg-white/10 dark:text-zinc-300"
+        >
+          {monogramOf(firm.firm_name)}
+        </span>
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="text-[15px] font-semibold leading-snug">{firm.firm_name}</p>
+        {firm.services.length > 0 ? (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {firm.services.map((service) => (
+              <span key={service} className={PILL}>
+                {service}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        {host ? (
+          <a
+            href={firm.website as string}
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+            className="mt-2 inline-flex min-h-[44px] items-center gap-1 font-mono text-xs text-zinc-500 hover:text-zinc-900 hover:underline hover:underline-offset-2 md:mt-0 md:min-h-0 md:justify-end dark:text-zinc-400 dark:hover:text-zinc-100"
+          >
+            {truncate(host, 300)}
+            <ArrowUpRight aria-hidden className="h-[13px] w-[13px]" />
+          </a>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function FirmsList({ firms }: { firms: PublicFirm[] }) {
+  const listed = firms.filter((f) => f.services.length > 0).length;
+  return (
+    <div className="relative mx-auto max-w-4xl px-4 py-12 sm:py-16">
+      <p className={MONO_LABEL}>
+        <Link href="/audits" className="hover:text-zinc-800 dark:hover:text-zinc-200">
+          Security audits
+        </Link>
+      </p>
+      <p className="mt-6 font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500 dark:text-zinc-400">
+        Ava Labs audit program · the whitelist
+      </p>
+      <h1 className="v2-display mt-4 text-5xl text-zinc-950 dark:text-zinc-50 sm:text-6xl">
+        {firms.length} vetted firms<span className="text-brand">.</span>
+      </h1>
+      <p className="mt-4 max-w-2xl text-lg text-zinc-600 dark:text-[#A2AFB2]">
+        Every firm below is on the Ava Labs audit whitelist. One request reaches all of them, or
+        only the ones you choose.
+      </p>
+      <div className="mt-6">
+        <Link
+          href="/audits/new"
+          className="audits-sweep inline-flex h-12 items-center rounded-lg bg-brand px-6 text-sm font-semibold text-white transition-colors"
+        >
+          Request quotes
+        </Link>
+      </div>
+
+      {firms.length === 0 ? (
+        <div className="mt-12 rounded-xl border border-zinc-200 px-5 py-10 text-center dark:border-white/10">
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">No firms are listed right now.</p>
+        </div>
+      ) : (
+        <>
+          <div className="mt-12 rounded-xl border border-zinc-200 dark:border-white/10">
+            <div className="flex items-center justify-between gap-3 border-b border-zinc-200 px-5 py-3.5 dark:border-white/10">
+              <p className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400">
+                Whitelisted firms · A to Z
+              </p>
+              <p className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400">
+                {listed > 0 ? `${listed} of ${firms.length} list their services` : "services not listed yet"}
+              </p>
+            </div>
+            {firms.map((firm) => (
+              <FirmRow key={firm.id} firm={firm} />
+            ))}
+          </div>
+          <p className="mt-3 font-mono text-[10.5px] uppercase tracking-[0.1em] text-zinc-400 dark:text-zinc-500">
+            Firms join the whitelist after Ava Labs&apos; security review · each firm lists its own services · firms that leave the program drop off this page
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/audits/landing/AuditsLanding.tsx
+++ b/components/audits/landing/AuditsLanding.tsx
@@ -12,7 +12,7 @@ const HOW_IT_WORKS = [
   {
     step: "02",
     title: "Quotes come to you",
-    body: "Every whitelisted firm is notified; quotes land within the 10-day window.",
+    body: "Every whitelisted firm, or just the ones you choose, is notified; quotes land within the 10-day window.",
   },
   {
     step: "03",
@@ -56,8 +56,8 @@ export function AuditsLanding({ firmCount }: { firmCount: number }) {
         <span className="text-brand">.</span>
       </h1>
       <p className="mt-4 max-w-2xl text-lg text-zinc-600 dark:text-[#A2AFB2]">
-        Describe your scope once. Every security firm on the Ava Labs whitelist quotes it,
-        privately. You compare, pick one, and the program can pay up to 75%.
+        Describe your scope once. Every security firm on the Ava Labs whitelist, or just the ones
+        you choose, quotes it privately. You compare, pick one, and the program can pay up to 75%.
       </p>
       <div className="mt-6">
         <Link
@@ -71,7 +71,21 @@ export function AuditsLanding({ firmCount }: { firmCount: number }) {
       {/* Indented to the same 16px rail as the FOR AUDIT FIRMS row and the
           plate label below: the three mono-caps lines share one left edge. */}
       <p className="mt-8 pl-4 font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500 dark:text-zinc-400">
-        {meta.join(" · ")}
+        {meta.map((item, index) => (
+          <span key={item}>
+            {index > 0 ? " · " : null}
+            {index === 0 ? (
+              <Link
+                href="/audits/firms"
+                className="underline decoration-1 underline-offset-4 decoration-zinc-300 hover:decoration-current"
+              >
+                {item}
+              </Link>
+            ) : (
+              item
+            )}
+          </span>
+        ))}
       </p>
 
       <Link

--- a/components/audits/landing/FirstRun.tsx
+++ b/components/audits/landing/FirstRun.tsx
@@ -5,9 +5,11 @@ import { EmptyState } from "@/components/audits/shared/EmptyState";
 export function FirstRun({
   isAdmin = false,
   isAuditor = false,
+  firmCount,
 }: {
   isAdmin?: boolean;
   isAuditor?: boolean;
+  firmCount: number;
 }) {
   return (
     <EmptyState
@@ -21,7 +23,7 @@ export function FirstRun({
           <span className="text-brand">.</span>
         </>
       }
-      body="Describe your scope once · every audit firm on the Ava Labs whitelist quotes it. You compare privately and pick one. Run by Ava Labs as a public good."
+      body="Describe your scope once · every audit firm on the Ava Labs whitelist quotes it, or just the ones you choose. You compare privately and pick one. Run by Ava Labs as a public good."
       action={
         <Link
           href="/audits/new"
@@ -30,7 +32,17 @@ export function FirstRun({
           Start your first request
         </Link>
       }
-      footnote="Typically several quotes within 10 days"
+      footnote={
+        <>
+          Typically several quotes within 10 days ·{" "}
+          <Link
+            href="/audits/firms"
+            className="underline decoration-1 underline-offset-4 decoration-zinc-300 hover:decoration-current"
+          >
+            {firmCount} vetted firms
+          </Link>
+        </>
+      }
       action2={
         isAdmin || isAuditor ? (
           // This empty state IS the home view for pure admins and auditors

--- a/components/audits/landing/MyRequestsList.tsx
+++ b/components/audits/landing/MyRequestsList.tsx
@@ -45,12 +45,14 @@ export function MyRequestsList({
   requests,
   isAdmin = false,
   isAuditor = false,
+  firmCount,
 }: {
   requests: OwnerRequestSummary[];
   /** Role doors ride here too, not only on first-run: an admin or auditor who
       files a single request would otherwise never see them again. */
   isAdmin?: boolean;
   isAuditor?: boolean;
+  firmCount: number;
 }) {
   const router = useRouter();
   const [filter, setFilter] = useState<Filter>("all");
@@ -103,7 +105,14 @@ export function MyRequestsList({
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Audit requests</h1>
           <p className="mt-1 text-sm text-zinc-600 dark:text-[#A2AFB2]">
-            Quotes from the Ava Labs whitelist, free and private to you.
+            Quotes from{" "}
+            <Link
+              href="/audits/firms"
+              className="underline decoration-1 underline-offset-4 decoration-zinc-300 hover:decoration-current"
+            >
+              {firmCount} vetted firms
+            </Link>{" "}
+            on the Ava Labs whitelist, free and private to you.
           </p>
         </div>
         {/* Doors first, red CTA last: the outline buttons keep "one red CTA

--- a/components/audits/portal/FirmDetails.tsx
+++ b/components/audits/portal/FirmDetails.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { ArrowUpRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { AUDIT_SERVICES, AUDITOR_MEMBER_LIMIT } from "@/lib/audits/constants";
+import type { OwnFirm } from "@/server/services/audits/visibility";
+import { ChipGroup, asChips } from "@/components/audits/shared/ChipGroup";
+import { CARD, MONO_LABEL_SM } from "@/components/audits/shared/classes";
+import { formatIsoDate, monogramOf } from "@/components/audits/shared/format";
+import { DeactivatedBanner } from "@/components/audits/portal/DeactivatedBanner";
+
+type Member = OwnFirm["members"][number];
+
+/**
+ * The firm's own self-service page (spec 7.4.3). Any active identity edits
+ * services and website; only the quote-email identity manages teammates. Firm
+ * name, quote email and active status stay admin-only. Follows the admin
+ * panel's write pattern: fetch, toast, optimistic member list, router.refresh.
+ */
+export function FirmDetails({
+  firm,
+  isOwner,
+  readOnly,
+}: {
+  firm: OwnFirm;
+  isOwner: boolean;
+  readOnly: boolean;
+}) {
+  const router = useRouter();
+  const [services, setServices] = useState<string[]>(firm.services);
+  const [website, setWebsite] = useState(firm.website ?? "");
+  const [members, setMembers] = useState<Member[]>(firm.members);
+  const [memberEmail, setMemberEmail] = useState("");
+  const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const locked = busy || readOnly;
+  const atCap = members.length >= AUDITOR_MEMBER_LIMIT;
+
+  const saveDetails = async () => {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/audits/portal/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ services, website }),
+      });
+      const body = await res.json().catch(() => null);
+      if (!res.ok || !body?.success) {
+        toast.error(body?.message ?? "That didn't work. Try again.");
+        return;
+      }
+      toast.success("Saved.");
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const addMember = async () => {
+    const email = memberEmail.trim().toLowerCase();
+    if (!email) return;
+    if (members.some((m) => m.email === email)) {
+      toast.error("This email is already on your team.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch("/api/audits/portal/me/members", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      const body = await res.json().catch(() => null);
+      if (!res.ok || !body?.success) {
+        toast.error(body?.message ?? "That didn't work. Try again.");
+        return;
+      }
+      setMembers((prev) => [...prev, body.member as Member]);
+      setMemberEmail("");
+      toast.success(
+        body.inviteSent === false
+          ? `Added ${email}. The invite email failed to send.`
+          : `Invite sent to ${email}.`,
+      );
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const removeMember = async (member: Member) => {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/audits/portal/me/members/${member.id}`, { method: "DELETE" });
+      const body = await res.json().catch(() => null);
+      if (!res.ok || !body?.success) {
+        toast.error(body?.message ?? "That didn't work. Try again.");
+        return;
+      }
+      setMembers((prev) => prev.filter((m) => m.id !== member.id));
+      setConfirmRemoveId(null);
+      toast.success(`${member.email} removed. They can no longer sign in.`);
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="py-10">
+      {readOnly ? <DeactivatedBanner /> : null}
+      <p className="text-[12.5px] text-zinc-500 dark:text-zinc-400">
+        <Link
+          href="/audits/portal"
+          className="underline underline-offset-2 hover:text-zinc-800 dark:hover:text-zinc-200"
+        >
+          Inbox
+        </Link>{" "}
+        / Firm details
+      </p>
+      <h1 className="mt-2 text-2xl font-semibold tracking-tight">Firm details</h1>
+
+      <div className="mt-6 space-y-5">
+        <div className={cn(CARD, "p-5")}>
+          <div className="flex items-center gap-3">
+            <span
+              aria-hidden
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-zinc-100 font-mono text-sm font-semibold text-zinc-600 dark:bg-white/10 dark:text-zinc-300"
+            >
+              {monogramOf(firm.firm_name)}
+            </span>
+            <div className="min-w-0">
+              <p className="text-[15px] font-semibold">{firm.firm_name}</p>
+              <p className="truncate font-mono text-xs text-zinc-500 dark:text-zinc-400">
+                {firm.quote_email}
+              </p>
+            </div>
+          </div>
+          <p className={`${MONO_LABEL_SM} mt-4 normal-case`}>
+            On the whitelist since {formatIsoDate(firm.invited_at)}
+          </p>
+          <a
+            href="/audits/firms"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-2 inline-flex items-center gap-1 text-sm text-zinc-600 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+          >
+            See how you appear on the vetted firms page{" "}
+            <ArrowUpRight aria-hidden className="h-3.5 w-3.5" />
+          </a>
+        </div>
+
+        <div className={cn(CARD, "space-y-5 p-5")}>
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Services</p>
+            <ChipGroup
+              multiple
+              options={asChips(AUDIT_SERVICES)}
+              value={services}
+              onChange={locked ? () => {} : setServices}
+              aria-label="Services"
+            />
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              Shown on the vetted firms page and on your quotes. Projects may use them to choose
+              which firms receive a request.
+            </p>
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium" htmlFor="firm-website">
+              Website
+            </label>
+            <Input
+              id="firm-website"
+              value={website}
+              onChange={(event) => setWebsite(event.target.value)}
+              disabled={locked}
+              placeholder="firm.example"
+              inputMode="url"
+              className="h-11 font-mono text-[13px] md:h-10"
+            />
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">Shown on the vetted firms page</p>
+          </div>
+          <div className="flex justify-end">
+            <Button disabled={locked} onClick={() => void saveDetails()}>
+              Save changes
+            </Button>
+          </div>
+        </div>
+
+        <div className={cn(CARD, "space-y-3 p-5")}>
+          <div>
+            <p className="text-sm font-medium">
+              Team emails{" "}
+              <span className="font-normal text-zinc-500 dark:text-zinc-400">
+                · sign in and get every notice, same as the quote email
+              </span>
+            </p>
+            <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+              Teammates receive every request this firm receives and can read its full history,
+              including project contacts on won requests.
+            </p>
+          </div>
+          <ul className="divide-y divide-zinc-200 rounded-[10px] border border-zinc-200 dark:divide-white/[0.08] dark:border-white/10">
+            {members.length === 0 ? (
+              <li className="px-3.5 py-2.5 text-sm text-zinc-500 dark:text-zinc-400">
+                No teammates yet · only the quote email can sign in.
+              </li>
+            ) : (
+              members.map((member) => (
+                <li key={member.id} className="flex items-center gap-3 px-3.5 py-2.5 text-sm">
+                  <span className="min-w-0 flex-1 truncate font-mono text-[13px]">
+                    {member.email}
+                  </span>
+                  <span className="shrink-0 text-xs text-zinc-500 dark:text-zinc-400">
+                    {member.first_login_at ? "active" : `invited ${formatIsoDate(member.invited_at)}`}
+                  </span>
+                  {isOwner ? (
+                    confirmRemoveId === member.id ? (
+                      <button
+                        type="button"
+                        disabled={locked}
+                        onClick={() => void removeMember(member)}
+                        className="shrink-0 cursor-pointer text-xs text-brand-deep underline underline-offset-2 dark:text-brand-soft"
+                      >
+                        Confirm remove
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        disabled={locked}
+                        onClick={() => setConfirmRemoveId(member.id)}
+                        className="shrink-0 cursor-pointer text-xs text-zinc-600 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                      >
+                        Remove
+                      </button>
+                    )
+                  ) : null}
+                </li>
+              ))
+            )}
+          </ul>
+          {isOwner ? (
+            <div className="space-y-1.5">
+              <div className="flex flex-wrap items-center gap-2">
+                <Input
+                  value={memberEmail}
+                  onChange={(event) => setMemberEmail(event.target.value)}
+                  disabled={locked || atCap}
+                  placeholder="teammate@firm.example"
+                  inputMode="email"
+                  className="h-11 flex-1 font-mono text-[13px] md:h-10"
+                />
+                <Button
+                  disabled={locked || atCap || !memberEmail.trim()}
+                  onClick={() => void addMember()}
+                >
+                  Add and invite
+                </Button>
+              </div>
+              {atCap ? (
+                <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                  A firm can have up to {AUDITOR_MEMBER_LIMIT} approved emails.
+                </p>
+              ) : null}
+            </div>
+          ) : (
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              Only {firm.quote_email} can add or remove teammates.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/audits/portal/PortalInbox.tsx
+++ b/components/audits/portal/PortalInbox.tsx
@@ -79,14 +79,30 @@ export function PortalInbox({
   items,
   notifyEmail,
   readOnly = false,
+  servicesEmpty = false,
 }: {
   items: AuditorInboxItem[];
   /** The signed-in address: quote email or approved teammate, both get the mail. */
   notifyEmail: string;
   /** Deactivated firms browse their history without action affordances (N-4). */
   readOnly?: boolean;
+  /** Active firm with no services tagged: a quiet pointer to the firm page. */
+  servicesEmpty?: boolean;
 }) {
   const [tab, setTab] = useState<Tab>("all");
+
+  // One quiet line, not a banner: gone the moment any service is saved (008 D-9).
+  const nudge = servicesEmpty ? (
+    <p className="mb-4 text-sm text-zinc-500 dark:text-zinc-400">
+      Your services aren&apos;t listed yet ·{" "}
+      <Link
+        href="/audits/portal/firm"
+        className="underline underline-offset-2 hover:text-zinc-900 dark:hover:text-zinc-100"
+      >
+        list them on your firm details page
+      </Link>
+    </p>
+  ) : null;
 
   if (items.length === 0) {
     // A deactivated firm with no history still needs the banner (the plain
@@ -105,7 +121,16 @@ export function PortalInbox({
         footnote={readOnly ? undefined : "Nothing to check · the email is the trigger"}
       />
     );
-    if (!readOnly) return empty;
+    if (!readOnly) {
+      return nudge ? (
+        <div className="py-10">
+          {nudge}
+          {empty}
+        </div>
+      ) : (
+        empty
+      );
+    }
     return (
       <div className="py-10">
         <DeactivatedBanner />
@@ -132,6 +157,7 @@ export function PortalInbox({
   return (
     <div className="py-10">
       {readOnly ? <DeactivatedBanner /> : null}
+      {nudge}
       {/* Short nowrap labels keep the row on ONE line at 375 (board 1g); the
           full "Awaiting your quote" returns from md up. Targets stay 44px. */}
       <div

--- a/components/audits/portal/PortalShell.tsx
+++ b/components/audits/portal/PortalShell.tsx
@@ -1,16 +1,10 @@
 "use client";
 
 import Link from "next/link";
+import { ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { MONO_LABEL_META } from "@/components/audits/shared/classes";
-
-const initialsOf = (name: string) =>
-  name
-    .split(/\s+/)
-    .map((word) => word[0])
-    .join("")
-    .slice(0, 2)
-    .toUpperCase();
+import { monogramOf } from "@/components/audits/shared/format";
 
 /**
  * Slim portal identity bar under the Builder Hub navbar: the marketplace's
@@ -32,15 +26,24 @@ export function PortalShell({ firmName }: { firmName: string | null }) {
         </Link>
         <div className="flex items-center gap-2">
           {firmName ? (
-            <span className="flex items-center gap-2 rounded-full border border-zinc-300 py-1 pl-1 pr-3 text-sm dark:border-white/[0.16]">
+            <Link
+              href="/audits/portal/firm"
+              title="Firm details"
+              aria-label="Firm details"
+              className="flex items-center gap-2 rounded-full border border-zinc-300 py-1 pl-1 pr-2 text-sm transition-colors hover:border-zinc-500 dark:border-white/[0.16] dark:hover:border-white/40"
+            >
               <span
                 aria-hidden
                 className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-zinc-100 font-mono text-[9.5px] font-semibold text-zinc-600 dark:bg-white/10 dark:text-zinc-300"
               >
-                {initialsOf(firmName)}
+                {monogramOf(firmName)}
               </span>
               <span className="hidden font-medium sm:inline">{firmName}</span>
-            </span>
+              <ChevronRight
+                aria-hidden
+                className="h-[13px] w-[13px] text-zinc-400 dark:text-zinc-500"
+              />
+            </Link>
           ) : null}
           <Button asChild variant="ghost" className="h-11 md:h-9">
             <Link href="/audits" title="Back to Security Audits, session intact">

--- a/components/audits/shared/EmptyState.tsx
+++ b/components/audits/shared/EmptyState.tsx
@@ -11,7 +11,7 @@ interface EmptyStateProps {
   action?: ReactNode;
   /** Quiet secondary affordance under the footnote. */
   action2?: ReactNode;
-  footnote?: string;
+  footnote?: ReactNode;
   /** Blocks cascade above the headline; marketing surfaces keep it on. */
   art?: boolean;
   /** Quiet bordered-panel form for utility contexts (portal empty inbox,

--- a/components/audits/shared/FanoutNoticeCard.tsx
+++ b/components/audits/shared/FanoutNoticeCard.tsx
@@ -3,19 +3,42 @@ import { BlocksArt } from "@/components/audits/shared/BlocksArt";
 // The step-4 fan-out notice (design 1b/1c): a dark card in BOTH themes, copy
 // verbatim from the design package. Do not reword. The mono footer line moved
 // to the wizard footer (round 2 board R-1), restoring step 4's footer anchor.
-export function FanoutNoticeCard() {
+// v1.1 adds a narrowed variant for a request with a shortlist; the default
+// copy stays verbatim.
+export function FanoutNoticeCard({
+  chosenCount = 0,
+  whitelistCount = 0,
+}: {
+  chosenCount?: number;
+  whitelistCount?: number;
+}) {
+  const narrowed = chosenCount > 0 && chosenCount < whitelistCount;
   return (
     <div className="relative overflow-hidden rounded-xl border border-white/10 bg-[#121212] p-5 text-left">
       <BlocksArt variant="corner" palette="plate" className="absolute right-0 top-0" />
       <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[#A2AFB2]">
         Fan-out · whitelist only
       </p>
-      <p className="v2-display mt-2 text-[19px] text-white">Sent to all whitelisted auditors.</p>
-      <p className="mt-2 max-w-[64ch] text-sm leading-relaxed text-[#A2AFB2]">
-        Your request reaches every firm on the Ava Labs approved list at once · that&apos;s what
-        makes the quotes competitive. Quotes are visible only to you and the Ava Labs program
-        admins. Nothing is published.
-      </p>
+      {narrowed ? (
+        <>
+          <p className="v2-display mt-2 text-[19px] text-white">
+            Sent to {chosenCount} of {whitelistCount} whitelisted auditors.
+          </p>
+          <p className="mt-2 max-w-[64ch] text-sm leading-relaxed text-[#A2AFB2]">
+            Your request reaches the {chosenCount} firms you chose at once. Quotes are visible only
+            to you and the Ava Labs program admins. Nothing is published.
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="v2-display mt-2 text-[19px] text-white">Sent to all whitelisted auditors.</p>
+          <p className="mt-2 max-w-[64ch] text-sm leading-relaxed text-[#A2AFB2]">
+            Your request reaches every firm on the Ava Labs approved list at once · that&apos;s what
+            makes the quotes competitive. Quotes are visible only to you and the Ava Labs program
+            admins. Nothing is published.
+          </p>
+        </>
+      )}
     </div>
   );
 }

--- a/components/audits/shared/format.ts
+++ b/components/audits/shared/format.ts
@@ -87,6 +87,22 @@ export function lowerFirst(text: string): string {
   return text.charAt(0).toLowerCase() + text.slice(1);
 }
 
+/**
+ * Two-letter firm monogram for the fallback tile. Splits on whitespace and on
+ * lowercase->uppercase boundaries (so "HackenProof" is HP, "BlockSec" is BS),
+ * takes the first letter of the first two parts, uppercased; a single part
+ * takes its first two letters. Replaces the panel's and the shell's local
+ * initialsOf (Tasks 8 and 10).
+ */
+export function monogramOf(name: string): string {
+  const parts = name
+    .trim()
+    .split(/\s+|(?<=[a-z])(?=[A-Z])/)
+    .filter(Boolean);
+  const letters = parts.length >= 2 ? parts[0][0] + parts[1][0] : (parts[0] ?? "").slice(0, 2);
+  return letters.toUpperCase();
+}
+
 /** Display host for a proposal link ("docs.google.com"), so the reader knows
     where the click goes. Empty on an unparsable value: legacy data must never
     crash a view. */

--- a/components/audits/wizard/AuditWizardContext.tsx
+++ b/components/audits/wizard/AuditWizardContext.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { Form } from "@/components/ui/form";
 import { zodResolver } from "@/lib/zodResolver";
 import { auditSubmitSchema } from "@/types/audits";
+import type { PublicFirm } from "@/server/services/audits/visibility";
 import { useAutosave, type SaveState } from "@/components/audits/wizard/useAutosave";
 import {
   FIELD_STEP,
@@ -34,6 +35,9 @@ interface AuditWizardContextValue {
       draft asks again. */
   consent: boolean;
   setConsent: (next: boolean) => void;
+  /** The public firm list, server-rendered once and held for the wizard's
+      lifetime; its length is the whitelist count. */
+  firms: PublicFirm[];
 }
 
 const AuditWizardContext = createContext<AuditWizardContextValue | null>(null);
@@ -47,10 +51,16 @@ export function useAuditWizard(): AuditWizardContextValue {
 interface AuditWizardProviderProps {
   initialDraft: { id: string; values: AuditWizardValues } | null;
   prefill: { contact_name: string; contact_email: string };
+  firms: PublicFirm[];
   children: ReactNode;
 }
 
-export function AuditWizardProvider({ initialDraft, prefill, children }: AuditWizardProviderProps) {
+export function AuditWizardProvider({
+  initialDraft,
+  prefill,
+  firms,
+  children,
+}: AuditWizardProviderProps) {
   const router = useRouter();
   const [step, setStepState] = useState(0);
   const [submitting, setSubmitting] = useState(false);
@@ -157,6 +167,7 @@ export function AuditWizardProvider({ initialDraft, prefill, children }: AuditWi
       submitting,
       consent,
       setConsent,
+      firms,
     }),
     [
       form,
@@ -171,6 +182,7 @@ export function AuditWizardProvider({ initialDraft, prefill, children }: AuditWi
       submit,
       submitting,
       consent,
+      firms,
     ],
   );
 

--- a/components/audits/wizard/FirmPicker.tsx
+++ b/components/audits/wizard/FirmPicker.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useState } from "react";
+import { Check, ArrowUpRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { PublicFirm } from "@/server/services/audits/visibility";
+import { MONO_LABEL } from "@/components/audits/shared/classes";
+import { ChipGroup } from "@/components/audits/shared/ChipGroup";
+
+function warnLine(n: number) {
+  return n === 1
+    ? "Only 1 firm will see this request. If it doesn't quote by your deadline, the request expires and can be reopened once."
+    : `Only ${n} firms will see this request. If neither quotes by your deadline, the request expires and can be reopened once.`;
+}
+
+/**
+ * The request shortlist picker (variant A). Selection is opt-in: an empty
+ * value means every active firm (the stored default). Names and counts come
+ * from the firms present in the list, so an id that has since been deactivated
+ * is neither counted nor named. Firms are never told they were chosen.
+ */
+export function FirmPicker({
+  firms,
+  neededServices,
+  value,
+  onChange,
+  defaultOpen = false,
+}: {
+  firms: PublicFirm[];
+  neededServices: string[];
+  value: string[];
+  onChange: (ids: string[]) => void;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const total = firms.length;
+  const chosen = firms.filter((f) => value.includes(f.id)); // resolved, in list order
+  const n = chosen.length;
+  const summaryNames =
+    chosen
+      .slice(0, 2)
+      .map((f) => f.firm_name)
+      .join(", ") + (chosen.length > 2 ? ` +${chosen.length - 2}` : "");
+  const allGone = value.length > 0 && n === 0;
+
+  const match = firms.filter(
+    (f) => f.services.length > 0 && f.services.some((s) => neededServices.includes(s)),
+  );
+  const unlisted = firms.filter((f) => f.services.length === 0);
+  const dayOne = unlisted.length === total; // every firm has empty services
+
+  const setGroup = (group: PublicFirm[]) => {
+    const ids = group.map((f) => f.id);
+    const allOn = ids.every((id) => value.includes(id));
+    onChange(
+      allOn ? value.filter((id) => !ids.includes(id)) : Array.from(new Set([...value, ...ids])),
+    );
+  };
+
+  if (!open) {
+    return (
+      <div className="rounded-[10px] border border-zinc-200 px-4 py-3 dark:border-white/10">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex items-start gap-3">
+            <span
+              className={cn(
+                "mt-0.5 flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full",
+                n > 0
+                  ? "border border-brand text-brand dark:border-[#FF394A] dark:text-brand-soft"
+                  : "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900",
+              )}
+            >
+              <Check aria-hidden className="h-3 w-3" />
+            </span>
+            <div className="min-w-0">
+              <p className="text-sm font-medium">
+                {allGone
+                  ? `0 of ${total} vetted firms · the firms you chose are no longer listed`
+                  : n > 0
+                    ? `${n} of ${total} vetted firms · ${summaryNames}`
+                    : `All ${total} vetted firms`}
+              </p>
+              <p className="mt-0.5 text-sm text-zinc-500 dark:text-zinc-400">
+                {n > 0 || allGone ? "" : "Default. Narrow it if only some firms interest you."}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className="shrink-0 cursor-pointer text-sm text-zinc-600 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+          >
+            {n > 0 || allGone ? "Edit" : "Choose firms"}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-[10px] border border-zinc-200 p-4 dark:border-white/10">
+      <div className="flex items-center justify-between gap-2">
+        <p className={cn(MONO_LABEL, "!text-zinc-600 dark:!text-zinc-300")}>
+          Who receives this request
+        </p>
+        <div className="flex items-center gap-3">
+          {value.length > 0 ? (
+            <button
+              type="button"
+              onClick={() => onChange([])}
+              className="cursor-pointer text-sm text-zinc-600 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+            >
+              Reset to all
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="cursor-pointer text-sm text-zinc-600 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+
+      {allGone ? (
+        <p className="mt-3 text-sm text-amber-700 dark:text-amber-400">
+          None of the firms you chose is still listed · reset to all or pick again
+        </p>
+      ) : dayOne ? (
+        <p className="mt-3 text-sm text-zinc-500 dark:text-zinc-400">
+          Firms haven&apos;t listed their services yet · pick by name
+        </p>
+      ) : (
+        <div className="mt-3 flex flex-wrap gap-2" role="group" aria-label="Quick pick">
+          {match.length > 0 ? (
+            <button
+              type="button"
+              onClick={() => setGroup(match)}
+              className="h-11 cursor-pointer rounded-full border border-zinc-900 bg-zinc-900 px-3.5 text-sm text-white transition-colors md:h-9 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
+            >
+              Offering your services <span className="opacity-70">{match.length}</span>
+            </button>
+          ) : (
+            <span className="text-sm text-zinc-500 dark:text-zinc-400">
+              No firm lists the services you need yet
+            </span>
+          )}
+          {unlisted.length > 0 && unlisted.length < total ? (
+            <button
+              type="button"
+              onClick={() => setGroup(unlisted)}
+              className="h-11 cursor-pointer rounded-full border border-zinc-900 bg-zinc-900 px-3.5 text-sm text-white transition-colors md:h-9 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
+            >
+              Services not listed <span className="opacity-70">{unlisted.length}</span>
+            </button>
+          ) : null}
+        </div>
+      )}
+
+      <div className="mt-3">
+        <ChipGroup
+          multiple
+          collapsible
+          options={firms.map((f) => ({ value: f.id, label: f.firm_name }))}
+          value={value}
+          onChange={onChange}
+          aria-label="Firms"
+        />
+      </div>
+
+      <p className="mt-3 text-sm text-zinc-500 dark:text-zinc-400">
+        {n > 0
+          ? `${n} of ${total} firms receive this request`
+          : `All ${total} firms receive this request · pick to narrow`}
+      </p>
+      {n > 0 && n < 3 ? (
+        <p className="mt-2 text-sm text-amber-700 dark:text-amber-400">{warnLine(n)}</p>
+      ) : null}
+      <p className="mt-3">
+        <a
+          href="/audits/firms"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-sm text-zinc-600 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+        >
+          About these firms <ArrowUpRight aria-hidden className="h-3.5 w-3.5" />
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/components/audits/wizard/FirmPicker.tsx
+++ b/components/audits/wizard/FirmPicker.tsx
@@ -13,6 +13,45 @@ function warnLine(n: number) {
     : `Only ${n} firms will see this request. If neither quotes by your deadline, the request expires and can be reopened once.`;
 }
 
+type GroupState = "none" | "partial" | "all";
+
+/**
+ * A quick-pick chip that reflects its group's selection: outline when none of
+ * the group is picked, dashed when some are, solid with a check when all are
+ * (a tap then clears them). Without this the chip looked identical whether a
+ * tap added or cleared the group.
+ */
+function QuickPickChip({
+  label,
+  count,
+  state,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  state: GroupState;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={state === "all"}
+      className={cn(
+        "inline-flex h-11 cursor-pointer items-center gap-1.5 rounded-full px-3.5 text-sm transition-colors md:h-9",
+        state === "all"
+          ? "border border-zinc-900 bg-zinc-900 text-white dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
+          : state === "partial"
+            ? "border border-dashed border-zinc-400 text-zinc-700 dark:border-white/40 dark:text-zinc-200"
+            : "border border-zinc-300 text-zinc-700 hover:border-zinc-500 dark:border-white/20 dark:text-zinc-200 dark:hover:border-white/40",
+      )}
+    >
+      {state === "all" ? <Check aria-hidden className="h-3 w-3" /> : null}
+      {label} <span className="opacity-70">{count}</span>
+    </button>
+  );
+}
+
 /**
  * The request shortlist picker (variant A). Selection is opt-in: an empty
  * value means every active firm (the stored default). Names and counts come
@@ -55,6 +94,13 @@ export function FirmPicker({
     onChange(
       allOn ? value.filter((id) => !ids.includes(id)) : Array.from(new Set([...value, ...ids])),
     );
+  };
+
+  const groupState = (group: PublicFirm[]): GroupState => {
+    const ids = group.map((f) => f.id);
+    if (ids.length === 0) return "none";
+    const selected = ids.filter((id) => value.includes(id)).length;
+    return selected === 0 ? "none" : selected === ids.length ? "all" : "partial";
   };
 
   if (!open) {
@@ -134,26 +180,24 @@ export function FirmPicker({
       ) : (
         <div className="mt-3 flex flex-wrap gap-2" role="group" aria-label="Quick pick">
           {match.length > 0 ? (
-            <button
-              type="button"
+            <QuickPickChip
+              label="Offering your services"
+              count={match.length}
+              state={groupState(match)}
               onClick={() => setGroup(match)}
-              className="h-11 cursor-pointer rounded-full border border-zinc-900 bg-zinc-900 px-3.5 text-sm text-white transition-colors md:h-9 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
-            >
-              Offering your services <span className="opacity-70">{match.length}</span>
-            </button>
+            />
           ) : (
             <span className="text-sm text-zinc-500 dark:text-zinc-400">
               No firm lists the services you need yet
             </span>
           )}
           {unlisted.length > 0 && unlisted.length < total ? (
-            <button
-              type="button"
+            <QuickPickChip
+              label="Services not listed"
+              count={unlisted.length}
+              state={groupState(unlisted)}
               onClick={() => setGroup(unlisted)}
-              className="h-11 cursor-pointer rounded-full border border-zinc-900 bg-zinc-900 px-3.5 text-sm text-white transition-colors md:h-9 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
-            >
-              Services not listed <span className="opacity-70">{unlisted.length}</span>
-            </button>
+            />
           ) : null}
         </div>
       )}

--- a/components/audits/wizard/StepReview.tsx
+++ b/components/audits/wizard/StepReview.tsx
@@ -20,8 +20,12 @@ import { formatIsoDate, lowerFirst } from "@/components/audits/shared/format";
 import { FanoutNoticeCard } from "@/components/audits/shared/FanoutNoticeCard";
 import { useAuditWizard } from "@/components/audits/wizard/AuditWizardContext";
 import type { AuditWizardValues } from "@/components/audits/wizard/types";
+import type { PublicFirm } from "@/server/services/audits/visibility";
 
-function summaryLines(values: AuditWizardValues): { label: string; line: string; step: number }[] {
+function summaryLines(
+  values: AuditWizardValues,
+  firms: PublicFirm[],
+): { label: string; line: string; step: number }[] {
   const target = values.deployment_target
     ? DEPLOYMENT_TARGET_LABELS[values.deployment_target]
     : "No deployment target";
@@ -37,6 +41,12 @@ function summaryLines(values: AuditWizardValues): { label: string; line: string;
   if (repoCount > 0) scopeParts.push(`${repoCount} ${repoCount === 1 ? "repo" : "repos"} pinned`);
   if (values.nsloc.trim() !== "") scopeParts.push(`~${values.nsloc} nSLOC`);
   if (values.frameworks.length > 0) scopeParts.push(values.frameworks.join(", "));
+  // Narrowed only when a real subset was chosen: the resolved count sits
+  // between one and the whitelist size (spec 7.2.4, copy row 12).
+  const chosen = values.shortlist_auditor_ids.length
+    ? firms.filter((f) => values.shortlist_auditor_ids.includes(f.id)).length
+    : 0;
+  if (chosen > 0 && chosen < firms.length) scopeParts.push(`${chosen} of ${firms.length} firms`);
 
   const timelineParts = [
     values.needed_by ? `needed by ${formatIsoDate(values.needed_by)}` : "no needed-by date",
@@ -55,8 +65,11 @@ function summaryLines(values: AuditWizardValues): { label: string; line: string;
 
 export function StepReview() {
   const form = useFormContext<AuditWizardValues>();
-  const { setStep, consent, setConsent } = useAuditWizard();
+  const { setStep, consent, setConsent, firms } = useAuditWizard();
   const values = form.watch();
+  const chosenCount = values.shortlist_auditor_ids.length
+    ? firms.filter((f) => values.shortlist_auditor_ids.includes(f.id)).length
+    : 0;
 
   return (
     <div className="space-y-6">
@@ -133,7 +146,7 @@ export function StepReview() {
 
       {/* Completed-step receipt rows: check circle + wash + underlined Edit (board 1c). */}
       <div className="space-y-2">
-        {summaryLines(values).map((row, index) => (
+        {summaryLines(values, firms).map((row, index) => (
           <div
             key={row.label}
             className="flex items-start gap-3 rounded-[10px] border border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-white/10 dark:bg-white/[0.03]"
@@ -164,7 +177,7 @@ export function StepReview() {
         ))}
       </div>
 
-      <FanoutNoticeCard />
+      <FanoutNoticeCard chosenCount={chosenCount} whitelistCount={firms.length} />
 
       {/* The consent gate. Placeholder wording until Legal supplies the final
           text; the timestamp is stamped server-side at submission. */}
@@ -177,7 +190,8 @@ export function StepReview() {
         />
         <span id="consent-copy" className="text-sm leading-relaxed text-zinc-700 dark:text-zinc-300">
           I understand that my contact details in this request are shared with the vetted audit
-          firms on the Ava Labs whitelist, and with the winning firm once I accept a quote.
+          firms on the Ava Labs whitelist that receive it, and with the winning firm once I accept a
+          quote.
         </span>
       </label>
     </div>

--- a/components/audits/wizard/StepScope.tsx
+++ b/components/audits/wizard/StepScope.tsx
@@ -16,10 +16,13 @@ import { ChipGroup, asChips } from "@/components/audits/shared/ChipGroup";
 import { RepoRepeater } from "@/components/audits/wizard/RepoRepeater";
 import { MultiLinkInput } from "@/components/audits/wizard/MultiLinkInput";
 import { AttachmentUploader } from "@/components/audits/wizard/AttachmentUploader";
+import { FirmPicker } from "@/components/audits/wizard/FirmPicker";
+import { useAuditWizard } from "@/components/audits/wizard/AuditWizardContext";
 import type { AuditWizardValues } from "@/components/audits/wizard/types";
 
 export function StepScope() {
   const form = useFormContext<AuditWizardValues>();
+  const { firms } = useAuditWizard();
 
   return (
     <div className="space-y-6">
@@ -42,6 +45,19 @@ export function StepScope() {
             />
             <FormMessage />
           </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="shortlist_auditor_ids"
+        render={({ field }) => (
+          <FirmPicker
+            firms={firms}
+            neededServices={form.watch("services")}
+            value={field.value}
+            onChange={field.onChange}
+          />
         )}
       />
 

--- a/components/audits/wizard/WizardHeader.tsx
+++ b/components/audits/wizard/WizardHeader.tsx
@@ -38,8 +38,8 @@ export function WizardHeader() {
         </p>
         <h1 className="mt-1.5 text-2xl font-semibold tracking-tight">New audit request</h1>
         <p className="mt-1 text-sm text-zinc-600 dark:text-[#A2AFB2]">
-          Goes to every whitelisted audit firm at once. Quotes come back privately · free, run by
-          Ava Labs.
+          Goes to every whitelisted audit firm at once, or just the ones you choose in step 2.
+          Quotes come back privately · free, run by Ava Labs.
         </p>
       </div>
       <div className="flex items-center gap-3 pt-1">

--- a/components/audits/wizard/WizardShell.tsx
+++ b/components/audits/wizard/WizardShell.tsx
@@ -17,6 +17,7 @@ import { StepScope } from "@/components/audits/wizard/StepScope";
 import { StepTimeline } from "@/components/audits/wizard/StepTimeline";
 import { StepReview } from "@/components/audits/wizard/StepReview";
 import { WIZARD_STEPS, type AuditWizardValues } from "@/components/audits/wizard/types";
+import type { PublicFirm } from "@/server/services/audits/visibility";
 
 const CONTINUE_LABELS = ["Continue to scope", "Continue to timeline", "Continue to review"];
 
@@ -154,11 +155,12 @@ export interface AuditWizardProps {
   initialDraft: { id: string; values: AuditWizardValues } | null;
   prefill: { contact_name: string; contact_email: string };
   importProjectId: string | null;
+  firms: PublicFirm[];
 }
 
-export function AuditWizard({ initialDraft, prefill, importProjectId }: AuditWizardProps) {
+export function AuditWizard({ initialDraft, prefill, importProjectId, firms }: AuditWizardProps) {
   return (
-    <AuditWizardProvider initialDraft={initialDraft} prefill={prefill}>
+    <AuditWizardProvider initialDraft={initialDraft} prefill={prefill} firms={firms}>
       <WizardBody importProjectId={importProjectId} />
     </AuditWizardProvider>
   );

--- a/components/audits/wizard/types.ts
+++ b/components/audits/wizard/types.ts
@@ -28,6 +28,7 @@ export interface AuditWizardValues {
   contact_email: string;
   contact_handle: string;
   contact_calendar_url: string;
+  shortlist_auditor_ids: string[];
 }
 
 // Which fields each step must pass (against auditSubmitSchema) before
@@ -95,6 +96,7 @@ export function wizardDefaults(prefill: {
     contact_email: prefill.contact_email,
     contact_handle: "",
     contact_calendar_url: "",
+    shortlist_auditor_ids: [],
   };
 }
 
@@ -128,6 +130,7 @@ export function toDraftPayload(values: AuditWizardValues): AuditDraftInput {
     contact_email: values.contact_email,
     contact_handle: values.contact_handle,
     contact_calendar_url: values.contact_calendar_url,
+    shortlist_auditor_ids: values.shortlist_auditor_ids,
   } as AuditDraftInput;
 }
 
@@ -154,6 +157,7 @@ interface DraftRow {
   contact_email: string;
   contact_handle: string | null;
   contact_calendar_url: string | null;
+  shortlist_auditor_ids: string[];
 }
 
 export function parseRepos(value: unknown): { url: string; ref: string }[] {
@@ -209,5 +213,6 @@ export function draftToValues(
     contact_email: row.contact_email || defaults.contact_email,
     contact_handle: row.contact_handle ?? "",
     contact_calendar_url: row.contact_calendar_url ?? "",
+    shortlist_auditor_ids: row.shortlist_auditor_ids ?? [],
   };
 }

--- a/lib/audits/constants.ts
+++ b/lib/audits/constants.ts
@@ -1,7 +1,8 @@
 // Wizard chip vocabularies, verbatim from the design package (Project
 // Portal.dc.html artboards 1a/1b, verified against live Areta 07-29). One
 // source for the wizard, the auditor-facing meta strips, and the admin
-// services chips; do not fork these lists locally.
+// services chips; do not fork these lists locally. "AI security scan" was
+// added for v1.1 (Joey's ask 3, 2026-09); it is not in the design package.
 
 import type { DeploymentTarget, UrgencyOption } from "@/lib/audits/status";
 
@@ -30,6 +31,7 @@ export const AUDIT_SERVICES = [
   "Bug bounty setup",
   "Audit contest",
   "Onchain monitoring",
+  "AI security scan",
   "OpSec",
   "Other",
 ] as const;
@@ -59,7 +61,11 @@ export const QUOTE_DEADLINE_DEFAULT_DAYS = 10;
     the schema's cap can never drift apart. */
 export const MAX_QUOTE_WEEKS = 52;
 /** Approved teammate addresses per firm, on top of the quote email. Bounds the
-    invite blast radius of one admin mistake; raise here if a firm needs more. */
+    invite blast radius of one mistaken add, admin or firm; raise here if a firm
+    needs more. */
 export const AUDITOR_MEMBER_LIMIT = 10;
+/** Max firms a project may shortlist on one request; raise here when the
+    whitelist outgrows it (16 firms today). */
+export const SHORTLIST_LIMIT = 50;
 export const QUOTE_DEADLINE_HELPER_COPY =
   "Defaulted to +10 days · the recommended window for competitive quotes.";

--- a/lib/audits/logoSrc.ts
+++ b/lib/audits/logoSrc.ts
@@ -1,0 +1,26 @@
+/**
+ * True only for an https URL on OUR OWN Vercel Blob store with a real path
+ * (S-9, S-10). Used as the zod refinement on Auditor.logo_url and again at
+ * render on the public row and the admin header preview, failing closed to
+ * the monogram. Repo paths (/images/...) are not a v1.1 shape.
+ */
+const STORE_HOST = (() => {
+  const base = process.env.BLOB_BASE_URL?.trim();
+  if (base) {
+    try {
+      return new URL(base).hostname;
+    } catch {
+      // fall through to the literal
+    }
+  }
+  return "qizat5l3bwvomkny.public.blob.vercel-storage.com";
+})();
+
+export function isAllowedLogoSrc(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && url.hostname === STORE_HOST && url.pathname.length > 1;
+  } catch {
+    return false;
+  }
+}

--- a/prisma/migrations/20260911000000_add_audit_firm_listing_and_shortlist/migration.sql
+++ b/prisma/migrations/20260911000000_add_audit_firm_listing_and_shortlist/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Auditor" ADD COLUMN "website" TEXT;
+ALTER TABLE "Auditor" ADD COLUMN "logo_url" TEXT;
+
+-- AlterTable
+ALTER TABLE "AuditRequest" ADD COLUMN "shortlist_auditor_ids" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -788,6 +788,10 @@ model AuditRequest {
   deployment_target    String    @default("") // c_chain | own_l1 | fuji_only
   multichain           Boolean   @default(false)
   services             String[]  @default([])
+  // Optional project narrowing of which firms this request fans out to; empty
+  // means every active firm (the default). Honoured at approval and the single
+  // reopen, never filters on the server otherwise (see fanout.ts fanoutFirmsWhere).
+  shortlist_auditor_ids String[]  @default([])
   repos                Json      @default("[]") // [{url, ref}]
   languages            String[]  @default([])
   frameworks           String[]  @default([])
@@ -838,14 +842,21 @@ model Auditor {
   // ALWAYS stored lowercase (no citext in this database); every write path
   // and the session resolver normalize with trim().toLowerCase().
   quote_email    String    @unique
-  // Informational only: shown on the whitelist and quote headers, NEVER
-  // filters fan-out (locked product decision 1).
+  // Offered services, tagged by the firm from the portal (admins may edit).
+  // Shown on the whitelist, on quote headers and on the public firms page.
+  // Never filters fan-out on the server; the wizard's quick-pick alone reads
+  // them, to help a project shortlist firms (decision 1 as amended 2026-09-09).
   services       String[]  @default([])
   active         Boolean   @default(true)
   invited_at     DateTime  @default(now()) @db.Timestamptz(3)
   first_login_at DateTime? @db.Timestamptz(3) // null = "Invited" state
   deactivated_at DateTime? @db.Timestamptz(3)
   attio_ref      String?
+  // Public firms page fields: website is admin-entered and firm-editable from
+  // the portal; logo_url holds a Vercel Blob URL, admin-only (column-name
+  // precedent Project.logo_url).
+  website        String?
+  logo_url       String?
   created_by     String?
   created_at     DateTime  @default(now()) @db.Timestamptz(3)
   updated_at     DateTime  @updatedAt @db.Timestamptz(3)

--- a/server/services/audits/auditors.ts
+++ b/server/services/audits/auditors.ts
@@ -1,6 +1,6 @@
 import { Prisma, type Auditor, type AuditorMember } from "@prisma/client";
 import { prisma } from "@/prisma/prisma";
-import { logAuditEvent } from "@/server/services/audits/events";
+import { logAuditEvent, type AuditActor } from "@/server/services/audits/events";
 import { sendAuditorInvite } from "@/server/services/audits/emails/sendAuditorInvite";
 import type { AuditorCreateInput, AuditorUpdateInput } from "@/types/audits";
 
@@ -85,31 +85,51 @@ export type UpdateAuditorResult =
 export async function updateAuditor(
   auditorId: string,
   input: AuditorUpdateInput,
-  admin: { id: string; name: string },
+  actor: AuditActor,
 ): Promise<UpdateAuditorResult> {
   const current = await prisma.auditor.findUnique({ where: { id: auditorId } });
   if (!current) return { success: false, code: "not_found" };
 
-  const activeFlips = input.active !== undefined && input.active !== current.active;
+  // Defence in depth behind the self schema's strictObject (S-13): an auditor
+  // actor can never move active or firm_name even if the input carried them.
+  const isAuditor = actor.type === "auditor";
+  const wantFirmName = !isAuditor && input.firm_name !== undefined;
+  const wantActive = !isAuditor && input.active !== undefined;
+  const activeFlips = wantActive && input.active !== current.active;
+
   const auditor = await prisma.auditor.update({
     where: { id: auditorId },
     data: {
-      ...(input.firm_name !== undefined ? { firm_name: input.firm_name } : {}),
+      ...(wantFirmName ? { firm_name: input.firm_name } : {}),
       ...(input.services !== undefined ? { services: input.services } : {}),
-      ...(input.active !== undefined ? { active: input.active } : {}),
+      ...(input.website !== undefined ? { website: input.website } : {}),
+      ...(input.logo_url !== undefined ? { logo_url: input.logo_url } : {}),
+      ...(wantActive ? { active: input.active } : {}),
       ...(activeFlips ? { deactivated_at: input.active ? null : new Date() } : {}),
     },
   });
 
+  const fields = [
+    ...(wantFirmName ? ["firm_name"] : []),
+    ...(input.services !== undefined ? ["services"] : []),
+    ...(input.website !== undefined ? ["website"] : []),
+    ...(input.logo_url !== undefined ? ["logo_url"] : []),
+    ...(wantActive ? ["active"] : []),
+  ];
+
   await logAuditEvent(prisma, {
-    actor_type: "admin",
-    actor_id: admin.id,
+    actor_type: actor.type,
+    actor_id: actor.id,
     action: activeFlips
       ? input.active
         ? "auditor_reactivated"
         : "auditor_deactivated"
       : "auditor_updated",
-    meta: { firm_name: auditor.firm_name },
+    meta: {
+      firm_name: auditor.firm_name,
+      fields,
+      ...(isAuditor ? { actor_email: actor.email } : {}),
+    },
   });
 
   return { success: true, auditor };
@@ -180,26 +200,32 @@ export async function resolveAuditorByEmail(email: string): Promise<Auditor | nu
 
   const actorEmail = identity.member?.email ?? identity.auditor.quote_email;
   // Only an active firm's teammate counts as having accepted the invite; a
-  // deactivated firm's read-only visit must not flip the row to active.
+  // deactivated firm's read-only visit must not flip the row to active. Guard
+  // the teammate stamp so a race stamps once (S-27).
   if (identity.auditor.active && identity.member && !identity.member.first_login_at) {
-    await prisma.auditorMember.update({
-      where: { id: identity.member.id },
+    await prisma.auditorMember.updateMany({
+      where: { id: identity.member.id, first_login_at: null },
       data: { first_login_at: new Date() },
     });
   }
 
   if (identity.auditor.active && !identity.auditor.first_login_at) {
-    const updated = await prisma.auditor.update({
-      where: { id: identity.auditor.id },
+    // Guard on first_login_at: null so two concurrent first logins log the
+    // event exactly once (the winner's updateMany reports count 1; S-27).
+    const stamp = await prisma.auditor.updateMany({
+      where: { id: identity.auditor.id, first_login_at: null },
       data: { first_login_at: new Date() },
     });
-    await logAuditEvent(prisma, {
-      actor_type: "auditor",
-      actor_id: identity.auditor.id,
-      action: "auditor_first_login",
-      meta: { firm_name: identity.auditor.firm_name, actor_email: actorEmail },
-    });
-    return updated;
+    if (stamp.count === 1) {
+      await logAuditEvent(prisma, {
+        actor_type: "auditor",
+        actor_id: identity.auditor.id,
+        action: "auditor_first_login",
+        meta: { firm_name: identity.auditor.firm_name, actor_email: actorEmail },
+      });
+    }
+    // Return a stamped row for both the winner and the loser of the race.
+    return { ...identity.auditor, first_login_at: identity.auditor.first_login_at ?? new Date() };
   }
 
   return identity.auditor;

--- a/server/services/audits/csv.ts
+++ b/server/services/audits/csv.ts
@@ -2,8 +2,12 @@
 
 function escapeCsv(value: unknown): string {
   if (value === null || value === undefined) return "";
-  const text = value instanceof Date ? value.toISOString().slice(0, 10) : String(value);
-  return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+  let text = value instanceof Date ? value.toISOString().slice(0, 10) : String(value);
+  // Formula-injection guard: a cell a spreadsheet would evaluate is prefixed
+  // so it renders as text (S-15; the whitelist export now carries firm-set
+  // team_emails).
+  if (/^[=+\-@]/.test(text)) text = `'${text}`;
+  return /[",\n]/.test(text) || text.startsWith("'") ? `"${text.replace(/"/g, '""')}"` : text;
 }
 
 export function toCsv(header: string[], rows: unknown[][]): string {

--- a/server/services/audits/emails/sendAuditorInvite.ts
+++ b/server/services/audits/emails/sendAuditorInvite.ts
@@ -10,9 +10,10 @@ export interface InviteRecipient {
 
 /**
  * Sent when an admin adds a firm to the whitelist (and on resend), and when an
- * admin approves a teammate address for a firm. The 6-digit OTP itself comes
- * from the existing sign-in flow; this only carries the instruction and the
- * portal link. Recipient is ALWAYS an Auditor or AuditorMember row's address.
+ * admin or the firm's quote-email identity approves a teammate address. The
+ * copy names no actor on purpose. The 6-digit OTP itself comes from the
+ * existing sign-in flow; this only carries the instruction and the portal
+ * link. Recipient is ALWAYS an Auditor or AuditorMember row's address.
  * Escaping lives in the shared template.
  */
 export async function sendAuditorInvite(auditor: InviteRecipient): Promise<void> {

--- a/server/services/audits/emails/sendNotSelectedNotice.ts
+++ b/server/services/audits/emails/sendNotSelectedNotice.ts
@@ -28,7 +28,7 @@ export async function sendNotSelectedNotice(
     body: "No further action is needed. Your quote stays private to the project and the program team, and new requests keep arriving in your inbox.",
     cta: { label: "Open the auditor portal", href: PORTAL_URL, variant: "neutral" },
     footerLines: [
-      "Your firm stays on the whitelist · every new request fans out to you automatically.",
+      "Your firm stays on the whitelist · nothing changes on your side.",
     ],
   });
 

--- a/server/services/audits/emails/sendTeamChangeNotice.ts
+++ b/server/services/audits/emails/sendTeamChangeNotice.ts
@@ -1,0 +1,43 @@
+import { sendMail } from "@/server/services/mail";
+import { renderAuditEmail } from "@/server/services/audits/emails/template";
+import { PORTAL_URL } from "@/server/services/audits/emails/links";
+
+export interface TeamChangeNotice {
+  quoteEmail: string;
+  firmName: string;
+  changedEmail: string;
+  actorEmail: string;
+  change: "added" | "removed";
+}
+
+/**
+ * Sent to a firm's quote email whenever its team changes FROM THE PORTAL
+ * (S-2). firm_name is admin-controlled and both addresses are validated
+ * lowercase emails; the shared template escapes once. Admin-originated
+ * changes send nothing (members.ts gates on actor.type).
+ */
+export async function sendTeamChangeNotice(notice: TeamChangeNotice): Promise<void> {
+  const added = notice.change === "added";
+  const subject = added
+    ? `A teammate was added to ${notice.firmName} on the audit whitelist`
+    : `A teammate was removed from ${notice.firmName} on the audit whitelist`;
+  const title = added
+    ? `${notice.changedEmail} was added to ${notice.firmName}.`
+    : `${notice.changedEmail} was removed from ${notice.firmName}.`;
+  const body = added
+    ? `${notice.actorEmail} added this address from the firm details page. It can now sign in to the auditor portal, receives every notice your firm receives and reads everything your firm's portal shows. Not expected? Remove it from the firm details page or contact the program team.`
+    : `${notice.actorEmail} removed this address from the firm details page. It can no longer sign in to the auditor portal. Not expected? Contact the program team.`;
+  const firmUrl = `${PORTAL_URL}/firm`;
+
+  const html = renderAuditEmail({
+    eyebrow: "Whitelist team change",
+    title,
+    body,
+    cta: { label: "Open firm details", href: firmUrl, variant: "neutral" },
+    footerLines: [
+      "Sent to the firm's quote email whenever a teammate is added or removed from the portal.",
+    ],
+  });
+  const text = [title, body, `Open firm details: ${firmUrl}`].join("\n");
+  await sendMail(notice.quoteEmail, html, subject, text);
+}

--- a/server/services/audits/events.ts
+++ b/server/services/audits/events.ts
@@ -15,6 +15,15 @@ export interface AuditEventInput {
   meta?: Prisma.InputJsonValue;
 }
 
+/**
+ * Who performed an audit-program action. `id` is the firm id for auditors
+ * (the established actor_id shape at auditors.ts:196-201, quotes.ts:83-93);
+ * `email` is the acting approved address. Admins carry their User id and name.
+ */
+export type AuditActor =
+  | { type: "admin"; id: string; name: string }
+  | { type: "auditor"; id: string; email: string };
+
 export async function logAuditEvent(db: AuditDb, entry: AuditEventInput): Promise<void> {
   await db.auditEventLog.create({
     data: {

--- a/server/services/audits/fanout.ts
+++ b/server/services/audits/fanout.ts
@@ -20,6 +20,15 @@ export const FANOUT_FIRM_SELECT = {
 } as const;
 export type FanoutFirm = Prisma.AuditorGetPayload<{ select: typeof FANOUT_FIRM_SELECT }>;
 
+/**
+ * The firms a request fans out to. An empty shortlist means every active firm
+ * (the stored default); a non-empty one narrows to those ids that are still
+ * active. Imported by requests.ts so approval and reopen cannot drift (S-20).
+ */
+export function fanoutFirmsWhere(ids: string[]) {
+  return { active: true as const, ...(ids.length > 0 ? { id: { in: ids } } : {}) };
+}
+
 export type SubmitResult =
   | { success: true }
   | { success: false; code: "not_found" }
@@ -59,6 +68,7 @@ const FANOUT_REQUEST_SELECT = {
   multichain: true,
   needed_by: true,
   urgency: true,
+  shortlist_auditor_ids: true,
 } as const;
 
 type FanoutRow = {
@@ -77,6 +87,7 @@ type FanoutRow = {
   multichain: boolean;
   needed_by: Date | null;
   urgency: string | null;
+  shortlist_auditor_ids: string[];
 };
 
 export function toFanoutRequest(row: FanoutRow): FanoutRequest {
@@ -189,8 +200,9 @@ export async function approveRequestAndFanout(
       data: { status: "collecting", quote_deadline },
     });
 
+    const shortlistIds = row.shortlist_auditor_ids;
     const auditors = await tx.auditor.findMany({
-      where: { active: true },
+      where: fanoutFirmsWhere(shortlistIds),
       select: FANOUT_FIRM_SELECT,
     });
 
@@ -200,6 +212,14 @@ export async function approveRequestAndFanout(
         skipDuplicates: true,
       });
     }
+
+    // Resolved count (not the raw array length) and the live whitelist size,
+    // for the admin trail (S-19). shortlist_count is 0 for an empty shortlist.
+    const shortlist_count =
+      shortlistIds.length > 0
+        ? await tx.auditor.count({ where: { id: { in: shortlistIds } } })
+        : 0;
+    const whitelist_count = await tx.auditor.count({ where: { active: true } });
 
     await tx.auditEventLog.createMany({
       data: [
@@ -215,7 +235,7 @@ export async function approveRequestAndFanout(
           actor_type: "system",
           actor_id: null,
           action: "fanout_created",
-          meta: { auditor_count: auditors.length },
+          meta: { auditor_count: auditors.length, shortlist_count, whitelist_count },
         },
       ],
     });

--- a/server/services/audits/members.ts
+++ b/server/services/audits/members.ts
@@ -1,8 +1,9 @@
 import { Prisma, type AuditorMember } from "@prisma/client";
 import { prisma } from "@/prisma/prisma";
 import { AUDITOR_MEMBER_LIMIT } from "@/lib/audits/constants";
-import { logAuditEvent } from "@/server/services/audits/events";
+import { logAuditEvent, type AuditActor } from "@/server/services/audits/events";
 import { sendAuditorInvite } from "@/server/services/audits/emails/sendAuditorInvite";
+import { sendTeamChangeNotice } from "@/server/services/audits/emails/sendTeamChangeNotice";
 import type { AuditorMemberCreateInput } from "@/types/audits";
 
 export type AddMemberResult =
@@ -11,17 +12,18 @@ export type AddMemberResult =
 
 type AddMemberTxOutcome =
   | { kind: "not_found" | "limit_reached" | "duplicate_email" }
-  | { kind: "ok"; member: AuditorMember; firm_name: string };
+  | { kind: "ok"; member: AuditorMember; firm_name: string; quote_email: string };
 
 /**
- * Approve one more sign-in address for a firm and invite it (Matthew's
- * 2026-09-01 ask, admin-managed by decision). Same shape as createAuditor: an
- * invite failure never loses the row, the response carries inviteSent.
+ * Approve one more sign-in address for a firm and invite it. Admins do it from
+ * the whitelist sheet; the firm's quote-email identity does it from the firm
+ * details page (v1.1). Same shape as createAuditor: an invite failure never
+ * loses the row, the response carries inviteSent.
  */
 export async function addAuditorMember(
   auditorId: string,
   input: AuditorMemberCreateInput,
-  admin: { id: string; name: string },
+  actor: AuditActor,
 ): Promise<AddMemberResult> {
   let outcome: AddMemberTxOutcome;
   try {
@@ -47,9 +49,20 @@ export async function addAuditorMember(
         if (firmClash) return { kind: "duplicate_email" };
 
         const member = await tx.auditorMember.create({
-          data: { auditor_id: auditor.id, email: input.email, added_by: admin.id },
+          data: {
+            auditor_id: auditor.id,
+            email: input.email,
+            // added_by is a real FK to User; an OTP session id "pending_<email>"
+            // is not a User row, so a portal (auditor) add stores null (5.5).
+            added_by: actor.type === "admin" ? actor.id : null,
+          },
         });
-        return { kind: "ok", member, firm_name: auditor.firm_name };
+        return {
+          kind: "ok",
+          member,
+          firm_name: auditor.firm_name,
+          quote_email: auditor.quote_email,
+        };
       },
       { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
     );
@@ -63,7 +76,7 @@ export async function addAuditorMember(
     throw error;
   }
   if (outcome.kind !== "ok") return { success: false, code: outcome.kind };
-  const { member, firm_name } = outcome;
+  const { member, firm_name, quote_email } = outcome;
 
   let inviteSent = true;
   try {
@@ -74,11 +87,31 @@ export async function addAuditorMember(
   }
 
   await logAuditEvent(prisma, {
-    actor_type: "admin",
-    actor_id: admin.id,
+    actor_type: actor.type,
+    actor_id: actor.id,
     action: "auditor_member_added",
-    meta: { firm_name, email: member.email, invite_sent: inviteSent },
+    meta: {
+      firm_name,
+      email: member.email,
+      invite_sent: inviteSent,
+      ...(actor.type === "auditor" ? { actor_email: actor.email } : {}),
+    },
   });
+
+  if (actor.type === "auditor") {
+    try {
+      await sendTeamChangeNotice({
+        quoteEmail: quote_email,
+        firmName: firm_name,
+        changedEmail: member.email,
+        actorEmail: actor.email,
+        change: "added",
+      });
+    } catch (error) {
+      // A notice failure never loses the write (the invite's pattern).
+      console.error("[Audits] team-change notice failed:", error);
+    }
+  }
 
   return { success: true, member, inviteSent };
 }
@@ -94,20 +127,39 @@ export type RemoveMemberResult = { success: true } | { success: false; code: "no
 export async function removeAuditorMember(
   auditorId: string,
   memberId: string,
-  admin: { id: string; name: string },
+  actor: AuditActor,
 ): Promise<RemoveMemberResult> {
   const member = await prisma.auditorMember.findFirst({
     where: { id: memberId, auditor_id: auditorId },
-    include: { auditor: { select: { firm_name: true } } },
+    include: { auditor: { select: { firm_name: true, quote_email: true } } },
   });
   if (!member) return { success: false, code: "not_found" };
 
   await prisma.auditorMember.delete({ where: { id: member.id } });
   await logAuditEvent(prisma, {
-    actor_type: "admin",
-    actor_id: admin.id,
+    actor_type: actor.type,
+    actor_id: actor.id,
     action: "auditor_member_removed",
-    meta: { firm_name: member.auditor.firm_name, email: member.email },
+    meta: {
+      firm_name: member.auditor.firm_name,
+      email: member.email,
+      ...(actor.type === "auditor" ? { actor_email: actor.email } : {}),
+    },
   });
+
+  if (actor.type === "auditor") {
+    try {
+      await sendTeamChangeNotice({
+        quoteEmail: member.auditor.quote_email,
+        firmName: member.auditor.firm_name,
+        changedEmail: member.email,
+        actorEmail: actor.email,
+        change: "removed",
+      });
+    } catch (error) {
+      console.error("[Audits] team-change notice failed:", error);
+    }
+  }
+
   return { success: true };
 }

--- a/server/services/audits/requests.ts
+++ b/server/services/audits/requests.ts
@@ -5,6 +5,7 @@ import { QUOTE_DEADLINE_DEFAULT_DAYS } from "@/lib/audits/constants";
 import { logAuditEvent } from "@/server/services/audits/events";
 import {
   deliverFanoutEmails,
+  fanoutFirmsWhere,
   FANOUT_FIRM_SELECT,
   toFanoutRequest,
   type FanoutFirm,
@@ -125,8 +126,9 @@ export async function reopen(userId: string, requestId: string): Promise<ReopenR
     const quote_deadline = new Date(Date.now() + QUOTE_DEADLINE_DEFAULT_DAYS * DAY);
     await tx.auditRequest.update({ where: { id: row.id }, data: { quote_deadline } });
 
+    const shortlistIds = row.shortlist_auditor_ids;
     const auditors = await tx.auditor.findMany({
-      where: { active: true },
+      where: fanoutFirmsWhere(shortlistIds),
       select: FANOUT_FIRM_SELECT,
     });
     if (auditors.length > 0) {
@@ -135,13 +137,18 @@ export async function reopen(userId: string, requestId: string): Promise<ReopenR
         skipDuplicates: true,
       });
     }
+    const shortlist_count =
+      shortlistIds.length > 0
+        ? await tx.auditor.count({ where: { id: { in: shortlistIds } } })
+        : 0;
+    const whitelist_count = await tx.auditor.count({ where: { active: true } });
     await tx.auditEventLog.create({
       data: {
         request_id: row.id,
         actor_type: "project_user",
         actor_id: userId,
         action: "request_reopened",
-        meta: { auditor_count: auditors.length },
+        meta: { auditor_count: auditors.length, shortlist_count, whitelist_count },
       },
     });
 

--- a/server/services/audits/visibility.ts
+++ b/server/services/audits/visibility.ts
@@ -148,18 +148,93 @@ export async function getOwnerRequestDetail(userId: string, requestId: string) {
       }
     : null;
 
+  // The chosen firms still active, by name; empty stored array means all.
+  const shortlistIds = row.shortlist_auditor_ids;
+  const shortlist_firms =
+    shortlistIds.length > 0
+      ? (
+          await prisma.auditor.findMany({
+            where: { id: { in: shortlistIds }, active: true },
+            select: { id: true, firm_name: true },
+          })
+        ).sort((a, b) =>
+          a.firm_name.localeCompare(b.firm_name, undefined, { sensitivity: "base" }),
+        )
+      : [];
+  const whitelist_count = await countActiveFirms();
+
   const { quotes: _quotes, subsidy_decisions: _decisions, _count, ...request } = row;
   return {
     ...request,
     display_status,
     quote_count: quotes.length,
     fanout_count: _count.fanout_deliveries,
+    shortlist_firms,
+    whitelist_count,
     quotes,
     subsidy,
   };
 }
 
 export type OwnerRequestDetail = NonNullable<Awaited<ReturnType<typeof getOwnerRequestDetail>>>;
+
+// ── Public scope ────────────────────────────────────────────────────────────
+// The only firm fields that reach a client without admin rights.
+
+export interface PublicFirm {
+  id: string;
+  firm_name: string;
+  services: string[];
+  website: string | null;
+  logo_url: string | null;
+}
+
+/**
+ * THE ONE read of firm fields that reaches a client without admin rights.
+ * Explicit select, never include, never a row spread (S-8). Sorted in code,
+ * case-insensitively, so the order is collation-independent.
+ */
+export async function getPublicFirms(): Promise<PublicFirm[]> {
+  const rows = await prisma.auditor.findMany({
+    where: { active: true },
+    select: { id: true, firm_name: true, services: true, website: true, logo_url: true },
+  });
+  return rows.sort((a, b) =>
+    a.firm_name.localeCompare(b.firm_name, undefined, { sensitivity: "base" }),
+  );
+}
+
+/** Active firms at this moment: the wizard and landing whitelist figure. */
+export async function countActiveFirms(): Promise<number> {
+  return prisma.auditor.count({ where: { active: true } });
+}
+
+/**
+ * A firm's own details for the portal firm page: identity, services, website
+ * and its teammates. Never attio_ref, created_by or logo_url (firms cannot
+ * change the logo).
+ */
+export async function getOwnFirm(auditorId: string) {
+  return prisma.auditor.findUnique({
+    where: { id: auditorId },
+    select: {
+      id: true,
+      firm_name: true,
+      quote_email: true,
+      services: true,
+      website: true,
+      active: true,
+      invited_at: true,
+      first_login_at: true,
+      deactivated_at: true,
+      members: {
+        orderBy: { created_at: "asc" },
+        select: { id: true, email: true, invited_at: true, first_login_at: true },
+      },
+    },
+  });
+}
+export type OwnFirm = NonNullable<Awaited<ReturnType<typeof getOwnFirm>>>;
 
 // ── Auditor scope ───────────────────────────────────────────────────────────
 // Every function pins auditor_id unconditionally; an auditor's inbox is
@@ -533,10 +608,28 @@ export async function getAdminRequestDetail(requestId: string) {
   });
   if (!row) return null;
 
+  // Every stored id that resolves to a firm, carrying active (admins see the
+  // deactivated ones too); empty stored array means all.
+  const shortlistIds = row.shortlist_auditor_ids;
+  const shortlist_firms =
+    shortlistIds.length > 0
+      ? (
+          await prisma.auditor.findMany({
+            where: { id: { in: shortlistIds } },
+            select: { id: true, firm_name: true, active: true },
+          })
+        ).sort((a, b) =>
+          a.firm_name.localeCompare(b.firm_name, undefined, { sensitivity: "base" }),
+        )
+      : [];
+  const whitelist_count = await countActiveFirms();
+
   const display_status = deriveRequestStatus(row, row.quotes.length);
   return {
     ...row,
     display_status,
+    shortlist_firms,
+    whitelist_count,
     quotes: row.quotes.map((quote) => ({
       id: quote.id,
       price_usd: quote.price_usd,
@@ -574,6 +667,8 @@ export interface AdminAuditorRow {
   first_login_at: Date | null;
   deactivated_at: Date | null;
   attio_ref: string | null;
+  website: string | null;
+  logo_url: string | null;
   sent: number;
   quoted: number;
   won: number;
@@ -605,6 +700,8 @@ export async function getAdminAuditors(): Promise<AdminAuditorRow[]> {
     first_login_at: row.first_login_at,
     deactivated_at: row.deactivated_at,
     attio_ref: row.attio_ref,
+    website: row.website,
+    logo_url: row.logo_url,
     members: row.members,
     sent: row._count.fanout_deliveries,
     quoted: row.quotes.length,

--- a/tests/unit/audits/auditors.test.ts
+++ b/tests/unit/audits/auditors.test.ts
@@ -4,18 +4,22 @@ import { Prisma } from "@prisma/client";
 const {
   auditorFindUniqueMock,
   auditorUpdateMock,
+  auditorUpdateManyMock,
   auditorCreateMock,
   memberFindUniqueMock,
   memberUpdateMock,
+  memberUpdateManyMock,
   eventCreateMock,
   inviteMock,
   transactionMock,
 } = vi.hoisted(() => ({
   auditorFindUniqueMock: vi.fn(),
   auditorUpdateMock: vi.fn(),
+  auditorUpdateManyMock: vi.fn(),
   auditorCreateMock: vi.fn(),
   memberFindUniqueMock: vi.fn(),
   memberUpdateMock: vi.fn(),
+  memberUpdateManyMock: vi.fn(),
   eventCreateMock: vi.fn(),
   inviteMock: vi.fn(),
   transactionMock: vi.fn(),
@@ -33,9 +37,14 @@ vi.mock("@/prisma/prisma", () => ({
     auditor: {
       findUnique: auditorFindUniqueMock,
       update: auditorUpdateMock,
+      updateMany: auditorUpdateManyMock,
       create: auditorCreateMock,
     },
-    auditorMember: { findUnique: memberFindUniqueMock, update: memberUpdateMock },
+    auditorMember: {
+      findUnique: memberFindUniqueMock,
+      update: memberUpdateMock,
+      updateMany: memberUpdateManyMock,
+    },
     auditEventLog: { create: eventCreateMock },
   },
 }));
@@ -47,6 +56,7 @@ import {
   createAuditor,
   findAuditorByEmail,
   resolveAuditorByEmail,
+  updateAuditor,
 } from "@/server/services/audits/auditors";
 
 const FIRM = {
@@ -56,6 +66,8 @@ const FIRM = {
   active: true,
   first_login_at: new Date("2026-08-01"),
 };
+const ADMIN_ACTOR = { type: "admin" as const, id: "admin-1", name: "Federico" };
+const AUDITOR_ACTOR = { type: "auditor" as const, id: "aud-1", email: "alice@nordlicht.example" };
 const MEMBER = {
   id: "mem-1",
   auditor_id: "aud-1",
@@ -72,6 +84,8 @@ beforeEach(() => {
     ...args.data,
   }));
   memberUpdateMock.mockResolvedValue({});
+  auditorUpdateManyMock.mockResolvedValue({ count: 1 });
+  memberUpdateManyMock.mockResolvedValue({ count: 1 });
   eventCreateMock.mockResolvedValue({});
   inviteMock.mockResolvedValue(undefined);
   transactionMock.mockImplementation(async (fn: (client: typeof tx) => Promise<unknown>) => fn(tx));
@@ -114,9 +128,11 @@ describe("resolveAuditorByEmail", () => {
     const auditor = await resolveAuditorByEmail("alice@nordlicht.example");
 
     expect(auditor).toEqual(FIRM);
-    expect(memberUpdateMock.mock.calls[0][0]).toMatchObject({ where: { id: "mem-1" } });
-    expect(memberUpdateMock.mock.calls[0][0].data.first_login_at).toBeInstanceOf(Date);
-    expect(auditorUpdateMock).not.toHaveBeenCalled();
+    expect(memberUpdateManyMock.mock.calls[0][0]).toMatchObject({
+      where: { id: "mem-1", first_login_at: null },
+    });
+    expect(memberUpdateManyMock.mock.calls[0][0].data.first_login_at).toBeInstanceOf(Date);
+    expect(auditorUpdateManyMock).not.toHaveBeenCalled();
     expect(eventCreateMock).not.toHaveBeenCalled();
   });
 
@@ -126,7 +142,9 @@ describe("resolveAuditorByEmail", () => {
 
     await resolveAuditorByEmail("alice@nordlicht.example");
 
-    expect(auditorUpdateMock.mock.calls[0][0]).toMatchObject({ where: { id: "aud-1" } });
+    expect(auditorUpdateManyMock.mock.calls[0][0]).toMatchObject({
+      where: { id: "aud-1", first_login_at: null },
+    });
     expect(eventCreateMock.mock.calls[0][0].data).toMatchObject({
       actor_type: "auditor",
       actor_id: "aud-1",
@@ -141,8 +159,8 @@ describe("resolveAuditorByEmail", () => {
     const auditor = await resolveAuditorByEmail("alice@nordlicht.example");
 
     expect(auditor).toMatchObject({ id: "aud-1", active: false });
-    expect(memberUpdateMock).not.toHaveBeenCalled();
-    expect(auditorUpdateMock).not.toHaveBeenCalled();
+    expect(memberUpdateManyMock).not.toHaveBeenCalled();
+    expect(auditorUpdateManyMock).not.toHaveBeenCalled();
   });
 
   it("does not re-stamp a teammate who already signed in", async () => {
@@ -154,7 +172,56 @@ describe("resolveAuditorByEmail", () => {
 
     await resolveAuditorByEmail("alice@nordlicht.example");
 
-    expect(memberUpdateMock).not.toHaveBeenCalled();
+    expect(memberUpdateManyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("updateAuditor", () => {
+  beforeEach(() => {
+    auditorFindUniqueMock.mockResolvedValue({ ...FIRM, active: true });
+    auditorUpdateMock.mockImplementation(async (a: { data: Record<string, unknown> }) => ({
+      ...FIRM,
+      ...a.data,
+    }));
+  });
+
+  it("an admin actor spreads services, website and logo_url", async () => {
+    await updateAuditor(
+      "aud-1",
+      { services: ["OpSec"], website: "https://x.example/", logo_url: "https://b" },
+      ADMIN_ACTOR,
+    );
+    expect(auditorUpdateMock.mock.calls[0][0].data).toMatchObject({
+      services: ["OpSec"],
+      website: "https://x.example/",
+      logo_url: "https://b",
+    });
+  });
+
+  it("logs an auditor actor with actor_type, actor_email and the changed fields", async () => {
+    await updateAuditor("aud-1", { website: "https://x.example/" }, AUDITOR_ACTOR);
+    expect(eventCreateMock.mock.calls[0][0].data).toMatchObject({
+      actor_type: "auditor",
+      actor_id: "aud-1",
+      action: "auditor_updated",
+      meta: {
+        firm_name: "Nordlicht Security",
+        actor_email: "alice@nordlicht.example",
+        fields: ["website"],
+      },
+    });
+  });
+
+  it("never lets an auditor actor write active or firm_name (S-13)", async () => {
+    await updateAuditor(
+      "aud-1",
+      { active: false, firm_name: "X", services: ["OpSec"] } as never,
+      AUDITOR_ACTOR,
+    );
+    const data = auditorUpdateMock.mock.calls[0][0].data;
+    expect("active" in data).toBe(false);
+    expect("firm_name" in data).toBe(false);
+    expect(data).toMatchObject({ services: ["OpSec"] });
   });
 });
 

--- a/tests/unit/audits/csv.test.ts
+++ b/tests/unit/audits/csv.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { toCsv } from "@/server/services/audits/csv";
+
+describe("escapeCsv formula-prefix guard (S-15)", () => {
+  it("prefixes and quotes a cell starting with =, +, - or @", () => {
+    const csv = toCsv(["h"], [["=1+1"], ["+1"], ["-1"], ["@x"], ["ok"]]);
+    const rows = csv.trim().split("\n");
+    for (const bad of ['"\'=1+1"', '"\'+1"', '"\'-1"', '"\'@x"']) expect(csv).toContain(bad);
+    expect(rows[rows.length - 1]).toBe("ok");
+  });
+});

--- a/tests/unit/audits/draftSchema.test.ts
+++ b/tests/unit/audits/draftSchema.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { auditDraftSchema, auditSubmitSchema } from "@/types/audits";
+
+const uuid = (n: number) => `00000000-0000-4000-8000-${String(n).padStart(12, "0")}`;
+
+describe("auditDraftSchema · shortlist_auditor_ids", () => {
+  it("accepts an empty array", () => {
+    expect(auditDraftSchema.safeParse({ shortlist_auditor_ids: [] }).success).toBe(true);
+  });
+
+  it("accepts 50 uuids and rejects 51", () => {
+    expect(
+      auditDraftSchema.safeParse({ shortlist_auditor_ids: Array.from({ length: 50 }, (_, i) => uuid(i)) }).success,
+    ).toBe(true);
+    expect(
+      auditDraftSchema.safeParse({ shortlist_auditor_ids: Array.from({ length: 51 }, (_, i) => uuid(i)) }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a non-uuid and rejects duplicates", () => {
+    expect(auditDraftSchema.safeParse({ shortlist_auditor_ids: ["not-a-uuid"] }).success).toBe(false);
+    expect(auditDraftSchema.safeParse({ shortlist_auditor_ids: [uuid(1), uuid(1)] }).success).toBe(false);
+  });
+
+  it("lowercases an uppercase uuid so the case-sensitive `in` clause still matches (S-28)", () => {
+    const parsed = auditDraftSchema.safeParse({ shortlist_auditor_ids: [uuid(1).toUpperCase()] });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.shortlist_auditor_ids).toEqual([uuid(1)]);
+  });
+
+  it("is absent from the submit schema, so an empty shortlist stays submittable (fanout.test.ts:117)", () => {
+    // auditSubmitSchema neither requires nor rejects the key: unknown keys are stripped.
+    const parsed = auditSubmitSchema.safeParse({
+      project_name: "X",
+      website: "https://x.example",
+      description: "0123456789",
+      scope: "0123456789",
+      deployment_target: "c_chain",
+      services: ["OpSec"],
+      needed_by: new Date(),
+      contact_name: "A",
+      contact_email: "a@b.example",
+      shortlist_auditor_ids: [uuid(1)],
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect("shortlist_auditor_ids" in parsed.data).toBe(false);
+  });
+
+  it("rejects reserved columns through the strictObject (S-18)", () => {
+    expect(auditDraftSchema.safeParse({ status: "collecting" }).success).toBe(false);
+    expect(auditDraftSchema.safeParse({ user_id: "u1" }).success).toBe(false);
+    expect(auditDraftSchema.safeParse({ id: "r1" }).success).toBe(false);
+  });
+});

--- a/tests/unit/audits/emails.test.ts
+++ b/tests/unit/audits/emails.test.ts
@@ -8,6 +8,7 @@ import { sendAuditorInvite } from "@/server/services/audits/emails/sendAuditorIn
 import { sendNotSelectedNotice } from "@/server/services/audits/emails/sendNotSelectedNotice";
 import { sendQuoteAcceptedNotice } from "@/server/services/audits/emails/sendQuoteAcceptedNotice";
 import { sendSubsidyDecisionNotice } from "@/server/services/audits/emails/sendSubsidyDecisionNotice";
+import { sendTeamChangeNotice } from "@/server/services/audits/emails/sendTeamChangeNotice";
 
 const AUDITOR = { firm_name: "Nordlicht Security", quote_email: "quotes@nordlicht.example" };
 const REQUEST = {
@@ -100,6 +101,45 @@ describe("sendNotSelectedNotice", () => {
 
     expect(htmlOf()).not.toContain("<script>");
     expect(htmlOf()).toContain("&lt;script&gt;");
+  });
+});
+
+describe("sendTeamChangeNotice", () => {
+  const base = {
+    quoteEmail: "quotes@nordlicht.example",
+    firmName: "Nordlicht Security",
+    changedEmail: "bob@nordlicht.example",
+    actorEmail: "alice@nordlicht.example",
+  };
+
+  it("notifies the quote email of an add, naming the address and the actor, no em dashes", async () => {
+    await sendTeamChangeNotice({ ...base, change: "added" });
+
+    const [to, html, subject, text] = sendMailMock.mock.calls[0] as [
+      string,
+      string,
+      string,
+      string,
+    ];
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
+    expect(to).toBe("quotes@nordlicht.example");
+    expect(subject).toContain("added");
+    for (const part of [html, text]) {
+      expect(part).toContain("bob@nordlicht.example");
+      expect(part).toContain("alice@nordlicht.example");
+    }
+    for (const part of [subject, html, text]) {
+      expect(part).not.toContain("—");
+    }
+  });
+
+  it("notifies the quote email of a removal in the removed variant", async () => {
+    await sendTeamChangeNotice({ ...base, change: "removed" });
+
+    const [to, , subject, text] = sendMailMock.mock.calls[0] as [string, string, string, string];
+    expect(to).toBe("quotes@nordlicht.example");
+    expect(subject).toContain("removed");
+    expect(text).toContain("can no longer sign in");
   });
 });
 

--- a/tests/unit/audits/fanout.test.ts
+++ b/tests/unit/audits/fanout.test.ts
@@ -4,6 +4,7 @@ const {
   txRequestFindFirstMock,
   txRequestUpdateMock,
   txAuditorFindManyMock,
+  txAuditorCountMock,
   txDeliveryCreateManyMock,
   txEventCreateManyMock,
   txEventCreateMock,
@@ -15,6 +16,7 @@ const {
   txRequestFindFirstMock: vi.fn(),
   txRequestUpdateMock: vi.fn(),
   txAuditorFindManyMock: vi.fn(),
+  txAuditorCountMock: vi.fn(),
   txDeliveryCreateManyMock: vi.fn(),
   txEventCreateManyMock: vi.fn(),
   txEventCreateMock: vi.fn(),
@@ -26,7 +28,7 @@ const {
 
 const tx = {
   auditRequest: { findFirst: txRequestFindFirstMock, update: txRequestUpdateMock },
-  auditor: { findMany: txAuditorFindManyMock },
+  auditor: { findMany: txAuditorFindManyMock, count: txAuditorCountMock },
   auditFanoutDelivery: { createMany: txDeliveryCreateManyMock },
   auditEventLog: { createMany: txEventCreateManyMock, create: txEventCreateMock },
 };
@@ -78,6 +80,7 @@ const completeDraft = {
   contact_name: "Alex Stone",
   contact_email: "alex@glacierswap.example",
   contact_calendar_url: null,
+  shortlist_auditor_ids: [],
 };
 
 const pendingRow = { ...completeDraft, status: "pending_review" };
@@ -98,6 +101,7 @@ beforeEach(() => {
   txRequestFindFirstMock.mockResolvedValue(completeDraft);
   txRequestUpdateMock.mockResolvedValue({});
   txAuditorFindManyMock.mockResolvedValue(ACTIVE_FIRMS);
+  txAuditorCountMock.mockResolvedValue(3);
   txDeliveryCreateManyMock.mockResolvedValue({ count: ACTIVE_FIRMS.length });
   txEventCreateManyMock.mockResolvedValue({ count: 2 });
   txEventCreateMock.mockResolvedValue({});
@@ -244,6 +248,34 @@ describe("approveRequestAndFanout", () => {
     expect(result).toMatchObject({ success: true, emailFailures: 1 });
     const statuses = deliveryUpdateMock.mock.calls.map((c) => c[0].data.email_status).sort();
     expect(statuses).toEqual(["failed", "sent", "sent"]);
+  });
+
+  it("fans out to a stored shortlist with an exact where clause", async () => {
+    txRequestFindFirstMock.mockResolvedValue({ ...pendingRow, shortlist_auditor_ids: ["aud-1", "aud-2"] });
+    await approveRequestAndFanout("req-1", ADMIN, ADMIN_NAME);
+    expect(txAuditorFindManyMock.mock.calls[0][0].where).toEqual({ active: true, id: { in: ["aud-1", "aud-2"] } });
+  });
+
+  it("fans out to every active firm when the shortlist is empty", async () => {
+    txRequestFindFirstMock.mockResolvedValue({ ...pendingRow, shortlist_auditor_ids: [] });
+    await approveRequestAndFanout("req-1", ADMIN, ADMIN_NAME);
+    expect(txAuditorFindManyMock.mock.calls[0][0].where).toEqual({ active: true });
+  });
+
+  it("records auditor_count, shortlist_count (resolved) and whitelist_count on fanout_created", async () => {
+    txRequestFindFirstMock.mockResolvedValue({ ...pendingRow, shortlist_auditor_ids: ["aud-1", "aud-2"] });
+    txAuditorCountMock.mockResolvedValueOnce(1).mockResolvedValueOnce(16); // resolved shortlist, then whitelist
+    await approveRequestAndFanout("req-1", ADMIN, ADMIN_NAME);
+    const fanoutEvent = txEventCreateManyMock.mock.calls[0][0].data[1];
+    expect(fanoutEvent.action).toBe("fanout_created");
+    expect(fanoutEvent.meta).toMatchObject({ auditor_count: 3, shortlist_count: 1, whitelist_count: 16 });
+  });
+
+  it("FANOUT_REQUEST_SELECT carries shortlist_auditor_ids but toFanoutRequest drops it", async () => {
+    await approveRequestAndFanout("req-1", ADMIN, ADMIN_NAME);
+    expect(txRequestFindFirstMock.mock.calls[0][0].select.shortlist_auditor_ids).toBe(true);
+    const { toFanoutRequest } = await import("@/server/services/audits/fanout");
+    expect("shortlist_auditor_ids" in toFanoutRequest({ ...completeDraft, quote_deadline: null } as never)).toBe(false);
   });
 });
 

--- a/tests/unit/audits/firmDetails.render.test.tsx
+++ b/tests/unit/audits/firmDetails.render.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: () => {} }) }));
+
+import { FirmDetails } from "@/components/audits/portal/FirmDetails";
+import type { OwnFirm } from "@/server/services/audits/visibility";
+
+const firm = (over: Partial<OwnFirm> = {}): OwnFirm => ({
+  id: "aud-1",
+  firm_name: "Nordlicht Security",
+  quote_email: "quotes@nordlicht.example",
+  services: ["OpSec"],
+  website: "https://nordlicht.example",
+  active: true,
+  invited_at: new Date("2026-09-04"),
+  first_login_at: new Date("2026-09-05"),
+  deactivated_at: null,
+  members: [
+    {
+      id: "mem-1",
+      email: "alice@nordlicht.example",
+      invited_at: new Date("2026-09-06"),
+      first_login_at: null,
+    },
+  ],
+  ...over,
+});
+
+const render = (props: { isOwner: boolean; readOnly: boolean; firm?: OwnFirm }) =>
+  renderToStaticMarkup(
+    createElement(FirmDetails, {
+      firm: props.firm ?? firm(),
+      isOwner: props.isOwner,
+      readOnly: props.readOnly,
+    }),
+  );
+
+describe("FirmDetails", () => {
+  it("the owner sees the add form and a Remove control", () => {
+    const html = render({ isOwner: true, readOnly: false });
+    expect(html).toContain("Add and invite");
+    expect(html).toContain("Remove");
+    expect(html).not.toContain("can add or remove teammates");
+  });
+
+  it("a teammate sees neither, and the pointer names the quote email", () => {
+    const html = render({ isOwner: false, readOnly: false });
+    expect(html).not.toContain("Add and invite");
+    expect(html).toContain("Only quotes@nordlicht.example can add or remove teammates.");
+  });
+
+  it("a deactivated firm shows the banner and disables the controls", () => {
+    const html = render({ isOwner: true, readOnly: true });
+    expect(html).toContain("Deactivated · read-only");
+    const disabledCount = (html.match(/disabled=""/g) ?? []).length;
+    expect(disabledCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders the services and website helpers and the teammate-grant sentence (S-12)", () => {
+    const html = render({ isOwner: true, readOnly: false });
+    expect(html).toContain("Shown on the vetted firms page and on your quotes.");
+    expect(html).toContain("Shown on the vetted firms page");
+    expect(html).toContain(
+      "Teammates receive every request this firm receives and can read its full history",
+    );
+  });
+});

--- a/tests/unit/audits/firmPicker.render.test.tsx
+++ b/tests/unit/audits/firmPicker.render.test.tsx
@@ -69,4 +69,20 @@ describe("FirmPicker", () => {
     expect(html).toContain("listed their services yet");
     expect(html).toContain("pick by name");
   });
+
+  it("quick-pick chip is dashed when its group is partly picked, solid when fully picked (open)", () => {
+    // Four firms so ChipGroup never collapses (its "N more" button is dashed
+    // too); any border-dashed then comes only from a partial quick-pick chip.
+    const firms4: PublicFirm[] = [
+      { id: "m1", firm_name: "Match One", services: ["OpSec"], website: null, logo_url: null },
+      { id: "m2", firm_name: "Match Two", services: ["OpSec"], website: null, logo_url: null },
+      { id: "u1", firm_name: "Unlisted One", services: [], website: null, logo_url: null },
+      { id: "u2", firm_name: "Unlisted Two", services: [], website: null, logo_url: null },
+    ];
+    const partial = render({ firms: firms4, value: ["m1"], defaultOpen: true });
+    expect(partial).toContain("border-dashed");
+    const full = render({ firms: firms4, value: ["m1", "m2"], defaultOpen: true });
+    expect(full).not.toContain("border-dashed");
+    expect(full).toContain('aria-pressed="true"');
+  });
 });

--- a/tests/unit/audits/firmPicker.render.test.tsx
+++ b/tests/unit/audits/firmPicker.render.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { FirmPicker } from "@/components/audits/wizard/FirmPicker";
+import type { PublicFirm } from "@/server/services/audits/visibility";
+
+const firms16: PublicFirm[] = Array.from({ length: 16 }, (_, i) => ({
+  id: `f${i}`,
+  firm_name: `Firm ${i}`,
+  services: i < 8 ? ["OpSec"] : [],
+  website: null,
+  logo_url: null,
+}));
+const firmsBare: PublicFirm[] = firms16.map((f) => ({ ...f, services: [] }));
+
+const noop = () => {};
+
+const render = (props: {
+  firms?: PublicFirm[];
+  value: string[];
+  neededServices?: string[];
+  defaultOpen?: boolean;
+}) =>
+  renderToStaticMarkup(
+    createElement(FirmPicker, {
+      firms: props.firms ?? firms16,
+      neededServices: props.neededServices ?? ["OpSec"],
+      value: props.value,
+      onChange: noop,
+      defaultOpen: props.defaultOpen ?? false,
+    }),
+  );
+
+describe("FirmPicker", () => {
+  it("collapsed default reads the firm count", () => {
+    expect(render({ value: [] })).toContain("All 16 vetted firms");
+  });
+
+  it("collapsed narrowed reads N of total with names", () => {
+    const html = render({ value: ["f0", "f1"] });
+    expect(html).toContain("2 of 16 vetted firms");
+    expect(html).toContain("Firm 0, Firm 1");
+  });
+
+  it("neither counts nor names a stored id absent from the list", () => {
+    const html = render({ value: ["f0", "zzz"] });
+    expect(html).toContain("1 of 16 vetted firms");
+    expect(html).toContain("Firm 0");
+    expect(html).not.toContain("zzz");
+  });
+
+  it("shows the all-gone state when no chosen id resolves", () => {
+    const html = render({ value: ["zzz"] });
+    expect(html).toContain("0 of 16 vetted firms");
+    expect(html).toContain("the firms you chose are no longer listed");
+  });
+
+  it("warns in the singular and the plural at 1 or 2 picked (open)", () => {
+    expect(render({ value: ["f0"], defaultOpen: true })).toContain(
+      "Only 1 firm will see this request.",
+    );
+    expect(render({ value: ["f0", "f1"], defaultOpen: true })).toContain(
+      "Only 2 firms will see this request.",
+    );
+  });
+
+  it("shows the day-one line when no firm has listed services (open)", () => {
+    const html = render({ firms: firmsBare, value: [], defaultOpen: true });
+    expect(html).toContain("listed their services yet");
+    expect(html).toContain("pick by name");
+  });
+});

--- a/tests/unit/audits/firmsList.render.test.tsx
+++ b/tests/unit/audits/firmsList.render.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { FirmsList } from "@/components/audits/firms/FirmsList";
+import type { PublicFirm } from "@/server/services/audits/visibility";
+
+const firm = (over: Partial<PublicFirm>): PublicFirm => ({
+  id: "a",
+  firm_name: "Bailsec",
+  services: [],
+  website: null,
+  logo_url: null,
+  ...over,
+});
+
+describe("FirmsList row", () => {
+  it("renders the hostname link with nofollow when website parses (S-11)", () => {
+    const html = renderToStaticMarkup(
+      createElement(FirmsList, { firms: [firm({ website: "https://bailsec.io/" })] }),
+    );
+    expect(html).toContain("bailsec.io");
+    expect(html).toMatch(/rel="[^"]*nofollow/);
+  });
+  it("shows no website link for a null or unparsable website", () => {
+    const html = renderToStaticMarkup(
+      createElement(FirmsList, { firms: [firm({ website: "javascript:alert(1)" })] }),
+    );
+    expect(html).not.toContain("javascript:");
+    // The website anchor is the only nofollow link (the header's back link and
+    // CTA are not nofollow); an unparsable host renders no website anchor.
+    expect(html).not.toContain("nofollow");
+  });
+  it("renders a monogram tile for a guard-failing logo and an img for a valid one", () => {
+    const monogram = renderToStaticMarkup(
+      createElement(FirmsList, {
+        firms: [firm({ firm_name: "Open Zeppelin", logo_url: "https://evil.example/x.png" })],
+      }),
+    );
+    expect(monogram).toContain("OZ");
+    expect(monogram).not.toContain("<img");
+    const HOST = "qizat5l3bwvomkny.public.blob.vercel-storage.com";
+    const logo = renderToStaticMarkup(
+      createElement(FirmsList, { firms: [firm({ logo_url: `https://${HOST}/u/a.png` })] }),
+    );
+    expect(logo).toContain(`src="https://${HOST}/u/a.png"`);
+    expect(logo).toContain('alt=""');
+  });
+  it("renders every service as a non-interactive pill and none when empty", () => {
+    const withPills = renderToStaticMarkup(
+      createElement(FirmsList, { firms: [firm({ services: ["OpSec", "AI security scan"] })] }),
+    );
+    expect(withPills).toContain("AI security scan");
+    expect(withPills).not.toContain("<button");
+  });
+  it("shows the empty state with zero active firms", () => {
+    const html = renderToStaticMarkup(createElement(FirmsList, { firms: [] }));
+    expect(html).toContain("No firms are listed right now.");
+  });
+});

--- a/tests/unit/audits/format.test.ts
+++ b/tests/unit/audits/format.test.ts
@@ -4,6 +4,7 @@ import {
   fromUtcCalendarDate,
   hostOf,
   isOutsideWindow,
+  monogramOf,
   parseWholeNumber,
   priceDeltaLabel,
   toUtcCalendarDate,
@@ -140,5 +141,17 @@ describe("isOutsideWindow", () => {
   it("never fires without a needed-by date", () => {
     expect(isOutsideWindow("2026-08-19", null)).toBe(false);
     expect(isOutsideWindow("2026-08-19", undefined)).toBe(false);
+  });
+});
+
+describe("monogramOf", () => {
+  it("takes the first letters of the first two words, or two of a single word", () => {
+    expect(monogramOf("Spearbit Labs")).toBe("SL");
+    expect(monogramOf("Open Zeppelin")).toBe("OZ");
+    expect(monogramOf("HackenProof")).toBe("HP");
+    expect(monogramOf("BlockSec")).toBe("BS");
+    expect(monogramOf("Halborn")).toBe("HA");
+    expect(monogramOf("shieldify")).toBe("SH");
+    expect(monogramOf("FYEO")).toBe("FY");
   });
 });

--- a/tests/unit/audits/logoSrc.test.ts
+++ b/tests/unit/audits/logoSrc.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { isAllowedLogoSrc } from "@/lib/audits/logoSrc";
+
+const HOST = "qizat5l3bwvomkny.public.blob.vercel-storage.com";
+
+describe("isAllowedLogoSrc", () => {
+  it("accepts an https URL on our own blob store with a path", () => {
+    expect(isAllowedLogoSrc(`https://${HOST}/userid/abc.png`)).toBe(true);
+  });
+  it("rejects everything else (S-9, S-10)", () => {
+    for (const bad of [
+      "javascript:alert(1)",
+      "data:image/png;base64,AAAA",
+      `http://${HOST}/a`,
+      "https://evil.example/logo.png",
+      `https://${HOST}.evil.example/a`,
+      "/images/bailsec.svg",
+      "../secret.png",
+      `https://evil.example/#.${HOST}/a.png`,
+      `https://evil.example/?x=.${HOST}/a.png`,
+      `https://${HOST}`,
+      "https://other.public.blob.vercel-storage.com/a.png",
+    ]) {
+      expect(isAllowedLogoSrc(bad)).toBe(false);
+    }
+  });
+});

--- a/tests/unit/audits/members.test.ts
+++ b/tests/unit/audits/members.test.ts
@@ -41,10 +41,16 @@ vi.mock("@/server/services/audits/emails/sendAuditorInvite", () => ({
   sendAuditorInvite: inviteMock,
 }));
 
+const { teamNoticeMock } = vi.hoisted(() => ({ teamNoticeMock: vi.fn() }));
+vi.mock("@/server/services/audits/emails/sendTeamChangeNotice", () => ({
+  sendTeamChangeNotice: teamNoticeMock,
+}));
+
 import { auditorMemberCreateSchema } from "@/types/audits";
 import { addAuditorMember, removeAuditorMember } from "@/server/services/audits/members";
 
-const ADMIN = { id: "admin-1", name: "Federico" };
+const ADMIN = { type: "admin" as const, id: "admin-1", name: "Federico" };
+const AUDITOR_ACTOR = { type: "auditor" as const, id: "aud-1", email: "alice@nordlicht.example" };
 const FIRM = {
   id: "aud-1",
   firm_name: "Nordlicht Security",
@@ -141,6 +147,27 @@ describe("addAuditorMember", () => {
       action: "auditor_member_added",
       meta: { firm_name: "Nordlicht Security", email: "bob@nordlicht.example", invite_sent: true },
     });
+    expect(teamNoticeMock).not.toHaveBeenCalled();
+  });
+
+  it("an auditor add records added_by null, logs the auditor actor and notifies once (S-2)", async () => {
+    await addAuditorMember("aud-1", { email: "bob@nordlicht.example" }, AUDITOR_ACTOR);
+
+    expect(memberCreateMock.mock.calls[0][0].data.added_by).toBeNull();
+    expect(eventCreateMock.mock.calls[0][0].data).toMatchObject({
+      actor_type: "auditor",
+      actor_id: "aud-1",
+      action: "auditor_member_added",
+      meta: { actor_email: "alice@nordlicht.example" },
+    });
+    expect(teamNoticeMock).toHaveBeenCalledTimes(1);
+    expect(teamNoticeMock.mock.calls[0][0]).toMatchObject({
+      quoteEmail: "quotes@nordlicht.example",
+      firmName: "Nordlicht Security",
+      changedEmail: "bob@nordlicht.example",
+      actorEmail: "alice@nordlicht.example",
+      change: "added",
+    });
   });
 
   it("keeps the teammate when the invite email fails and says so", async () => {
@@ -229,5 +256,39 @@ describe("removeAuditorMember", () => {
       code: "not_found",
     });
     expect(memberDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it("an auditor remove logs the auditor actor and notifies the quote email (S-2)", async () => {
+    memberFindFirstMock.mockResolvedValue({
+      ...NEW_MEMBER,
+      auditor: { firm_name: "Nordlicht Security", quote_email: "quotes@nordlicht.example" },
+    });
+
+    await removeAuditorMember("aud-1", "mem-2", AUDITOR_ACTOR);
+
+    expect(eventCreateMock.mock.calls[0][0].data).toMatchObject({
+      actor_type: "auditor",
+      actor_id: "aud-1",
+      action: "auditor_member_removed",
+      meta: { actor_email: "alice@nordlicht.example" },
+    });
+    expect(teamNoticeMock).toHaveBeenCalledTimes(1);
+    expect(teamNoticeMock.mock.calls[0][0]).toMatchObject({
+      quoteEmail: "quotes@nordlicht.example",
+      changedEmail: "bob@nordlicht.example",
+      actorEmail: "alice@nordlicht.example",
+      change: "removed",
+    });
+  });
+
+  it("an admin remove sends no team-change notice (S-2)", async () => {
+    memberFindFirstMock.mockResolvedValue({
+      ...NEW_MEMBER,
+      auditor: { firm_name: "Nordlicht Security", quote_email: "quotes@nordlicht.example" },
+    });
+
+    await removeAuditorMember("aud-1", "mem-2", ADMIN);
+
+    expect(teamNoticeMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/audits/ogCard.test.ts
+++ b/tests/unit/audits/ogCard.test.ts
@@ -33,12 +33,12 @@ describe('audits section card', () => {
       createElement(SectionCard, {
         title: 'Security Audits',
         description:
-          'Request audit quotes from every vetted security firm on the Ava Labs whitelist. Free, private, subsidized up to 75%.',
+          'Request audit quotes from the vetted security firms on the Ava Labs whitelist. Free, private, subsidized up to 75%.',
         path: 'audits',
       }),
     );
     expect(html).toContain('SECURITY AUDITS');
-    expect(html).toContain('EVERY VETTED SECURITY FIRM ON THE AVA LABS WHITELIST');
+    expect(html).toContain('THE VETTED SECURITY FIRMS ON THE AVA LABS WHITELIST');
     expect(html).toContain('SUBSIDIZED UP TO 75%.');
     expect(html).toContain('BUILD.AVAX.NETWORK/AUDITS');
     expect(html).toContain('AVA LABS AUDIT PROGRAM · FREE FOR BUILDERS');

--- a/tests/unit/audits/requests.test.ts
+++ b/tests/unit/audits/requests.test.ts
@@ -9,6 +9,7 @@ const {
   txEventCountMock,
   txEventCreateMock,
   txAuditorFindManyMock,
+  txAuditorCountMock,
   txDeliveryCreateManyMock,
   deliverFanoutEmailsMock,
 } = vi.hoisted(() => ({
@@ -20,6 +21,7 @@ const {
   txEventCountMock: vi.fn(),
   txEventCreateMock: vi.fn(),
   txAuditorFindManyMock: vi.fn(),
+  txAuditorCountMock: vi.fn(),
   txDeliveryCreateManyMock: vi.fn(),
   deliverFanoutEmailsMock: vi.fn(),
 }));
@@ -27,7 +29,7 @@ const {
 const tx = {
   auditRequest: { findFirst: txRequestFindFirstMock, update: txRequestUpdateMock },
   auditEventLog: { count: txEventCountMock, create: txEventCreateMock },
-  auditor: { findMany: txAuditorFindManyMock },
+  auditor: { findMany: txAuditorFindManyMock, count: txAuditorCountMock },
   auditFanoutDelivery: { createMany: txDeliveryCreateManyMock },
 };
 
@@ -74,6 +76,11 @@ describe("patchDraft", () => {
     const result = await patchDraft(OWNER, "req-1", { project_name: "X" });
 
     expect(result).toEqual({ success: false, code: "not_found" });
+  });
+
+  it("passes shortlist_auditor_ids straight through patchDraft to updateMany data", async () => {
+    await patchDraft(OWNER, "req-1", { shortlist_auditor_ids: ["aud-1"] });
+    expect(updateManyMock.mock.calls[0][0].data).toMatchObject({ shortlist_auditor_ids: ["aud-1"] });
   });
 });
 
@@ -127,12 +134,14 @@ describe("reopen", () => {
     nsloc: 4200,
     status: "collecting",
     quote_deadline: new Date(Date.now() - 2 * DAY),
+    shortlist_auditor_ids: [],
     _count: { quotes: 0 },
   };
 
   beforeEach(() => {
     txRequestFindFirstMock.mockResolvedValue(expiredRow);
     txEventCountMock.mockResolvedValue(0);
+    txAuditorCountMock.mockResolvedValue(15);
     txRequestUpdateMock.mockResolvedValue({});
     txAuditorFindManyMock.mockResolvedValue([
       {
@@ -176,5 +185,23 @@ describe("reopen", () => {
 
     expect(result).toEqual({ success: false, code: "already_reopened" });
     expect(txRequestUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("reopens to a stored shortlist with an exact where clause (S-20)", async () => {
+    txRequestFindFirstMock.mockResolvedValue({ ...expiredRow, shortlist_auditor_ids: ["aud-1"] });
+    await reopen(OWNER, "req-1");
+    expect(txAuditorFindManyMock.mock.calls[0][0].where).toEqual({ active: true, id: { in: ["aud-1"] } });
+  });
+
+  it("reopens to every active firm for an empty shortlist (S-20)", async () => {
+    await reopen(OWNER, "req-1");
+    expect(txAuditorFindManyMock.mock.calls[0][0].where).toEqual({ active: true });
+  });
+
+  it("records the three counts on request_reopened", async () => {
+    txRequestFindFirstMock.mockResolvedValue({ ...expiredRow, shortlist_auditor_ids: ["aud-1"] });
+    txAuditorCountMock.mockResolvedValueOnce(1).mockResolvedValueOnce(15);
+    await reopen(OWNER, "req-1");
+    expect(txEventCreateMock.mock.calls[0][0].data.meta).toMatchObject({ auditor_count: 1, shortlist_count: 1, whitelist_count: 15 });
   });
 });

--- a/tests/unit/audits/selfService.test.ts
+++ b/tests/unit/audits/selfService.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { auditorSelfUpdateSchema, auditorUpdateSchema } from "@/types/audits";
+import { isFirmOwner } from "@/app/api/audits/portal/utils";
+
+describe("auditorSelfUpdateSchema", () => {
+  it("accepts a services subset and a website", () => {
+    const parsed = auditorSelfUpdateSchema.safeParse({ services: ["OpSec"], website: "avax.network" });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.website).toBe("https://avax.network");
+  });
+
+  it("turns an empty website into null and dedupes services (S-14)", () => {
+    const parsed = auditorSelfUpdateSchema.safeParse({ services: ["OpSec", "OpSec"], website: "" });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.website).toBeNull();
+      expect(parsed.data.services).toEqual(["OpSec"]);
+    }
+  });
+
+  it("rejects active, firm_name, quote_email, logo_url and unknown keys", () => {
+    for (const bad of [
+      { active: false },
+      { firm_name: "X" },
+      { quote_email: "a@b.example" },
+      { logo_url: "https://x" },
+      { attio_ref: "y" },
+    ]) {
+      expect(auditorSelfUpdateSchema.safeParse(bad).success).toBe(false);
+    }
+  });
+
+  it("rejects a non-http(s) scheme, javascript: and a bare scheme (S-7)", () => {
+    for (const bad of ["javascript:alert(1)", "data:text/html,x", "vbscript:x", "https://"]) {
+      expect(auditorSelfUpdateSchema.safeParse({ website: bad }).success).toBe(false);
+    }
+  });
+});
+
+describe("auditorUpdateSchema (admin) gains website and logo_url", () => {
+  it("dedupes services and accepts a null website", () => {
+    const parsed = auditorUpdateSchema.safeParse({ services: ["OpSec", "OpSec"], website: "" });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.services).toEqual(["OpSec"]);
+  });
+});
+
+describe("isFirmOwner", () => {
+  it("is true only for the quote email", () => {
+    const firm = { quote_email: "quotes@nordlicht.example" };
+    expect(isFirmOwner(firm, "quotes@nordlicht.example")).toBe(true);
+    expect(isFirmOwner(firm, "alice@nordlicht.example")).toBe(false);
+  });
+});

--- a/tests/unit/audits/shortlistSurfaces.render.test.tsx
+++ b/tests/unit/audits/shortlistSurfaces.render.test.tsx
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: () => {}, push: () => {} }) }));
+
+import { FanoutNoticeCard } from "@/components/audits/shared/FanoutNoticeCard";
+import { SubmissionReceipt } from "@/components/audits/detail/SubmissionReceipt";
+import { RequestSummary } from "@/components/audits/detail/RequestSummary";
+import { CollectingBanner } from "@/components/audits/detail/CollectingBanner";
+import { RequestDetailView } from "@/components/audits/detail/RequestDetailView";
+import { ReviewDecision } from "@/components/audits/admin/ReviewDecision";
+import { ActivityTrail } from "@/components/audits/admin/ActivityTrail";
+import type { OwnerRequestDetail } from "@/server/services/audits/visibility";
+
+const el = (c: Parameters<typeof createElement>[0], p: Record<string, unknown>) =>
+  renderToStaticMarkup(createElement(c as never, p as never));
+
+// A complete-enough OwnerRequestDetail; extra fields are harmless, missing ones
+// are only read on branches these cases do not hit.
+const ownerDetail = (over: Partial<OwnerRequestDetail> = {}): OwnerRequestDetail =>
+  ({
+    id: "req-1",
+    user_id: "u1",
+    project_name: "Glacierswap",
+    description: "A DEX",
+    scope: "The router",
+    services: ["OpSec"],
+    project_types: [],
+    deployment_target: "c_chain",
+    multichain: false,
+    repos: [],
+    languages: [],
+    frameworks: [],
+    nsloc: null,
+    doc_links: [],
+    attachments: [],
+    needed_by: null,
+    quote_deadline: new Date("2026-09-20"),
+    urgency: null,
+    contact_name: "Ada",
+    contact_email: "ada@x.example",
+    contact_handle: null,
+    status: "collecting",
+    display_status: "collecting",
+    submitted_at: new Date("2026-09-04"),
+    created_at: new Date("2026-09-04"),
+    updated_at: new Date("2026-09-04"),
+    quote_count: 0,
+    fanout_count: 3,
+    shortlist_auditor_ids: [],
+    shortlist_firms: [],
+    whitelist_count: 16,
+    quotes: [],
+    subsidy: null,
+    ...over,
+  }) as unknown as OwnerRequestDetail;
+
+describe("FanoutNoticeCard", () => {
+  it("default and narrowed", () => {
+    expect(el(FanoutNoticeCard, {})).toContain("Sent to all whitelisted auditors.");
+    const n = el(FanoutNoticeCard, { chosenCount: 7, whitelistCount: 16 });
+    expect(n).toContain("Sent to 7 of 16 whitelisted auditors.");
+    expect(n).toContain("Your request reaches the 7 firms you chose at once.");
+  });
+});
+
+describe("SubmissionReceipt", () => {
+  const base = { requestId: "req-1", projectName: "Glacierswap", submittedAt: null, quoteDeadline: null };
+  it("default and narrowed", () => {
+    expect(el(SubmissionReceipt, base)).toContain(
+      "Once approved, every whitelisted firm is notified",
+    );
+    const n = el(SubmissionReceipt, { ...base, chosenCount: 7, whitelistCount: 16 });
+    expect(n).toContain("Once approved, the 7 firms you chose are notified");
+    expect(n).toContain("The 7 firms you chose are notified the moment the program team approves it");
+  });
+});
+
+describe("RequestSummary", () => {
+  it("pre-approval Firms row and narrowed header after approval", () => {
+    const pre = el(RequestSummary, {
+      detail: ownerDetail({
+        status: "pending_review",
+        shortlist_auditor_ids: ["a", "b"],
+        shortlist_firms: [
+          { id: "a", firm_name: "Nordlicht Security" },
+          { id: "b", firm_name: "Cipherline" },
+        ],
+      }),
+    });
+    expect(pre).toContain("Nordlicht Security · Cipherline");
+    expect(pre).toContain("2 of 16 whitelisted firms");
+
+    const gone = el(RequestSummary, {
+      detail: ownerDetail({ status: "pending_review", shortlist_auditor_ids: ["a"], shortlist_firms: [] }),
+    });
+    expect(gone).toContain("None of the firms you chose is still listed.");
+
+    const post = el(RequestSummary, {
+      detail: ownerDetail({ status: "collecting", shortlist_auditor_ids: ["a"], shortlist_firms: [] }),
+    });
+    expect(post).toContain("Your request · what the firms you chose received");
+    expect(post).not.toContain("whitelisted firms");
+  });
+});
+
+describe("CollectingBanner", () => {
+  it("narrowed zero line and label", () => {
+    const html = el(CollectingBanner, {
+      detail: ownerDetail({ fanout_count: 0, shortlist_auditor_ids: ["a"] }),
+    });
+    expect(html).toContain("none of the firms you chose was still listed at approval");
+    expect(html).toContain("Reopen after expiry re-notifies the firms you chose");
+  });
+});
+
+describe("RequestDetailView expired card", () => {
+  it("default and narrowed", () => {
+    const def = el(RequestDetailView, {
+      detail: ownerDetail({ status: "expired", display_status: "expired" }),
+      userId: "u1",
+    });
+    expect(def).toContain("every active firm is notified again");
+    const narrowed = el(RequestDetailView, {
+      detail: ownerDetail({ status: "expired", display_status: "expired", shortlist_auditor_ids: ["a"] }),
+      userId: "u1",
+    });
+    expect(narrowed).toContain("the firms you chose are notified again");
+  });
+});
+
+describe("ReviewDecision", () => {
+  const base = { requestId: "req-1", fanoutTarget: 16 };
+  it("three panel states", () => {
+    expect(el(ReviewDecision, base)).toContain("Approving notifies 16 active firms");
+    const some = el(ReviewDecision, {
+      ...base,
+      shortlistFirms: [
+        { id: "a", firm_name: "Nordlicht Security", active: true },
+        { id: "b", firm_name: "Halborn", active: false },
+      ],
+      whitelistCount: 16,
+    });
+    expect(some).toContain("Approving notifies 1 of the 2 firms this project chose");
+    expect(some).toContain("Halborn (deactivated)");
+    const none = el(ReviewDecision, {
+      ...base,
+      shortlistFirms: [{ id: "b", firm_name: "Halborn", active: false }],
+      whitelistCount: 16,
+    });
+    expect(none).toContain("None of the 1 firms this project chose is still active.");
+  });
+});
+
+const event = (action: string, meta: Record<string, unknown>) => ({
+  id: `e-${action}`,
+  request_id: "req-1",
+  actor_type: "system",
+  actor_id: null,
+  action,
+  meta,
+  created_at: new Date("2026-09-04T10:00:00Z"),
+});
+
+describe("ActivityTrail", () => {
+  it("fan-out and reopen with and without a shortlist, and a pre-v1.1 event", () => {
+    const noShortlist = el(ActivityTrail, {
+      events: [event("fanout_created", { auditor_count: 16, whitelist_count: 16, shortlist_count: 0 })],
+      fanoutFirms: [],
+    });
+    expect(noShortlist).toContain("Fanned out to 16 whitelisted firms");
+
+    const shortlisted = el(ActivityTrail, {
+      events: [event("fanout_created", { auditor_count: 4, whitelist_count: 15, shortlist_count: 5 })],
+      fanoutFirms: [],
+    });
+    expect(shortlisted).toContain("Fanned out to 4 of 15 whitelisted firms · project chose 5");
+
+    const reopened = el(ActivityTrail, {
+      events: [event("request_reopened", { auditor_count: 4, whitelist_count: 15, shortlist_count: 5 })],
+      fanoutFirms: [],
+    });
+    expect(reopened).toContain(
+      "Request reopened for one more round · 4 of 15 whitelisted firms notified again · project chose 5",
+    );
+
+    const legacy = el(ActivityTrail, {
+      events: [event("fanout_created", { auditor_count: 12 })],
+      fanoutFirms: [],
+    });
+    expect(legacy).toContain("Fanned out to 12 whitelisted firms");
+  });
+});

--- a/tests/unit/audits/sourceGuard.test.ts
+++ b/tests/unit/audits/sourceGuard.test.ts
@@ -9,7 +9,12 @@ import { join, relative } from "node:path";
  * bypass, a route or service touching prisma.auditQuote directly, fails this
  * suite before it can ship.
  */
-const ROOTS = ["server/services/audits", "app/api/audits"];
+const ROOTS = [
+  "server/services/audits",
+  "app/api/audits",
+  "app/(home)/audits",
+  "app/(audit-portal)/audits",
+];
 const READ_RE = /auditQuote\s*\.\s*(findMany|findFirst|findUnique|count|aggregate|groupBy)/;
 const WRITE_RE = /auditQuote\s*\.\s*(create|createMany|update|updateMany|upsert|delete|deleteMany)/;
 const READ_ALLOWLIST = new Set(["server/services/audits/visibility.ts"]);
@@ -17,6 +22,24 @@ const WRITE_ALLOWLIST = new Set([
   "server/services/audits/quotes.ts",
   "server/services/audits/acceptance.ts",
 ]);
+
+// The Auditor fence (S-3): every read of firm rows lives in one of five
+// service files, so no route or page can widen the firm surface a client sees.
+const AUDITOR_READ_RE = /\bauditor\s*\.\s*(findMany|findFirst|findUnique|count|aggregate|groupBy)/;
+const AUDITOR_READ_ALLOW = new Set([
+  "server/services/audits/visibility.ts",
+  "server/services/audits/fanout.ts",
+  "server/services/audits/requests.ts",
+  "server/services/audits/auditors.ts",
+  "server/services/audits/members.ts",
+]);
+const MEMBER_READ_RE = /\bauditorMember\s*\.\s*(findMany|findFirst|findUnique|count|aggregate|groupBy)/;
+const MEMBER_READ_ALLOW = new Set([
+  "server/services/audits/auditors.ts",
+  "server/services/audits/members.ts",
+]);
+const INCLUDE_AUDITOR_RE = /auditor:\s*true/;
+const INCLUDE_AUDITOR_ALLOW = new Set(["server/services/audits/auditors.ts"]);
 
 function walk(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
@@ -47,5 +70,34 @@ describe("AuditQuote source guard", () => {
       (file) => !WRITE_ALLOWLIST.has(file) && WRITE_RE.test(readFileSync(file, "utf8")),
     );
     expect(offenders).toEqual([]);
+  });
+
+  it("only the enumerated readers touch Auditor (S-3)", () => {
+    const offenders = files.filter(
+      (file) => !AUDITOR_READ_ALLOW.has(file) && AUDITOR_READ_RE.test(readFileSync(file, "utf8")),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("only auditors.ts and members.ts read AuditorMember (S-3)", () => {
+    const offenders = files.filter(
+      (file) => !MEMBER_READ_ALLOW.has(file) && MEMBER_READ_RE.test(readFileSync(file, "utf8")),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("only auditors.ts uses a full-row auditor include (S-3)", () => {
+    const offenders = files.filter(
+      (file) => !INCLUDE_AUDITOR_ALLOW.has(file) && INCLUDE_AUDITOR_RE.test(readFileSync(file, "utf8")),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("both portal member route files reference isFirmOwner (S-16)", () => {
+    const memberRoutes = files.filter((file) =>
+      file.startsWith("app/api/audits/portal/me/members"),
+    );
+    expect(memberRoutes.length).toBeGreaterThanOrEqual(2);
+    for (const file of memberRoutes) expect(readFileSync(file, "utf8")).toContain("isFirmOwner");
   });
 });

--- a/tests/unit/audits/visibility.test.ts
+++ b/tests/unit/audits/visibility.test.ts
@@ -5,6 +5,8 @@ const {
   requestFindFirstMock,
   requestFindUniqueMock,
   auditorFindManyMock,
+  auditorFindUniqueMock,
+  auditorCountMock,
   deliveryFindManyMock,
   deliveryFindUniqueMock,
   quoteFindManyMock,
@@ -15,6 +17,8 @@ const {
   requestFindFirstMock: vi.fn(),
   requestFindUniqueMock: vi.fn(),
   auditorFindManyMock: vi.fn(),
+  auditorFindUniqueMock: vi.fn(),
+  auditorCountMock: vi.fn(),
   deliveryFindManyMock: vi.fn(),
   deliveryFindUniqueMock: vi.fn(),
   quoteFindManyMock: vi.fn(),
@@ -31,6 +35,8 @@ vi.mock("@/prisma/prisma", () => ({
     },
     auditor: {
       findMany: auditorFindManyMock,
+      findUnique: auditorFindUniqueMock,
+      count: auditorCountMock,
     },
     auditSubsidyDecision: {
       findFirst: subsidyFindFirstMock,
@@ -47,12 +53,16 @@ vi.mock("@/prisma/prisma", () => ({
 }));
 
 import {
+  countActiveFirms,
   getAdminAuditors,
   getAdminOverview,
+  getAdminRequestDetail,
   getAdminRequests,
   getAuditorInbox,
+  getOwnFirm,
   getOwnerRequests,
   getOwnerRequestDetail,
+  getPublicFirms,
   getRequestForAuditor,
 } from "@/server/services/audits/visibility";
 
@@ -68,12 +78,14 @@ const baseRequest = {
   status: "collecting",
   quote_deadline: FUTURE,
   services: ["Smart contract audit (Solidity / Vyper)"],
+  shortlist_auditor_ids: [],
   created_at: new Date(),
   submitted_at: new Date(),
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  auditorCountMock.mockResolvedValue(16);
 });
 
 describe("getOwnerRequests", () => {
@@ -383,6 +395,8 @@ describe("auditor scope", () => {
     expect(requestSelect.contact_handle).toBeUndefined();
     expect(requestSelect.contact_calendar_url).toBeUndefined();
     expect(requestSelect.user).toBeUndefined();
+    // The shortlist never reaches an auditor's inbox projection (S-3).
+    expect(requestSelect.shortlist_auditor_ids).toBeUndefined();
   });
 
   it("hides a request without this auditor's fan-out row", async () => {
@@ -469,5 +483,139 @@ describe("auditor scope · subsidy", () => {
 
     expect(view!.subsidy).toBeNull();
     expect(subsidyFindFirstMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("getPublicFirms", () => {
+  it("selects exactly the five public fields of active firms, sorted case-insensitively (S-8)", async () => {
+    auditorFindManyMock.mockResolvedValue([
+      { id: "b", firm_name: "zellic", services: [], website: null, logo_url: null },
+      {
+        id: "a",
+        firm_name: "Bailsec",
+        services: ["OpSec"],
+        website: "https://bailsec.io/",
+        logo_url: null,
+      },
+    ]);
+
+    const rows = await getPublicFirms();
+
+    expect(auditorFindManyMock.mock.calls[0][0].where).toEqual({ active: true });
+    expect(auditorFindManyMock.mock.calls[0][0].select).toEqual({
+      id: true,
+      firm_name: true,
+      services: true,
+      website: true,
+      logo_url: true,
+    });
+    expect(Object.keys(rows[0]).sort()).toEqual([
+      "firm_name",
+      "id",
+      "logo_url",
+      "services",
+      "website",
+    ]);
+    expect(rows.map((r) => r.firm_name)).toEqual(["Bailsec", "zellic"]);
+    expect(JSON.stringify(rows)).not.toContain("quote_email");
+  });
+});
+
+describe("countActiveFirms", () => {
+  it("counts active firms only", async () => {
+    auditorCountMock.mockResolvedValue(16);
+    expect(await countActiveFirms()).toBe(16);
+    expect(auditorCountMock.mock.calls[0][0]).toEqual({ where: { active: true } });
+  });
+});
+
+describe("getOwnFirm", () => {
+  it("pins the firm id and never selects attio_ref, created_by or logo_url", async () => {
+    auditorFindUniqueMock.mockResolvedValue({
+      id: "aud-1",
+      firm_name: "Nordlicht Security",
+      members: [],
+    });
+
+    await getOwnFirm("aud-1");
+
+    const call = auditorFindUniqueMock.mock.calls[0][0];
+    expect(call.where).toEqual({ id: "aud-1" });
+    expect(call.select.attio_ref).toBeUndefined();
+    expect(call.select.created_by).toBeUndefined();
+    expect(call.select.logo_url).toBeUndefined();
+    expect(call.select.members.select).toEqual({
+      id: true,
+      email: true,
+      invited_at: true,
+      first_login_at: true,
+    });
+  });
+});
+
+describe("shortlist projections", () => {
+  it("owner detail resolves active chosen firms with id+firm_name only and a whitelist_count", async () => {
+    requestFindFirstMock.mockResolvedValue({
+      ...baseRequest,
+      shortlist_auditor_ids: ["aud-1", "aud-2"],
+      _count: { fanout_deliveries: 3 },
+      quotes: [],
+      subsidy_decisions: [],
+    });
+    auditorFindManyMock.mockResolvedValue([{ id: "aud-1", firm_name: "Nordlicht Security" }]);
+    auditorCountMock.mockResolvedValue(16);
+
+    const detail = await getOwnerRequestDetail(OWNER, "req-1");
+
+    expect(auditorFindManyMock.mock.calls[0][0].where).toEqual({
+      id: { in: ["aud-1", "aud-2"] },
+      active: true,
+    });
+    expect(auditorFindManyMock.mock.calls[0][0].select).toEqual({ id: true, firm_name: true });
+    expect(detail!.shortlist_firms).toEqual([{ id: "aud-1", firm_name: "Nordlicht Security" }]);
+    expect(detail!.whitelist_count).toBe(16);
+  });
+
+  it("owner detail leaves shortlist_firms empty for an empty shortlist (no firm read)", async () => {
+    requestFindFirstMock.mockResolvedValue({
+      ...baseRequest,
+      shortlist_auditor_ids: [],
+      _count: { fanout_deliveries: 3 },
+      quotes: [],
+      subsidy_decisions: [],
+    });
+
+    const detail = await getOwnerRequestDetail(OWNER, "req-1");
+
+    expect(detail!.shortlist_firms).toEqual([]);
+    expect(auditorFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("admin detail resolves every stored firm carrying active, no active filter", async () => {
+    requestFindFirstMock.mockResolvedValue({
+      ...baseRequest,
+      shortlist_auditor_ids: ["aud-1", "aud-2"],
+      user: { name: "Alex", email: "alex@example.com" },
+      quotes: [],
+      subsidy_decisions: [],
+      events: [],
+      fanout_deliveries: [],
+    });
+    auditorFindManyMock.mockResolvedValue([
+      { id: "aud-1", firm_name: "Nordlicht Security", active: true },
+      { id: "aud-2", firm_name: "Halborn", active: false },
+    ]);
+    auditorCountMock.mockResolvedValue(15);
+
+    const detail = await getAdminRequestDetail("req-1");
+
+    expect(auditorFindManyMock.mock.calls[0][0].where).toEqual({ id: { in: ["aud-1", "aud-2"] } });
+    expect(auditorFindManyMock.mock.calls[0][0].select).toEqual({
+      id: true,
+      firm_name: true,
+      active: true,
+    });
+    expect(detail!.shortlist_firms.map((f) => f.firm_name)).toEqual(["Halborn", "Nordlicht Security"]);
+    expect(detail!.whitelist_count).toBe(15);
   });
 });

--- a/types/audits.ts
+++ b/types/audits.ts
@@ -11,8 +11,10 @@ import {
   AUDIT_PROJECT_TYPES,
   AUDIT_SERVICES,
   MAX_QUOTE_WEEKS,
+  SHORTLIST_LIMIT,
 } from "@/lib/audits/constants";
 import { SUBSIDY_MAX_PCT } from "@/lib/audits/subsidy";
+import { isAllowedLogoSrc } from "@/lib/audits/logoSrc";
 
 const MAX_NAME = 200;
 const MAX_URL = 2048;
@@ -45,8 +47,29 @@ const httpsUrl = z.preprocess(
   normalizeUrlInput,
   trimmed(MAX_URL)
     .min(1, "Link is required")
-    .refine((v) => /^https?:\/\//i.test(v), "URL must start with http(s)://"),
+    .refine((v) => /^https?:\/\//i.test(v), "URL must start with http(s)://")
+    // Rejects javascript:/data:/vbscript: (which normalizeUrlInput leaves as
+    // "https://javascript:alert(1)") and the bare "https://" (S-7).
+    .refine((v) => {
+      try {
+        const u = new URL(v);
+        return u.protocol === "https:" || u.protocol === "http:";
+      } catch {
+        return false;
+      }
+    }, "Enter a valid URL"),
 );
+
+// One website field shared by both auditor schemas so they cannot drift:
+// httpsUrl, nullable, "" becomes null (the contact_calendar_url shape at :124).
+const auditorWebsiteField = httpsUrl.nullable().optional().or(z.literal("").transform(() => null));
+
+// One services field shared by both auditor schemas: dedupe on parse (S-14;
+// thirteen copies of one value pass .max today).
+const auditorServicesField = z
+  .array(z.enum(AUDIT_SERVICES))
+  .max(AUDIT_SERVICES.length)
+  .transform((values) => Array.from(new Set(values)));
 // z.coerce.date() would coerce null to 1970-01-01 (a valid Date), silently
 // passing a missing required date. Map nullish to undefined so it fails as
 // "required" instead.
@@ -95,6 +118,13 @@ export const auditDraftSchema = z.strictObject({
   contact_email: trimmed(320).optional(),
   contact_handle: trimmed(100).nullable().optional(),
   contact_calendar_url: trimmed(MAX_URL).nullable().optional(),
+  shortlist_auditor_ids: z
+    .preprocess(
+      (v) => (Array.isArray(v) ? v.map((x) => (typeof x === "string" ? x.toLowerCase() : x)) : v),
+      z.array(z.uuid()).max(SHORTLIST_LIMIT),
+    )
+    .refine((ids) => new Set(ids).size === ids.length, "Duplicate firm ids")
+    .optional(),
 });
 export type AuditDraftInput = z.infer<typeof auditDraftSchema>;
 
@@ -180,10 +210,22 @@ export type AuditorCreateInput = z.infer<typeof auditorCreateSchema>;
 
 export const auditorUpdateSchema = z.strictObject({
   firm_name: trimmed(MAX_NAME).min(1).optional(),
-  services: z.array(z.enum(AUDIT_SERVICES)).max(AUDIT_SERVICES.length).optional(),
+  services: auditorServicesField.optional(),
   active: z.boolean().optional(),
+  website: auditorWebsiteField,
+  logo_url: trimmed(MAX_URL)
+    .refine((v) => isAllowedLogoSrc(v), "Unsupported logo URL")
+    .nullable()
+    .optional()
+    .or(z.literal("").transform(() => null)),
 });
 export type AuditorUpdateInput = z.infer<typeof auditorUpdateSchema>;
+
+export const auditorSelfUpdateSchema = z.strictObject({
+  services: auditorServicesField.optional(),
+  website: auditorWebsiteField,
+});
+export type AuditorSelfUpdateInput = z.infer<typeof auditorSelfUpdateSchema>;
 
 export const auditorMemberCreateSchema = z.strictObject({
   email: normalizedEmail,


### PR DESCRIPTION
## Summary

Audit marketplace v1.1: Joey's four post-launch asks, plus his preview feedback, one PR. The `fix/audits-admin-page-gate` hotfix (#4532) is already merged.

1. **Vetted firms page** `/audits/firms`: every active firm with its logo tile, offered services and website, linked from the "N vetted firms" figure in all three `/audits` states.
2. **Project shortlist** in the request wizard: default send-to-all, honoured at approval and the single reopen, firms never told they were chosen.
3. **`AI security scan`** as the thirteenth service value, self-tagged like any other.
4. **Firm details page** `/audits/portal/firm`: any active firm identity edits services and website; only the quote email manages teammates.
5. **Portal navigation row**: "Inbox" and "Firm details" under the portal bar, active tab underlined, an awaiting-quote count on Inbox. The firm pill stays a shortcut. Follows Joey's feedback that the pill alone was not discoverable.
6. **Firm logo self-upload**: the identity tile on Firm details is the upload control (PNG or JPEG, 2MB). A dedicated route `POST/DELETE /api/audits/portal/me/logo` stores under `audits/firms/<firm id>/<uuid>` on our blob store, refuses cross-site requests, rate-limits per firm, checks the store host before saving, records the actor on the trail and unpublishes the firm's previous file. The generic `/api/file` route is not used: it keys blobs by the session user id, which for portal-only sessions is the signed-in email.

Also: the duplicate first-login event fix; `getAuditorInbox` wrapped in React `cache()` so the layout badge and the inbox page share one read per request; the security review pins S-2 to S-22 with S-23 to S-32 recorded.

## Migration and environment

One migration, `20260911000000_add_audit_firm_listing_and_shortlist`: `Auditor.website` and `Auditor.logo_url` (both nullable) and `AuditRequest.shortlist_auditor_ids TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[]`. Apply by hand to production before deploy, with the read-back query. Then `prisma migrate resolve --applied` for every audit migration `_prisma_migrations` does not record yet: `20260730000000_add_audit_marketplace`, `20260805000000_add_quote_deal_doc_and_consent`, `20260902000000_add_auditor_members`, `20260911000000_add_audit_firm_listing_and_shortlist`. Never `prisma migrate deploy`.

Firm logo uploads reuse `BLOB_READ_WRITE_TOKEN`, already set for `/api/file`. The host guard defaults to the store the site already serves images from (`qizat5l3bwvomkny.public.blob.vercel-storage.com`); `BLOB_BASE_URL` overrides it if the store ever changes. A mismatch fails closed: 500, and the stored object is deleted.

## Test plan

- [ ] `yarn tsc --noEmit` clean
- [ ] `npx vitest run tests/unit/audits` green (28 suites, 261 tests)
- [ ] `./scripts/check-console-design.sh` green over changed `components/audits/**`
- [ ] `/audits/firms` anonymous and signed in: alphabetical firms, monogram tiles day one, empty state, light/dark/375, the figure links in all three states
- [ ] Wizard: "All 16 vetted firms" default, no refetch between steps, warning at 1 to 2 firms, resumed draft names its firms, `pending_` session sees the list
- [ ] Portal: tab row on inbox, request and firm pages; Inbox current on request pages; count only when a quote is awaited; no row on sign-in
- [ ] Firm details: quote email edits services/website and manages teammates; a teammate is read-only on the team; a deactivated firm is read-only, tile included
- [ ] Logo: upload PNG via the tile, replace, remove; SVG and files over 2MB refused; the new logo shows on `/audits/firms`; the trail names the actor
- [ ] Admin sheet: website + logo, header preview before Save, Remove; no tile column in the table
- [ ] Narrowed request: receipt, detail, admin pending panel (three states), trail after approval and reopen
- [ ] Firms never see a per-request count anywhere; the not-selected email footer reads "nothing changes on your side"
